### PR TITLE
[FIX] arreglado el problema a la hora de importar un archivo n43 de B…

### DIFF
--- a/l10n_es_account_bank_statement_import_n43/models/account_bank_statement_import_n43.py
+++ b/l10n_es_account_bank_statement_import_n43/models/account_bank_statement_import_n43.py
@@ -243,7 +243,7 @@ class AccountBankStatementImport(models.TransientModel):
         return partners and partners[0].id or False
 
     def _get_partner(self, line):
-        if not line.get('conceptos'):
+        if not line.get('conceptos') and line.get('conceptos') == "":
             return False
         partner_id = self._get_partner_from_caixabank(line['conceptos'])
         if partner_id:


### PR DESCRIPTION
Cuando se importaba un archivo n43 de bankinter generaba error porque la variable line.get('conceptos') no tenia un valor false pero si era vacía por lo tanto al intentar obtener posiciones que no existían fallaba. Se ha añadido la comprobación de que esa cadena no sea vacía, si es vacía la importación continua pero el partner de cada movimiento es vació al no poder obtenerlo.
