### PR TITLE
[IMP] l10n_es_aeat/l10n_es_aeat_mod303: Crear asiento de regularización cuando se hace la declaración

### DIFF
--- a/l10n_es/data/account_account_common.xml
+++ b/l10n_es/data/account_account_common.xml
@@ -4270,7 +4270,7 @@
         </record>
         <record id="pgc_4750_child" model="account.account.template">
             <field name="code">4750</field>
-            <field name="reconcile" eval="False"/>
+            <field name="reconcile" eval="True"/>
             <field name="parent_id" ref="pgc_4750"/>
             <field name="type">payable</field>
             <field name="name">Hacienda Pública, acreedora por IVA</field>

--- a/l10n_es_aeat/README.rst
+++ b/l10n_es_aeat/README.rst
@@ -13,7 +13,8 @@ Módulo base para declaraciones de la AEAT, que incluye:
 * Motor de exportación paramétrica basado en una configuración que puede ser
   introducida por datos XML o por interfaz.
 * Motor de cálculo de importes por códigos de impuestos.
-* Las partes específicas de las Diputaciones Forales no están incluidas.
+* Generador del asiento de regularización con cargo a un proveedor "Agencia
+  Estatal de Administración Tributaria" creado al efecto.
 
 Configuración
 =============
@@ -22,11 +23,17 @@ Todos aquellos modelos que se especifiquen en los módulos adicionales y
 hereden el AEAT base, deberán definir una variable interna que se llame
 '_aeat_number' asignándole como valor, el número del modelo (130, 340, 347...).
 
+Para activar la creación del asiento de regularización en un modelo, hay que
+poner en el modelo correspondiente el campo allow_posting a True, y establecer
+en la configuración de impuestos los conceptos que se regularizarán con el
+flag "to_regularize".
+
 Problemas conocidos / Hoja de ruta
 ==================================
 
 * La configuración de exportación a BOE no se filtran ni se auto-selecciona por
   fechas de validez.
+* Las partes específicas de las Diputaciones Forales no están incluidas.
 
 Créditos
 ========

