### PR TITLE
[FIX] Arreglada comparación de tipos unicode e int.

### DIFF
--- a/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
+++ b/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
@@ -87,7 +87,7 @@ class L10nEsAeatMod340CalculateRecords(orm.TransientModel):
                     if tax_line.base_code_id.mod340 is True:
                         include = True
             if include is True:
-                if invoice.partner_id.vat_type == 1:
+                if invoice.partner_id.vat_type == '1':
                     if not invoice.partner_id.vat:
                         raise orm.except_orm(
                             _('La siguiente empresa no tiene asignado nif:'),


### PR DESCRIPTION
En el wizard de cálculo de registros del 340, dicha comparación hacía siempre False el if, no advirtiendo en ningún caso de ausencia del NIF.
