### PR TITLE
[FIX] No se aplican los reemplazos de cadenas al crear BOE

### DIFF
--- a/l10n_es_aeat/wizard/export_to_boe.py
+++ b/l10n_es_aeat/wizard/export_to_boe.py
@@ -77,6 +77,12 @@ class l10n_es_aeat_report_export_to_boe(osv.osv_memory):
             (u'Û', 'U'),(u'û', 'U')]
 
         #
+        # String replacement
+        #
+        for a, b in replacements:
+            text = text.replace(a, b)
+
+        #
         # String uppercase
         #
         text = text.upper()


### PR DESCRIPTION
La lista 'replacements' no se estaba aplicando al adaptar cadenas al formato 'BOE' y este no validaba cuando aparecían caracteres especiales.
