### PR TITLE
Exportación de facturas XLS

### DIFF
--- a/account_invoice_export_xls/__init__.py
+++ b/account_invoice_export_xls/__init__.py
@@ -1,0 +1,3 @@
+from . import models
+from . import wizard
+from . import report

--- a/account_invoice_export_xls/__openerp__.py
+++ b/account_invoice_export_xls/__openerp__.py
@@ -1,0 +1,60 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#
+#    Copyright (c)
+#        2015 - Factor Libre (http://factorlibre.com)
+#                 Hugo Santos <hugo.santos@factorlibre.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses
+#
+##############################################################################
+
+{
+    "name": "Invoice export XLS",
+    "version": "1.0",
+    "author": "Spanish Localization Team",
+    'website': 'http://odoo-spain.org',
+    "category": "Accounting / Reports",
+    "description": """
+Excel export for account invoices
+=================================================
+
+Allow export invoices to xls
+
+**WARNING:** This module requires module *report_xls*, available on:
+
+  https://github.com/OCA/reporting-engine/
+
+Contributors
+------------
+* Hugo Santos <hugo.santos@factorlibre.com>
+    """,
+    'depends': [
+        'account',
+        'report_xls',
+    ],
+    'contributors': [
+        'Hugo Santos <hugo.santos@factorlibre.com>'
+    ],
+    'external_dependencies': {
+        'python': ['xlwt'],
+    },
+    'data': [
+        'report/export_invoice_xls.xml',
+        'wizard/xls_invoice_report_wizard.xml',
+    ],
+    'installable': True,
+}

--- a/account_invoice_export_xls/i18n/es.po
+++ b/account_invoice_export_xls/i18n/es.po
@@ -1,0 +1,208 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#   * account_invoice_export_xls
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-02-23 09:32+0000\n"
+"PO-Revision-Date: 2015-02-23 09:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:170
+#, python-format
+msgid "Amount Total"
+msgstr "Total"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:163
+#, python-format
+msgid "Amount Untaxed"
+msgstr "Base Moneda Compañía"
+
+#. module: account_invoice_export_xls
+#: view:xls.invoice.report.wizard:0
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: account_invoice_export_xls
+#: field:xls.invoice.report.wizard,company_id:0
+msgid "Company"
+msgstr "Compañía"
+
+#. module: account_invoice_export_xls
+#: selection:xls.invoice.report.wizard,invoice_type:0
+msgid "Customer Invoice"
+msgstr "Facturas de cliente"
+
+#. module: account_invoice_export_xls
+#: selection:xls.invoice.report.wizard,invoice_type:0
+msgid "Customer Refund Invoice"
+msgstr "Facturas rectificativas de cliente"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:140
+#, python-format
+msgid "Date"
+msgstr "Fecha"
+
+#. module: account_invoice_export_xls
+#: view:xls.invoice.report.wizard:0
+msgid "Export"
+msgstr "Exportar"
+
+#. module: account_invoice_export_xls
+#: model:ir.actions.report.xml,name:account_invoice_export_xls.report_export_invoice_xls
+msgid "Export Selected Lines"
+msgstr "Exportar Líneas seleccionadas"
+
+#. module: account_invoice_export_xls
+#: code:_description:0
+#: model:ir.model,name:account_invoice_export_xls.model_account_invoice
+#, python-format
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: account_invoice_export_xls
+#: model:ir.actions.act_window,name:account_invoice_export_xls.xls_invoice_report_wizard_action
+#: model:ir.ui.menu,name:account_invoice_export_xls.xls_invoice_report_wizard_menu
+#: view:xls.invoice.report.wizard:0
+msgid "Invoice Report XLS"
+msgstr "Exportar Facturas XLS"
+
+#. module: account_invoice_export_xls
+#: field:xls.invoice.report.wizard,invoice_type:0
+msgid "Invoice Type"
+msgstr "Tipo de factura"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:148
+#, python-format
+msgid "Number"
+msgstr "Número"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:153
+#, python-format
+msgid "Partner Name"
+msgstr "Empresa"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:158
+#, python-format
+msgid "Partner Vat"
+msgstr "CIF/NIF Empresa"
+
+#. module: account_invoice_export_xls
+#: field:xls.invoice.report.wizard,period_ids:0
+msgid "Periods"
+msgstr "Periodos"
+
+#. module: account_invoice_export_xls
+#: field:xls.invoice.report.wizard,period_id:0
+msgid "Period"
+msgstr "Periodo"
+
+#. module: account_invoice_export_xls
+#: selection:xls.invoice.report.wizard,invoice_type:0
+msgid "Supplier Invoice"
+msgstr "Factura de proveedor"
+
+#. module: account_invoice_export_xls
+#: selection:xls.invoice.report.wizard,invoice_type:0
+msgid "Supplier Refund Invoice"
+msgstr "Factura rectificativa de proveedor"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:190
+#, python-format
+msgid "Tax Line Amount"
+msgstr "Línea de impuestos/Importe"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:177
+#, python-format
+msgid "Tax Line Base"
+msgstr "Línea de impuestos/Base"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:197
+#, python-format
+msgid "Tax Line Base Amount"
+msgstr "Línea de impuestos/Importe código base"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:205
+#, python-format
+msgid "Tax Line Base Tax Code"
+msgstr "Línea de impuestos/Código Base"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:211
+#, python-format
+msgid "Tax Line Base Tax Name"
+msgstr "Línea de impuestos/Nombre de código base"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:184
+#, python-format
+msgid "Tax Line Description"
+msgstr "Línea de impuestos/Descripción"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:217
+#, python-format
+msgid "Tax Line Tax Amount"
+msgstr "Línea de impuestos/Importe código impuesto"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:225
+#, python-format
+msgid "Tax Line Tax Code"
+msgstr "Línea de impuestos/Código de impuesto"
+
+#. module: account_invoice_export_xls
+#: code:addons/account_invoice_export_xls/report/export_invoice_xls.py:231
+#, python-format
+msgid "Tax Line Tax Name"
+msgstr "Línea de impuestos/Nombre de código de impuesto"
+
+#. module: account_invoice_export_xls
+#: view:xls.invoice.report.wizard:0
+msgid "or"
+msgstr "o"
+
+#. module: account_invoice_export_xls
+#: code:_description:0
+#: model:ir.model,name:account_invoice_export_xls.model_xls_invoice_report_wizard
+#, python-format
+msgid "xls.invoice.report.wizard"
+msgstr "xls.invoice.report.wizard"
+
+#. module: account_invoice_export_xls
+#: report:account.invoice.export.xls:0
+msgid "out_invoice"
+msgstr "Facturas de cliente"
+
+#. module: account_invoice_export_xls
+#: report:account.invoice.export.xls:0
+msgid "out_refund"
+msgstr "Facturas rectificativas de cliente"
+
+#. module: account_invoice_export_xls
+#: report:account.invoice.export.xls:0
+msgid "in_invoice"
+msgstr "Facturas de proveedor"
+
+#. module: account_invoice_export_xls
+#: report:account.invoice.export.xls:0
+msgid "in_refund"
+msgstr "Facturas rectificativas de proveedor"
+

