### PR TITLE
[IMP] l10n_es_account_invoice_sequence: Configuración automática de diarios + tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - travis_install_nightly
 
 script:
-  - travis_run_tests
+  - travis_wait travis_run_tests
 
 after_success:
   - travis_after_tests_success

--- a/l10n_es_account_invoice_sequence/README.rst
+++ b/l10n_es_account_invoice_sequence/README.rst
@@ -1,3 +1,7 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+============================================================
 Secuencia para facturas separada de la secuencia de asientos
 ============================================================
 
@@ -11,13 +15,76 @@ asiento se guardan para que si se vuelve a validar, se mantengan ambos.
 
 Su uso es obligatorio para España, ya que el sistema que utiliza por defecto
 Odoo no cumple los siguientes requisitos legales en España:
- - Las facturas deben llevar una numeración única y continua
- - Los asientos de un diario deben ser correlativos según las fechas
+
+* Las facturas deben llevar una numeración única y continua
+* Los asientos de un diario deben ser correlativos según las fechas
 
 Al separar la numeración de las facturas de los asientos, es posible
 renumerar los asientos al final del ejercicio (por ejemplo mediante el
-módulo account_renumber) sin afectar a las facturas
+módulo *account_renumber*) sin afectar a las facturas.
 
-**AVISO**: Hay que configurar las secuencias correspondientes para todos los
-diarios de ventas, compras, abono de ventas y abono de compras utilizados
-después de instalar este módulo.
+Instalación
+===========
+
+En el momento de la instalación, se auto-configuran las secuencias de facturas
+de todos los diarios de todas las compañías españolas existentes, poniendo la
+secuencia que había anteriormente en el campo "Secuencia de asiento", y
+creándose una nueva secuencia única por compañía para ese campo.
+
+Uso
+===
+
+Cuando se valide una factura, la secuencia que se utilizará será la configurada
+en el campo "Secuencia de factura" en lugar de la "Secuencia de asiento".
+
+En caso de crear una nueva compañía e instalar un plan contable español, la
+creación de los diarios se hará también con las secuencias correctamente
+definidas.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/189/8.0
+
+Problemas conocidos / Hoja de ruta
+==================================
+
+* Cuando se instala un nuevo plan, los diarios "Efectivo" y "Banco" no cogen
+  ahora mismo la misma secuencia de asientos que el resto de diarios.
+* En la pantalla Configuración > Contabilidad, los proximos números de factura
+  no son los que corresponden a las secuencias reales.
+* Al crear una cuenta bancaria, no se asigna la secuencia general de asientos,
+  si no una nueva.
+
+Gestión de errores
+==================
+
+Los errores/fallos se gestionan en `las incidencias de GitHub <https://github.com/OCA/l10n-spain/issues>`_.
+En caso de problemas, compruebe por favor si su incidencia ha sido ya
+reportada. Si fue el primero en descubrirla, ayúdenos a solucionarla proveyendo
+una detallada y bienvenida retroalimentación
+`aquí <https://github.com/OCA/l10n-spain/issues/new?body=module:%20l10n_es_account_invoice_sequence%0AVersion:%208.0%0A%0A**Pasos%20para%20reproducirlo**%0A-%20...%0A%0A**Comportamiento%20actual**%0A%0A**Comportamiento%20esperado**>`_.
+
+Créditos
+========
+
+Contribuidores
+--------------
+
+* NaN·Tic
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Roberto Lizana <roberto.lizana@trey.es>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/l10n_es_account_invoice_sequence/__init__.py
+++ b/l10n_es_account_invoice_sequence/__init__.py
@@ -1,19 +1,36 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# (c) 2015 Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from .constants import ALLOWED_JOURNAL_TYPES
 from . import models
