### PR TITLE
[FIX] l10n_es_aeat_mod111 calcular Total liquidación

### DIFF
--- a/l10n_es_aeat_mod111/README.rst
+++ b/l10n_es_aeat_mod111/README.rst
@@ -20,6 +20,7 @@ Contribuidores
 * Carlos Sánchez Cifuentes <csanchez@grupovermon.com>
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * AvanzOSC (http://www.avanzosc.es)
+* Antonio Espinosa <antonioea@antiun.com>
 
 Maintainer
 ----------

--- a/l10n_es_aeat_mod111/__openerp__.py
+++ b/l10n_es_aeat_mod111/__openerp__.py
@@ -18,7 +18,7 @@
 
 {
     'name': 'AEAT modelo 111',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.1.0',
     'category': "Localisation/Accounting",
     'author': "AvanzOSC,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza,"

--- a/l10n_es_aeat_mod111/i18n/es.po
+++ b/l10n_es_aeat_mod111/i18n/es.po
@@ -1,23 +1,23 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat_mod111
-# 
+#	* l10n_es_aeat_mod111
+#
 # Translators:
 # Alejandro Santana <alejandrosantana@anubia.es>, 2015
 # Carles Antolí <carlesantoli@hotmail.com>, 2015
+# Antonio Espinosa <antonioea@antiun.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-spain (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-20 19:02+0000\n"
-"PO-Revision-Date: 2015-10-18 17:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/es/)\n"
+"POT-Creation-Date: 2015-11-03 11:08+0000\n"
+"PO-Revision-Date: 2015-11-03 11:08+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_aeat_mod111
 #: model:ir.model,name:l10n_es_aeat_mod111.model_l10n_es_aeat_mod111_report
@@ -40,154 +40,139 @@ msgid "Cancelled"
 msgstr "Cancelado"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_01:0
-msgid "Casilla [01]"
-msgstr "Casilla [01]"
+#: help:l10n.es.aeat.mod111.report,casilla_01:0
+msgid "Casilla [01]: Rendimientos del trabajo - Rendimientos dinerarios - Nº de perceptores"
+msgstr "Casilla [01]: Rendimientos del trabajo - Rendimientos dinerarios - Nº de perceptores"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_02:0
-msgid "Casilla [02]"
-msgstr "Casilla [02]"
+#: help:l10n.es.aeat.mod111.report,casilla_02:0
+msgid "Casilla [02]: Rendimientos del trabajo - Rendimientos dinerarios - Importe de las percepciones"
+msgstr "Casilla [02]: Rendimientos del trabajo - Rendimientos dinerarios - Importe de las percepciones"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_03:0
-msgid "Casilla [03]"
-msgstr "Casilla [03]"
+#: help:l10n.es.aeat.mod111.report,casilla_03:0
+msgid "Casilla [03]: Rendimientos del trabajo - Rendimientos dinerarios - Importe de las retenciones"
+msgstr "Casilla [03]: Rendimientos del trabajo - Rendimientos dinerarios - Importe de las retenciones"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_04:0
-msgid "Casilla [04]"
-msgstr "Casilla [04]"
+#: help:l10n.es.aeat.mod111.report,casilla_04:0
+msgid "Casilla [04]: Rendimientos del trabajo - Rendimientos en especie - Nº de perceptores"
+msgstr "Casilla [04]: Rendimientos del trabajo - Rendimientos en especie - Nº de perceptores"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_05:0
-msgid "Casilla [05]"
-msgstr "Casilla [05]"
+#: help:l10n.es.aeat.mod111.report,casilla_05:0
+msgid "Casilla [05]: Rendimientos del trabajo - Rendimientos en especie - Valor percepciones en especie"
+msgstr "Casilla [05]: Rendimientos del trabajo - Rendimientos en especie - Valor percepciones en especie"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_06:0
-msgid "Casilla [06]"
-msgstr "Casilla [06]"
+#: help:l10n.es.aeat.mod111.report,casilla_06:0
+msgid "Casilla [06]: Rendimientos del trabajo - Rendimientos en especie - Importe de los ingresos a cuenta"
+msgstr "Casilla [06]: Rendimientos del trabajo - Rendimientos en especie - Importe de los ingresos a cuenta"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_07:0
-msgid "Casilla [07]"
-msgstr "Casilla [07]"
+#: help:l10n.es.aeat.mod111.report,casilla_07:0
+msgid "Casilla [07]: Rendimientos de actividades económicas - Rendimientos dinerarios - Nº de perceptores"
+msgstr "Casilla [07]: Rendimientos de actividades económicas - Rendimientos dinerarios - Nº de perceptores"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_08:0
-msgid "Casilla [08]"
-msgstr "Casilla [08]"
+#: help:l10n.es.aeat.mod111.report,casilla_08:0
+msgid "Casilla [08]: Rendimientos de actividades económicas - Rendimientos dinerarios - Importe de las percepciones"
+msgstr "Casilla [08]: Rendimientos de actividades económicas - Rendimientos dinerarios - Importe de las percepciones"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_09:0
-msgid "Casilla [09]"
-msgstr "Casilla [09]"
+#: help:l10n.es.aeat.mod111.report,casilla_09:0
+msgid "Casilla [09]: Rendimientos de actividades económicas - Rendimientos dinerarios - Importe de las retenciones"
+msgstr "Casilla [09]: Rendimientos de actividades económicas - Rendimientos dinerarios - Importe de las retenciones"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_10:0
-msgid "Casilla [10]"
-msgstr "Casilla [10]"
+#: help:l10n.es.aeat.mod111.report,casilla_10:0
+msgid "Casilla [10]: Rendimientos de actividades económicas - Rendimientos en especie - Nº de perceptores"
+msgstr "Casilla [10]: Rendimientos de actividades económicas - Rendimientos en especie - Nº de perceptores"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_11:0
-msgid "Casilla [11]"
-msgstr "Casilla [11]"
+#: help:l10n.es.aeat.mod111.report,casilla_11:0
+msgid "Casilla [11]: Rendimientos de actividades económicas - Rendimientos en especie - Valor percepciones en especie"
+msgstr "Casilla [11]: Rendimientos de actividades económicas - Rendimientos en especie - Valor percepciones en especie"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_12:0
-msgid "Casilla [12]"
-msgstr "Casilla [12]"
+#: help:l10n.es.aeat.mod111.report,casilla_12:0
+msgid "Casilla [12]: Rendimientos de actividades económicas - Rendimientos en especie - Importe de los ingresos a cuenta"
+msgstr "Casilla [12]: Rendimientos de actividades económicas - Rendimientos en especie - Importe de los ingresos a cuenta"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_13:0
-msgid "Casilla [13]"
-msgstr "Casilla [13]"
+#: help:l10n.es.aeat.mod111.report,casilla_13:0
+msgid "Casilla [13]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en metálico - Nº de perceptores"
+msgstr "Casilla [13]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en metálico - Nº de perceptores"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_14:0
-msgid "Casilla [14]"
-msgstr "Casilla [14]"
+#: help:l10n.es.aeat.mod111.report,casilla_14:0
+msgid "Casilla [14]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en metálico - Importe de las percepciones"
+msgstr "Casilla [14]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en metálico - Importe de las percepciones"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_15:0
-msgid "Casilla [15]"
-msgstr "Casilla [15]"
+#: help:l10n.es.aeat.mod111.report,casilla_15:0
+msgid "Casilla [15]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en metálico - Importe de las retenciones"
+msgstr "Casilla [15]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en metálico - Importe de las retenciones"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_16:0
-msgid "Casilla [16]"
-msgstr "Casilla [16]"
+#: help:l10n.es.aeat.mod111.report,casilla_16:0
+msgid "Casilla [16]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en especie - Nº de perceptores"
+msgstr "Casilla [16]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en especie - Nº de perceptores"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_17:0
-msgid "Casilla [17]"
-msgstr "Casilla [17]"
+#: help:l10n.es.aeat.mod111.report,casilla_17:0
+msgid "Casilla [17]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en especie - Valor percepciones en especie"
+msgstr "Casilla [17]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en especie - Valor percepciones en especie"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_18:0
-msgid "Casilla [18]"
-msgstr "Casilla [18]"
+#: help:l10n.es.aeat.mod111.report,casilla_18:0
+msgid "Casilla [18]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en especie - Importe de los ingresos a cuenta"
+msgstr "Casilla [18]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en especie - Importe de los ingresos a cuenta"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_19:0
-msgid "Casilla [19]"
-msgstr "Casilla [19]"
+#: help:l10n.es.aeat.mod111.report,casilla_19:0
+msgid "Casilla [19]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones dinerarias - Nº de perceptores"
+msgstr "Casilla [19]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones dinerarias - Nº de perceptores"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_20:0
-msgid "Casilla [20]"
-msgstr "Casilla [20]"
+#: help:l10n.es.aeat.mod111.report,casilla_20:0
+msgid "Casilla [20]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones dinerarias - Importe de las percepciones"
+msgstr "Casilla [20]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones dinerarias - Importe de las percepciones"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_21:0
-msgid "Casilla [21]"
-msgstr "Casilla [21]"
+#: help:l10n.es.aeat.mod111.report,casilla_21:0
+msgid "Casilla [21]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones dinerarias - Importe de las retenciones"
+msgstr "Casilla [21]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones dinerarias - Importe de las retenciones"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_22:0
-msgid "Casilla [22]"
-msgstr "Casilla [22]"
+#: help:l10n.es.aeat.mod111.report,casilla_22:0
+msgid "Casilla [22]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones en especie - Nº de perceptores"
+msgstr "Casilla [22]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones en especie - Nº de perceptores"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_23:0
-msgid "Casilla [23]"
-msgstr "Casilla [23]"
+#: help:l10n.es.aeat.mod111.report,casilla_23:0
+msgid "Casilla [23]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones en especie - Valor percepciones en especie"
+msgstr "Casilla [23]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones en especie - Valor percepciones en especie"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_24:0
-msgid "Casilla [24]"
-msgstr "Casilla [24]"
+#: help:l10n.es.aeat.mod111.report,casilla_24:0
+msgid "Casilla [24]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones en especie - Importe de los ingresos a cuenta"
+msgstr "Casilla [24]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones en especie - Importe de los ingresos a cuenta"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_25:0
-msgid "Casilla [25]"
-msgstr "Casilla [25]"
+#: help:l10n.es.aeat.mod111.report,casilla_25:0
+msgid "Casilla [25]: Contraprestaciones por la cesión de derechos de imagen: ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Contraprestaciones dinerarias o en especie - Nº de perceptores"
+msgstr "Casilla [25]: Contraprestaciones por la cesión de derechos de imagen: ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Contraprestaciones dinerarias o en especie - Nº de perceptores"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_26:0
-msgid "Casilla [26]"
-msgstr "Casilla [26]"
+#: help:l10n.es.aeat.mod111.report,casilla_26:0
+msgid "Casilla [26]: Contraprestaciones por la cesión de derechos de imagen: ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Contraprestaciones dinerarias o en especie - Contraprestaciones satisfechas"
+msgstr "Casilla [26]: Contraprestaciones por la cesión de derechos de imagen: ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Contraprestaciones dinerarias o en especie - Contraprestaciones satisfechas"
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_27:0
-msgid "Casilla [27]"
-msgstr "Casilla [27]"
-
-#. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_28:0
-msgid "Casilla [28]"
-msgstr "Casilla [28]"
-
-#. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_29:0
-msgid "Casilla [29]"
-msgstr "Casilla [29]"
-
-#. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_30:0
-msgid "Casilla [30]"
-msgstr "Casilla [30]"
+#: help:l10n.es.aeat.mod111.report,casilla_27:0
+msgid "Casilla [27]: Contraprestaciones por la cesión de derechos de imagen: ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Contraprestaciones dinerarias o en especie - Importe de los ingresos a cuenta"
+msgstr "Casilla [27]: Contraprestaciones por la cesión de derechos de imagen: ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Contraprestaciones dinerarias o en especie - Importe de los ingresos a cuenta"
 
 #. module: l10n_es_aeat_mod111
 #: field:l10n.es.aeat.mod111.report,colegio_concertado:0
@@ -208,21 +193,6 @@ msgstr "Complementaria"
 #: view:l10n.es.aeat.mod111.report:l10n_es_aeat_mod111.view_l10n_es_aeat_mod111_report_form
 msgid "Contraprest. cesión dchos. imagen"
 msgstr "Contraprest. cesión dchos. imagen"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_26:0
-msgid "Contraprest. cesión dchos. imagen - Contraprestaciones satisfechas"
-msgstr "Contraprest. cesión dchos. imagen - Contraprestaciones satisfechas"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_27:0
-msgid "Contraprest. cesión dchos. imagen - Importe de los ingresos a cuenta"
-msgstr "Contraprest. cesión dchos. imagen - Importe de los ingresos a cuenta"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_25:0
-msgid "Contraprest. cesión dchos. imagen - Nº de perceptores"
-msgstr "Contraprest. cesión dchos. imagen - Nº de perceptores"
 
 #. module: l10n_es_aeat_mod111
 #: field:l10n.es.aeat.mod111.report,counterpart_account:0
@@ -253,10 +223,7 @@ msgstr "Código electrónico"
 
 #. module: l10n_es_aeat_mod111
 #: help:l10n.es.aeat.mod111.report,codigo_electronico_anterior:0
-msgid ""
-"Código electrónico de la declaración anterior (si se presentó "
-"telemáticamente). A cumplimentar sólo en el caso de declaración "
-"complementaria."
+msgid "Código electrónico de la declaración anterior (si se presentó telemáticamente). A cumplimentar sólo en el caso de declaración complementaria."
 msgstr "Código electrónico de la declaración anterior (si se presentó telemáticamente). A cumplimentar sólo en el caso de declaración complementaria."
 
 #. module: l10n_es_aeat_mod111
@@ -338,48 +305,6 @@ msgstr "Nombre completo"
 #: view:l10n.es.aeat.mod111.report:l10n_es_aeat_mod111.view_l10n_es_aeat_mod111_report_form
 msgid "Ganancias patrim. Aprovecham. Forestales"
 msgstr "Ganancias patrim. Aprovecham. Forestales"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_20:0
-msgid ""
-"Ganancias patrim. Aprovecham. Forestales - Percep. dinerarias - Importe "
-"percepciones"
-msgstr "Ganancias patrim. Aprovecham. Forestales - Percep. dinerarias - Importe percepciones"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_21:0
-msgid ""
-"Ganancias patrim. Aprovecham. Forestales - Percep. dinerarias - Importe "
-"retenciones"
-msgstr "Ganancias patrim. Aprovecham. Forestales - Percep. dinerarias - Importe retenciones"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_19:0
-msgid ""
-"Ganancias patrim. Aprovecham. Forestales - Percep. dinerarias - Nº "
-"perceptores"
-msgstr "Ganancias patrim. Aprovecham. Forestales - Percep. dinerarias - Nº perceptores"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_24:0
-msgid ""
-"Ganancias patrim. Aprovecham. Forestales - Percep. en especie - Importe "
-"ingresos a cuenta"
-msgstr "Ganancias patrim. Aprovecham. Forestales - Percep. en especie - Importe ingresos a cuenta"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_23:0
-msgid ""
-"Ganancias patrim. Aprovecham. Forestales - Percep. en especie - Importe "
-"percepciones"
-msgstr "Ganancias patrim. Aprovecham. Forestales - Percep. en especie - Importe percepciones"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_22:0
-msgid ""
-"Ganancias patrim. Aprovecham. Forestales - Percep. en especie - Nº "
-"perceptores"
-msgstr "Ganancias patrim. Aprovecham. Forestales - Percep. en especie - Nº perceptores"
 
 #. module: l10n_es_aeat_mod111
 #: field:l10n.es.aeat.mod111.export_to_boe,id:0
@@ -505,36 +430,6 @@ msgid "Premios"
 msgstr "Premios"
 
 #. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_14:0
-msgid "Premios - Premios dinerarios - Importe de las percepciones"
-msgstr "Premios - Premios dinerarios - Importe de las percepciones"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_15:0
-msgid "Premios - Premios dinerarios - Importe de las retenciones"
-msgstr "Premios - Premios dinerarios - Importe de las retenciones"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_13:0
-msgid "Premios - Premios dinerarios - Nº de perceptores"
-msgstr "Premios - Premios dinerarios - Nº de perceptores"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_17:0
-msgid "Premios - Premios en especie - Importe de las percepciones"
-msgstr "Premios - Premios en especie - Importe de las percepciones"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_18:0
-msgid "Premios - Premios en especie - Importe de los ingresos a cuenta"
-msgstr "Premios - Premios en especie - Importe de los ingresos a cuenta"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_16:0
-msgid "Premios - Premios en especie - Nº de perceptores"
-msgstr "Premios - Premios en especie - Nº de perceptores"
-
-#. module: l10n_es_aeat_mod111
 #: view:l10n.es.aeat.mod111.report:l10n_es_aeat_mod111.view_l10n_es_aeat_mod111_report_form
 msgid "Premios dinerarios:"
 msgstr "Premios dinerarios:"
@@ -560,82 +455,9 @@ msgid "Rendim. actividades económicas"
 msgstr "Rendim. actividades económicas"
 
 #. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_08:0
-msgid ""
-"Rendim. actividades económicas - Rendimientos dinerarios - Importe "
-"percepciones"
-msgstr "Rendim. actividades económicas - Rendimientos dinerarios - Importe percepciones"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_09:0
-msgid ""
-"Rendim. actividades económicas - Rendimientos dinerarios - Importe "
-"retenciones"
-msgstr "Rendim. actividades económicas - Rendimientos dinerarios - Importe retenciones"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_07:0
-msgid ""
-"Rendim. actividades económicas - Rendimientos dinerarios - Nº de perceptores"
-msgstr "Rendim. actividades económicas - Rendimientos dinerarios - Nº de perceptores"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_12:0
-msgid ""
-"Rendim. actividades económicas - Rendimientos en especie - Importe de los "
-"ingresos en cuenta"
-msgstr "Rendim. actividades económicas - Rendimientos en especie - Importe de los ingresos en cuenta"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_10:0
-msgid ""
-"Rendim. actividades económicas - Rendimientos en especie - Nº de perceptores"
-msgstr "Rendim. actividades económicas - Rendimientos en especie - Nº de perceptores"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_11:0
-msgid ""
-"Rendim. actividades económicas - Rendimientos en especie - Valor "
-"percepciones en especie"
-msgstr "Rendim. actividades económicas - Rendimientos en especie - Valor percepciones en especie"
-
-#. module: l10n_es_aeat_mod111
 #: view:l10n.es.aeat.mod111.report:l10n_es_aeat_mod111.view_l10n_es_aeat_mod111_report_form
 msgid "Rendim. del trabajo"
 msgstr "Rendim. del trabajo"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_02:0
-msgid "Rendim. del trabajo - Rendimientos dinerarios - Importe percepciones"
-msgstr "Rendim. del trabajo - Rendimientos dinerarios - Importe percepciones"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_03:0
-msgid "Rendim. del trabajo - Rendimientos dinerarios - Importe retenciones"
-msgstr "Rendim. del trabajo - Rendimientos dinerarios - Importe retenciones"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_01:0
-msgid "Rendim. del trabajo - Rendimientos dinerarios - Nº de perceptores"
-msgstr "Rendim. del trabajo - Rendimientos dinerarios - Nº de perceptores"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_06:0
-msgid ""
-"Rendim. del trabajo - Rendimientos en especie - Importe ingresos en cuenta"
-msgstr "Rendim. del trabajo - Rendimientos en especie - Importe ingresos en cuenta"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_04:0
-msgid "Rendim. del trabajo - Rendimientos en especie - Nº de perceptores"
-msgstr "Rendim. del trabajo - Rendimientos en especie - Nº de perceptores"
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_05:0
-msgid ""
-"Rendim. del trabajo - Rendimientos en especie - Valor percepciones en "
-"especie"
-msgstr "Rendim. del trabajo - Rendimientos en especie - Valor percepciones en especie"
 
 #. module: l10n_es_aeat_mod111
 #: view:l10n.es.aeat.mod111.report:l10n_es_aeat_mod111.view_l10n_es_aeat_mod111_report_form
@@ -665,9 +487,7 @@ msgstr "Secuencia"
 #. module: l10n_es_aeat_mod111
 #: code:addons/l10n_es_aeat_mod111/models/mod111.py:190
 #, python-format
-msgid ""
-"Si se marca la casilla de liquidación complementaria, debe rellenar el "
-"código electrónico o el número de justificante de la declaración anterior."
+msgid "Si se marca la casilla de liquidación complementaria, debe rellenar el código electrónico o el número de justificante de la declaración anterior."
 msgstr "Si se marca la casilla de liquidación complementaria, debe rellenar el código electrónico o el número de justificante de la declaración anterior."
 
 #. module: l10n_es_aeat_mod111
@@ -703,9 +523,7 @@ msgstr "Telemático"
 
 #. module: l10n_es_aeat_mod111
 #: help:l10n.es.aeat.mod111.report,counterpart_account:0
-msgid ""
-"This account will be the counterpart for all the journal items that are "
-"regularized when posting the report."
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
 msgstr "Esta cuenta será la contrapartida para todos los elementos del diario que están regularizados al contabilizar el informe."
 
 #. module: l10n_es_aeat_mod111
@@ -719,24 +537,174 @@ msgid "Total liquidación"
 msgstr "Total liquidación"
 
 #. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_30:0
-msgid "Total liquidación - Resultado a ingresar"
-msgstr "Total liquidación - Resultado a ingresar"
+#: help:l10n.es.aeat.mod111.report,casilla_29:0
+msgid "Total liquidación - A deducir (exclusivamente en caso de autoliquidación complementaria): Resultados a ingresar de anteriores autoliquidaciones por el mismo concepto, ejercicio y período"
+msgstr "Total liquidación - A deducir (exclusivamente en caso de autoliquidación complementaria): Resultados a ingresar de anteriores autoliquidaciones por el mismo concepto, ejercicio y período"
 
 #. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_29:0
-msgid "Total liquidación - Resultado de anteriores declaraciones"
-msgstr "Total liquidación - Resultado de anteriores declaraciones"
+#: help:l10n.es.aeat.mod111.report,casilla_30:0
+msgid "Total liquidación - Resultado a ingresar: ([28] - [29])"
+msgstr "Total liquidación - Resultado a ingresar: ([28] - [29])"
 
 #. module: l10n_es_aeat_mod111
 #: help:l10n.es.aeat.mod111.report,casilla_28:0
-msgid "Total liquidación - Suma retencones e ingresos a cuenta"
-msgstr "Total liquidación - Suma retencones e ingresos a cuenta"
+msgid "Total liquidación - Suma de retenciones e ingresos a cuenta: ([03] + [06] + [09] + [12] + [15] + [18] + [21] + [24] + [27])"
+msgstr "Total liquidación - Suma de retenciones e ingresos a cuenta: ([03] + [06] + [09] + [12] + [15] + [18] + [21] + [24] + [27])"
 
 #. module: l10n_es_aeat_mod111
 #: field:l10n.es.aeat.mod111.report,company_vat:0
 msgid "VAT number"
 msgstr "NIF"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_01:0
+msgid "[01] Nº de perceptores"
+msgstr "[01] Nº de perceptores"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_02:0
+msgid "[02] Importe de las percepciones"
+msgstr "[02] Importe de las percepciones"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_03:0
+msgid "[03] Importe de las retenciones"
+msgstr "[03] Importe de las retenciones"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_04:0
+msgid "[04] Nº de perceptores"
+msgstr "[04] Nº de perceptores"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_05:0
+msgid "[05] Valor percepciones en especie"
+msgstr "[05] Valor percepciones en especie"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_06:0
+msgid "[06] Importe de los ingresos a cuenta"
+msgstr "[06] Importe de los ingresos a cuenta"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_07:0
+msgid "[07] Nº de perceptores"
+msgstr "[07] Nº de perceptores"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_08:0
+msgid "[08] Importe de las percepciones"
+msgstr "[08] Importe de las percepciones"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_09:0
+msgid "[09] Importe de las retenciones"
+msgstr "[09] Importe de las retenciones"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_10:0
+msgid "[10] Nº de perceptores "
+msgstr "[10] Nº de perceptores "
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_11:0
+msgid "[11] Valor percepciones en especie"
+msgstr "[11] Valor percepciones en especie"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_12:0
+msgid "[12] Importe de los ingresos a cuenta"
+msgstr "[12] Importe de los ingresos a cuenta"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_13:0
+msgid "[13] Nº de perceptores"
+msgstr "[13] Nº de perceptores"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_14:0
+msgid "[14] Importe de las percepciones"
+msgstr "[14] Importe de las percepciones"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_15:0
+msgid "[15] Importe de las retenciones"
+msgstr "[15] Importe de las retenciones"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_16:0
+msgid "[16] Nº de perceptores"
+msgstr "[16] Nº de perceptores"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_17:0
+msgid "[17] Valor percepciones en especie"
+msgstr "[17] Valor percepciones en especie"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_18:0
+msgid "[18] Importe de los ingresos a cuenta"
+msgstr "[18] Importe de los ingresos a cuenta"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_19:0
+msgid "[19] Nº de perceptores"
+msgstr "[19] Nº de perceptores"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_20:0
+msgid "[20] Importe de las percepciones"
+msgstr "[20] Importe de las percepciones"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_21:0
+msgid "[21] Importe de las retenciones"
+msgstr "[21] Importe de las retenciones"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_22:0
+msgid "[22] Nº de perceptores"
+msgstr "[22] Nº de perceptores"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_23:0
+msgid "[23] Valor percepciones en especie"
+msgstr "[23] Valor percepciones en especie"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_24:0
+msgid "[24] Importe de los ingresos a cuenta"
+msgstr "[24] Importe de los ingresos a cuenta"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_25:0
+msgid "[25] Nº de perceptores"
+msgstr "[25] Nº de perceptores"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_26:0
+msgid "[26] Contraprestaciones satisfechas"
+msgstr "[26] Contraprestaciones satisfechas"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_27:0
+msgid "[27] Importe de los ingresos a cuenta"
+msgstr "[27] Importe de los ingresos a cuenta"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_28:0
+msgid "[28] Suma de retenciones"
+msgstr "[28] Suma de retenciones"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_29:0
+msgid "[29] Resultados a ingresar anteriores"
+msgstr "[29] Resultados a ingresar anteriores"
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_30:0
+msgid "[30] Resultado a ingresar"
+msgstr "[30] Resultado a ingresar"
 
 #. module: l10n_es_aeat_mod111
 #: selection:l10n.es.aeat.mod111.export_to_boe,state:0
@@ -752,3 +720,4 @@ msgstr "abierto"
 #: view:l10n.es.aeat.mod111.report:l10n_es_aeat_mod111.view_l10n_es_aeat_mod111_report_form
 msgid "{'invisible': [('type','==','N')]}"
 msgstr "{'invisible': [('type','==','N')]}"
+

--- a/l10n_es_aeat_mod111/i18n/l10n_es_aeat_mod111.pot
+++ b/l10n_es_aeat_mod111/i18n/l10n_es_aeat_mod111.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-25 21:59+0000\n"
-"PO-Revision-Date: 2015-06-25 21:59+0000\n"
+"POT-Creation-Date: 2015-11-03 11:08+0000\n"
+"PO-Revision-Date: 2015-11-03 11:08+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,6 +21,11 @@ msgid "AEAT 111 report"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,move_id:0
+msgid "Account entry"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
 #: field:l10n.es.aeat.mod111.report,calculation_date:0
 msgid "Calculation date"
 msgstr ""
@@ -31,153 +36,138 @@ msgid "Cancelled"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_01:0
-msgid "Casilla [01]"
+#: help:l10n.es.aeat.mod111.report,casilla_01:0
+msgid "Casilla [01]: Rendimientos del trabajo - Rendimientos dinerarios - Nº de perceptores"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_02:0
-msgid "Casilla [02]"
+#: help:l10n.es.aeat.mod111.report,casilla_02:0
+msgid "Casilla [02]: Rendimientos del trabajo - Rendimientos dinerarios - Importe de las percepciones"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_03:0
-msgid "Casilla [03]"
+#: help:l10n.es.aeat.mod111.report,casilla_03:0
+msgid "Casilla [03]: Rendimientos del trabajo - Rendimientos dinerarios - Importe de las retenciones"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_04:0
-msgid "Casilla [04]"
+#: help:l10n.es.aeat.mod111.report,casilla_04:0
+msgid "Casilla [04]: Rendimientos del trabajo - Rendimientos en especie - Nº de perceptores"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_05:0
-msgid "Casilla [05]"
+#: help:l10n.es.aeat.mod111.report,casilla_05:0
+msgid "Casilla [05]: Rendimientos del trabajo - Rendimientos en especie - Valor percepciones en especie"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_06:0
-msgid "Casilla [06]"
+#: help:l10n.es.aeat.mod111.report,casilla_06:0
+msgid "Casilla [06]: Rendimientos del trabajo - Rendimientos en especie - Importe de los ingresos a cuenta"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_07:0
-msgid "Casilla [07]"
+#: help:l10n.es.aeat.mod111.report,casilla_07:0
+msgid "Casilla [07]: Rendimientos de actividades económicas - Rendimientos dinerarios - Nº de perceptores"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_08:0
-msgid "Casilla [08]"
+#: help:l10n.es.aeat.mod111.report,casilla_08:0
+msgid "Casilla [08]: Rendimientos de actividades económicas - Rendimientos dinerarios - Importe de las percepciones"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_09:0
-msgid "Casilla [09]"
+#: help:l10n.es.aeat.mod111.report,casilla_09:0
+msgid "Casilla [09]: Rendimientos de actividades económicas - Rendimientos dinerarios - Importe de las retenciones"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_10:0
-msgid "Casilla [10]"
+#: help:l10n.es.aeat.mod111.report,casilla_10:0
+msgid "Casilla [10]: Rendimientos de actividades económicas - Rendimientos en especie - Nº de perceptores"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_11:0
-msgid "Casilla [11]"
+#: help:l10n.es.aeat.mod111.report,casilla_11:0
+msgid "Casilla [11]: Rendimientos de actividades económicas - Rendimientos en especie - Valor percepciones en especie"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_12:0
-msgid "Casilla [12]"
+#: help:l10n.es.aeat.mod111.report,casilla_12:0
+msgid "Casilla [12]: Rendimientos de actividades económicas - Rendimientos en especie - Importe de los ingresos a cuenta"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_13:0
-msgid "Casilla [13]"
+#: help:l10n.es.aeat.mod111.report,casilla_13:0
+msgid "Casilla [13]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en metálico - Nº de perceptores"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_14:0
-msgid "Casilla [14]"
+#: help:l10n.es.aeat.mod111.report,casilla_14:0
+msgid "Casilla [14]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en metálico - Importe de las percepciones"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_15:0
-msgid "Casilla [15]"
+#: help:l10n.es.aeat.mod111.report,casilla_15:0
+msgid "Casilla [15]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en metálico - Importe de las retenciones"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_16:0
-msgid "Casilla [16]"
+#: help:l10n.es.aeat.mod111.report,casilla_16:0
+msgid "Casilla [16]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en especie - Nº de perceptores"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_17:0
-msgid "Casilla [17]"
+#: help:l10n.es.aeat.mod111.report,casilla_17:0
+msgid "Casilla [17]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en especie - Valor percepciones en especie"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_18:0
-msgid "Casilla [18]"
+#: help:l10n.es.aeat.mod111.report,casilla_18:0
+msgid "Casilla [18]: Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Premios en especie - Importe de los ingresos a cuenta"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_19:0
-msgid "Casilla [19]"
+#: help:l10n.es.aeat.mod111.report,casilla_19:0
+msgid "Casilla [19]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones dinerarias - Nº de perceptores"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_20:0
-msgid "Casilla [20]"
+#: help:l10n.es.aeat.mod111.report,casilla_20:0
+msgid "Casilla [20]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones dinerarias - Importe de las percepciones"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_21:0
-msgid "Casilla [21]"
+#: help:l10n.es.aeat.mod111.report,casilla_21:0
+msgid "Casilla [21]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones dinerarias - Importe de las retenciones"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_22:0
-msgid "Casilla [22]"
+#: help:l10n.es.aeat.mod111.report,casilla_22:0
+msgid "Casilla [22]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones en especie - Nº de perceptores"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_23:0
-msgid "Casilla [23]"
+#: help:l10n.es.aeat.mod111.report,casilla_23:0
+msgid "Casilla [23]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones en especie - Valor percepciones en especie"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_24:0
-msgid "Casilla [24]"
+#: help:l10n.es.aeat.mod111.report,casilla_24:0
+msgid "Casilla [24]: Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en montes públicos - Percepciones en especie - Importe de los ingresos a cuenta"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_25:0
-msgid "Casilla [25]"
+#: help:l10n.es.aeat.mod111.report,casilla_25:0
+msgid "Casilla [25]: Contraprestaciones por la cesión de derechos de imagen: ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Contraprestaciones dinerarias o en especie - Nº de perceptores"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_26:0
-msgid "Casilla [26]"
+#: help:l10n.es.aeat.mod111.report,casilla_26:0
+msgid "Casilla [26]: Contraprestaciones por la cesión de derechos de imagen: ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Contraprestaciones dinerarias o en especie - Contraprestaciones satisfechas"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_27:0
-msgid "Casilla [27]"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_28:0
-msgid "Casilla [28]"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_29:0
-msgid "Casilla [29]"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,casilla_30:0
-msgid "Casilla [30]"
+#: help:l10n.es.aeat.mod111.report,casilla_27:0
+msgid "Casilla [27]: Contraprestaciones por la cesión de derechos de imagen: ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Contraprestaciones dinerarias o en especie - Importe de los ingresos a cuenta"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
@@ -201,18 +191,8 @@ msgid "Contraprest. cesión dchos. imagen"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_26:0
-msgid "Contraprest. cesión dchos. imagen - Contraprestaciones satisfechas"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_27:0
-msgid "Contraprest. cesión dchos. imagen - Importe de los ingresos a cuenta"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_25:0
-msgid "Contraprest. cesión dchos. imagen - Nº de perceptores"
+#: field:l10n.es.aeat.mod111.report,counterpart_account:0
+msgid "Counterpart account"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
@@ -323,36 +303,6 @@ msgid "Ganancias patrim. Aprovecham. Forestales"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_20:0
-msgid "Ganancias patrim. Aprovecham. Forestales - Percep. dinerarias - Importe percepciones"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_21:0
-msgid "Ganancias patrim. Aprovecham. Forestales - Percep. dinerarias - Importe retenciones"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_19:0
-msgid "Ganancias patrim. Aprovecham. Forestales - Percep. dinerarias - Nº perceptores"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_24:0
-msgid "Ganancias patrim. Aprovecham. Forestales - Percep. en especie - Importe ingresos a cuenta"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_23:0
-msgid "Ganancias patrim. Aprovecham. Forestales - Percep. en especie - Importe percepciones"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_22:0
-msgid "Ganancias patrim. Aprovecham. Forestales - Percep. en especie - Nº perceptores"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
 #: field:l10n.es.aeat.mod111.export_to_boe,id:0
 #: field:l10n.es.aeat.mod111.report,id:0
 msgid "ID"
@@ -366,6 +316,16 @@ msgstr ""
 #. module: l10n_es_aeat_mod111
 #: selection:l10n.es.aeat.mod111.report,tipo_declaracion:0
 msgid "Ingreso a anotar en CCT"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,journal_id:0
+msgid "Journal"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: help:l10n.es.aeat.mod111.report,journal_id:0
+msgid "Journal in which post the move."
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
@@ -441,8 +401,13 @@ msgid "Percep.dinerarias:"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: field:l10n.es.aeat.mod111.report,period_id:0
-msgid "Periodo"
+#: field:l10n.es.aeat.mod111.report,period_type:0
+msgid "Period type"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,periods:0
+msgid "Period(s)"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
@@ -451,38 +416,13 @@ msgid "Phone"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
+#: selection:l10n.es.aeat.mod111.report,state:0
+msgid "Posted"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
 #: view:l10n.es.aeat.mod111.report:l10n_es_aeat_mod111.view_l10n_es_aeat_mod111_report_form
 msgid "Premios"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_14:0
-msgid "Premios - Premios dinerarios - Importe de las percepciones"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_15:0
-msgid "Premios - Premios dinerarios - Importe de las retenciones"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_13:0
-msgid "Premios - Premios dinerarios - Nº de perceptores"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_17:0
-msgid "Premios - Premios en especie - Importe de las percepciones"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_18:0
-msgid "Premios - Premios en especie - Importe de los ingresos a cuenta"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_16:0
-msgid "Premios - Premios en especie - Nº de perceptores"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
@@ -511,68 +451,8 @@ msgid "Rendim. actividades económicas"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_08:0
-msgid "Rendim. actividades económicas - Rendimientos dinerarios - Importe percepciones"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_09:0
-msgid "Rendim. actividades económicas - Rendimientos dinerarios - Importe retenciones"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_07:0
-msgid "Rendim. actividades económicas - Rendimientos dinerarios - Nº de perceptores"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_12:0
-msgid "Rendim. actividades económicas - Rendimientos en especie - Importe de los ingresos en cuenta"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_10:0
-msgid "Rendim. actividades económicas - Rendimientos en especie - Nº de perceptores"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_11:0
-msgid "Rendim. actividades económicas - Rendimientos en especie - Valor percepciones en especie"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
 #: view:l10n.es.aeat.mod111.report:l10n_es_aeat_mod111.view_l10n_es_aeat_mod111_report_form
 msgid "Rendim. del trabajo"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_02:0
-msgid "Rendim. del trabajo - Rendimientos dinerarios - Importe percepciones"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_03:0
-msgid "Rendim. del trabajo - Rendimientos dinerarios - Importe retenciones"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_01:0
-msgid "Rendim. del trabajo - Rendimientos dinerarios - Nº de perceptores"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_06:0
-msgid "Rendim. del trabajo - Rendimientos en especie - Importe ingresos en cuenta"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_04:0
-msgid "Rendim. del trabajo - Rendimientos en especie - Nº de perceptores"
-msgstr ""
-
-#. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_05:0
-msgid "Rendim. del trabajo - Rendimientos en especie - Valor percepciones en especie"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
@@ -601,7 +481,7 @@ msgid "Sequence"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: code:addons/l10n_es_aeat_mod111/models/mod111.py:193
+#: code:addons/l10n_es_aeat_mod111/models/mod111.py:235
 #, python-format
 msgid "Si se marca la casilla de liquidación complementaria, debe rellenar el código electrónico o el número de justificante de la declaración anterior."
 msgstr ""
@@ -628,8 +508,18 @@ msgid "Support Type"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,tax_lines:0
+msgid "Tax lines"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
 #: selection:l10n.es.aeat.mod111.report,support_type:0
 msgid "Telematics"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: help:l10n.es.aeat.mod111.report,counterpart_account:0
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
@@ -643,22 +533,187 @@ msgid "Total liquidación"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_30:0
-msgid "Total liquidación - Resultado a ingresar"
+#: help:l10n.es.aeat.mod111.report,casilla_29:0
+msgid "Total liquidación - A deducir (exclusivamente en caso de autoliquidación complementaria): Resultados a ingresar de anteriores autoliquidaciones por el mismo concepto, ejercicio y período"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
-#: help:l10n.es.aeat.mod111.report,casilla_29:0
-msgid "Total liquidación - Resultado de anteriores declaraciones"
+#: help:l10n.es.aeat.mod111.report,casilla_30:0
+msgid "Total liquidación - Resultado a ingresar: ([28] - [29])"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
 #: help:l10n.es.aeat.mod111.report,casilla_28:0
-msgid "Total liquidación - Suma retencones e ingresos a cuenta"
+msgid "Total liquidación - Suma de retenciones e ingresos a cuenta: ([03] + [06] + [09] + [12] + [15] + [18] + [21] + [24] + [27])"
 msgstr ""
 
 #. module: l10n_es_aeat_mod111
 #: field:l10n.es.aeat.mod111.report,company_vat:0
 msgid "VAT number"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_01:0
+msgid "[01] Nº de perceptores"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_02:0
+msgid "[02] Importe de las percepciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_03:0
+msgid "[03] Importe de las retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_04:0
+msgid "[04] Nº de perceptores"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_05:0
+msgid "[05] Valor percepciones en especie"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_06:0
+msgid "[06] Importe de los ingresos a cuenta"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_07:0
+msgid "[07] Nº de perceptores"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_08:0
+msgid "[08] Importe de las percepciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_09:0
+msgid "[09] Importe de las retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_10:0
+msgid "[10] Nº de perceptores "
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_11:0
+msgid "[11] Valor percepciones en especie"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_12:0
+msgid "[12] Importe de los ingresos a cuenta"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_13:0
+msgid "[13] Nº de perceptores"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_14:0
+msgid "[14] Importe de las percepciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_15:0
+msgid "[15] Importe de las retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_16:0
+msgid "[16] Nº de perceptores"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_17:0
+msgid "[17] Valor percepciones en especie"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_18:0
+msgid "[18] Importe de los ingresos a cuenta"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_19:0
+msgid "[19] Nº de perceptores"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_20:0
+msgid "[20] Importe de las percepciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_21:0
+msgid "[21] Importe de las retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_22:0
+msgid "[22] Nº de perceptores"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_23:0
+msgid "[23] Valor percepciones en especie"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_24:0
+msgid "[24] Importe de los ingresos a cuenta"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_25:0
+msgid "[25] Nº de perceptores"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_26:0
+msgid "[26] Contraprestaciones satisfechas"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_27:0
+msgid "[27] Importe de los ingresos a cuenta"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_28:0
+msgid "[28] Suma de retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_29:0
+msgid "[29] Resultados a ingresar anteriores"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: field:l10n.es.aeat.mod111.report,casilla_30:0
+msgid "[30] Resultado a ingresar"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: selection:l10n.es.aeat.mod111.export_to_boe,state:0
+msgid "get"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: selection:l10n.es.aeat.mod111.export_to_boe,state:0
+msgid "open"
+msgstr ""
+
+#. module: l10n_es_aeat_mod111
+#: view:l10n.es.aeat.mod111.report:l10n_es_aeat_mod111.view_l10n_es_aeat_mod111_report_form
+msgid "{'invisible': [('type','==','N')]}"
 msgstr ""
 

--- a/l10n_es_aeat_mod111/models/mod111.py
+++ b/l10n_es_aeat_mod111/models/mod111.py
@@ -28,128 +28,173 @@ class L10nEsAeatMod111Report(models.Model):
     _name = 'l10n.es.aeat.mod111.report'
 
     number = fields.Char(default='111')
-    casilla_01 = fields.Integer('Casilla [01]', readonly=True,
-                                states={'calculated': [('readonly', False)]},
-                                help='Rendim. del trabajo - Rendimientos '
-                                'dinerarios - Nº de perceptores')
-    casilla_02 = fields.Float('Casilla [02]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Rendim. del trabajo - Rendimientos '
-                              'dinerarios - Importe percepciones')
-    casilla_03 = fields.Float('Casilla [03]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Rendim. del trabajo - Rendimientos '
-                              'dinerarios - Importe retenciones')
-    casilla_04 = fields.Integer('Casilla [04]', readonly=True,
-                                states={'calculated': [('readonly', False)]},
-                                help='Rendim. del trabajo - Rendimientos '
-                                'en especie - Nº de perceptores')
-    casilla_05 = fields.Float('Casilla [05]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Rendim. del trabajo - Rendimientos '
-                              'en especie - Valor percepciones en especie')
-    casilla_06 = fields.Float('Casilla [06]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Rendim. del trabajo - Rendimientos '
-                              'en especie - Importe ingresos en cuenta')
-    casilla_07 = fields.Integer('Casilla [07]', readonly=True,
-                                states={'calculated': [('readonly', False)]},
-                                help='Rendim. actividades económicas - '
-                                'Rendimientos dinerarios - Nº de perceptores')
-    casilla_08 = fields.Float('Casilla [08]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Rendim. actividades económicas - '
-                              'Rendimientos dinerarios - Importe percepciones')
-    casilla_09 = fields.Float('Casilla [09]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Rendim. actividades económicas - '
-                              'Rendimientos dinerarios - Importe retenciones')
-    casilla_10 = fields.Integer('Casilla [10]', readonly=True,
-                                states={'calculated': [('readonly', False)]},
-                                help='Rendim. actividades económicas - '
-                                'Rendimientos en especie - Nº de perceptores')
-    casilla_11 = fields.Float('Casilla [11]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Rendim. actividades económicas - '
-                              'Rendimientos en especie - Valor percepciones en'
-                              ' especie')
-    casilla_12 = fields.Float('Casilla [12]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Rendim. actividades económicas - '
-                              'Rendimientos en especie - Importe de los '
-                              'ingresos en cuenta')
-    casilla_13 = fields.Integer('Casilla [13]', readonly=True,
-                                states={'calculated': [('readonly', False)]},
-                                help='Premios - Premios dinerarios - Nº de '
-                                'perceptores')
-    casilla_14 = fields.Float('Casilla [14]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Premios - Premios dinerarios - Importe de '
-                              'las percepciones')
-    casilla_15 = fields.Float('Casilla [15]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Premios - Premios dinerarios - Importe de '
-                              'las retenciones')
-    casilla_16 = fields.Integer('Casilla [16]', readonly=True,
-                                states={'calculated': [('readonly', False)]},
-                                help='Premios - Premios en especie - Nº de '
-                                'perceptores')
-    casilla_17 = fields.Float('Casilla [17]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Premios - Premios en especie - Importe de '
-                              'las percepciones')
-    casilla_18 = fields.Float('Casilla [18]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Premios - Premios en especie - Importe de '
-                              'los ingresos a cuenta')
-    casilla_19 = fields.Integer('Casilla [19]', readonly=True,
-                                states={'calculated': [('readonly', False)]},
-                                help='Ganancias patrim. Aprovecham. Forestales'
-                                ' - Percep. dinerarias - Nº perceptores')
-    casilla_20 = fields.Float('Casilla [20]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Ganancias patrim. Aprovecham. Forestales'
-                              ' - Percep. dinerarias - Importe percepciones')
-    casilla_21 = fields.Float('Casilla [21]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Ganancias patrim. Aprovecham. Forestales'
-                              ' - Percep. dinerarias - Importe retenciones')
-    casilla_22 = fields.Integer('Casilla [22]', readonly=True,
-                                states={'calculated': [('readonly', False)]},
-                                help='Ganancias patrim. Aprovecham. Forestales'
-                                ' - Percep. en especie - Nº perceptores')
-    casilla_23 = fields.Float('Casilla [23]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Ganancias patrim. Aprovecham. Forestales -'
-                              ' Percep. en especie - Importe percepciones')
-    casilla_24 = fields.Float('Casilla [24]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Ganancias patrim. Aprovecham. Forestales'
-                              ' - Percep. en especie - Importe ingresos a '
-                              'cuenta')
-    casilla_25 = fields.Integer('Casilla [25]', readonly=True,
-                                states={'calculated': [('readonly', False)]},
-                                help='Contraprest. cesión dchos. imagen - Nº '
-                                'de perceptores')
-    casilla_26 = fields.Float('Casilla [26]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Contraprest. cesión dchos. imagen - '
-                              'Contraprestaciones satisfechas')
-    casilla_27 = fields.Float('Casilla [27]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Contraprest. cesión dchos. imagen - '
-                              'Importe de los ingresos a cuenta')
-    casilla_28 = fields.Float('Casilla [28]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Total liquidación - Suma retencones e '
-                              'ingresos a cuenta')
-    casilla_29 = fields.Float('Casilla [29]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Total liquidación - Resultado de '
-                              'anteriores declaraciones')
-    casilla_30 = fields.Float('Casilla [30]', readonly=True,
-                              states={'calculated': [('readonly', False)]},
-                              help='Total liquidación - Resultado a ingresar')
+    casilla_01 = fields.Integer(
+        '[01] Nº de perceptores', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [01]: Rendimientos del trabajo - '
+             'Rendimientos dinerarios - Nº de perceptores')
+    casilla_02 = fields.Float(
+        '[02] Importe de las percepciones', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [02]: Rendimientos del trabajo - '
+             'Rendimientos dinerarios - Importe de las percepciones')
+    casilla_03 = fields.Float(
+        '[03] Importe de las retenciones', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [03]: Rendimientos del trabajo - '
+             'Rendimientos dinerarios - Importe de las retenciones')
+    casilla_04 = fields.Integer(
+        '[04] Nº de perceptores', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [04]: Rendimientos del trabajo - '
+             'Rendimientos en especie - Nº de perceptores')
+    casilla_05 = fields.Float(
+        '[05] Valor percepciones en especie', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [05]: Rendimientos del trabajo - '
+             'Rendimientos en especie - Valor percepciones en especie')
+    casilla_06 = fields.Float(
+        '[06] Importe de los ingresos a cuenta', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [06]: Rendimientos del trabajo - '
+             'Rendimientos en especie - Importe de los ingresos a cuenta')
+    casilla_07 = fields.Integer(
+        '[07] Nº de perceptores', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [07]: Rendimientos de actividades económicas - '
+             'Rendimientos dinerarios - Nº de perceptores')
+    casilla_08 = fields.Float(
+        '[08] Importe de las percepciones', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [08]: Rendimientos de actividades económicas - '
+             'Rendimientos dinerarios - Importe de las percepciones')
+    casilla_09 = fields.Float(
+        '[09] Importe de las retenciones', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [09]: Rendimientos de actividades económicas - '
+             'Rendimientos dinerarios - Importe de las retenciones')
+    casilla_10 = fields.Integer(
+        '[10] Nº de perceptores ', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [10]: Rendimientos de actividades económicas - '
+             'Rendimientos en especie - Nº de perceptores')
+    casilla_11 = fields.Float(
+        '[11] Valor percepciones en especie', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [11]: Rendimientos de actividades económicas - '
+             'Rendimientos en especie - Valor percepciones en especie')
+    casilla_12 = fields.Float(
+        '[12] Importe de los ingresos a cuenta', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [12]: Rendimientos de actividades económicas - '
+        'Rendimientos en especie - Importe de los ingresos a cuenta')
+    casilla_13 = fields.Integer(
+        '[13] Nº de perceptores', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [13]: Premios por la participación en juegos, '
+             'concursos, rifas o combinaciones aleatorias - '
+             'Premios en metálico - Nº de perceptores')
+    casilla_14 = fields.Float(
+        '[14] Importe de las percepciones', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [14]: Premios por la participación en juegos, '
+             'concursos, rifas o combinaciones aleatorias - '
+             'Premios en metálico - Importe de las percepciones')
+    casilla_15 = fields.Float(
+        '[15] Importe de las retenciones', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [15]: Premios por la participación en juegos, '
+             'concursos, rifas o combinaciones aleatorias - '
+             'Premios en metálico - Importe de las retenciones')
+    casilla_16 = fields.Integer(
+        '[16] Nº de perceptores', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [16]: Premios por la participación en juegos, '
+             'concursos, rifas o combinaciones aleatorias - '
+             'Premios en especie - Nº de perceptores')
+    casilla_17 = fields.Float(
+        '[17] Valor percepciones en especie', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [17]: Premios por la participación en juegos, '
+             'concursos, rifas o combinaciones aleatorias - '
+             'Premios en especie - Valor percepciones en especie')
+    casilla_18 = fields.Float(
+        '[18] Importe de los ingresos a cuenta', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [18]: Premios por la participación en juegos, '
+             'concursos, rifas o combinaciones aleatorias - '
+             'Premios en especie - Importe de los ingresos a cuenta')
+    casilla_19 = fields.Integer(
+        '[19] Nº de perceptores', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [19]: Ganancias patrimoniales derivadas de los '
+             'aprovechamientos forestales de los vecinos en montes públicos - '
+             'Percepciones dinerarias - Nº de perceptores')
+    casilla_20 = fields.Float(
+        '[20] Importe de las percepciones', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [20]: Ganancias patrimoniales derivadas de los '
+             'aprovechamientos forestales de los vecinos en montes públicos - '
+             'Percepciones dinerarias - Importe de las percepciones')
+    casilla_21 = fields.Float(
+        '[21] Importe de las retenciones', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [21]: Ganancias patrimoniales derivadas de los '
+             'aprovechamientos forestales de los vecinos en montes públicos - '
+             'Percepciones dinerarias - Importe de las retenciones')
+    casilla_22 = fields.Integer(
+        '[22] Nº de perceptores', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [22]: Ganancias patrimoniales derivadas de los '
+             'aprovechamientos forestales de los vecinos en montes públicos - '
+             'Percepciones en especie - Nº de perceptores')
+    casilla_23 = fields.Float(
+        '[23] Valor percepciones en especie', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [23]: Ganancias patrimoniales derivadas de los '
+             'aprovechamientos forestales de los vecinos en montes públicos - '
+             'Percepciones en especie - Valor percepciones en especie')
+    casilla_24 = fields.Float(
+        '[24] Importe de los ingresos a cuenta', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [24]: Ganancias patrimoniales derivadas de los '
+             'aprovechamientos forestales de los vecinos en montes públicos - '
+             'Percepciones en especie - Importe de los ingresos a cuenta')
+    casilla_25 = fields.Integer(
+        '[25] Nº de perceptores', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [25]: Contraprestaciones por la cesión de derechos de '
+             'imagen: ingresos a cuenta previstos en el artículo 92.8 de la '
+             'Ley del Impuesto - Contraprestaciones dinerarias o en especie '
+             '- Nº de perceptores')
+    casilla_26 = fields.Float(
+        '[26] Contraprestaciones satisfechas', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [26]: Contraprestaciones por la cesión de derechos de '
+             'imagen: ingresos a cuenta previstos en el artículo 92.8 de la '
+             'Ley del Impuesto - Contraprestaciones dinerarias o en especie '
+             '- Contraprestaciones satisfechas')
+    casilla_27 = fields.Float(
+        '[27] Importe de los ingresos a cuenta', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Casilla [27]: Contraprestaciones por la cesión de derechos de '
+             'imagen: ingresos a cuenta previstos en el artículo 92.8 de la '
+             'Ley del Impuesto - Contraprestaciones dinerarias o en especie '
+             '- Importe de los ingresos a cuenta')
+    casilla_28 = fields.Float(
+        '[28] Suma de retenciones', readonly=True, compute='_compute_28',
+        help='Total liquidación - Suma de retenciones e ingresos a cuenta: '
+             '([03] + [06] + [09] + [12] + [15] + [18] + [21] + [24] + [27])')
+    casilla_29 = fields.Float(
+        '[29] Resultados a ingresar anteriores', readonly=True,
+        states={'calculated': [('readonly', False)]},
+        help='Total liquidación - A deducir (exclusivamente en caso de '
+             'autoliquidación complementaria): Resultados a ingresar de '
+             'anteriores autoliquidaciones por el mismo concepto, ejercicio '
+             'y período')
+    casilla_30 = fields.Float(
+        '[30] Resultado a ingresar', readonly=True, compute='_compute_30',
+        help='Total liquidación - Resultado a ingresar: ([28] - [29])')
     codigo_electronico_anterior = fields.Char(
         'Código electrónico', size=16, readonly=True,
         states={'draft': [('readonly', False)]},
@@ -198,6 +243,9 @@ class L10nEsAeatMod111Report(models.Model):
     @api.multi
     def calculate(self):
         self.ensure_one()
+        # I. Rendimientos del trabajo
+        #    El usuario lo introduce a mano después de calcular
+        # II. Rendimientos de actividades económicas
         move_lines08 = self._get_tax_code_lines(
             ['IRPBI'], periods=self.periods)
         move_lines09 = self._get_tax_code_lines(
@@ -208,3 +256,29 @@ class L10nEsAeatMod111Report(models.Model):
         self.casilla_09 = sum([x.tax_amount for x in move_lines09])
         self.casilla_07 = len(set([x.partner_id for x in (move_lines08 +
                                                           move_lines09)]))
+        # III. Premios por la participación en juegos, concursos,
+        #      rifas o combinaciones aleatorias
+        #      El usuario lo introduce a mano después de calcular
+        # IV. Ganancias patrimoniales derivadas de los aprovechamientos
+        #     forestales de los vecinos en montes públicos
+        #     El usuario lo introduce a mano después de calcular
+        # V. Contraprestaciones por la cesión de derechos de imagen:
+        #    ingresos a cuenta previstos en el artículo 92.8 de la
+        #    Ley del Impuesto
+        #    El usuario lo introduce a mano después de calcular
+
+    @api.one
+    @api.depends('casilla_03', 'casilla_06', 'casilla_09', 'casilla_12',
+                 'casilla_15', 'casilla_18', 'casilla_21', 'casilla_24',
+                 'casilla_27')
+    def _compute_28(self):
+        self.casilla_28 = (
+            self.casilla_03 + self.casilla_06 + self.casilla_09 +
+            self.casilla_12 + self.casilla_15 + self.casilla_18 +
+            self.casilla_21 + self.casilla_24 + self.casilla_27
+        )
+
+    @api.one
+    @api.depends('casilla_28', 'casilla_29')
+    def _compute_30(self):
+        self.casilla_30 = self.casilla_28 - self.casilla_29


### PR DESCRIPTION
Este PR modifica lo siguiente:
- Define unos labels de los campos correspondientes a las casillas del modelo más descriptivos, porque la mayoría de los campos los tiene que rellenar el usuario, ya que Odoo no puede calcularlos.
- Calcula las casillas 28 y 30, que son computables. Y las define como readonly siempre
- Actualiza la traducción al español

He tomado las labels de los campos del modelo oficial: http://www.economistasalicante.com/doc/actualidad/MODELO%20111.pdf
