### PR TITLE
l10n_es_account_summary

### DIFF
--- a/l10n_es_account_summary/__init__.py
+++ b/l10n_es_account_summary/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo - Account summary
+#    Copyright (C) 2014 Luis Martinez Ontalba (www.tecnisagra.com).
+#      
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import account_summary
+
+
+

--- a/l10n_es_account_summary/__init__.py
+++ b/l10n_es_account_summary/__init__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Odoo - Account summary
-#    Copyright (C) 2014 Luis Martinez Ontalba (www.tecnisagra.com).
+#    Copyright (C) 2015 Luis Martinez Ontalba (www.tecnisagra.com).
 #      
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 
-import account_summary
+from . import account_summary
 
 
 

--- a/l10n_es_account_summary/__openerp__.py
+++ b/l10n_es_account_summary/__openerp__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo - Account summary
+#    Copyright (C) 2014 Luis Martinez Ontalba (www.tecnisagra.com).
+#	 
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Account summary",
+    "version": "1.1",
+    "author": "Luis Martinez Ontalba",
+    "website": "http://www.tecnisagra.com",
+    "category": "Enterprise Specific Modules",
+    "description": """
+	Este modulo crea un tablero de resumen de datos contables de interés:
+		* Ingresos, gastos y resultado:
+			* Agrupado por año fiscal
+			* Agrupado por periodo fiscal en el año en curso
+		* Activo a corto, pasivo a corto y fondo de maniobra (diferencia entre ambos) 
+	Al tablero se accede desde el menu Contabilidad/Contabilidad/Resumen de cuentas
+            """,
+    "depends": [
+        'account', 'l10n_es_account', 'account_payment'
+    ],
+    "init_xml": [
+    ],
+    "demo_xml": [
+	],
+    "update_xml": [
+        'account_summary.xml',
+	],
+    "installable": True,
+    "active": False,
+}