--- a/account_invoice_export_xls/models/__init__.py
+++ b/account_invoice_export_xls/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice

--- a/account_invoice_export_xls/models/account_invoice.py
+++ b/account_invoice_export_xls/models/account_invoice.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# License, author and contributors information in:
+# __openerp__.py file at the root folder of this module.
+from openerp.osv import orm
+
+
+class AccountInvoice(orm.Model):
+    _inherit = 'account.invoice'
+
+    def _report_xls_fields(self, cr, uid, context=None):
+        return [
+            'date_invoice', 'invoice_number', 'partner_name', 'partner_vat',
+            'amount_untaxed', 'amount_total', 'tax_line_base',
+            'tax_line_description', 'tax_line_amount', 'tax_line_base_amount',
+            'tax_line_base_tax_code', 'tax_line_base_tax_name',
+            'tax_line_tax_amount', 'tax_line_tax_tax_code',
+            'tax_line_tax_tax_name'
+        ]
+
+    def _report_xls_template(self, cr, uid, context=None):
+        return {}

--- a/account_invoice_export_xls/report/__init__.py
+++ b/account_invoice_export_xls/report/__init__.py
@@ -1,0 +1,1 @@
+from . import export_invoice_xls

--- a/account_invoice_export_xls/report/export_invoice_xls.py
+++ b/account_invoice_export_xls/report/export_invoice_xls.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+# License, author and contributors information in:
+# __openerp__.py file at the root folder of this module.
+
+try:
+    import xlwt
+except ImportError:
+    xlwt = None
+from datetime import datetime
+from openerp.report import report_sxw
+from openerp.tools.translate import translate, _
+
+_ir_translation_name = 'account.invoice.export.xls'
+
+
+class AccountInvoiceExportReportXlsParser(report_sxw.rml_parse):
+
+    def set_context(self, objects, data, ids, report_type=None):
+        super(AccountInvoiceExportReportXlsParser, self).set_context(
+            objects, data, ids, report_type=report_type)
+        self.invoice_type = data['invoice_type']
+        self.company_id = data['company_id']
+        self.period_ids = data['period_ids']
+
+    def __init__(self, cr, uid, name, context=None):
+        if context is None:
+            context = {}
+        super(AccountInvoiceExportReportXlsParser, self).__init__(
+            cr, uid, name, context=context)
+        invoice_pool = self.pool['account.invoice']
+        wanted_list = invoice_pool._report_xls_fields(cr, uid, context)
+        template_changes = invoice_pool._report_xls_template(cr, uid, context)
+        self.localcontext.update({
+            'datetime': datetime,
+            'title': self._title,
+            'wanted_list': wanted_list,
+            'template_changes': template_changes,
+            'lines': self._lines,
+            '_': self._
+        })
+        self.context = context
+
+    def _(self, src):
+        lang = self.context.get('lang', 'en_US')
+        return translate(self.cr, _ir_translation_name, 'report', lang, src) \
+            or src
+
+    def _title(self):
+        return self._(self.invoice_type)
+
+    def _lines(self, object):
+        additional_where = ""
+
+        if self.period_ids:
+            additional_where += "AND inv.period_id in (%s)" % (
+                ','.join(map(lambda p_id: str(p_id), self.period_ids)))
+
+        self.cr.execute(
+            "SELECT inv.date_invoice as date_invoice, "
+            "inv.number as invoice_number, "
+            "cp.name as partner_name, cp.vat as partner_vat, "
+            "inv.amount_untaxed as amount_untaxed, "
+            "inv.amount_total as amount_total, "
+            "inv_tx.base as tax_line_base, "
+            "inv_tx.name as tax_line_description, "
+            "inv_tx.amount as tax_line_amount, "
+            "inv_tx.base_amount as tax_line_base_amount, "
+            "tx_cd.code as tax_line_base_tax_code, "
+            "tx_cd.name as tax_line_base_tax_name, "
+            "inv_tx.tax_amount as tax_line_tax_amount, "
+            "tx_cd_t.code as tax_line_tax_tax_code, "
+            "tx_cd_t.name as tax_line_tax_tax_name "
+            "FROM account_invoice inv "
+            "INNER JOIN res_partner cp "
+            "    on cp.id=inv.partner_id "
+            "INNER JOIN account_invoice_tax inv_tx "
+            "    on inv_tx.invoice_id=inv.id "
+            "INNER JOIN account_tax_code tx_cd "
+            "    on tx_cd.id=inv_tx.base_code_id "
+            "INNER JOIN account_tax_code tx_cd_t "
+            "    on tx_cd_t.id=inv_tx.tax_code_id "
+            "WHERE inv.move_id is not null "
+            "    AND inv.type='" + self.invoice_type + "' "
+            "    AND inv.company_id=" + str(self.company_id) + " "
+            "    AND inv.state in ('open', 'paid') "
+            + additional_where +
+            " ORDER BY date_invoice ASC")
+        lines = self.cr.dictfetchall()
+
+        return lines
+
+try:
+    from openerp.addons.report_xls.report_xls import report_xls
+    from openerp.addons.report_xls.utils import _render
+
+    class AccountInvoiceExportReportXls(report_xls):
+
+        def __init__(self, name, table,
+                     rml=False, parser=False, header=True, store=False):
+            super(AccountInvoiceExportReportXls,
+                  self).__init__(name, table, rml, parser, header, store)
+            # Cell Styles
+            _xs = self.xls_styles
+            # header
+            rh_cell_format = _xs['bold'] + _xs['fill'] + _xs['borders_all']
+            self.rh_cell_style = xlwt.easyxf(rh_cell_format)
+            self.rh_cell_style_center = xlwt.easyxf(
+                rh_cell_format + _xs['center'])
+            self.rh_cell_style_right = xlwt.easyxf(
+                rh_cell_format + _xs['right'])
+            # lines
+            aml_cell_format = _xs['borders_all']
+            self.aml_cell_style = xlwt.easyxf(aml_cell_format)
+            self.aml_cell_style_center = xlwt.easyxf(
+                aml_cell_format + _xs['center'])
+            self.aml_cell_style_date = xlwt.easyxf(
+                aml_cell_format + _xs['left'],
+                num_format_str=report_xls.date_format)
+            self.aml_cell_style_decimal = xlwt.easyxf(
+                aml_cell_format + _xs['right'],
+                num_format_str=report_xls.decimal_format)
+            # totals
+            rt_cell_format = _xs['bold'] + _xs['fill'] + _xs['borders_all']
+            self.rt_cell_style = xlwt.easyxf(rt_cell_format)
+            self.rt_cell_style_right = xlwt.easyxf(rt_cell_format +
+                                                   _xs['right'])
+            self.rt_cell_style_decimal = xlwt.easyxf(
+                rt_cell_format + _xs['right'],
+                num_format_str=report_xls.decimal_format)
+
+        def _prepare_col_spec_lines_template(self):
+            # This is needed for translate tool to catch correctly lang handled
+            user = self.pool['res.users'].browse(self.cr, self.uid, self.uid)
+            context = {}
+            context.update({'lang': user.lang})
+            # XLS Template
+            # [Cell columns span, cell width, content type, ??]
+            return {
+                'date_invoice': {
+                    'header': [1, 13, 'text', _('Date')],
+                    'lines': [1, 0, 'date', _render(
+                        "datetime.strptime(l['date_invoice'], '%Y-%m-%d')"),
+                        None,
+                        self.aml_cell_style_date],
+                    'totals': [1, 0, 'text', None],
+                },
+                'invoice_number': {
+                    'header': [1, 13, 'text', _('Number')],
+                    'lines': [1, 0, 'text', _render("l['invoice_number']")],
+                    'totals': [1, 0, 'text', None]
+                },
+                'partner_name': {
+                    'header': [1, 20, 'text', _('Partner Name')],
+                    'lines': [1, 0, 'text', _render("l['partner_name']")],
+                    'totals': [1, 0, 'text', None]
+                },
+                'partner_vat': {
+                    'header': [1, 15, 'text', _('Partner Vat')],
+                    'lines': [1, 0, 'text', _render("l['partner_vat']")],
+                    'totals': [1, 0, 'text', None]
+                },
+                'amount_untaxed': {
+                    'header': [1, 10, 'text', _('Amount Untaxed')],
+                    'lines': [1, 0, 'number', _render("l['amount_untaxed']"),
+                              None,
+                              self.aml_cell_style_decimal],
+                    'totals': [1, 0, 'text', None]
+                },
+                'amount_total': {
+                    'header': [1, 10, 'text', _('Amount Total')],
+                    'lines': [1, 0, 'number', _render("l['amount_total']"),
+                              None,
+                              self.aml_cell_style_decimal],
+                    'totals': [1, 0, 'text', None]
+                },
+                'tax_line_base': {
+                    'header': [1, 10, 'text', _('Tax Line Base')],
+                    'lines': [1, 0, 'number', _render("l['tax_line_base']"),
+                              None,
+                              self.aml_cell_style_decimal],
+                    'totals': [1, 0, 'text', None]
+                },
+                'tax_line_description': {
+                    'header': [1, 25, 'text', _('Tax Line Description')],
+                    'lines': [1, 0, 'text',
+                              _render("l['tax_line_description']")],
+                    'totals': [1, 0, 'text', None]
+                },
+                'tax_line_amount': {
+                    'header': [1, 10, 'text', _('Tax Line Amount')],
+                    'lines': [1, 0, 'number', _render("l['tax_line_amount']"),
+                              None,
+                              self.aml_cell_style_decimal],
+                    'totals': [1, 0, 'text', None]
+                },
+                'tax_line_base_amount': {
+                    'header': [1, 10, 'text', _('Tax Line Base Amount')],
+                    'lines': [1, 0, 'number',
+                              _render("l['tax_line_base_amount']"),
+                              None,
+                              self.aml_cell_style_decimal],
+                    'totals': [1, 0, 'text', None]
+                },
+                'tax_line_base_tax_code': {
+                    'header': [1, 10, 'text', _('Tax Line Base Tax Code')],
+                    'lines': [1, 0, 'text',
+                              _render("l['tax_line_base_tax_code']")],
+                    'totals': [1, 0, 'text', None]
+                },
+                'tax_line_base_tax_name': {
+                    'header': [1, 25, 'text', _('Tax Line Base Tax Name')],
+                    'lines': [1, 0, 'text',
+                              _render("l['tax_line_base_tax_name']")],
+                    'totals': [1, 0, 'text', None]
+                },
+                'tax_line_tax_amount': {
+                    'header': [1, 10, 'text', _('Tax Line Tax Amount')],
+                    'lines': [1, 0, 'number',
+                              _render("l['tax_line_tax_amount']"),
+                              None,
+                              self.aml_cell_style_decimal],
+                    'totals': [1, 0, 'text', None]
+                },
+                'tax_line_tax_tax_code': {
+                    'header': [1, 10, 'text', _('Tax Line Tax Code')],
+                    'lines': [1, 0, 'text',
+                              _render("l['tax_line_tax_tax_code']")],
+                    'totals': [1, 0, 'text', None]
+                },
+                'tax_line_tax_tax_name': {
+                    'header': [1, 25, 'text', _('Tax Line Tax Name')],
+                    'lines': [1, 0, 'text',
+                              _render("l['tax_line_tax_tax_name']")],
+                    'totals': [1, 0, 'text', None]
+                }
+            }
+
+        def get_new_ws(self, _p, _xs, sheet_name, wb):
+            wanted_list = _p.wanted_list
+            self.wanted_list = wanted_list
+
+            title = _p.title()
+            report_name = title
+            ws = wb.add_sheet(sheet_name)
+            ws.panes_frozen = True
+            ws.remove_splits = True
+            ws.portrait = 0  # Landscape
+            ws.fit_width_to_pages = 1
+            # set print header/footer
+            ws.header_str = self.xls_headers['standard']
+            ws.footer_str = self.xls_footers['standard']
+            row_pos = 0
+            # Title
+            cell_style = xlwt.easyxf(_xs['xls_title'])
+            c_specs = [
+                ('report_name', 1, 0, 'text', report_name),
+            ]
+            row_data = self.xls_row_template(c_specs, ['report_name'])
+            row_pos = self.xls_write_row(ws, row_pos, row_data,
+                                         row_style=cell_style)
+            row_pos += 1
+            # Column headers
+            c_specs = map(lambda x: self.render(
+                x, self.col_specs_lines_template, 'header',
+                render_space={'_': _p._}), wanted_list)
+            row_data = self.xls_row_template(c_specs, [x[0] for x in c_specs])
+            row_pos = self.xls_write_row(
+                ws, row_pos, row_data, row_style=self.rh_cell_style,
+                set_column_size=True)
+            ws.set_horz_split_pos(row_pos)
+            return ws, row_pos
+
+        def generate_xls_report(self, _p, _xs, data, objects, wb):
+            wanted_list = _p.wanted_list
+            self.wanted_list = wanted_list
+            self.col_specs_lines_template = \
+                self._prepare_col_spec_lines_template()
+            self.col_specs_lines_template.update(_p.template_changes)
+            title = _p.title()
+            sheet_name = title[:31]
+            ws, row_pos = self.get_new_ws(_p, _xs, sheet_name, wb)
+
+            ws_count = 0
+            for o in objects:
+                for l in _p.lines(o):
+                    if row_pos >= 65536:
+                        ws_count += 1
+                        new_sheet_name = "%s_%s" % (sheet_name, ws_count)
+                        ws, row_pos = self.get_new_ws(_p, _xs, new_sheet_name,
+                                                      wb)
+                    # Data
+                    cslt = self.col_specs_lines_template
+                    c_specs = map(lambda x: self.render(x, cslt, 'lines'),
+                                  wanted_list)
+                    row_data = self.xls_row_template(c_specs,
+                                                     [x[0] for x in c_specs])
+                    row_pos = self.xls_write_row(ws, row_pos, row_data)
+
+    AccountInvoiceExportReportXls(
+        'report.account.invoice.export.xls', 'xls.invoice.report.wizard',
+        parser=AccountInvoiceExportReportXlsParser)
+
+except ImportError:
+    pass

