### PR TITLE
[ADD] account_refund_original: Pasado a la nueva API

### DIFF
--- a/account_refund_original/README.rst
+++ b/account_refund_original/README.rst
@@ -1,0 +1,5 @@
+Relationship between a refund and its original invoice
+======================================================
+
+This module links customer and supplier refunds with the invoice that originate
+them.

--- a/account_refund_original/__init__.py
+++ b/account_refund_original/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import models
+from . import wizard

--- a/account_refund_original/__openerp__.py
+++ b/account_refund_original/__openerp__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2004-2011
+#        Pexego Sistemas Informáticos. (http://pexego.es)
+#    Copyright (c) 2014 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
+#                       Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Relationship refund - origin invoice",
+    "version": "1.0",
+    "author": "Spanish Localization Team",
+    "website": "https://github.com/OCA/l10n-spain",
+    "contributors": [
+        'Pexego <www.pexego.es>',
+        'Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>',
+    ],
+    "category": "Localisation/Accounting",
+    "depends": [
+        'account',
+    ],
+    "data": [
+        'views/account_invoice_view.xml',
+    ],
+    "installable": True,
+}

--- a/account_refund_original/i18n/account_refund_original.pot
+++ b/account_refund_original/i18n/account_refund_original.pot
@@ -1,0 +1,42 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_refund_original
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 6.0.0-rc2\n"
+"Report-Msgid-Bugs-To: support@openerp.com\n"
+"POT-Creation-Date: 2011-01-10 12:48:59+0000\n"
+"PO-Revision-Date: 2011-01-10 13:49+0100\n"
+"Last-Translator: Luis Manuel Angueira Blanco <manuel@pexego.es>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Refunded invoices"
+msgstr "Refunded invoices"
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Refunds"
+msgstr "Refunds"
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Description"
+msgstr "Description"
+
+#. module: account_refund_original
+#: model:ir.model,name:account_refund_original.model_account_invoice
+msgid "Invoice"
+msgstr "Invoice"
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Payments"
+msgstr "Payments"
+

--- a/account_refund_original/i18n/bg.po
+++ b/account_refund_original/i18n/bg.po
@@ -1,0 +1,43 @@
+# Bulgarian translation for openobject-addons
+# Copyright (c) 2011 Rosetta Contributors and Canonical Ltd 2011
+# This file is distributed under the same license as the openobject-addons package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2011.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: openobject-addons\n"
+"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2011-01-10 12:48+0000\n"
+"PO-Revision-Date: 2011-03-30 07:49+0000\n"
+"Last-Translator: Dimitar Markov <dimitar.markov@gmail.com>\n"
+"Language-Team: Bulgarian <bg@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2011-10-28 05:57+0000\n"
+"X-Generator: Launchpad (build 14197)\n"
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Refunded invoices"
+msgstr ""
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Refunds"
+msgstr ""
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Description"
+msgstr "Описание"
+
+#. module: account_refund_original
+#: model:ir.model,name:account_refund_original.model_account_invoice
+msgid "Invoice"
+msgstr "Фактура"
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Payments"
+msgstr "Плащания"

--- a/account_refund_original/i18n/es.po
+++ b/account_refund_original/i18n/es.po
@@ -1,0 +1,42 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* account_refund_original
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 6.0.0-rc2\n"
+"Report-Msgid-Bugs-To: support@openerp.com\n"
+"POT-Creation-Date: 2011-01-10 12:48+0000\n"
+"PO-Revision-Date: 2011-03-08 16:03+0000\n"
+"Last-Translator: Luis Manuel Angueira Blanco (Pexego) <Unknown>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Launchpad-Export-Date: 2011-10-28 05:57+0000\n"
+"X-Generator: Launchpad (build 14197)\n"
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Refunded invoices"
+msgstr "Facturas rectificadas"
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Refunds"
+msgstr "Rectificaciones"
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Description"
+msgstr "Descripción"
+
+#. module: account_refund_original
+#: model:ir.model,name:account_refund_original.model_account_invoice
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: account_refund_original
+#: view:account.invoice:0
+msgid "Payments"
+msgstr "Pagos"