+from . import wizard
+
+
+def fill_invoice_sequences(cr, registry):
+    from openerp import SUPERUSER_ID, _
+    company_obj = registry['res.company']
+    journal_obj = registry['account.journal']
+    model_data_obj = registry['ir.model.data']
+    sequence_obj = registry['ir.sequence']
+    company_ids = company_obj.search(cr, SUPERUSER_ID, [])
+    for company in company_obj.browse(cr, SUPERUSER_ID, company_ids):
+        if company.country_id and company.country_id.code != 'ES':
+            # Discard non spanish companies (by the country of the address)
+            # Companies with no country are not discarded
+            continue
+        journal_ids = journal_obj.search(
+            cr, SUPERUSER_ID, [('company_id', '=', company.id)])
+        generic_journal_seq_id = model_data_obj.get_object_reference(
+            cr, SUPERUSER_ID, 'l10n_es_account_invoice_sequence',
+            'sequence_spanish_journal')[1]
+        journal_seq_id = sequence_obj.copy(
+            cr, SUPERUSER_ID, generic_journal_seq_id,
+            {'name': _('Journal Entries Sequence'),
+             'company_id': company.id})
+        for journal in journal_obj.browse(cr, SUPERUSER_ID, journal_ids):
+            vals = {'sequence_id': journal_seq_id}
+            if journal.type in ALLOWED_JOURNAL_TYPES:
+                vals['invoice_sequence_id'] = journal.sequence_id.id
+            journal_obj.write(
+                cr, SUPERUSER_ID, journal.id, vals)

--- a/l10n_es_account_invoice_sequence/__openerp__.py
+++ b/l10n_es_account_invoice_sequence/__openerp__.py
@@ -23,22 +23,26 @@
 
 {
     "name": "Secuencia para facturas separada de la secuencia de asientos",
-    "version": "1.1",
+    "version": "8.0.1.2.0",
     "author": "Spanish Localization Team, "
+              "NaN·Tic, "
+              "Trey, "
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "category": "Accounting",
     "license": "AGPL-3",
     "depends": [
-        'account',
+        'l10n_es',
     ],
     "data": [
+        'data/sequence_data.xml',
         'views/account_view.xml',
     ],
     "demo": [],
     "test": [
         'test/sequence.yml'
     ],
-    "active": False,
+    "post_init_hook": "fill_invoice_sequences",
     "installable": True,
 }

--- a/l10n_es_account_invoice_sequence/constants.py
+++ b/l10n_es_account_invoice_sequence/constants.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+ALLOWED_JOURNAL_TYPES = ('sale', 'sale_refund', 'purchase', 'purchase_refund')

--- a/l10n_es_account_invoice_sequence/data/sequence_data.xml
+++ b/l10n_es_account_invoice_sequence/data/sequence_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="sequence_spanish_journal" model="ir.sequence">
+            <field name="name">Account Default Journal (Spanish)</field>
+            <field eval="5" name="padding"/>
+            <field name="implementation">no_gap</field>
+            <field name="prefix">%(year)s/</field>
+        </record>
+
+    </data>
+</openerp>

--- a/l10n_es_account_invoice_sequence/i18n/es.po
+++ b/l10n_es_account_invoice_sequence/i18n/es.po
@@ -53,3 +53,11 @@ msgstr "Secuencia de la factura"
 #: help:account.journal,invoice_sequence_id:0
 msgid "The sequence used for invoice numbers in this journal."
 msgstr "La secuencia utilizada para los números de factura en este diario."
+
+#. module: l10n_es_account_invoice_sequence
+#: code:addons/l10n_es_account_invoice_sequence/__init__.py:31
+#: code:addons/l10n_es_account_invoice_sequence/wizard/wizard_multi_charts_accounts.py:32
+#, python-format
+msgid "Journal Entries Sequence"
+msgstr "Secuencia de asientos contables"
+

