### PR TITLE
[FIX] Error al crear el asiento de cierre

### DIFF
--- a/l10n_es_fiscal_year_closing/wizard/wizard_run.py
+++ b/l10n_es_fiscal_year_closing/wizard/wizard_run.py
@@ -327,34 +327,38 @@ class ExecuteFyc(orm.TransientModel):
                                 dest_id = account_map.dest_account_id.id
                                 dest_accounts_totals[dest_id] -= balance
                     elif account.user_type.close_method == 'unreconciled':
-                        found_lines = move_line_obj.search(
-                            cr, uid, [('period_id', 'in', period_ids),
-                                      ('account_id', '=', account.id),
-                                      ('company_id', '=', company_id)])
-                        lines_by_partner = {}
-                        for line in move_line_obj.browse(cr, uid, found_lines):
-                            balance = line.debit - line.credit
-                            if line.partner_id.id in lines_by_partner:
-                                lines_by_partner[line.partner_id.id] += balance
-                            else:
-                                lines_by_partner[line.partner_id.id] = balance
-                        for partner_id in lines_by_partner.keys():
-                            balance = lines_by_partner[partner_id]
-                            if balance:
-                                move_lines.append(
-                                    {'account_id': account.id,
-                                     'debit': balance < 0 and -balance,
-                                     'credit': balance > 0 and balance,
-                                     'name': description,
-                                     'date': date,
-                                     'period_id': period_id,
-                                     'journal_id': journal_id,
-                                     'partner_id': partner_id})
-                            # Update the dest account total (with the inverse
-                            # of the balance)
-                            if account_map.dest_account_id:
-                                dest_id = account_map.dest_account_id.id
-                                dest_accounts_totals[dest_id] -= balance
+                        if account.balance:
+                            found_lines = move_line_obj.search(
+                                cr, uid, [('period_id', 'in', period_ids),
+                                          ('account_id', '=', account.id),
+                                          ('company_id', '=', company_id)])
+                            lines_by_partner = {}
+                            for line in move_line_obj.browse(
+                                    cr, uid, found_lines):
+                                balance = line.debit - line.credit
+                                if line.partner_id.id in lines_by_partner:
+                                    lines_by_partner[
+                                        line.partner_id.id] += balance
+                                else:
+                                    lines_by_partner[
+                                        line.partner_id.id] = balance
+                            for partner_id in lines_by_partner.keys():
+                                balance = lines_by_partner[partner_id]
+                                if balance:
+                                    move_lines.append(
+                                        {'account_id': account.id,
+                                         'debit': balance < 0 and -balance,
+                                         'credit': balance > 0 and balance,
+                                         'name': description,
+                                         'date': date,
+                                         'period_id': period_id,
+                                         'journal_id': journal_id,
+                                         'partner_id': partner_id})
+                                # Update the dest account total (with the
+                                # inverse of the balance)
+                                if account_map.dest_account_id:
+                                    dest_id = account_map.dest_account_id.id
+                                    dest_accounts_totals[dest_id] -= balance
                     elif account.user_type.close_method == 'detail':
                         raise orm.except_orm(
                             _('UserError'),


### PR DESCRIPTION
Detectado error en los asientos de cierre.

Las cuentas con el método de cierre 'unreconcilied' deben de añadirse al cierre si existe balance, porque si no es así, se añaden lineas al asiento de cierre redundantes (porque el balance es cero) y/o otras que no deberían de estar como 477, 472 etc.

Probado en clientes en producción.
