### PR TITLE
[IMP] l10n_es_account_invoice_sequence: Añadir nº factura a la referencia del asiento

### DIFF
--- a/l10n_es_account_invoice_sequence/__openerp__.py
+++ b/l10n_es_account_invoice_sequence/__openerp__.py
@@ -23,7 +23,7 @@
 
 {
     "name": "Secuencia para facturas separada de la secuencia de asientos",
-    "version": "8.0.1.2.0",
+    "version": "8.0.1.2.1",
     "author": "Spanish Localization Team, "
               "NaN·Tic, "
               "Trey, "

--- a/l10n_es_account_invoice_sequence/models/account_invoice.py
+++ b/l10n_es_account_invoice_sequence/models/account_invoice.py
@@ -51,10 +51,13 @@ class AccountInvoice(models.Model):
                 inv.write({
                     'number': inv.invoice_number,
                 })
+            if inv.move_id.ref:
+                inv.move_id.ref += " - %s" % inv.invoice_number
+            else:
+                inv.move_id.ref = inv.invoice_number
         re = super(AccountInvoice, self).action_number()
         for inv in self:
             inv.write({'internal_number': inv.move_id.name})
-
         return re
 
     @api.multi


### PR DESCRIPTION
La razón es que al hacer conciliación de los extractos bancarios, no aparece por ningún sitio el número de factura, y eso es debido a que como en el Odoo estándar los asientos llevan el mismo número que la factura, no es necesario mostrarlo dos veces. En lugar de tocar el código JavaScript de la conciliación de extractos, es más sencillo añadir el número de factura a la referencia del asiento, que sí que se muestra.
