### PR TITLE
[FIX] Fix for validation error on invoices with l10n_es_account_invoice_...

### DIFF
--- a/l10n_es_account_invoice_sequence/account_invoice.py
+++ b/l10n_es_account_invoice_sequence/account_invoice.py
@@ -67,8 +67,7 @@ class AccountInvoice(orm.Model):
             number = sequence_obj.get_id(cr, uid, sequence.id, context=ctx)
             self.write(cr, uid, [invoice.id], {'number': number},
                        context=context)
-        result = super(AccountInvoice, self).action_number(cr, uid, ids,
-                                                           context=context)
+        result = super(AccountInvoice, self).action_number(cr, uid, ids,ctx)
         # As super's action_number() will store internal_number we clear it
         # afterwards. The reason is that post() function in account.move will
         # try to use this 'internal_number' if move is created again. As this


### PR DESCRIPTION
...sequence

The module raises the error:

File "/opt/openerp/v7/spain/l10n_es_account_invoice_sequence/account_invoice.py", line 71, in action_number
    context=context)
TypeError: action_number() got an unexpected keyword argument 'context'

This fix worked for me.

More info: https://groups.google.com/forum/#!msg/openerp-spain-users/Znh1SS3HiTo/zVvQIhB9CCUJ
