### PR TITLE
l10n_es_aeat_mod349: Se corrige un problema al calcular las rectificativas

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -140,7 +140,10 @@ class Mod349(models.Model):
                         # creates a dictionary key with partner_record id to
                         # after recover it
                         key = refund_details.partner_record_id
-                        record[key] = record.get(key, []).append(refund)
+                        if record.get(key, False):
+                            record[key].append(refund)
+                        else:
+                            record[key] = [refund]
                         break
         # recorremos nuestro diccionario y vamos creando registros
         for partner_rec in record:


### PR DESCRIPTION
record.get(key, []) siempre devuelve None sino existe la clave, por lo que fallaba al crear posteriormente la linea de rectificativas.