--- a/account_invoice_export_xls/report/export_invoice_xls.xml
+++ b/account_invoice_export_xls/report/export_invoice_xls.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="report_export_invoice_xls" model="ir.actions.report.xml">
+          <field name="name">Export Selected Lines</field>
+          <field name="model">xls.invoice.report.wizard</field>
+          <field name="type">ir.actions.report.xml</field>
+          <field name="report_name">account.invoice.export.xls</field>
+          <field name="report_type">xls</field>
+          <field name="auto" eval="False"/>
+        </record>
+    </data>
+</openerp>

--- a/account_invoice_export_xls/wizard/__init__.py
+++ b/account_invoice_export_xls/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import xls_invoice_report_wizard

--- a/account_invoice_export_xls/wizard/xls_invoice_report_wizard.py
+++ b/account_invoice_export_xls/wizard/xls_invoice_report_wizard.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# License, author and contributors information in:
+# __openerp__.py file at the root folder of this module.
+from openerp.osv import orm, fields
+
+
+class XlsInvoiceReportWizard(orm.TransientModel):
+    _name = 'xls.invoice.report.wizard'
+
+    INVOICE_TYPES = [
+        ('out_invoice', 'Customer Invoice'),
+        ('out_refund', 'Customer Refund Invoice'),
+        ('in_invoice', 'Supplier Invoice'),
+        ('in_refund', 'Supplier Refund Invoice')
+    ]
+
+    _columns = {
+        'period_id': fields.many2one('account.period', 'Period'),
+        'invoice_type': fields.selection(INVOICE_TYPES, 'Invoice Type',
+                                         required=True),
+        'period_ids': fields.many2many(
+            'account.period', 'period_xls_invoice_report_rel',
+            'wizard_id', 'period_id', 'Periods'),
+        'company_id': fields.many2one('res.company', 'Company',
+                                      required=True)
+    }
+
+    _defaults = {
+        'company_id': lambda self, cr, uid, context: self.pool['res.users']
+        .browse(cr, uid, [uid], context)[0].company_id.id
+    }
+
+    def xls_export(self, cr, uid, ids, context=None):
+        wiz = self.browse(cr, uid, ids[0], context=context)
+        datas = {
+            'model': 'xls.invoice.report.wizard',
+            'invoice_type': wiz.invoice_type,
+            'company_id': wiz.company_id.id,
+            'period_ids': map(lambda p: p.id, wiz.period_ids),
+            'ids': [wiz.id]
+        }
+
+        return {
+            'type': 'ir.actions.report.xml',
+            'report_name': 'account.invoice.export.xls',
+            'datas': datas
+        }