--- a/account_refund_original/models/__init__.py
+++ b/account_refund_original/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import account_invoice

--- a/account_refund_original/models/account_invoice.py
+++ b/account_refund_original/models/account_invoice.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from openerp import models, fields
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    refund_invoices_description = fields.Text('Refund invoices description')
+    origin_invoices_ids = fields.Many2many(
+        comodel_name='account.invoice', column1='refund_invoice_id',
+        column2='original_invoice_id', relation='account_invoice_refunds_rel',
+        string='Refund invoice', help='Links to original invoice which is '
+                                      'referred by current refund invoice')

--- a/account_refund_original/views/account_invoice_view.xml
+++ b/account_refund_original/views/account_invoice_view.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_customer_account_invoice_add_refunds_details_form" model="ir.ui.view">
+            <field name="name">Account invoice (customer) | add Refunds details (form)</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_form"/>
+            <field name="arch" type="xml">
+                <page string="Payments" position="after">
+                    <page string="Refunds" attrs="{'invisible':[('type', 'not in', ['in_refund', 'out_refund'])]}">
+                        <separator string="Description" colspan="4"/>
+                        <field name="refund_invoices_description" colspan="4" nolabel="1"/>
+                        <separator string="Refunded invoices" colspan="4"/>
+                        <field name="origin_invoices_ids" colspan="4" nolabel="1"/>
+                    </page>
+                </page>
+            </field>
+        </record>
+
+        <record id="view_supplier_account_invoice_add_refunds_details_form" model="ir.ui.view">
+            <field name="name">Account invoice (supplier) | add Refunds details (form)</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_supplier_form"/>
+            <field name="arch" type="xml">
+                <page string="Payments" position="after">
+                    <page string="Refunds" attrs="{'invisible':[('type', 'not in', ['in_refund', 'out_refund'])]}">
+                        <separator string="Description" colspan="4"/>
+                        <field name="refund_invoices_description" colspan="4" nolabel="1"/>
+                        <separator string="Refunded invoices" colspan="4"/>
+                        <field name="origin_invoices_ids" colspan="4" nolabel="1"/>
+                    </page>
+                </page>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/account_refund_original/wizard/__init__.py
+++ b/account_refund_original/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import account_invoice_refund

--- a/account_refund_original/wizard/account_invoice_refund.py
+++ b/account_refund_original/wizard/account_invoice_refund.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api
+
+
+class AccountInvoiceRefund(models.TransientModel):
+    _inherit = "account.invoice.refund"
+
+    @api.multi
+    def compute_refund(self, mode='refund'):
+        result = super(AccountInvoiceRefund, self).compute_refund(mode)
+        active_ids = self.env.context.get('active_ids')
+        if not active_ids:
+            return result
+        inv_obj = self.env['account.invoice']
+        # An example of result['domain'] computed by the parent wizard is:
+        # [('type', '=', 'out_refund'), ('id', 'in', [43L, 44L])]
+        # The created refund invoice is the first invoice in the
+        # ('id', 'in', ...) tupla
+        created_inv = [x[2] for x in result['domain']
+                       if x[0] == 'id' and x[1] == 'in']
+        if created_inv and created_inv[0]:
+            for form in self:
+                refund_inv_id = created_inv[0][0]
+                inv_obj.browse(refund_inv_id).write(
+                    {'origin_invoices_ids': [(6, 0, active_ids)],
+                     'refund_invoices_description': form.description or ''})
+        return result


### PR DESCRIPTION
Al igual que se hizo en v7, traer este módulo a la localización, ya que es una dependencia del modelo 340, que debe mantenerse a la vez con él, y no en un repositorio privado.