--- a/l10n_es_account_summary/__openerp__.py
+++ b/l10n_es_account_summary/__openerp__.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Odoo - Account summary
-#    Copyright (C) 2014 Luis Martinez Ontalba (www.tecnisagra.com).
+#    Copyright (C) 2015 Luis Martinez Ontalba (www.tecnisagra.com).
 #	 
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published
@@ -18,6 +18,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
+
 {
     "name": "Account summary",
     "version": "1.1",
@@ -29,8 +30,9 @@
 		* Ingresos, gastos y resultado:
 			* Agrupado por año fiscal
 			* Agrupado por periodo fiscal en el año en curso
-		* Activo a corto, pasivo a corto y fondo de maniobra (diferencia entre ambos) 
-	Al tablero se accede desde el menu Contabilidad/Contabilidad/Resumen de cuentas
+		* Activo a corto, pasivo a corto y fondo de maniobra 
+	Al tablero se accede desde el menu:
+        Contabilidad/Contabilidad/Resumen de cuentas
             """,
     "depends": [
         'account', 'l10n_es_account', 'account_payment'

--- a/l10n_es_account_summary/account_summary.py
+++ b/l10n_es_account_summary/account_summary.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo - Account summary
+#    Copyright (C) 2014 Luis Martinez Ontalba (www.tecnisagra.com).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import tools
+from osv import fields,osv
+import decimal_precision as dp
+
+class account_account(osv.osv):
+    _name = "account.account"
+    _inherit = "account.account"
+	
+    def _get_code_2(self, cr, uid, ids, field_name, arg, context=None):
+        result={}
+        acc_obj = self.browse(cr,uid,ids,context=context)
+        for acc in acc_obj:
+			result[acc.id]= acc.code[0:2]
+        return result
+	
+    _columns = {
+        'code_2' : fields.function(_get_code_2, string = 'Código corto', method=True, type='char', store=True)
+    }
+
+account_account()	
+	
+
+class account_summary(osv.osv):
+
+    _name = "account.summary"
+    _auto = False
+    _columns = {
+        'debit': fields.float('Debe', readonly=True),
+        'credit': fields.float('Haber', readonly=True),
+        'balance': fields.float('Balance', readonly=True),
+        'balance_inv': fields.float('Balance inverso', readonly=True),
+        'account_code': fields.char('Cuenta', size=8, readonly=True),
+        'year': fields.char('Año', size=4, readonly=True),
+        'date': fields.date('Fecha', size=128, readonly=True),
+        'period_id': fields.many2one('account.period', 'Periodo', readonly=True),
+        'account_id': fields.many2one('account.account', 'Cuenta', readonly=True),
+		'fiscalyear_id': fields.many2one('account.fiscalyear', 'Año fiscal', readonly=True),
+    }
+
+    _order = 'date desc'
+
+
+    def init(self, cr):
+        tools.drop_view_if_exists(cr, 'account_summary')
+        cr.execute("""
+            create or replace view account_summary as (
+            select
+                l.id as id,
+                am.date as date,
+                to_char(am.date, 'YYYY') as year,
+                p.fiscalyear_id as fiscalyear_id,
+                am.period_id as period_id,
+                l.account_id as account_id,
+				a.code_2 as account_code,
+                l.debit as debit,
+                l.credit as credit,
+                l.debit-l.credit as balance,
+                l.credit-l.debit as balance_inv
+            from
+                account_move_line l
+                left join account_account a on (l.account_id = a.id)
+                left join account_move am on (am.id=l.move_id)
+                left join account_period p on (am.period_id=p.id)
+                where l.state != 'draft'
+            )
+        """)
+
+account_summary()
+
+

--- a/l10n_es_account_summary/account_summary.py
+++ b/l10n_es_account_summary/account_summary.py
@@ -2,7 +2,7 @@
 ##############################################################################
 #
 #    Odoo - Account summary
-#    Copyright (C) 2014 Luis Martinez Ontalba (www.tecnisagra.com).
+#    Copyright (C) 2015 Luis Martinez Ontalba (www.tecnisagra.com).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as published
@@ -20,10 +20,13 @@
 ##############################################################################
 
 import tools
-from osv import fields,osv
 import decimal_precision as dp
 
-class account_account(osv.osv):
+from osv import fields,orm
+
+
+class account_account(orm.Model):
+
     _name = "account.account"
     _inherit = "account.account"
 	
@@ -35,16 +38,18 @@ class account_account(osv.osv):
         return result
 	
     _columns = {
-        'code_2' : fields.function(_get_code_2, string = 'Código corto', method=True, type='char', store=True)
+        'code_2' : fields.function(_get_code_2, string = 'Código corto',
+                                   method=True, type='char', store=True)
     }
 
 account_account()	
 	
 
-class account_summary(osv.osv):
+class account_summary(orm.Model):
 
     _name = "account.summary"
     _auto = False
+	
     _columns = {
         'debit': fields.float('Debe', readonly=True),
         'credit': fields.float('Haber', readonly=True),
@@ -53,16 +58,20 @@ class account_summary(osv.osv):
         'account_code': fields.char('Cuenta', size=8, readonly=True),
         'year': fields.char('Año', size=4, readonly=True),
         'date': fields.date('Fecha', size=128, readonly=True),
-        'period_id': fields.many2one('account.period', 'Periodo', readonly=True),
-        'account_id': fields.many2one('account.account', 'Cuenta', readonly=True),
-		'fiscalyear_id': fields.many2one('account.fiscalyear', 'Año fiscal', readonly=True),
+        'period_id': fields.many2one('account.period', 'Periodo',
+                                     readonly=True),
+        'account_id': fields.many2one('account.account', 'Cuenta',
+                                      readonly=True),
+		'fiscalyear_id': fields.many2one('account.fiscalyear', 'Año fiscal',
+                                         readonly=True),
     }
 
     _order = 'date desc'
 
-
     def init(self, cr):
+
         tools.drop_view_if_exists(cr, 'account_summary')
+		
         cr.execute("""
             create or replace view account_summary as (
             select

--- a/l10n_es_account_summary/account_summary.xml
+++ b/l10n_es_account_summary/account_summary.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+	
+    <record id="view_account_summary_tree1" model="ir.ui.view">
+        <field name="name">view.account.summary.tree1</field>
+        <field name="model">account.summary</field>
+        <field name="type">tree</field>
+        <field name="arch" type="xml">
+            <tree string="Resumen de ingresos">
+                <field name="balance_inv" string="Ingresos"/>
+                <field name="year"  invisible="1"/>
+                <field name="fiscalyear_id" invisible="1"/>
+                <field name="period_id" invisible="1"/>
+                <field name="account_code" invisible="1"/>
+           </tree>
+        </field>
+    </record>
+	<record id="action_view_account_summary_tree11" model="ir.actions.act_window">
+		<field name="name">Resumen de ingresos</field>
+		<field name="context">{'group_by':['period_id'], 'group_by_no_leaf':1}</field>
+		<field name="res_model">account.summary</field>
+		<field name="view_type">form</field>
+		<field name="view_mode">tree</field>
+		<field name="view_id" ref="view_account_summary_tree1"/>
+		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('70','71','72','73','74','75','76','77','78','79'))]</field>
+	</record>
+	<record id="action_view_account_summary_tree12" model="ir.actions.act_window">
+		<field name="name">Resumen de ingresos anual</field>
+		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
+		<field name="res_model">account.summary</field>
+		<field name="view_type">form</field>
+		<field name="view_mode">tree</field>
+		<field name="view_id" ref="view_account_summary_tree1"/>
+		<field name="domain">[('account_code','in',('70','71','72','73','74','75','76','77','78','79'))]</field>
+	</record>
+		
+    <record id="view_account_summary_tree2" model="ir.ui.view">
+        <field name="name">view.account.summary.tree2</field>
+        <field name="model">account.summary</field>
+        <field name="type">tree</field>
+        <field name="arch" type="xml">
+            <tree string="Resumen de gastos">
+                <field name="balance" string="Gastos"/>
+                <field name="year"  invisible="1"/>
+                <field name="fiscalyear_id" invisible="1"/>
+                <field name="period_id" invisible="1"/>
+                <field name="account_code" invisible="1"/>
+           </tree>
+        </field>
+    </record>
+	<record id="action_view_account_summary_tree21" model="ir.actions.act_window">
+		<field name="name">Resumen de gastos</field>
+		<field name="context">{'group_by':['period_id'], 'group_by_no_leaf':1}</field>
+		<field name="res_model">account.summary</field>
+		<field name="view_type">form</field>
+		<field name="view_mode">tree</field>
+		<field name="view_id" ref="view_account_summary_tree2"/>
+		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('60','61','62','63','64','65','66','67','68','69'))]</field>
+	</record>
+	<record id="action_view_account_summary_tree22" model="ir.actions.act_window">
+		<field name="name">Resumen de gastos anual</field>
+		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
+		<field name="res_model">account.summary</field>
+		<field name="view_type">form</field>
+		<field name="view_mode">tree</field>
+		<field name="view_id" ref="view_account_summary_tree2"/>
+		<field name="domain">[('account_code','in',('60','61','62','63','64','65','66','67','68','69'))]</field>
+	</record>
+	
+    <record id="view_account_summary_tree3" model="ir.ui.view">
+        <field name="name">view.account.summary.tree3</field>
+        <field name="model">account.summary</field>
+        <field name="type">tree</field>
+        <field name="arch" type="xml">
+            <tree string="Resumen de resultados">
+                <field name="balance_inv" string="Resultados"/>
+                <field name="year"  invisible="1"/>
+                <field name="fiscalyear_id" invisible="1"/>
+                <field name="period_id" invisible="1"/>
+                <field name="account_code" invisible="1"/>
+           </tree>
+        </field>
+    </record>
+	<record id="action_view_account_summary_tree31" model="ir.actions.act_window">
+		<field name="name">Resumen de resultados</field>
+		<field name="context">{'group_by':['period_id'], 'group_by_no_leaf':1}</field>
+		<field name="res_model">account.summary</field>
+		<field name="view_type">form</field>
+		<field name="view_mode">tree</field>
+		<field name="view_id" ref="view_account_summary_tree3"/>
+		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('60','61','62','63','64','65','66','67','68','69','70','71','72','73','74','75','76','77','78','79'))]</field>
+	</record>
+	<record id="action_view_account_summary_tree32" model="ir.actions.act_window">
+		<field name="name">Resumen de resultados anual</field>
+		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
+		<field name="res_model">account.summary</field>
+		<field name="view_type">form</field>
+		<field name="view_mode">tree</field>
+		<field name="view_id" ref="view_account_summary_tree3"/>
+		<field name="domain">[('account_code','in',('60','61','62','63','64','65','66','67','68','69','70','71','72','73','74','75','76','77','78','79'))]</field>
+	</record>
+    
+	<record id="view_account_summary_tree4" model="ir.ui.view">
+        <field name="name">view.account.summary.tree4</field>
+        <field name="model">account.summary</field>
+        <field name="type">tree</field>
+        <field name="arch" type="xml">
+            <tree string="Activo circulante">
+                <field name="balance" string="Activos a corto"/>
+                <field name="year"  invisible="1"/>
+                <field name="fiscalyear_id" invisible="1"/>
+                <field name="account_code" invisible="1"/>
+           </tree>
+        </field>
+    </record>
+	<record id="action_view_account_summary_tree4" model="ir.actions.act_window">
+		<field name="name">Activo circulante</field>
+		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
+		<field name="res_model">account.summary</field>
+		<field name="view_type">form</field>
+		<field name="view_mode">tree</field>
+		<field name="view_id" ref="view_account_summary_tree4"/>
+		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('30','31','32','33','34','35','36','37','38','39','43','44','53','54','55','57'))]</field>
+	</record>
+	
+	<record id="view_account_summary_tree5" model="ir.ui.view">
+        <field name="name">view.account.summary.tree5</field>
+        <field name="model">account.summary</field>
+        <field name="type">tree</field>
+        <field name="arch" type="xml">
+            <tree string="Pasivo circulante">
+                <field name="balance_inv" string="Pasivos a corto"/>
+                <field name="year"  invisible="1"/>
+                <field name="fiscalyear_id" invisible="1"/>
+                <field name="account_code" invisible="1"/>
+           </tree>
+        </field>
+    </record>
+	<record id="action_view_account_summary_tree5" model="ir.actions.act_window">
+		<field name="name">Pasivo circulante</field>
+		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
+		<field name="res_model">account.summary</field>
+		<field name="view_type">form</field>
+		<field name="view_mode">tree</field>
+		<field name="view_id" ref="view_account_summary_tree5"/>
+		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('40','41','42','45','46','47','48','49','50','51','52','56','58','59'))]</field>
+	</record>
+	
+	<record id="view_account_summary_tree6" model="ir.ui.view">
+        <field name="name">view.account.summary.tree6</field>
+        <field name="model">account.summary</field>
+        <field name="type">tree</field>
+        <field name="arch" type="xml">
+            <tree string="Fondo de maniobra">
+                <field name="balance" string="Fondo"/>
+                <field name="year"  invisible="1"/>
+                <field name="fiscalyear_id" invisible="1"/>
+                <field name="account_code" invisible="1"/>
+           </tree>
+        </field>
+    </record>
+	<record id="action_view_account_summary_tree6" model="ir.actions.act_window">
+		<field name="name">Fondo de maniobra</field>
+		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
+		<field name="res_model">account.summary</field>
+		<field name="view_type">form</field>
+		<field name="view_mode">tree</field>
+		<field name="view_id" ref="view_account_summary_tree6"/>
+		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('30','31','32','33','34','35','36','37','38','39','40','41','42','43','44','45','46','47','48','49','50','51','52','53','54','55','56','57','58','59'))]</field>
+	</record>
+	
+	<record id="board_account_summary" model="ir.ui.view">
+        <field name="name">board.account.summary</field>
+        <field name="model">board.board</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <form string = "Resumen anual">
+                <board style="1-1-1">
+                    <column>
+                        <action name="%(action_view_account_summary_tree12)d" string="Ingresos anuales"/>
+						<action name="%(action_view_account_summary_tree11)d" string="Desglose de ingresos"/>
+						<action name="%(action_view_account_summary_tree4)d" string="Activo circulante"/>
+                    </column>
+                    <column>
+                        <action name="%(action_view_account_summary_tree22)d" string="Gastos anuales"/>
+	                    <action name="%(action_view_account_summary_tree21)d" string="Desglose de gastos"/>
+						<action name="%(action_view_account_summary_tree5)d" string="Pasivo circulante"/>
+                    </column>
+                    <column>
+                        <action name="%(action_view_account_summary_tree32)d" string="Resultados anuales"/>
+	                    <action name="%(action_view_account_summary_tree31)d" string="Desglose de resultados"/>
+						<action name="%(action_view_account_summary_tree6)d" string="Fondo de maniobra"/>
+                    </column>
+                </board>
+            </form>
+        </field>
+    </record>
+	
+    <record id="action_board_account_summary" model="ir.actions.act_window">
+            <field name="name">Resumen de cuentas</field>
+            <field name="res_model">board.board</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="usage">menu</field>
+            <field name="view_id" ref="board_account_summary"/>
+        </record>
+	
+	<menuitem id="menu_account_summary1" name="Resumen de cuentas" sequence="4" parent="account.menu_finance_reporting"/>
+    <menuitem action="action_board_account_summary" icon="terp-graph" id="menu_account_summary2" parent="menu_account_summary1" sequence="1"/>
+	
+	</data>
+</openerp>