--- a/account_invoice_export_xls/wizard/xls_invoice_report_wizard.xml
+++ b/account_invoice_export_xls/wizard/xls_invoice_report_wizard.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="xls_invoice_report_wizard_form_view" model="ir.ui.view">
+            <field name="name">xls.invoice.report.wizard.form</field>
+            <field name="model">xls.invoice.report.wizard</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Invoice Report XLS" version="7.0">
+                    <group>
+                        <field name="invoice_type"/>
+                        <field name="company_id" groups="base.group_multi_company"/>
+                        <field name="period_ids" colspan="4"/>
+                    </group>
+                    <footer>
+                        <button name="xls_export" type="object"
+                            string="Export" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="xls_invoice_report_wizard_action" model="ir.actions.act_window">
+            <field name="name">Invoice Report XLS</field>
+            <field name="res_model">xls.invoice.report.wizard</field>
+            <field name="view_mode">form</field>
+            <field name="view_type">form</field>
+            <field name="target">new</field>
+            <field name="view_id" ref="xls_invoice_report_wizard_form_view"/>
+        </record>
+
+        <menuitem id="xls_invoice_report_wizard_menu" action="xls_invoice_report_wizard_action"
+            parent="account.menu_finance_generic_reporting"/>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Hemos creado un módulo para realizar una exportación de facturas a XLS junto con sus líneas de Impuestos.

Se exportarían desde Contabilidad -> Informes Génericos -> Exportar facturas XLS.
Siendo posible filtrar por tipo de factura, compañía y periodos desde el propio wizard y exportando los siguientes campos:
- Fecha
- Número
- Empresa
- CIF/NIF Empresa
- Base Moneda Compañía
- Total
- Línea de impuestos/Base
- Línea de impuestos/Descripción
- Línea de impuestos/Importe
- Línea de impuestos/Importe código base
- Línea de impuestos/Código Base
- Línea de impuestos/Nombre de código base
- Línea de impuestos/Importe código impuesto
- Línea de impuestos/Código de impuesto
- Línea de impuestos/Nombre de código de impuesto

Lo he hecho apoyándome en el módulo report_xls de la rama https://github.com/OCA/reporting-engine/

¿Cómo lo veis? 