--- a/l10n_es_aeat/__openerp__.py
+++ b/l10n_es_aeat/__openerp__.py
@@ -28,7 +28,7 @@
 ##############################################################################
 {
     'name': "AEAT Base",
-    'version': "1.1",
+    'version': "8.0.1.2.0",
     'author': "Pexego,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
               "AvanzOSC,"
@@ -51,6 +51,7 @@
         'security/aeat_security.xml',
         'security/ir.model.access.csv',
         'data/aeat_sequence_type.xml',
+        'data/aeat_partner.xml',
         'wizard/export_to_boe_wizard.xml',
         'views/aeat_menuitem.xml',
         'views/aeat_view.xml',

--- a/l10n_es_aeat/data/aeat_partner.xml
+++ b/l10n_es_aeat/data/aeat_partner.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="res_partner_aeat" model="res.partner">
+            <field name="name">Agencia Estatal de Administración Tributaria (AEAT)</field>
+            <field name="supplier">1</field>
+            <field name="customer" eval="False"/>
+            <field name="is_company">1</field>
+            <field name="city">Madrid</field>
+            <field name="zip">28020</field>
+            <field name="country_id" ref="base.es"/>
+            <field name="vat">ESQ2826000H</field>
+            <field name="street">C/ Lérida 32-34 </field>
+            <field name="phone">91 583 80 72</field>
+            <field name="fax">91 583 70 05</field>
+            <field name="website">https://www.agenciatributaria.gob.es</field>
+            <field name="image" type="base64" file="l10n_es_aeat/static/description/icon.png"/>
+        </record>
+
+    </data>
+</openerp>

--- a/l10n_es_aeat/i18n/es.po
+++ b/l10n_es_aeat/i18n/es.po
@@ -1,34 +1,31 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat
-# 
-# Translators:
-# Pedro M. Baeza <pedro.baeza@gmail.com>, 2015
+#	* l10n_es_aeat
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-spain (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-08-14 00:52+0000\n"
-"PO-Revision-Date: 2015-07-10 10:58+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/es/)\n"
+"POT-Creation-Date: 2015-09-15 14:40+0000\n"
+"PO-Revision-Date: 2015-09-15 14:40+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_aeat
 #: code:addons/l10n_es_aeat/wizard/export_to_boe.py:199
 #, python-format
 msgid "%s_report_%s.txt"
-msgstr "%s_report_%s.txt"
+msgstr "%s_declaración_%s.txt"
 
 #. module: l10n_es_aeat
 #: code:addons/l10n_es_aeat/models/aeat_export_configuration.py:110
 #, python-format
 msgid "<blank>"
-msgstr "<blank>"
+msgstr "<vacío>"
 
 #. module: l10n_es_aeat
 #: model:ir.ui.menu,name:l10n_es_aeat.menu_l10n_es_aeat_config
@@ -76,6 +73,11 @@ msgstr "La secuencia de la declaración AEAT debe ser única"
 #: model:ir.ui.menu,name:l10n_es_aeat.menu_root_aeat
 msgid "AEAT reports"
 msgstr "Declaraciones AEAT"
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.report,move_id:0
+msgid "Account entry"
+msgstr "Asiento contable"
 
 #. module: l10n_es_aeat
 #: view:aeat.model.export.config.line:l10n_es_aeat.aeat_model_export_config_line_form
@@ -207,6 +209,16 @@ msgid "Contact data"
 msgstr "Datos de contacto"
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.report,counterpart_account:0
+msgid "Counterpart account"
+msgstr "Cuenta de contrapartida"
+
+#. module: l10n_es_aeat
+#: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
+msgid "Create move"
+msgstr "Crear asiento contable"
+
+#. module: l10n_es_aeat
 #: field:aeat.mod.map.tax.code,create_uid:0
 #: field:aeat.mod.map.tax.code.line,create_uid:0
 #: field:aeat.model.export.config,create_uid:0
@@ -284,7 +296,7 @@ msgstr "Exportar archivo AEAT BOE"
 #. module: l10n_es_aeat
 #: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_report_export_to_boe
 msgid "Export Report to BOE Format"
-msgstr "Exportar a formato BOE"
+msgstr "Exportar declaración al formato BOE"
 
 #. module: l10n_es_aeat
 #: model:ir.actions.act_window,name:l10n_es_aeat.action_aeat_export_config
@@ -377,9 +389,11 @@ msgid "Full Name"
 msgstr "Nombre completo"
 
 #. module: l10n_es_aeat
-#: field:aeat.mod.map.tax.code,id:0 field:aeat.mod.map.tax.code.line,id:0
+#: field:aeat.mod.map.tax.code,id:0
+#: field:aeat.mod.map.tax.code.line,id:0
 #: field:aeat.model.export.config,id:0
-#: field:aeat.model.export.config.line,id:0 field:l10n.es.aeat.report,id:0
+#: field:aeat.model.export.config.line,id:0
+#: field:l10n.es.aeat.report,id:0
 #: field:l10n.es.aeat.report.export_to_boe,id:0
 #: field:l10n.es.aeat.tax.line,id:0
 msgid "ID"
@@ -387,16 +401,12 @@ msgstr "ID"
 
 #. module: l10n_es_aeat
 #: help:aeat.model.export.config.line,repeat_expression:0
-msgid ""
-"If set, this expression will be used for getting the list of elements to "
-"iterate on"
+msgid "If set, this expression will be used for getting the list of elements to iterate on"
 msgstr "Si está establecida, esta expresión se usará para obtener una lista de los elementos por los que iterar"
 
 #. module: l10n_es_aeat
 #: help:aeat.model.export.config.line,conditional_expression:0
-msgid ""
-"If set, this expression will be used to evaluate if this line should be "
-"added"
+msgid "If set, this expression will be used to evaluate if this line should be added"
 msgstr "Si está establecida, esta expresión será usada para evaluar si la línea debe ser añadida"
 
 #. module: l10n_es_aeat
@@ -415,13 +425,20 @@ msgid "Informativas"
 msgstr "Informativas"
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:203
+#: code:addons/l10n_es_aeat/models/aeat_report.py:225
 #, python-format
-msgid ""
-"It seems that you have defined quarterly periods or periods in the middle of"
-" the month. This cannot be automatically handled. You should select manually"
-" the periods."
+msgid "It seems that you have defined quarterly periods or periods in the middle of the month. This cannot be automatically handled. You should select manually the periods."
 msgstr "Parece que ha definido periodos trimestrales o periodos en mitad del mes. Esto no se puede gestionar automáticamente, por lo que deberá seleccionar a mano los periodos."
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.report,journal_id:0
+msgid "Journal"
+msgstr "Diario"
+
+#. module: l10n_es_aeat
+#: help:l10n.es.aeat.report,journal_id:0
+msgid "Journal in which post the move."
+msgstr "Diario en el que crear el asiento contable."
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.tax.line,move_lines:0
@@ -532,7 +549,7 @@ msgid "Odoo model"
 msgstr "Modelo Odoo"
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:297
+#: code:addons/l10n_es_aeat/models/aeat_report.py:405
 #, python-format
 msgid "Only reports in 'draft' or 'cancelled' state can be removed"
 msgstr "Sólo los informes en estado 'borrador' or 'cancelado' pueden ser eliminados"
@@ -564,10 +581,13 @@ msgstr "Teléfono"
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
-msgid ""
-"Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el "
-"programa"
+msgid "Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el programa"
 msgstr "Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el programa"
+
+#. module: l10n_es_aeat
+#: selection:l10n.es.aeat.report,state:0
+msgid "Posted"
+msgstr "Contabilizado"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,previous_number:0
@@ -588,6 +608,12 @@ msgstr "Pulse el botón"
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 msgid "Recalculate"
 msgstr "Recalcular"
+
+#. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_report.py:319
+#, python-format
+msgid "Regularization"
+msgstr "Regularización"
 
 #. module: l10n_es_aeat
 #: field:aeat.model.export.config.line,repeat:0
@@ -622,16 +648,19 @@ msgid "Show journal items"
 msgstr "Mostrar apuntes contables"
 
 #. module: l10n_es_aeat
+#: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
+msgid "Show move"
+msgstr "Abrir asiento contable"
+
+#. module: l10n_es_aeat
 #: field:aeat.model.export.config.line,sign:0
 msgid "Sign character"
 msgstr "Carácter del signo"
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:163
+#: code:addons/l10n_es_aeat/models/aeat_report.py:185
 #, python-format
-msgid ""
-"Split fiscal years cannot be automatically handled. You should select "
-"manually the periods."
+msgid "Split fiscal years cannot be automatically handled. You should select manually the periods."
 msgstr "Los ejercicios fiscales separados no pueden ser gestionados automáticamente. Debe seleccionar manualmente los periodos."
 
 #. module: l10n_es_aeat
@@ -708,9 +737,24 @@ msgid "The formated string must match the given length"
 msgstr "La cadena formateada debe satisfacer el tamaño dado."
 
 #. module: l10n_es_aeat
+#: help:l10n.es.aeat.report,counterpart_account:0
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
+msgstr "Esta cuenta será la contrapartida para todos los apuntes que se regularicen cuando se contabilice la declaración."
+
+#. module: l10n_es_aeat
+#: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
+msgid "This button creates the regularization move for the selected report"
+msgstr "Este botón crea el asiento de regularización para la declaración seleccionada"
+
+#. module: l10n_es_aeat
 #: field:aeat.mod.map.tax.code,date_to:0
 msgid "To Date"
 msgstr "Hasta la fecha"
+
+#. module: l10n_es_aeat
+#: field:aeat.mod.map.tax.code.line,to_regularize:0
+msgid "To regularize"
+msgstr "A regularizar"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,company_vat:0
@@ -731,13 +775,19 @@ msgstr "Valor para el no"
 #. module: l10n_es_aeat
 #: field:aeat.model.export.config.line,bool_yes:0
 msgid "Value for yes"
-msgstr "Value para el sí"
+msgstr "Valor para el sí"
 
 #. module: l10n_es_aeat
 #: code:addons/l10n_es_aeat/wizard/export_to_boe.py:71
 #, python-format
 msgid "Wrong aling option. It should be < or >"
 msgstr "Opción de alineamiento errónea. Debería ser < o >"
+
+#. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_report.py:352
+#, python-format
+msgid "You must fill both journal and counterpart account."
+msgstr "Debe rellenar tanto el diario como la cuenta de contrapartida."
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
@@ -768,3 +818,4 @@ msgstr "o"
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
 msgid "para iniciar el proceso de exportación del archivo BOE de la AEAT."
 msgstr "para iniciar el proceso de exportación del archivo BOE de la AEAT."
+

--- a/l10n_es_aeat/i18n/l10n_es_aeat.pot
+++ b/l10n_es_aeat/i18n/l10n_es_aeat.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-10 07:45+0000\n"
-"PO-Revision-Date: 2015-07-10 07:45+0000\n"
+"POT-Creation-Date: 2015-09-15 14:39+0000\n"
+"PO-Revision-Date: 2015-09-15 14:39+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -72,6 +72,11 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.ui.menu,name:l10n_es_aeat.menu_root_aeat
 msgid "AEAT reports"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.report,move_id:0
+msgid "Account entry"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -201,6 +206,16 @@ msgstr ""
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 msgid "Contact data"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.report,counterpart_account:0
+msgid "Counterpart account"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
+msgid "Create move"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -410,9 +425,19 @@ msgid "Informativas"
 msgstr ""
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:196
+#: code:addons/l10n_es_aeat/models/aeat_report.py:225
 #, python-format
 msgid "It seems that you have defined quarterly periods or periods in the middle of the month. This cannot be automatically handled. You should select manually the periods."
+msgstr ""
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.report,journal_id:0
+msgid "Journal"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: help:l10n.es.aeat.report,journal_id:0
+msgid "Journal in which post the move."
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -524,7 +549,7 @@ msgid "Odoo model"
 msgstr ""
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:290
+#: code:addons/l10n_es_aeat/models/aeat_report.py:405
 #, python-format
 msgid "Only reports in 'draft' or 'cancelled' state can be removed"
 msgstr ""
@@ -560,6 +585,11 @@ msgid "Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en 
 msgstr ""
 
 #. module: l10n_es_aeat
+#: selection:l10n.es.aeat.report,state:0
+msgid "Posted"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,previous_number:0
 msgid "Previous declaration number"
 msgstr ""
@@ -577,6 +607,12 @@ msgstr ""
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 msgid "Recalculate"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_report.py:319
+#, python-format
+msgid "Regularization"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -612,12 +648,17 @@ msgid "Show journal items"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
+msgid "Show move"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: field:aeat.model.export.config.line,sign:0
 msgid "Sign character"
 msgstr ""
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:156
+#: code:addons/l10n_es_aeat/models/aeat_report.py:185
 #, python-format
 msgid "Split fiscal years cannot be automatically handled. You should select manually the periods."
 msgstr ""
@@ -696,8 +737,23 @@ msgid "The formated string must match the given length"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: help:l10n.es.aeat.report,counterpart_account:0
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
+msgstr ""
+
+#. module: l10n_es_aeat
+#: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
+msgid "This button creates the regularization move for the selected report"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: field:aeat.mod.map.tax.code,date_to:0
 msgid "To Date"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: field:aeat.mod.map.tax.code.line,to_regularize:0
+msgid "To regularize"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -725,6 +781,12 @@ msgstr ""
 #: code:addons/l10n_es_aeat/wizard/export_to_boe.py:71
 #, python-format
 msgid "Wrong aling option. It should be < or >"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_report.py:352
+#, python-format
+msgid "You must fill both journal and counterpart account."
 msgstr ""
 
 #. module: l10n_es_aeat

--- a/l10n_es_aeat/models/aeat_tax_code_mapping.py
+++ b/l10n_es_aeat/models/aeat_tax_code_mapping.py
@@ -80,6 +80,7 @@ class AeatModMapTaxCodeLine(models.Model):
         required=True)
     name = fields.Char(required=True)
     map_parent_id = fields.Many2one('aeat.mod.map.tax.code', required=True)
+    to_regularize = fields.Boolean()
 
     def get_taxes_amount(self, report, periods):
         tax_amount = 0

--- a/l10n_es_aeat/views/aeat_tax_code_mapping_view.xml
+++ b/l10n_es_aeat/views/aeat_tax_code_mapping_view.xml
@@ -37,6 +37,7 @@
                 <tree string="Tax code mapping lines" editable="bottom">
                     <field name="field_number"/>
                     <field name="name"/>
+                    <field name="to_regularize"/>
                     <field name="tax_codes" widget="many2many_tags"/>
                 </tree>
             </field>
@@ -51,6 +52,7 @@
                         <group>
                             <field name="name"/>
                             <field name="field_number"/>
+                            <field name="to_regularize"/>
                         </group>
                         <group>
                             <field name="tax_codes"/>

--- a/l10n_es_aeat/views/aeat_view.xml
+++ b/l10n_es_aeat/views/aeat_view.xml
@@ -28,10 +28,28 @@
                         <button name="button_confirm" string="Confirm" type="object" states="calculated" icon="gtk-ok"/>
                         <button name="%(action_wizard_aeat_export)d" type="action" string="Export to BOE" states="done" icon="gtk-execute"/>
                         <button name="button_recover" string="Draft" type="object" states="cancelled" icon="gtk-undo"/>
+                        <button name="button_open_move"
+                                string="Show move"
+                                type="object"
+                                states="posted"
+                                />
+                        <button name="button_post"
+                                string="Create move"
+                                help="This button creates the regularization move for the selected report"
+                                type="object"
+                                class="oe_highlight"
+                                attrs="{'invisible': ['|', ('state', '!=', 'done'), ('allow_posting', '=', False)]}"
+                                />
                         <button name="button_cancel" string="Cancel" type="object" states="calculated,done" icon="gtk-cancel"/>
-                        <field name="state" widget="statusbar"/>
+                        <button name="button_unpost" string="Cancel" type="object" states="posted" icon="gtk-cancel"/>
+                        <field name="state"
+                               widget="statusbar"
+                               statusbar_visible="draft,calculated,done,cancelled"
+                               statusbar_colors="{'cancelled': 'red', 'done': 'blue', 'posted': 'blue'}"
+                               />
                     </header>
                     <sheet>
+                        <field name="allow_posting" invisible="1"/>
                         <field name="number" invisible="1"/>
                         <field name="model" invisible="1"/>
                         <h1>
@@ -47,9 +65,16 @@
                                 <field name="fiscalyear_id"/>
                                 <field name="period_type"/>
                                 <field name="periods" widget="many2many_tags"/>
-                                <field name="export_config" />
+                                <field name="export_config"
+                                       groups="base.group_no_one"/>
                             </group>
                             <group>
+                                <field name="journal_id"
+                                       attrs="{'invisible': [('allow_posting', '=', False)]}"
+                                        />
+                                <field name="counterpart_account"
+                                       attrs="{'invisible': [('allow_posting', '=', False)]}"
+                                        />
                                 <field name="representative_vat"/>
                                 <field name="support_type"/>
                                 <field name="calculation_date" readonly="1"/>

--- a/l10n_es_aeat_mod303/__openerp__.py
+++ b/l10n_es_aeat_mod303/__openerp__.py
@@ -26,7 +26,7 @@
 
 {
     "name": "AEAT modelo 303",
-    "version": "1.1",
+    "version": "8.0.1.2.0",
     'category': "Accounting & Finance",
     'author': "Guadaltech,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_data.xml
@@ -2423,7 +2423,7 @@
 
         <!--  MAIN-303  -->
         <record id="aeat_mod303_main_export_config" model="aeat.model.export.config">
-            <field name="name">Exportación modelo 303 2014</field>
+            <field name="name">Exportación modelo 303 2014-actualidad</field>
             <field name="date_start">2014-01-01</field>
             <field name="model_number">303</field>
             <field name="model" ref="l10n_es_aeat_mod303.model_l10n_es_aeat_mod303_report"/>

--- a/l10n_es_aeat_mod303/data/tax_code_map_mod303_data.xml
+++ b/l10n_es_aeat_mod303/data/tax_code_map_mod303_data.xml
@@ -129,6 +129,7 @@
             <field name="tax_codes" eval="[(4, ref('l10n_es.account_tax_code_template_ITDC'))]"/>
             <field name="map_parent_id" ref="aeat_mod303_map"/>
             <field name="name">Total cuota devengada ([03]+[06]+[09]+[11]+[13]+[15]+[18]+[21]+[24]+[26])</field>
+            <field name="to_regularize" eval="True"/>
         </record>
         <record id="aeat_mod303_map_line_28" model="aeat.mod.map.tax.code.line">
             <field name="field_number">28</field>
@@ -237,6 +238,7 @@
             <field name="tax_codes" eval="[(4, ref('l10n_es.account_tax_code_template_ITADC'))]"/>
             <field name="map_parent_id" ref="aeat_mod303_map"/>
             <field name="name">Total a deducir ([29]+[31]+[33]+[35]+[37]+[39]+[41]+[42]+[43]+[44])</field>
+            <field name="to_regularize" eval="True"/>
         </record>
         <record id="aeat_mod303_map_line_59" model="aeat.mod.map.tax.code.line">
             <field name="field_number">59</field>


### PR DESCRIPTION
Este PR incluye la posibilidad genérica de hacer asientos de regularización en el módulo base de la AEAT. Se ha activado esa funcionalidad para el modelo 303, y se puede activar para otros como el 111/115, etc.

Además, se ha añadido la Agencia Tributaria como proveedor y se asigna en el asiento de regularización para que el total a pagar se cargue a esa empresa y luego pueda conciliarse vía el extracto bancario.
