### PR TITLE
[IMP] l10n_es_acount_asset. Mejora cálculo para para importes ya amortizados

### DIFF
--- a/l10n_es_account_asset/account_asset.py
+++ b/l10n_es_account_asset/account_asset.py
@@ -210,7 +210,7 @@ class account_asset_asset(orm.Model):
                 if asset.method_period == 1:
                         total_days = calendar.monthrange(
                             depreciation_date.year, depreciation_date.month)[1]
-                        days = total_days - float(depreciation_date.day)
+                        days = total_days - float(depreciation_date.day) + 1
                 else:
                     days = (total_days -
                             float(depreciation_date.strftime('%j'))) + 1

--- a/l10n_es_account_asset/account_asset.py
+++ b/l10n_es_account_asset/account_asset.py
@@ -68,20 +68,21 @@ class account_asset_category(orm.Model):
 class account_asset_asset(orm.Model):
     _inherit = 'account.asset.asset'
 
-
     def _get_last_depreciation_date(self, cr, uid, ids, context=None):
         """
         @param id: ids of a account.asset.asset objects
-        @return: Returns a dictionary of the effective dates of the last depreciation entry made for given asset ids. If there isn't any, return the purchase date of this asset
+        @return: Returns a dictionary of the effective dates of the last
+        depreciation entry made for given asset ids. If there isn't any,
+        return the purchase date of this asset
         """
         cr.execute("""
-            SELECT a.id as id, COALESCE(MAX(l.date),a.start_depreciation_date,a.purchase_date) AS date
+            SELECT a.id as id, COALESCE(MAX(l.date),a.start_depreciation_date,
+            a.purchase_date) AS date
             FROM account_asset_asset a
             LEFT JOIN account_move_line l ON (l.asset_id = a.id)
             WHERE a.id IN %s
             GROUP BY a.id, a.purchase_date """, (tuple(ids),))
         return dict(cr.fetchall())
-
 
     _columns = {
         'move_end_period': fields.boolean(
@@ -106,13 +107,11 @@ class account_asset_asset(orm.Model):
                  "depreciations and the percentage to depreciate."),
         'method_percentage': fields.float('Depreciation percentage',
                                           digits=(3, 2)),
-        'start_depreciation_date': fields.date('Start Depreciation Date',
-                                               readonly=True,
-                                               states={'draft':[('readonly',
-                                                                 False)]},
-                                                help="Only needed if"
-                                                     " not the same that "
-                                                     "purchase date"),
+        'start_depreciation_date': fields.date(
+            'Start Depreciation Date',
+            readonly=True,
+            states={'draft': [('readonly', False)]},
+            help="Only needed if not the same that purchase date"),
 
     }
 
@@ -126,7 +125,6 @@ class account_asset_asset(orm.Model):
          ' CHECK (method_percentage > 0 and method_percentage <= 100)',
          'Wrong percentage!'),
     ]
-
 
     def onchange_ext_method_time(self, cr, uid, ids, ext_method_time,
                                  context=None):
@@ -191,13 +189,14 @@ class account_asset_asset(orm.Model):
         elif (asset.method == 'linear' and asset.prorata and
               i != undone_dotation_number):
             # Caso especial de cálculo que cambia
-            #Debemos considerar también las cantidades ya depreciadas
+            # Debemos considerar también las cantidades ya depreciadas
             depreciated_amount = 0
             depr_lin_obj = self.pool['account.asset.depreciation.line']
             for line in depr_lin_obj.browse(cr, uid,
                                             posted_depreciation_line_ids):
                 depreciated_amount += line.amount
-            amount = (amount_to_depr + depreciated_amount) / asset.method_number
+            amount = (amount_to_depr + depreciated_amount) \
+                / asset.method_number
             if i == 1:
                 days = (total_days -
                         float(depreciation_date.strftime('%j'))) + 1
@@ -225,24 +224,26 @@ class account_asset_asset(orm.Model):
                 # al período siguiente
                 depreciation_date = datetime.strptime(
                     self._get_last_depreciation_date(cr, uid, [asset.id],
-                                                    context)[asset.id], '%Y-%m-%d')
+                                                     context)[asset.id],
+                    '%Y-%m-%d')
                 fix_depreciation = False
