### PR TITLE
[IMP] añadido fecha de certificado de AEAT y de Seguridad Social

### DIFF
--- a/l10n_es_subcontractor_certificate/i18n/es.po
+++ b/l10n_es_subcontractor_certificate/i18n/es.po
@@ -1,25 +1,26 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* l10n_es_subcontractor_certificate
-#
+# * l10n_es_subcontractor_certificate
+# angel <angel.moya@domatix.com>, 2015.
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-24 07:37+0000\n"
-"PO-Revision-Date: 2014-11-24 08:38+0100\n"
-"Last-Translator: Angel Moya - Domatix <angel.moya@domatix.com>\n"
-"Language-Team: \n"
+"POT-Creation-Date: 2015-01-13 08:40+0000\n"
+"PO-Revision-Date: 2015-01-13 09:43+0200\n"
+"Last-Translator: angel <angel.moya@domatix.com>\n"
+"Language-Team: Domatix\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: \n"
-"X-Generator: Poedit 1.5.4\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Virtaal 0.7.1\n"
 
 #. module: l10n_es_subcontractor_certificate
-#: field:res.partner,certificate_expiration:0
-msgid "Certificate Expiration"
-msgstr "Caducidad de certificado"
+#: field:res.partner,certificate_expiration_aeat:0
+msgid "AEAT Certificate Expiration"
+msgstr "Fecha de certificado de AEAT"
 
 #. module: l10n_es_subcontractor_certificate
 #: field:res.partner,certificate_required:0
@@ -42,25 +43,43 @@ msgid "Purchase Order"
 msgstr "Pedido de compra"
 
 #. module: l10n_es_subcontractor_certificate
+#: field:res.partner,certificate_expiration_ss:0
+msgid "SS Certificate Expiration"
+msgstr "Fecha de certificado de Seguridad Social"
+
+#. module: l10n_es_subcontractor_certificate
 #: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:28
 #, python-format
-msgid ""
-"The subcontractor certificate for this supplier                     has "
-"expired"
-msgstr "El certificado de subcontratista ha caducado."
+msgid "The AEAT certificate for this supplier has expired"
+msgstr "El certificado de AEAT de este proveedor ha caducado"
 
 #. module: l10n_es_subcontractor_certificate
 #: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:34
 #, python-format
-msgid ""
-"The subcontractor certificate is required and                     expiration "
-"date is not set"
+msgid "The AEAT certificate is required and expiration date is not set"
 msgstr ""
-"No se ha indicado la fecha de caducidad del certificado de subcontratista."
+"El certificado de subcontratista es necesario y no se ha indicado fecha de "
+"certificado de AEAT"
+
+#. module: l10n_es_subcontractor_certificate
+#: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:40
+#, python-format
+msgid "The SS certificate for this supplier has expired"
+msgstr "El certificado de seguridad social de este proveedor ha caducado"
+
+#. module: l10n_es_subcontractor_certificate
+#: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:46
+#, python-format
+msgid "The SS certificate is required and expiration date is not set"
+msgstr ""
+"El certificado de subcontratista es necesario y no se ha indicado fecha de "
+"certificado de seguridad social"
 
 #. module: l10n_es_subcontractor_certificate
 #: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:27
 #: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:33
+#: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:39
+#: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:45
 #, python-format
 msgid "Warning!"
 msgstr "¡Aviso!"

--- a/l10n_es_subcontractor_certificate/i18n/l10n_es_subcontractor_certificate.pot
+++ b/l10n_es_subcontractor_certificate/i18n/l10n_es_subcontractor_certificate.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-24 18:08+0000\n"
-"PO-Revision-Date: 2014-11-24 18:08+0000\n"
+"POT-Creation-Date: 2015-01-13 08:44+0000\n"
+"PO-Revision-Date: 2015-01-13 08:44+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,8 +16,8 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_es_subcontractor_certificate
-#: field:res.partner,certificate_expiration:0
-msgid "Certificate Expiration"
+#: field:res.partner,certificate_expiration_aeat:0
+msgid "AEAT Certificate Expiration"
 msgstr ""
 
 #. module: l10n_es_subcontractor_certificate
@@ -41,20 +41,39 @@ msgid "Purchase Order"
 msgstr ""
 
 #. module: l10n_es_subcontractor_certificate
+#: field:res.partner,certificate_expiration_ss:0
+msgid "SS Certificate Expiration"
+msgstr ""
+
+#. module: l10n_es_subcontractor_certificate
 #: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:28
 #, python-format
-msgid "The subcontractor certificate for this supplier has expired"
+msgid "The AEAT certificate for this supplier has expired"
 msgstr ""
 
 #. module: l10n_es_subcontractor_certificate
 #: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:34
 #, python-format
-msgid "The subcontractor certificate is required and expiration date is not set"
+msgid "The AEAT certificate is required and expiration date is not set"
+msgstr ""
+
+#. module: l10n_es_subcontractor_certificate
+#: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:40
+#, python-format
+msgid "The SS certificate for this supplier has expired"
+msgstr ""
+
+#. module: l10n_es_subcontractor_certificate
+#: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:46
+#, python-format
+msgid "The SS certificate is required and expiration date is not set"
 msgstr ""
 
 #. module: l10n_es_subcontractor_certificate
 #: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:27
 #: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:33
+#: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:39
+#: code:addons/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py:45
 #, python-format
 msgid "Warning!"
 msgstr ""

