### PR TITLE
[IMP] Error si el cliente no tiene NIF/CIF

### DIFF
--- a/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
+++ b/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
@@ -90,8 +90,13 @@ class L10nEsAeatMod340CalculateRecords(orm.TransientModel):
                         raise orm.except_orm(
                             _('La siguiente empresa no tiene asignado nif:'),
                             invoice.partner_id.name)
-                country_code, nif = (re.match(r"([A-Z]{0,2})(.*)",
-                                              invoice.partner_id.vat).groups())
+                if invoice.partner_id.vat:
+                    country_code, nif = (
+                        re.match(r"([A-Z]{0,2})(.*)",
+                                 invoice.partner_id.vat).groups())
+                else:
+                    country_code = False
+                    nif = False
                 values = {
                     'mod340_id': mod340.id,
                     'partner_id': invoice.partner_id.id,


### PR DESCRIPTION
No entiendo esta condición que produce un error si el cliente NO tiene introducido CIF/NIF y el tipo de iva es distinto de 1, porque la ejecución continua y casca en la comparación del re.

Tal vez habría que avisar que es indispensable que el tipo de iva sea 1.