--- a/l10n_es_account_summary/account_summary.xml
+++ b/l10n_es_account_summary/account_summary.xml
@@ -1,213 +1,273 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <openerp>
-    <data>
+<data>
+
+<record id="view_account_summary_tree1" model="ir.ui.view">
+	<field name="name">view.account.summary.tree1</field>
+	<field name="model">account.summary</field>
+	<field name="type">tree</field>
+	<field name="arch" type="xml">
+		<tree string="Resumen de ingresos">
+			<field name="balance_inv" string="Ingresos"/>
+			<field name="year"  invisible="1"/>
+			<field name="fiscalyear_id" invisible="1"/>
+			<field name="period_id" invisible="1"/>
+			<field name="account_code" invisible="1"/>
+	   </tree>
+	</field>
+</record>
+
+<record id="action_view_account_summary_tree11" model="ir.actions.act_window">
+	<field name="name">Resumen de ingresos</field>
+	<field name="context">{'group_by':['period_id'],
+'group_by_no_leaf':1}</field>
+	<field name="res_model">account.summary</field>
+	<field name="view_type">form</field>
+	<field name="view_mode">tree</field>
+	<field name="view_id" ref="view_account_summary_tree1"/>
+	<field name="domain">[('year','=',time.strftime('%Y')),
+('account_code','in',
+('70','71','72','73','74','75','76','77','78','79'))]</field>
+</record>
+
+<record id="action_view_account_summary_tree12" model="ir.actions.act_window">
+	<field name="name">Resumen de ingresos anual</field>
+	<field name="context">{'group_by':['fiscalyear_id'],
+'group_by_no_leaf':1}</field>
+	<field name="res_model">account.summary</field>
+	<field name="view_type">form</field>
+	<field name="view_mode">tree</field>
+	<field name="view_id" ref="view_account_summary_tree1"/>
+	<field name="domain">[('account_code','in',
+('70','71','72','73','74','75','76','77','78','79'))]</field>
+</record>
 	