--- a/l10n_es_account_invoice_sequence/i18n/l10n_es_account_invoice_sequence.pot
+++ b/l10n_es_account_invoice_sequence/i18n/l10n_es_account_invoice_sequence.pot
@@ -1,13 +1,13 @@
-# Translation of OpenERP Server.
+# Translation of Odoo Server.
 # This file contains the translation of the following modules:
 #	* l10n_es_account_invoice_sequence
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenERP Server 7.0\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-07-03 13:52+0000\n"
-"PO-Revision-Date: 2013-07-03 13:52+0000\n"
+"POT-Creation-Date: 2015-08-20 16:07+0000\n"
+"PO-Revision-Date: 2015-08-20 16:07+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,14 +16,18 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_es_account_invoice_sequence
-#: code:addons/l10n_es_account_invoice_sequence/account_invoice.py:64
-#, python-format
-msgid "Journal %s has no sequence defined for invoices."
+#: model:ir.model,name:l10n_es_account_invoice_sequence.model_account_invoice
+msgid "Invoice"
 msgstr ""
 
 #. module: l10n_es_account_invoice_sequence
-#: constraint:account.journal:0
-msgid "Journal company and invoice sequence company do not match."
+#: field:account.invoice,invoice_number:0
+msgid "Invoice number"
+msgstr ""
+
+#. module: l10n_es_account_invoice_sequence
+#: field:account.journal,invoice_sequence_id:0
+msgid "Invoice sequence"
 msgstr ""
 
 #. module: l10n_es_account_invoice_sequence
@@ -32,19 +36,22 @@ msgid "Journal"
 msgstr ""
 
 #. module: l10n_es_account_invoice_sequence
-#: code:addons/l10n_es_account_invoice_sequence/account_invoice.py:64
+#: code:addons/l10n_es_account_invoice_sequence/models/account_invoice.py:41
 #, python-format
-msgid "Error!"
+msgid "Journal %s has no sequence defined for invoices."
 msgstr ""
 
 #. module: l10n_es_account_invoice_sequence
-#: model:ir.model,name:l10n_es_account_invoice_sequence.model_account_invoice
-msgid "Invoice"
+#: code:addons/l10n_es_account_invoice_sequence/__init__.py:31
+#: code:addons/l10n_es_account_invoice_sequence/wizard/wizard_multi_charts_accounts.py:32
+#, python-format
+msgid "Journal Entries Sequence"
 msgstr ""
 
 #. module: l10n_es_account_invoice_sequence
-#: field:account.journal,invoice_sequence_id:0
-msgid "Invoice sequence"
+#: code:addons/l10n_es_account_invoice_sequence/models/account_journal.py:41
+#, python-format
+msgid "Journal company and invoice sequence company do not match."
 msgstr ""
 
 #. module: l10n_es_account_invoice_sequence

--- a/l10n_es_account_invoice_sequence/models/account_journal.py
+++ b/l10n_es_account_invoice_sequence/models/account_journal.py
@@ -23,7 +23,7 @@
 from openerp import models, fields, api, exceptions, _
 
 
