### PR TITLE
[FIX] l10n_es_bank_statement: Sustituir utilizacion de eval por safe_eval

### DIFF
--- a/l10n_es_bank_statement/models/account_statement_completion_rule.py
+++ b/l10n_es_bank_statement/models/account_statement_completion_rule.py
@@ -20,6 +20,7 @@
 #
 ##############################################################################
 from openerp.osv import orm, fields
+from openerp.tools.safe_eval import safe_eval
 from openerp.tools.translate import _
 
 
@@ -55,7 +56,7 @@ class AccountStatementCompletionRule(orm.Model):
         """
         partner_obj = self.pool['res.partner']
         st_line_obj = self.pool['account.bank.statement.line']
-        conceptos = eval(st_line['name'])
+        conceptos = safe_eval(st_line['name'])
         ids = []
         res = {}
         # Try to match from VAT included in concept complementary record #02
@@ -103,7 +104,7 @@ class AccountStatementCompletionRule(orm.Model):
         """
         partner_obj = self.pool['res.partner']
         st_line_obj = self.pool['account.bank.statement.line']
-        conceptos = eval(st_line['name'])
+        conceptos = safe_eval(st_line['name'])
         ids = []
         res = {}
         # Try to match from VAT included in concept complementary record #01


### PR DESCRIPTION
Con este commit se pretende sustituir el uso de la función eval, que es insegura por defecto, por la función safe_eval proporcionada por OpenERP.

Así se evitaría que cualquier usuario pueda ejecutar código modificando el campo OBI de las líneas de extractos bancarios.
