### PR TITLE
[FIX] l10n_es_bank_statement: Añadir correctamente el tipo a la selección

### DIFF
--- a/l10n_es_bank_statement/models/c43_account_statement_profile.py
+++ b/l10n_es_bank_statement/models/c43_account_statement_profile.py
@@ -26,10 +26,10 @@ from openerp.osv import orm
 class AccountStatementProfil(orm.Model):
     _inherit = "account.statement.profile"
 
-    def get_import_type_selection(self, cr, uid, context=None):
+    def _get_import_type_selection(self, cr, uid, context=None):
         """Inherited from parent to add parser."""
         selection = super(AccountStatementProfil, self
-                          ).get_import_type_selection(cr, uid,
-                                                      context=context)
+                          )._get_import_type_selection(cr, uid,
+                                                       context=context)
         selection.append(('aeb_c43', _('AEB C43 standard')))
         return selection


### PR DESCRIPTION
Debido a una actualización que se hizo en los módulos de los que depende éste, la adicción del tipo de perfil de extracto dejó de funcionar. Este PR lo soluciona.
