### PR TITLE
[FIX] Renumeración de factura cancelada

### DIFF
--- a/l10n_es_account_invoice_sequence/models/account_invoice.py
+++ b/l10n_es_account_invoice_sequence/models/account_invoice.py
@@ -34,7 +34,7 @@ class AccountInvoice(models.Model):
     @api.multi
     def action_number(self):
         for inv in self:
-            if not inv.internal_number:
+            if not inv.number:
                 sequence = inv.journal_id.invoice_sequence_id
                 if not sequence:
                     raise exceptions.Warning(


### PR DESCRIPTION
Al cancelar una factura, volverla a borrador y volver a validar volvía a ejecutar el action_number, con lo que se generaban huecos en la secuencia de facturación. 

Se ha solucionado controlando en la llamada a action_number que no tenga number, en lugar de controlar que no tenga internal_number.