-class account_journal(models.Model):
+class AccountJournal(models.Model):
     _inherit = 'account.journal'
 
     invoice_sequence_id = fields.Many2one(

--- a/l10n_es_account_invoice_sequence/tests/__init__.py
+++ b/l10n_es_account_invoice_sequence/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import test_l10n_es_account_invoice_sequence

--- a/l10n_es_account_invoice_sequence/tests/test_l10n_es_account_invoice_sequence.py
+++ b/l10n_es_account_invoice_sequence/tests/test_l10n_es_account_invoice_sequence.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+from openerp.addons.l10n_es_account_invoice_sequence.constants import \
+    ALLOWED_JOURNAL_TYPES
+
+
+class TestL10nEsAccountInvoiceSequence(common.TransactionCase):
+
+    def setUp(self):
+        super(TestL10nEsAccountInvoiceSequence, self).setUp()
+
+    def test_create_chart_of_accounts(self):
+        company = self.env['res.company'].create(
+            {'name': 'Spanish company'})
+        wizard = self.env['wizard.multi.charts.accounts'].create(
+            {'company_id': company.id,
+             'chart_template_id': self.env.ref(
+                 'l10n_es.account_chart_template_pymes').id,
+             'code_digits': 6,
+             'currency_id': self.env.ref('base.EUR').id})
+        wizard.execute()
+        journals = self.env['account.journal'].search(
+            [('company_id', '=', company.id),
+             ('type', 'in', ALLOWED_JOURNAL_TYPES)])
+        self.assertTrue(
+            all([j.sequence_id for j in journals]),
+            "Not all company journals have sequence")
+        sequence = journals[:1].sequence_id
+        for journal in journals:
+            self.assertEqual(journal.sequence_id, sequence)
+        self.assertTrue(
+            all([j.invoice_sequence_id for j in journals]),
+            "Not all company journals have invoice sequence")

--- a/l10n_es_account_invoice_sequence/views/account_view.xml
+++ b/l10n_es_account_invoice_sequence/views/account_view.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <field name="sequence_id" position="after">
                 <field name="invoice_sequence_id"
-                        attrs="{'invisible': [('type', '!=', 'sale'), ('type', '!=', 'sale_refund'), ('type', '!=', 'purchase'), ('type', '!=', 'purchase_refund')]}"/>
+                        attrs="{'invisible': [('type', 'not in', ('sale', 'sale_refund', 'purchase', 'purchase_refund'))]}"/>
             </field>
         </field>
     </record>

--- a/l10n_es_account_invoice_sequence/wizard/__init__.py
+++ b/l10n_es_account_invoice_sequence/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import wizard_multi_charts_accounts

--- a/l10n_es_account_invoice_sequence/wizard/wizard_multi_charts_accounts.py
+++ b/l10n_es_account_invoice_sequence/wizard/wizard_multi_charts_accounts.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, api, _
+from openerp.addons.l10n_es_account_invoice_sequence.constants import \
+    ALLOWED_JOURNAL_TYPES
+
+
+class WizardMultiChartsAccounts(models.TransientModel):
+    _inherit = 'wizard.multi.charts.accounts'
+
+    @api.model
+    def _prepare_all_journals(self, chart_template_id, acc_template_ref,
+                              company_id):
+        journal_data = super(WizardMultiChartsAccounts, self).\
+            _prepare_all_journals(chart_template_id, acc_template_ref,
+                                  company_id)
+        spanish_charts = [
+            self.env.ref('l10n_es.account_chart_template_common').id,
+            self.env.ref('l10n_es.account_chart_template_assoc').id,
+            self.env.ref('l10n_es.account_chart_template_pymes').id,
+            self.env.ref('l10n_es.account_chart_template_full').id,
+        ]
+        if chart_template_id not in spanish_charts:
+            # Discard non spanish companies
+            return journal_data
+        journal_model = self.env['account.journal']
+        # Create unified sequence for journal entries
+        generic_journal_seq = self.env.ref(
+            'l10n_es_account_invoice_sequence.sequence_spanish_journal')
+        journal_seq = generic_journal_seq.copy(
+            {'name': _('Journal Entries Sequence'),
+             'company_id': company_id})
+        for journal_vals in journal_data:
+            journal_vals['sequence_id'] = journal_seq.id
+            if journal_vals['type'] in ALLOWED_JOURNAL_TYPES:
+                journal_vals['invoice_sequence_id'] = (
+                    journal_model.create_sequence(journal_vals))
+        return journal_data


### PR DESCRIPTION
Para hacer la vida un poco más fácil, restando configuración inicial:
- En la instalación, asigna las secuencias de cada diario aplicable como secuencia de factura, y crea una nueva para los asientos.
- En cada compañía que se agregue y se instale un plan contable español, ya aparece correctamente definidos los diarios.

@antespi, @rafaelbn, revisad por favor