-    <record id="view_account_summary_tree1" model="ir.ui.view">
-        <field name="name">view.account.summary.tree1</field>
-        <field name="model">account.summary</field>
-        <field name="type">tree</field>
-        <field name="arch" type="xml">
-            <tree string="Resumen de ingresos">
-                <field name="balance_inv" string="Ingresos"/>
-                <field name="year"  invisible="1"/>
-                <field name="fiscalyear_id" invisible="1"/>
-                <field name="period_id" invisible="1"/>
-                <field name="account_code" invisible="1"/>
-           </tree>
-        </field>
-    </record>
-	<record id="action_view_account_summary_tree11" model="ir.actions.act_window">
-		<field name="name">Resumen de ingresos</field>
-		<field name="context">{'group_by':['period_id'], 'group_by_no_leaf':1}</field>
-		<field name="res_model">account.summary</field>
+<record id="view_account_summary_tree2" model="ir.ui.view">
+	<field name="name">view.account.summary.tree2</field>
+	<field name="model">account.summary</field>
+	<field name="type">tree</field>
+	<field name="arch" type="xml">
+		<tree string="Resumen de gastos">
+			<field name="balance" string="Gastos"/>
+			<field name="year"  invisible="1"/>
+			<field name="fiscalyear_id" invisible="1"/>
+			<field name="period_id" invisible="1"/>
+			<field name="account_code" invisible="1"/>
+	   </tree>
+	</field>
+</record>
+
+<record id="action_view_account_summary_tree21" model="ir.actions.act_window">
+	<field name="name">Resumen de gastos</field>
+	<field name="context">{'group_by':['period_id'],
+'group_by_no_leaf':1}</field>
+	<field name="res_model">account.summary</field>
+	<field name="view_type">form</field>
+	<field name="view_mode">tree</field>
+	<field name="view_id" ref="view_account_summary_tree2"/>
+	<field name="domain">[('year','=',time.strftime('%Y')),
+('account_code','in',('60','61','62','63','64',
+'65','66','67','68','69'))]</field>
+</record>
+
+<record id="action_view_account_summary_tree22" model="ir.actions.act_window">
+	<field name="name">Resumen de gastos anual</field>
+	<field name="context">{'group_by':['fiscalyear_id'],
+'group_by_no_leaf':1}</field>
+	<field name="res_model">account.summary</field>
+	<field name="view_type">form</field>
+	<field name="view_mode">tree</field>
+	<field name="view_id" ref="view_account_summary_tree2"/>
+	<field name="domain">[('account_code','in',
+('60','61','62','63','64','65','66','67','68','69'))]</field>
+</record>
+
+<record id="view_account_summary_tree3" model="ir.ui.view">
+	<field name="name">view.account.summary.tree3</field>
+	<field name="model">account.summary</field>
+	<field name="type">tree</field>
+	<field name="arch" type="xml">
+		<tree string="Resumen de resultados">
+			<field name="balance_inv" string="Resultados"/>
+			<field name="year"  invisible="1"/>
+			<field name="fiscalyear_id" invisible="1"/>
+			<field name="period_id" invisible="1"/>
+			<field name="account_code" invisible="1"/>
+	   </tree>
+	</field>
+</record>
+
+<record id="action_view_account_summary_tree31" model="ir.actions.act_window">
+	<field name="name">Resumen de resultados</field>
+	<field name="context">{'group_by':['period_id'],
+'group_by_no_leaf':1}</field>
+	<field name="res_model">account.summary</field>
+	<field name="view_type">form</field>
+	<field name="view_mode">tree</field>
+	<field name="view_id" ref="view_account_summary_tree3"/>
+	<field name="domain">[('year','=',time.strftime('%Y')),
+('account_code','in',
+('60','61','62','63','64','65','66','67','68','69',
+'70','71','72','73','74','75','76','77','78','79'))]</field>
+</record>
+
+<record id="action_view_account_summary_tree32" model="ir.actions.act_window">
+	<field name="name">Resumen de resultados anual</field>
+	<field name="context">{'group_by':['fiscalyear_id'],
+                           'group_by_no_leaf':1}</field>
+	<field name="res_model">account.summary</field>
+	<field name="view_type">form</field>
+	<field name="view_mode">tree</field>
+	<field name="view_id" ref="view_account_summary_tree3"/>
+	<field name="domain">[('account_code','in',
+('60','61','62','63','64','65','66','67','68','69',
+'70','71','72','73','74','75','76','77','78','79'))]</field>
+</record>
+
+<record id="view_account_summary_tree4" model="ir.ui.view">
+	<field name="name">view.account.summary.tree4</field>
+	<field name="model">account.summary</field>
+	<field name="type">tree</field>
+	<field name="arch" type="xml">
+		<tree string="Activo circulante">
+			<field name="balance" string="Activos a corto"/>
+			<field name="year"  invisible="1"/>
+			<field name="fiscalyear_id" invisible="1"/>
+			<field name="account_code" invisible="1"/>
+	   </tree>
+	</field>
+</record>
+
+<record id="action_view_account_summary_tree4" model="ir.actions.act_window">
+	<field name="name">Activo circulante</field>
+	<field name="context">{'group_by':['fiscalyear_id'],
+'group_by_no_leaf':1}</field>
+	<field name="res_model">account.summary</field>
+	<field name="view_type">form</field>
+	<field name="view_mode">tree</field>
+	<field name="view_id" ref="view_account_summary_tree4"/>
+	<field name="domain">[('year','=',time.strftime('%Y')),
+('account_code','in',
+('30','31','32','33','34','35','36','37','38','39',
+'43','44','53','54','55','57'))]</field>
+</record>
+
+<record id="view_account_summary_tree5" model="ir.ui.view">
+	<field name="name">view.account.summary.tree5</field>
+	<field name="model">account.summary</field>
+	<field name="type">tree</field>
+	<field name="arch" type="xml">
+		<tree string="Pasivo circulante">
+			<field name="balance_inv" string="Pasivos a corto"/>
+			<field name="year"  invisible="1"/>
+			<field name="fiscalyear_id" invisible="1"/>
+			<field name="account_code" invisible="1"/>
+	   </tree>
+	</field>
+</record>
+
+<record id="action_view_account_summary_tree5" model="ir.actions.act_window">
+	<field name="name">Pasivo circulante</field>
+	<field name="context">{'group_by':['fiscalyear_id'],
+'group_by_no_leaf':1}</field>
+	<field name="res_model">account.summary</field>
+	<field name="view_type">form</field>
+	<field name="view_mode">tree</field>
+	<field name="view_id" ref="view_account_summary_tree5"/>
+	<field name="domain">[('year','=',time.strftime('%Y')),
+('account_code','in',
+('40','41','42','45','46','47','48','49',
+'50','51','52','56','58','59'))]</field>
+</record>
+
+<record id="view_account_summary_tree6" model="ir.ui.view">
+	<field name="name">view.account.summary.tree6</field>
+	<field name="model">account.summary</field>
+	<field name="type">tree</field>
+	<field name="arch" type="xml">
+		<tree string="Fondo de maniobra">
+			<field name="balance" string="Fondo"/>
+			<field name="year"  invisible="1"/>
+			<field name="fiscalyear_id" invisible="1"/>
+			<field name="account_code" invisible="1"/>
+	   </tree>
+	</field>
+</record>
+
+<record id="action_view_account_summary_tree6" model="ir.actions.act_window">
+	<field name="name">Fondo de maniobra</field>
+	<field name="context">{'group_by':['fiscalyear_id'],
+'group_by_no_leaf':1}</field>
+	<field name="res_model">account.summary</field>
+	<field name="view_type">form</field>
+	<field name="view_mode">tree</field>
+	<field name="view_id" ref="view_account_summary_tree6"/>
+	<field name="domain">[('year','=',time.strftime('%Y')),
+('account_code','in',
+('30','31','32','33','34','35','36','37','38','39',
+'40','41','42','43','44','45','46','47','48','49',
+'50','51','52','53','54','55','56','57','58','59'))]</field>
+</record>
+
+<record id="board_account_summary" model="ir.ui.view">
+	<field name="name">board.account.summary</field>
+	<field name="model">board.board</field>
+	<field name="type">form</field>
+	<field name="arch" type="xml">
+		<form string = "Resumen anual">
+			<board style="1-1-1">
+				<column>
+					<action
+						name="%(action_view_account_summary_tree12)d"
+						string="Ingresos anuales"/>
+					<action
+						name="%(action_view_account_summary_tree11)d"
+						string="Desglose de ingresos"/>
+					<action
+						name="%(action_view_account_summary_tree4)d"
+						string="Activo circulante"/>
+				</column>
+				<column>
+					<action
+						name="%(action_view_account_summary_tree22)d"
+						string="Gastos anuales"/>
+					<action
+						name="%(action_view_account_summary_tree21)d"
+						string="Desglose de gastos"/>
+					<action
+						name="%(action_view_account_summary_tree5)d"
+						string="Pasivo circulante"/>
+				</column>
+				<column>
+					<action
+						name="%(action_view_account_summary_tree32)d"
+						string="Resultados anuales"/>
+					<action
+						name="%(action_view_account_summary_tree31)d"
+						string="Desglose de resultados"/>
+					<action
+						name="%(action_view_account_summary_tree6)d"
+						string="Fondo de maniobra"/>
+				</column>
+			</board>
+		</form>
+	</field>
+</record>
+
+<record id="action_board_account_summary" model="ir.actions.act_window">
+		<field name="name">Resumen de cuentas</field>
+		<field name="res_model">board.board</field>
 		<field name="view_type">form</field>