-                if (depreciation_date != datetime.strptime(asset.purchase_date,
-                                                          '%Y-%m-%d') and
-                    depreciation_date != datetime.strptime(asset.start_depreciation_date,
-                                                          '%Y-%m-%d')):
+                if (depreciation_date != datetime.strptime(
+                        asset.purchase_date, '%Y-%m-%d') and
+                        depreciation_date != datetime.strptime(
+                            asset.start_depreciation_date, '%Y-%m-%d')):
                     fix_depreciation = True
                 for depr_line in depr_lin_obj.browse(cr, uid,
                                                      new_depr_line_ids):
                     depr_date = datetime.strptime(
                         depr_line.depreciation_date, DSDF)
                     if fix_depreciation:
-                       depr_date = depr_date + relativedelta(months=+asset.method_period)
+                        depr_date = depr_date + relativedelta(
+                            months=+asset.method_period)
                     if asset.method_period == 12:
                         depr_date = depr_date.replace(depr_date.year, 12, 31)
                     else:
                         last_month_day = calendar.monthrange(
-                            depr_date.year, month)[1]
+                            depr_date.year, depr_date.month)[1]
                         depr_date = depr_date.replace(depr_date.year,
                                                       depr_date.month,
                                                       last_month_day)

--- a/l10n_es_account_asset/account_asset.py
+++ b/l10n_es_account_asset/account_asset.py
@@ -254,14 +254,19 @@ class account_asset_asset(orm.Model):
                     depr_date = datetime.strptime(
                         depr_line.depreciation_date, DSDF)
                     if fix_depreciation:
-                        depr_date = depr_date + relativedelta(
-                            months=+asset.method_period)
+                        if depr_date.day != 1:
+                            depr_date = depr_date + relativedelta(
+                                months=+asset.method_period)
                     if asset.method_period == 12:
                         depr_date = depr_date.replace(depr_date.year, 12, 31)
                     else:
                         if not asset.prorata:
-                            depr_date = depreciation_date + relativedelta(
-                                months=+ (asset.method_period * nb))
+                            if depr_date.day != 1:
+                                depr_date = depreciation_date + relativedelta(
+                                    months=+ (asset.method_period * (nb+1)))
+                            else:
+                                depr_date = depreciation_date + relativedelta(
+                                    months=+ (asset.method_period * nb))
                             nb += 1
                         last_month_day = calendar.monthrange(
                             depr_date.year, depr_date.month)[1]

--- a/l10n_es_account_asset/account_asset_view.xml
+++ b/l10n_es_account_asset/account_asset_view.xml
@@ -48,6 +48,9 @@
             <field name="prorata" position="after">
                 <field name="move_end_period"/>
             </field>
+            <field name="purchase_date" position="after">
+                <field name="start_depreciation_date"/>
+            </field>
         </field>
     </record>
 

--- a/l10n_es_account_asset/i18n/es.po
+++ b/l10n_es_account_asset/i18n/es.po
@@ -35,6 +35,11 @@ msgid "Wrong percentage!"
 msgstr "¡Porcentaje incorrecto!"
 
 #. module: l10n_es_account_asset
+#: help:account.asset.asset,start_depreciation_date:0
+msgid "Only needed if not the same that purchase date"
+msgstr "Solo necesario si no es la misma qu ela fecha de compra"
+
+#. module: l10n_es_account_asset
 #: help:account.asset.asset,move_end_period:0
 msgid ""
 "Move the depreciation entry at the end of the period. If the period are 12 "
@@ -81,6 +86,11 @@ msgstr "Categoría de activo"
 #: selection:account.asset.category,ext_method_time:0
 msgid "Number of Depreciations"
 msgstr "Número de amortizaciones"
+
+#. module: l10n_es_account_asset
+#: field:account.asset.asset,start_depreciation_date:0
+msgid "Start Depreciation Date"
+msgstr "Fecha inicio de uso"
 
 #. module: l10n_es_account_asset
 #: selection:account.asset.asset,ext_method_time:0


### PR DESCRIPTION
 Se añadió a mayores de esta corrección la fecha de inicio de uso para empezar a calcular amortizaciones.

Añade el control para saber si se debe amortizar en el período siguiente o no segun exista una amortización anterior o se amortiza desde la fecha de compra o la de inicio de uso (se añadió también este campo y se modificó la consulta para obtener la fecha de última amortización  sobreescribiendo _get_last_depreciation_date de account_asset , entendiendo que esta no es la mejor solución y que podría ser mejor llamar a super y según fuese necesario considerar esta fecha de uso).

También se gestiona que las cantidades a amortizar al generar el cuadro consideren las cantidades ya amortizadas para poder hacer un cálculo correcto del pendiente.
