### PR TITLE
[FIX] Falta un espacio en la excepcion

### DIFF
--- a/l10n_es_account_invoice_sequence/models/account_invoice.py
+++ b/l10n_es_account_invoice_sequence/models/account_invoice.py
@@ -38,7 +38,7 @@ class AccountInvoice(models.Model):
                 sequence = inv.journal_id.invoice_sequence_id
                 if not sequence:
                     raise exceptions.Warning(
-                        _('Error!:: Journal %s has no sequence defined for'
+                        _('Error!:: Journal %s has no sequence defined for '
                           'invoices.') % inv.journal_id.name)
                 inv.number = sequence.with_context({
                     'fiscalyear_id': inv.period_id.fiscalyear_id.id

--- a/l10n_es_account_invoice_sequence/models/account_invoice.py
+++ b/l10n_es_account_invoice_sequence/models/account_invoice.py
@@ -55,3 +55,8 @@ class AccountInvoice(models.Model):
                     'internal_number': inv.move_id.name,
                 })
         return re
+
+    @api.multi
+    def unlink(self):
+        self.write({'internal_number': False})
+        return super(AccountInvoice, self).unlink()

--- a/l10n_es_account_invoice_sequence/models/account_invoice.py
+++ b/l10n_es_account_invoice_sequence/models/account_invoice.py
@@ -33,14 +33,25 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def action_number(self):
+        re = super(AccountInvoice, self).action_number()
         for inv in self:
-            if not inv.internal_number:
+            if not inv.invoice_number:
                 sequence = inv.journal_id.invoice_sequence_id
                 if not sequence:
                     raise exceptions.Warning(
-                        _('Error!:: Journal %s has no sequence defined for '
-                          'invoices.') % inv.journal_id.name)
-                inv.number = sequence.with_context({
+                        (_('Journal %s has no sequence defined for invoices.')
+                         % inv.journal_id.name))
+                number = sequence.with_context({
                     'fiscalyear_id': inv.period_id.fiscalyear_id.id
                 }).next_by_id(sequence.id)
-        return super(AccountInvoice, self).action_number()
+                inv.write({
+                    'number': number,
+                    'internal_number': inv.move_id.name,
+                    'invoice_number': number
+                })
+            else:
+                inv.write({
+                    'number': inv.invoice_number,
+                    'internal_number': inv.move_id.name,
+                })
+        return re


### PR DESCRIPTION
Falta un espacio en en el mensaje de la excepción que se lanza al no asignar una secuencia de facturación al diario.