--- a/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py
+++ b/l10n_es_subcontractor_certificate/models/subcontractor_certificate.py
@@ -23,15 +23,27 @@
 
 from openerp import models, fields, api, _
 
-EXPIRED_WARNING = {
+EXPIRED_WARNING_AEAT = {
     'title': _('Warning!'),
-    'message': _('The subcontractor certificate for this supplier '
+    'message': _('The AEAT certificate for this supplier '
                  'has expired')
     }
 
-REQUIRED_WARNING = {
+REQUIRED_WARNING_AEAT = {
     'title': _('Warning!'),
-    'message': _('The subcontractor certificate is required and '
+    'message': _('The AEAT certificate is required and '
+                 'expiration date is not set')
+    }
+
+EXPIRED_WARNING_SS = {
+    'title': _('Warning!'),
+    'message': _('The SS certificate for this supplier '
+                 'has expired')
+    }
+
+REQUIRED_WARNING_SS = {
+    'title': _('Warning!'),
+    'message': _('The SS certificate is required and '
                  'expiration date is not set')
     }
 
@@ -40,13 +52,23 @@ class ResPartner(models.Model):
     _inherit = ['res.partner']
 
     certificate_required = fields.Boolean(string='Certificate Required')
-    certificate_expiration = fields.Date(string='Certificate Expiration')
-    certificate_expired = fields.Boolean(string='Certificate Expirated',
-                                         compute='_certificate_expired')
+    certificate_expiration_aeat = fields.Date(
+        string='AEAT Certificate Expiration')
+    certificate_expired_aeat = fields.Boolean(
+        string='AEAT Certificate Expirated',
+        compute='_certificate_expired_aeat')
+    certificate_expiration_ss = fields.Date(string='SS Certificate Expiration')
+    certificate_expired_ss = fields.Boolean(
+        string='SS Certificate Expirated',
+        compute='_certificate_expired_ss')
 
-    def _certificate_expired(self):
-        self.certificate_expired = self.certificate_expiration and \
-            (self.certificate_expiration < fields.Date.today())
+    def _certificate_expired_aeat(self):
+        self.certificate_expired_aeat = self.certificate_expiration_aeat and \
+            (self.certificate_expiration_aeat < fields.Date.today())
+
+    def _certificate_expired_ss(self):
+        self.certificate_expired_ss = self.certificate_expiration_ss and \
+            (self.certificate_expiration_ss < fields.Date.today())
 
 
 class PurchaseOrder(models.Model):
@@ -58,10 +80,14 @@ class PurchaseOrder(models.Model):
         if partner_id:
             partner = self.env['res.partner'].browse(partner_id)[0]
             if partner.certificate_required:
-                if not partner.certificate_expiration:
-                    res['warning'] = REQUIRED_WARNING
-                elif partner.certificate_expired:
-                    res['warning'] = EXPIRED_WARNING
+                if not partner.certificate_expiration_aeat:
+                    res['warning'] = REQUIRED_WARNING_AEAT
+                elif partner.certificate_expired_aeat:
+                    res['warning'] = EXPIRED_WARNING_AEAT
+                elif not partner.certificate_expiration_ss:
+                    res['warning'] = REQUIRED_WARNING_SS
+                elif partner.certificate_expired_ss:
+                    res['warning'] = EXPIRED_WARNING_SS
         return res
 
 
@@ -79,8 +105,12 @@ class AccountInvoice(models.Model):
         if type == 'in_invoice' and partner_id:
             partner = self.env['res.partner'].browse(partner_id)
             if partner.certificate_required:
-                if not partner.certificate_expiration:
-                    res['warning'] = REQUIRED_WARNING
-                elif partner.certificate_expired:
-                    res['warning'] = EXPIRED_WARNING
+                if not partner.certificate_expiration_aeat:
+                    res['warning'] = REQUIRED_WARNING_AEAT
+                elif partner.certificate_expired_aeat:
+                    res['warning'] = EXPIRED_WARNING_AEAT
+                elif not partner.certificate_expiration_ss:
+                    res['warning'] = REQUIRED_WARNING_SS
+                elif partner.certificate_expired_ss:
+                    res['warning'] = EXPIRED_WARNING_SS
         return res

--- a/l10n_es_subcontractor_certificate/views/subcontractor_certificate_view.xml
+++ b/l10n_es_subcontractor_certificate/views/subcontractor_certificate_view.xml
@@ -9,7 +9,8 @@
 				<xpath expr="//page[@name='sales_purchases']/group" position="inside">
 					<group attrs="{'invisible': [('supplier','=', False)]}">
 						<field name="certificate_required"/>
-						<field name="certificate_expiration" attrs="{'invisible': [('certificate_required','=', False)]}"/>
+						<field name="certificate_expiration_aeat" attrs="{'invisible': [('certificate_required','=', False)]}"/>
+						<field name="certificate_expiration_ss" attrs="{'invisible': [('certificate_required','=', False)]}"/>
 					</group>
 				</xpath>
 			</field>


### PR DESCRIPTION
Después de validar el módulo y consultar funcionalidad, nos hemos dado cuenta que hace falta tener dos fechas, una para el certificado de seguridad social y otro para el certificado de la agencia tributaria. Se ha mantenido la misma funcionalidad, pero añadiendo dos fechas de caducidad.
