### PR TITLE
[FIX] l10n_es_aeat_mod303: Corregido cálculo 'resultado_liquidación' 

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -139,7 +139,7 @@ class L10nEsAeatMod303Report(models.Model):
                 casilla_46 * mod303.porcentaje_atribuible_estado / 100)
             casilla_69 = (atribuible_estado - mod303.cuota_compensar +
                           mod303.regularizacion_anual)
-            resultado_liquidacion = casilla_46 - mod303.previous_result
+            resultado_liquidacion = casilla_69 - mod303.previous_result
             vals = {
                 'total_devengado': total_devengado,
                 'total_deducir': total_deducir,

--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -65,7 +65,7 @@
                                    options="{'currency_field': 'currency_id'}"
                                    attrs="{'readonly': [('period_type', 'not in', ('4T', '12'))]}"
                                     />
-                            <field name="casilla_46"
+                            <field name="casilla_69"
                                    widget="monetary"
                                    options="{'currency_field': 'currency_id'}"
                                     />


### PR DESCRIPTION
Corregido cálculo del campo resultado_liquidacion en el método calculate y corregido formulario de mod303, sustituido campo casilla_46 repetido por campo casilla_69.
