### PR TITLE
[FIX] l10n_es_aeat_mod340: Código de país utilizado

### DIFF
--- a/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
+++ b/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
@@ -95,10 +95,8 @@ class L10nEsAeatMod340CalculateRecords(orm.TransientModel):
                         raise orm.except_orm(
                             _('La siguiente empresa no tiene asignado nif:'),
                             invoice.partner_id.name)
-                nif = invoice.partner_id.vat and \
-                    re.match(r"([A-Z]{0,2})(.*)",
-                             invoice.partner_id.vat).groups()[1]
-                country_code = invoice.partner_id.country_id.code
+                country_code, nif = (re.match(r"([A-Z]{0,2})(.*)",
+                                              invoice.partner_id.vat).groups())
                 values = {
                     'mod340_id': mod340.id,
                     'partner_id': invoice.partner_id.id,


### PR DESCRIPTION
Cuando se tienen clientes/proveedores extranjeros, en la dirección del partner podemos tener una dirección española, porque ésos sean sus datos de contacto, pero esa dirección no debe cogerse a efectos de rellenar los campos "NIF del declarado" y "Clave de identificación en el país de residencia". En su lugar, hay que coger el código de país de las dos letras del NIF.