-		<field name="view_mode">tree</field>
-		<field name="view_id" ref="view_account_summary_tree1"/>
-		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('70','71','72','73','74','75','76','77','78','79'))]</field>
-	</record>
-	<record id="action_view_account_summary_tree12" model="ir.actions.act_window">
-		<field name="name">Resumen de ingresos anual</field>
-		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
-		<field name="res_model">account.summary</field>
-		<field name="view_type">form</field>
-		<field name="view_mode">tree</field>
-		<field name="view_id" ref="view_account_summary_tree1"/>
-		<field name="domain">[('account_code','in',('70','71','72','73','74','75','76','77','78','79'))]</field>
-	</record>
-		
-    <record id="view_account_summary_tree2" model="ir.ui.view">
-        <field name="name">view.account.summary.tree2</field>
-        <field name="model">account.summary</field>
-        <field name="type">tree</field>
-        <field name="arch" type="xml">
-            <tree string="Resumen de gastos">
-                <field name="balance" string="Gastos"/>
-                <field name="year"  invisible="1"/>
-                <field name="fiscalyear_id" invisible="1"/>
-                <field name="period_id" invisible="1"/>
-                <field name="account_code" invisible="1"/>
-           </tree>
-        </field>
-    </record>
-	<record id="action_view_account_summary_tree21" model="ir.actions.act_window">
-		<field name="name">Resumen de gastos</field>
-		<field name="context">{'group_by':['period_id'], 'group_by_no_leaf':1}</field>
-		<field name="res_model">account.summary</field>
-		<field name="view_type">form</field>
-		<field name="view_mode">tree</field>
-		<field name="view_id" ref="view_account_summary_tree2"/>
-		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('60','61','62','63','64','65','66','67','68','69'))]</field>
-	</record>
-	<record id="action_view_account_summary_tree22" model="ir.actions.act_window">
-		<field name="name">Resumen de gastos anual</field>
-		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
-		<field name="res_model">account.summary</field>
-		<field name="view_type">form</field>
-		<field name="view_mode">tree</field>
-		<field name="view_id" ref="view_account_summary_tree2"/>
-		<field name="domain">[('account_code','in',('60','61','62','63','64','65','66','67','68','69'))]</field>
-	</record>
-	
-    <record id="view_account_summary_tree3" model="ir.ui.view">
-        <field name="name">view.account.summary.tree3</field>
-        <field name="model">account.summary</field>
-        <field name="type">tree</field>
-        <field name="arch" type="xml">
-            <tree string="Resumen de resultados">
-                <field name="balance_inv" string="Resultados"/>
-                <field name="year"  invisible="1"/>
-                <field name="fiscalyear_id" invisible="1"/>
-                <field name="period_id" invisible="1"/>
-                <field name="account_code" invisible="1"/>
-           </tree>
-        </field>
-    </record>
-	<record id="action_view_account_summary_tree31" model="ir.actions.act_window">
-		<field name="name">Resumen de resultados</field>
-		<field name="context">{'group_by':['period_id'], 'group_by_no_leaf':1}</field>
-		<field name="res_model">account.summary</field>
-		<field name="view_type">form</field>
-		<field name="view_mode">tree</field>
-		<field name="view_id" ref="view_account_summary_tree3"/>
-		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('60','61','62','63','64','65','66','67','68','69','70','71','72','73','74','75','76','77','78','79'))]</field>
-	</record>
-	<record id="action_view_account_summary_tree32" model="ir.actions.act_window">
-		<field name="name">Resumen de resultados anual</field>
-		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
-		<field name="res_model">account.summary</field>
-		<field name="view_type">form</field>
-		<field name="view_mode">tree</field>
-		<field name="view_id" ref="view_account_summary_tree3"/>
-		<field name="domain">[('account_code','in',('60','61','62','63','64','65','66','67','68','69','70','71','72','73','74','75','76','77','78','79'))]</field>
-	</record>
-    
-	<record id="view_account_summary_tree4" model="ir.ui.view">
-        <field name="name">view.account.summary.tree4</field>
-        <field name="model">account.summary</field>
-        <field name="type">tree</field>
-        <field name="arch" type="xml">
-            <tree string="Activo circulante">
-                <field name="balance" string="Activos a corto"/>
-                <field name="year"  invisible="1"/>
-                <field name="fiscalyear_id" invisible="1"/>
-                <field name="account_code" invisible="1"/>
-           </tree>
-        </field>
-    </record>
-	<record id="action_view_account_summary_tree4" model="ir.actions.act_window">
-		<field name="name">Activo circulante</field>
-		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
-		<field name="res_model">account.summary</field>
-		<field name="view_type">form</field>
-		<field name="view_mode">tree</field>
-		<field name="view_id" ref="view_account_summary_tree4"/>
-		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('30','31','32','33','34','35','36','37','38','39','43','44','53','54','55','57'))]</field>
-	</record>
-	
-	<record id="view_account_summary_tree5" model="ir.ui.view">
-        <field name="name">view.account.summary.tree5</field>
-        <field name="model">account.summary</field>
-        <field name="type">tree</field>
-        <field name="arch" type="xml">
-            <tree string="Pasivo circulante">
-                <field name="balance_inv" string="Pasivos a corto"/>
-                <field name="year"  invisible="1"/>
-                <field name="fiscalyear_id" invisible="1"/>
-                <field name="account_code" invisible="1"/>
-           </tree>
-        </field>
-    </record>
-	<record id="action_view_account_summary_tree5" model="ir.actions.act_window">
-		<field name="name">Pasivo circulante</field>
-		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
-		<field name="res_model">account.summary</field>
-		<field name="view_type">form</field>
-		<field name="view_mode">tree</field>
-		<field name="view_id" ref="view_account_summary_tree5"/>
-		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('40','41','42','45','46','47','48','49','50','51','52','56','58','59'))]</field>
-	</record>
-	
-	<record id="view_account_summary_tree6" model="ir.ui.view">
-        <field name="name">view.account.summary.tree6</field>
-        <field name="model">account.summary</field>
-        <field name="type">tree</field>
-        <field name="arch" type="xml">
-            <tree string="Fondo de maniobra">
-                <field name="balance" string="Fondo"/>
-                <field name="year"  invisible="1"/>
-                <field name="fiscalyear_id" invisible="1"/>
-                <field name="account_code" invisible="1"/>
-           </tree>
-        </field>
-    </record>
-	<record id="action_view_account_summary_tree6" model="ir.actions.act_window">
-		<field name="name">Fondo de maniobra</field>
-		<field name="context">{'group_by':['fiscalyear_id'], 'group_by_no_leaf':1}</field>
-		<field name="res_model">account.summary</field>
-		<field name="view_type">form</field>
-		<field name="view_mode">tree</field>
-		<field name="view_id" ref="view_account_summary_tree6"/>
-		<field name="domain">[('year','=',time.strftime('%Y')),('account_code','in',('30','31','32','33','34','35','36','37','38','39','40','41','42','43','44','45','46','47','48','49','50','51','52','53','54','55','56','57','58','59'))]</field>
-	</record>
-	
-	<record id="board_account_summary" model="ir.ui.view">
-        <field name="name">board.account.summary</field>
-        <field name="model">board.board</field>
-        <field name="type">form</field>
-        <field name="arch" type="xml">
-            <form string = "Resumen anual">
-                <board style="1-1-1">
-                    <column>
-                        <action name="%(action_view_account_summary_tree12)d" string="Ingresos anuales"/>
-						<action name="%(action_view_account_summary_tree11)d" string="Desglose de ingresos"/>
-						<action name="%(action_view_account_summary_tree4)d" string="Activo circulante"/>
-                    </column>
-                    <column>
-                        <action name="%(action_view_account_summary_tree22)d" string="Gastos anuales"/>
-	                    <action name="%(action_view_account_summary_tree21)d" string="Desglose de gastos"/>
-						<action name="%(action_view_account_summary_tree5)d" string="Pasivo circulante"/>
-                    </column>
-                    <column>
-                        <action name="%(action_view_account_summary_tree32)d" string="Resultados anuales"/>
-	                    <action name="%(action_view_account_summary_tree31)d" string="Desglose de resultados"/>
-						<action name="%(action_view_account_summary_tree6)d" string="Fondo de maniobra"/>
-                    </column>
-                </board>
-            </form>
-        </field>
-    </record>
-	
-    <record id="action_board_account_summary" model="ir.actions.act_window">
-            <field name="name">Resumen de cuentas</field>
-            <field name="res_model">board.board</field>
-            <field name="view_type">form</field>
-            <field name="view_mode">form</field>
-            <field name="usage">menu</field>
-            <field name="view_id" ref="board_account_summary"/>
-        </record>
-	
-	<menuitem id="menu_account_summary1" name="Resumen de cuentas" sequence="4" parent="account.menu_finance_reporting"/>
-    <menuitem action="action_board_account_summary" icon="terp-graph" id="menu_account_summary2" parent="menu_account_summary1" sequence="1"/>
-	
-	</data>
+		<field name="view_mode">form</field>
+		<field name="usage">menu</field>
+		<field name="view_id" ref="board_account_summary"/>
+</record>
+
+<menuitem id="menu_account_summary1" name="Resumen de cuentas" sequence="4"
+	parent="account.menu_finance_reporting"/>
+<menuitem action="action_board_account_summary" icon="terp-graph"
+	id="menu_account_summary2" parent="menu_account_summary1" sequence="1"/>
+
+</data>
 </openerp>

--- a/l10n_es_account_summary/security/ir.model.access.csv
+++ b/l10n_es_account_summary/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_account_summary","Account manager","account_summary.model_account_summary","account.group_account_manager",1,1,1,1


### PR DESCRIPTION
Es un módulo que crea un tablero con datos prácticos: ingresos, gastos, resultados, activos a corto, pasivos a corto y fondo de maniobra, agrupados por año y por periodo fiscal. Se lanza desde un menú pero también se puede asociar la acción al inicio de sesión.
No se si merece la pena incluirlo en la localización.
