### PR TITLE
[IMP] l10n_es_aeat_mod216 mejoras visuales y cálculo automático de la liquidación

### DIFF
--- a/l10n_es_aeat_mod216/README.rst
+++ b/l10n_es_aeat_mod216/README.rst
@@ -1,3 +1,8 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+================================
 Presentación del Modelo AEAT 216
 ================================
 
@@ -5,10 +10,36 @@ Modelo 216 de la AEAT. IRNR. Impuesto sobre la Renta de no Residentes. Rentas
 obtenidas sin mediación de establecimiento permanente. Retenciones e ingresos
 a cuenta.
 
-Problemas conocidos / Hoja de ruta
-==================================
 
-* Permitir periodos trimestrales.
+Uso
+===
+
+Primero deberemos indicar los proveedores que son no residentes, en la ficha
+de la empresa: Contabilidad > Proveedores > Proveedores, pestaña de
+Contabilidad. El campo "Es no residente" tiene que estar marcado para que
+las retenciones realizadas a éste proveedor se incluyan en el modelo 216
+
+Para crear un modelo, por ejemplo de un trimestre del año:
+
+1. Ir a Contabilidad > Informe > Informes legales > Declaraciones AEAT > Modelo 216
+2. Pulsar en el botón "Crear"
+3. Seleccionar el ejercicio fiscal y el tipo de período, los periodos incluidos
+   se calculan automáticamente
+4. Seleccionar el tipo de declaración
+5. Rellenar el teléfono de contacto, necesario para la exportacion BOE
+6. Guardar y pulsar en el botón "Calcular"
+7. Rellenar (si es necesario) aquellos campos que Odoo no calcula automáticamente:
+
+   * Rentas no sometidas a retención/ingreso a cuenta: [04] Nº de rentas y [05] Base de retenciones
+   * Resultados a ingresar anteriores: [06]
+
+8. Cuando los valores sean los correctos, pulsar en el botón "Confirmar"
+9. Podemos exportar en formato BOE para presentarlo telemáticamente en el portal
+   de la AEAT
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Pruébalo en Runbot
+   :target: https://runbot.odoo-community.org/runbot/189/8.0
 
 Créditos
 ========
@@ -18,6 +49,7 @@ Contribuidores
 
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Ainara Galdona <ainara.galdona@avanzosc.es>
+* Antonio Espinosa <antonioea@antiun.com>
 
 Maintainer
 ----------

--- a/l10n_es_aeat_mod216/__openerp__.py
+++ b/l10n_es_aeat_mod216/__openerp__.py
@@ -18,7 +18,7 @@
 
 {
     'name': 'AEAT modelo 216',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.1.0',
     'category': "Localisation/Accounting",
     'author': "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod216/i18n/es.po
+++ b/l10n_es_aeat_mod216/i18n/es.po
@@ -1,21 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat_mod216
-# 
-# Translators:
+#	* l10n_es_aeat_mod216
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-spain (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-20 19:02+0000\n"
-"PO-Revision-Date: 2015-10-18 17:09+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/es/)\n"
+"POT-Creation-Date: 2015-11-04 13:08+0000\n"
+"PO-Revision-Date: 2015-11-04 13:08+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_aeat_mod216
 #: model:ir.model,name:l10n_es_aeat_mod216.model_l10n_es_aeat_mod111_report
@@ -26,6 +24,12 @@ msgstr "Declaración AEAT 111"
 #: model:ir.model,name:l10n_es_aeat_mod216.model_l10n_es_aeat_mod216_report
 msgid "AEAT 216 report"
 msgstr "Declaración AEAT 216"
+
+#. module: l10n_es_aeat_mod216
+#: code:addons/l10n_es_aeat_mod216/models/mod216.py:129
+#, python-format
+msgid "Account Move Lines"
+msgstr "Apuntes contables"
 
 #. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,move_id:0
@@ -41,41 +45,6 @@ msgstr "Fecha de cálculo"
 #: selection:l10n.es.aeat.mod216.report,state:0
 msgid "Cancelled"
 msgstr "Cancelada"
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_01:0
-msgid "Casilla [01]"
-msgstr "Casilla [01]"
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_02:0
-msgid "Casilla [02]"
-msgstr "Casilla [02]"
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_03:0
-msgid "Casilla [03]"
-msgstr "Casilla [03]"
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_04:0
-msgid "Casilla [04]"
-msgstr "Casilla [04]"
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_05:0
-msgid "Casilla [05]"
-msgstr "Casilla [05]"
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_06:0
-msgid "Casilla [06]"
-msgstr "Casilla [06]"
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_07:0
-msgid "Casilla [07]"
-msgstr "Casilla [07]"
 
 #. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,company_id:0
@@ -201,9 +170,9 @@ msgid "Ingreso a anotar en CCT"
 msgstr "Ingreso a anotar en CCT"
 
 #. module: l10n_es_aeat_mod216
-#: field:res.partner,is_resident:0
-msgid "Is resident"
-msgstr "Es residente"
+#: field:res.partner,is_non_resident:0
+msgid "Is non-resident"
+msgstr "Es no residente"
 
 #. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,journal_id:0
@@ -243,39 +212,34 @@ msgid "Liquidación"
 msgstr "Liquidación"
 
 #. module: l10n_es_aeat_mod216
-#: help:l10n.es.aeat.mod216.report,casilla_01:0
-msgid "Liquidación - Partida 1 - Núm. Rentas"
-msgstr "Liquidación - Partida 1 - Núm. Rentas"
-
-#. module: l10n_es_aeat_mod216
-#: help:l10n.es.aeat.mod216.report,casilla_02:0
-msgid "Liquidación - Partida 2 - Base ret. ing. cuenta"
-msgstr "Liquidación - Partida 2 - Base ret. ing. cuenta"
-
-#. module: l10n_es_aeat_mod216
-#: help:l10n.es.aeat.mod216.report,casilla_03:0
-msgid "Liquidación - Partida 3 - Retenciones ingresos a cuenta"
-msgstr "Liquidación - Partida 3 - Retenciones ingresos a cuenta"
+#: help:l10n.es.aeat.mod216.report,casilla_06:0
+msgid "Liquidación - Casilla [06] A deducir (exclusivamente en caso de complementaria): Resultados a ingresar de anteriores declaraciones por el mismo concepto, ejercicio y período"
+msgstr ""
 
 #. module: l10n_es_aeat_mod216
 #: help:l10n.es.aeat.mod216.report,casilla_04:0
-msgid "Liquidación - Partida 4 - Núm. Rentas"
-msgstr "Liquidación - Partida 4 - Núm. Rentas"
+msgid "Liquidación - Rentas no sometidas a retención/ingreso a cuenta - Casilla [04] Número de rentas"
+msgstr ""
 
 #. module: l10n_es_aeat_mod216
 #: help:l10n.es.aeat.mod216.report,casilla_05:0
-msgid "Liquidación - Partida 5 - Base ret. ing. cuenta."
-msgstr "Liquidación - Partida 5 - Base ret. ing. cuenta."
+msgid "Liquidación - Rentas no sometidas a retención/ingreso a cuenta - Casilla [05] Base de retenciones e ingresos a cuenta/Importe de las rentas"
+msgstr ""
 
 #. module: l10n_es_aeat_mod216
-#: help:l10n.es.aeat.mod216.report,casilla_06:0
-msgid "Liquidación - Partida 6 - Resultado ing. anteriores declaraciones"
-msgstr "Liquidación - Partida 6 - Resultado ing. anteriores declaraciones"
+#: help:l10n.es.aeat.mod216.report,casilla_01:0
+msgid "Liquidación - Rentas sometidas a retención/ingreso a cuenta - Casilla [01] Número de rentas"
+msgstr ""
 
 #. module: l10n_es_aeat_mod216
-#: help:l10n.es.aeat.mod216.report,casilla_07:0
-msgid "Liquidación - Partida 7 - Resultado ingresar"
-msgstr "Liquidación - Partida 7 - Resultado ingresar"
+#: help:l10n.es.aeat.mod216.report,casilla_02:0
+msgid "Liquidación - Rentas sometidas a retención/ingreso a cuenta - Casilla [02] Base de retenciones e ingresos a cuenta/Importe de las rentas"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: help:l10n.es.aeat.mod216.report,casilla_03:0
+msgid "Liquidación - Rentas sometidas a retención/ingreso a cuenta - Casilla [03] Retenciones e ingresos a cuenta"
+msgstr ""
 
 #. module: l10n_es_aeat_mod216
 #: model:ir.ui.menu,name:l10n_es_aeat_mod216.menu_aeat_mod216_report
@@ -285,7 +249,17 @@ msgstr "Modelo 216"
 #. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,currency_id:0
 msgid "Moneda"
-msgstr "Moneda"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,move_lines_base:0
+msgid "Account move lines for bases"
+msgstr "Apuntes contables para las bases"
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,move_lines_cuota:0
+msgid "Account move lines for amounts"
+msgstr "Apuntes contable para las cuotas "
 
 #. module: l10n_es_aeat_mod216
 #: help:l10n.es.aeat.mod216.report,contact_name:0
@@ -318,11 +292,6 @@ msgid "Period(s)"
 msgstr "Periodo(s)"
 
 #. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,period_id:0
-msgid "Periodo"
-msgstr "Periodo"
-
-#. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,contact_phone:0
 msgid "Phone"
 msgstr "Teléfono"
@@ -341,6 +310,21 @@ msgstr "Nº declaración previa"
 #: selection:l10n.es.aeat.mod216.report,state:0
 msgid "Processed"
 msgstr "Procesada"
+
+#. module: l10n_es_aeat_mod216
+#: view:l10n.es.aeat.mod216.report:l10n_es_aeat_mod216.view_l10n_es_aeat_mod216_report_form
+msgid "Rentas no sometidas a retención"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: view:l10n.es.aeat.mod216.report:l10n_es_aeat_mod216.view_l10n_es_aeat_mod216_report_form
+msgid "Rentas sometidas a retención"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: view:l10n.es.aeat.mod216.report:l10n_es_aeat_mod216.view_l10n_es_aeat_mod216_report_form
+msgid "Resultado"
+msgstr ""
 
 #. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,sequence:0
@@ -380,9 +364,7 @@ msgstr "Telemático"
 
 #. module: l10n_es_aeat_mod216
 #: help:l10n.es.aeat.mod216.report,counterpart_account:0
-msgid ""
-"This account will be the counterpart for all the journal items that are "
-"regularized when posting the report."
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
 msgstr "Esta cuenta será la contrapartida para todos los elementos del diario que están regularizados al contabilizar el informe."
 
 #. module: l10n_es_aeat_mod216
@@ -394,6 +376,46 @@ msgstr "Tipo de declaración"
 #: field:l10n.es.aeat.mod216.report,company_vat:0
 msgid "VAT number"
 msgstr "NIF"
+
+#. module: l10n_es_aeat_mod216
+#: view:l10n.es.aeat.mod216.report:l10n_es_aeat_mod216.view_l10n_es_aeat_mod216_report_form
+msgid "Show account move lines for base"
+msgstr "Mostrar apuntes de la base"
+
+#. module: l10n_es_aeat_mod216
+#: view:l10n.es.aeat.mod216.report:l10n_es_aeat_mod216.view_l10n_es_aeat_mod216_report_form
+msgid "Show account move lines for amount"
+msgstr "Mostrar apuntes de la cuota"
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_01:0
+msgid "[01] Número de rentas"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_02:0
+msgid "[02] Base de retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_03:0
+msgid "[03] Retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_04:0
+msgid "[04] Número de rentas"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_05:0
+msgid "[05] Base de retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_06:0
+msgid "[06] Resultados a ingresar anteriores"
+msgstr ""
 
 #. module: l10n_es_aeat_mod216
 #: selection:l10n.es.aeat.mod216.export_to_boe,state:0

--- a/l10n_es_aeat_mod216/i18n/l10n_es_aeat_mod216.pot
+++ b/l10n_es_aeat_mod216/i18n/l10n_es_aeat_mod216.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-28 13:20+0000\n"
-"PO-Revision-Date: 2015-06-28 13:20+0000\n"
+"POT-Creation-Date: 2015-11-04 13:08+0000\n"
+"PO-Revision-Date: 2015-11-04 13:08+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -26,6 +26,17 @@ msgid "AEAT 216 report"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
+#: code:addons/l10n_es_aeat_mod216/models/mod216.py:129
+#, python-format
+msgid "Account Move Lines"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,move_id:0
+msgid "Account entry"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,calculation_date:0
 msgid "Calculation date"
 msgstr ""
@@ -36,41 +47,6 @@ msgid "Cancelled"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_01:0
-msgid "Casilla [01]"
-msgstr ""
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_02:0
-msgid "Casilla [02]"
-msgstr ""
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_03:0
-msgid "Casilla [03]"
-msgstr ""
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_04:0
-msgid "Casilla [04]"
-msgstr ""
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_05:0
-msgid "Casilla [05]"
-msgstr ""
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_06:0
-msgid "Casilla [06]"
-msgstr ""
-
-#. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,casilla_07:0
-msgid "Casilla [07]"
-msgstr ""
-
-#. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,company_id:0
 msgid "Company"
 msgstr ""
@@ -78,6 +54,11 @@ msgstr ""
 #. module: l10n_es_aeat_mod216
 #: selection:l10n.es.aeat.mod216.report,type:0
 msgid "Complementary"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,counterpart_account:0
+msgid "Counterpart account"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
@@ -189,6 +170,21 @@ msgid "Ingreso a anotar en CCT"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
+#: field:res.partner,is_non_resident:0
+msgid "Is non-resident"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,journal_id:0
+msgid "Journal"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: help:l10n.es.aeat.mod216.report,journal_id:0
+msgid "Journal in which post the move."
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,representative_vat:0
 msgid "L.R. VAT number"
 msgstr ""
@@ -216,38 +212,33 @@ msgid "Liquidación"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
-#: help:l10n.es.aeat.mod216.report,casilla_01:0
-msgid "Liquidación - Partida 1 - Núm. Rentas"
-msgstr ""
-
-#. module: l10n_es_aeat_mod216
-#: help:l10n.es.aeat.mod216.report,casilla_02:0
-msgid "Liquidación - Partida 2 - Base ret. ing. cuenta"
-msgstr ""
-
-#. module: l10n_es_aeat_mod216
-#: help:l10n.es.aeat.mod216.report,casilla_03:0
-msgid "Liquidación - Partida 3 - Retenciones ingresos a cuenta"
+#: help:l10n.es.aeat.mod216.report,casilla_06:0
+msgid "Liquidación - Casilla [06] A deducir (exclusivamente en caso de complementaria): Resultados a ingresar de anteriores declaraciones por el mismo concepto, ejercicio y período"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
 #: help:l10n.es.aeat.mod216.report,casilla_04:0
-msgid "Liquidación - Partida 4 - Núm. Rentas"
+msgid "Liquidación - Rentas no sometidas a retención/ingreso a cuenta - Casilla [04] Número de rentas"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
 #: help:l10n.es.aeat.mod216.report,casilla_05:0
-msgid "Liquidación - Partida 5 - Base ret. ing. cuenta."
+msgid "Liquidación - Rentas no sometidas a retención/ingreso a cuenta - Casilla [05] Base de retenciones e ingresos a cuenta/Importe de las rentas"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
-#: help:l10n.es.aeat.mod216.report,casilla_06:0
-msgid "Liquidación - Partida 6 - Resultado ing. anteriores declaraciones"
+#: help:l10n.es.aeat.mod216.report,casilla_01:0
+msgid "Liquidación - Rentas sometidas a retención/ingreso a cuenta - Casilla [01] Número de rentas"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
-#: help:l10n.es.aeat.mod216.report,casilla_07:0
-msgid "Liquidación - Partida 7 - Resultado ingresar"
+#: help:l10n.es.aeat.mod216.report,casilla_02:0
+msgid "Liquidación - Rentas sometidas a retención/ingreso a cuenta - Casilla [02] Base de retenciones e ingresos a cuenta/Importe de las rentas"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: help:l10n.es.aeat.mod216.report,casilla_03:0
+msgid "Liquidación - Rentas sometidas a retención/ingreso a cuenta - Casilla [03] Retenciones e ingresos a cuenta"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
@@ -258,6 +249,16 @@ msgstr ""
 #. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,currency_id:0
 msgid "Moneda"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,move_lines_base:0
+msgid "Account move lines for bases"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,move_lines_cuota:0
+msgid "Account move lines for amounts"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
@@ -281,13 +282,23 @@ msgid "Partner"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
-#: field:l10n.es.aeat.mod216.report,period_id:0
-msgid "Periodo"
+#: field:l10n.es.aeat.mod216.report,period_type:0
+msgid "Period type"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,periods:0
+msgid "Period(s)"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
 #: field:l10n.es.aeat.mod216.report,contact_phone:0
 msgid "Phone"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: selection:l10n.es.aeat.mod216.report,state:0
+msgid "Posted"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
@@ -298,6 +309,21 @@ msgstr ""
 #. module: l10n_es_aeat_mod216
 #: selection:l10n.es.aeat.mod216.report,state:0
 msgid "Processed"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: view:l10n.es.aeat.mod216.report:l10n_es_aeat_mod216.view_l10n_es_aeat_mod216_report_form
+msgid "Rentas no sometidas a retención"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: view:l10n.es.aeat.mod216.report:l10n_es_aeat_mod216.view_l10n_es_aeat_mod216_report_form
+msgid "Rentas sometidas a retención"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: view:l10n.es.aeat.mod216.report:l10n_es_aeat_mod216.view_l10n_es_aeat_mod216_report_form
+msgid "Resultado"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
@@ -327,8 +353,18 @@ msgid "Support Type"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,tax_lines:0
+msgid "Tax lines"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
 #: selection:l10n.es.aeat.mod216.report,support_type:0
 msgid "Telematics"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: help:l10n.es.aeat.mod216.report,counterpart_account:0
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
@@ -342,6 +378,46 @@ msgid "VAT number"
 msgstr ""
 
 #. module: l10n_es_aeat_mod216
+#: view:l10n.es.aeat.mod216.report:l10n_es_aeat_mod216.view_l10n_es_aeat_mod216_report_form
+msgid "Show account move lines for base"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: view:l10n.es.aeat.mod216.report:l10n_es_aeat_mod216.view_l10n_es_aeat_mod216_report_form
+msgid "Show account move lines for amount"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_01:0
+msgid "[01] Número de rentas"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_02:0
+msgid "[02] Base de retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_03:0
+msgid "[03] Retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_04:0
+msgid "[04] Número de rentas"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_05:0
+msgid "[05] Base de retenciones"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
+#: field:l10n.es.aeat.mod216.report,casilla_06:0
+msgid "[06] Resultados a ingresar anteriores"
+msgstr ""
+
+#. module: l10n_es_aeat_mod216
 #: selection:l10n.es.aeat.mod216.export_to_boe,state:0
 msgid "get"
 msgstr ""
@@ -349,10 +425,5 @@ msgstr ""
 #. module: l10n_es_aeat_mod216
 #: selection:l10n.es.aeat.mod216.export_to_boe,state:0
 msgid "open"
-msgstr ""
-
-#. module: l10n_es_aeat_mod216
-#: field:res.partner,is_resident:0
-msgid "Is resident"
 msgstr ""
 

--- a/l10n_es_aeat_mod216/models/mod111.py
+++ b/l10n_es_aeat_mod216/models/mod111.py
@@ -28,6 +28,6 @@ class L10nEsAeatMod111Report(models.Model):
     def _get_partner_domain(self):
         res = super(L10nEsAeatMod111Report, self)._get_partner_domain()
         partners = self.env['res.partner'].search(
-            [('is_resident', '=', False)])
+            [('is_non_resident', '=', False)])
         res += [('partner_id', 'in', partners.ids)]
         return res

--- a/l10n_es_aeat_mod216/models/mod216.py
+++ b/l10n_es_aeat_mod216/models/mod216.py
@@ -18,7 +18,7 @@
 #
 ##############################################################################
 
-from openerp import fields, models, api
+from openerp import fields, models, api, _
 
 
 class L10nEsAeatMod216Report(models.Model):
@@ -29,40 +29,54 @@ class L10nEsAeatMod216Report(models.Model):
 
     number = fields.Char(default='216')
     casilla_01 = fields.Integer(
-        'Casilla [01]', readonly=True,
+        '[01] Número de rentas', readonly=True,
         states={'calculated': [('readonly', False)]},
-        help='Liquidación - Partida 1 - Núm. Rentas')
+        help='Liquidación - Rentas sometidas a retención/ingreso a cuenta - '
+             'Casilla [01] Número de rentas')
     casilla_02 = fields.Float(
-        'Casilla [02]', readonly=True,
+        '[02] Base de retenciones', readonly=True,
         states={'calculated': [('readonly', False)]},
-        help='Liquidación - Partida 2 - Base ret. ing. cuenta')
+        help='Liquidación - Rentas sometidas a retención/ingreso a cuenta - '
+             'Casilla [02] Base de retenciones e ingresos a cuenta/Importe '
+             'de las rentas')
     casilla_03 = fields.Float(
-        'Casilla [03]', readonly=True,
+        '[03] Retenciones', readonly=True,
         states={'calculated': [('readonly', False)]},
-        help='Liquidación - Partida 3 - Retenciones ingresos a cuenta')
+        help='Liquidación - Rentas sometidas a retención/ingreso a cuenta - '
+             'Casilla [03] Retenciones e ingresos a cuenta')
     casilla_04 = fields.Integer(
-        'Casilla [04]', readonly=True,
+        '[04] Número de rentas', readonly=True,
         states={'calculated': [('readonly', False)]},
-        help='Liquidación - Partida 4 - Núm. Rentas')
+        help='Liquidación - Rentas no sometidas a retención/ingreso a cuenta'
+             ' - Casilla [04] Número de rentas')
     casilla_05 = fields.Float(
-        'Casilla [05]', readonly=True,
+        '[05] Base de retenciones', readonly=True,
         states={'calculated': [('readonly', False)]},
-        help='Liquidación - Partida 5 - Base ret. ing. cuenta.')
+        help='Liquidación - Rentas no sometidas a retención/ingreso a cuenta'
+             ' - Casilla [05] Base de retenciones e ingresos a cuenta/Importe '
+             'de las rentas')
     casilla_06 = fields.Float(
-        'Casilla [06]', readonly=True,
+        '[06] Resultados a ingresar anteriores', readonly=True,
         states={'calculated': [('readonly', False)]},
-        help='Liquidación - Partida 6 - Resultado ing. anteriores '
-             'declaraciones')
+        help='Liquidación - Casilla [06] A deducir (exclusivamente en caso '
+             'de complementaria): Resultados a ingresar de anteriores '
+             'declaraciones por el mismo concepto, ejercicio y período')
     casilla_07 = fields.Integer(
-        'Casilla [07]', readonly=True,
-        states={'calculated': [('readonly', False)]},
-        help='Liquidación - Partida 7 - Resultado ingresar')
+        '[07] Resultado a ingresar', readonly=True, compute='_compute_07',
+        help='Liquidación - Casilla [07] Resultado a ingresar ([03] - [06])')
+    move_lines_base = fields.Many2many(
+        string="Account move lines for bases",
+        comodel_name='account.move.line',
+        relation='mod216_account_move_lines_base_rel',
+        column1='mod216', column2='account_move_line')
+    move_lines_cuota = fields.Many2many(
+        string="Account move lines for amounts",
+        comodel_name='account.move.line',
+        relation='mod216_account_move_line_cuota_rel',
+        column1='mod216', column2='account_move_line')
     currency_id = fields.Many2one(
         'res.currency', string='Moneda',
         related='company_id.currency_id', store=True)
-    period_id = fields.Many2one(
-        'account.period', 'Periodo', readonly=True,
-        states={'draft': [('readonly', False)]}, required=True)
     tipo_declaracion = fields.Selection(
         [('I', 'Ingreso'), ('U', 'Domiciliación'),
          ('G', 'Ingreso a anotar en CCT'), ('N', 'Negativa')],
@@ -77,7 +91,7 @@ class L10nEsAeatMod216Report(models.Model):
     def _get_partner_domain(self):
         res = super(L10nEsAeatMod216Report, self)._get_partner_domain()
         partners = self.env['res.partner'].search(
-            [('is_resident', '=', True)])
+            [('is_non_resident', '=', True)])
         res += [('partner_id', 'in', partners.ids)]
         return res
 
@@ -85,11 +99,38 @@ class L10nEsAeatMod216Report(models.Model):
     def calculate(self):
         self.ensure_one()
         move_lines_base = self._get_tax_code_lines(
-            ['IRPBI'], periods=self.period_id)
+            ['IRPBI'], periods=self.periods)
         move_lines_cuota = self._get_tax_code_lines(
-            ['ITRPC'], periods=self.period_id)
+            ['ITRPC'], periods=self.periods)
+        self.move_lines_base = move_lines_base.ids
+        self.move_lines_cuota = move_lines_cuota.ids
         partner_lst = set([x.partner_id for x in
                            (move_lines_base + move_lines_cuota)])
+        # I. Rentas sometidas a retención/ingreso a cuenta
         self.casilla_01 = len(partner_lst)
         self.casilla_02 = sum(move_lines_base.mapped('tax_amount'))
         self.casilla_03 = sum(move_lines_cuota.mapped('tax_amount'))
+        # II. Rentas no sometidas a retención/ingreso a cuenta
+        #     No existe código de impuesto para calcular las bases
+        #     de la rentas no sometidas a retención.
+        #     El usuario introduce este dato de manera manual.
+
+    @api.one
+    @api.depends('casilla_03', 'casilla_06')
+    def _compute_07(self):
+        self.casilla_07 = self.casilla_03 - self.casilla_06
+
+    @api.multi
+    def show_move_lines(self):
+        move_lines = []
+        if self.env.context.get('move_lines_base', False):
+            move_lines = self.move_lines_base.ids
+        elif self.env.context.get('move_lines_cuota', False):
+            move_lines = self.move_lines_cuota.ids
+        return {'type': 'ir.actions.act_window',
+                'name': _('Account Move Lines'),
+                'view_mode': 'tree,form',
+                'view_type': 'form',
+                'res_model': 'account.move.line',
+                'domain': [('id', 'in', move_lines)]
+                }

--- a/l10n_es_aeat_mod216/models/res_partner.py
+++ b/l10n_es_aeat_mod216/models/res_partner.py
@@ -22,4 +22,5 @@ from openerp import models, fields
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    is_resident = fields.Boolean(string='Is resident')
+    is_non_resident = fields.Boolean(string='Is non-resident',
+                                     oldname='is_resident')

--- a/l10n_es_aeat_mod216/views/mod216_view.xml
+++ b/l10n_es_aeat_mod216/views/mod216_view.xml
@@ -1,32 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-            <record id="view_l10n_es_aeat_mod216_report_form" model="ir.ui.view">
-                <field name="name">l10n_es.aeat.mod216.report.form</field>
-                <field name="model">l10n.es.aeat.mod216.report</field>
-                <field name="inherit_id" ref="l10n_es_aeat.view_l10n_es_aeat_report_form"/>
-                <field name="arch" type="xml">
-                    <button name="%(l10n_es_aeat.action_wizard_aeat_export)d" position="attributes">
-                        <attribute name="name">%(action_wizard_aeat_mod216_export)d</attribute>
-                    </button>
-                    <field name="fiscalyear_id" position="after">
-                        <field name="period_id" domain="[('special','=',False),('fiscalyear_id','=',fiscalyear_id)]"/>
-                        <field name="currency_id" invisible="1"/>
-                    </field>
-                    <field name="previous_number" position="after">
-                            <field name="tipo_declaracion"/>
-                    </field>
-                    <group string="Declaración" position="after">
-                        <group string="Liquidación" colspan="4" states="calculated,done,cancelled">
+        <record id="view_l10n_es_aeat_mod216_report_form" model="ir.ui.view">
+            <field name="name">l10n_es.aeat.mod216.report.form</field>
+            <field name="model">l10n.es.aeat.mod216.report</field>
+            <field name="inherit_id" ref="l10n_es_aeat.view_l10n_es_aeat_report_form"/>
+            <field name="arch" type="xml">
+                <button name="%(l10n_es_aeat.action_wizard_aeat_export)d" position="attributes">
+                    <attribute name="name">%(action_wizard_aeat_mod216_export)d</attribute>
+                </button>
+                <field name="fiscalyear_id" position="after">
+                    <field name="currency_id" invisible="1"/>
+                </field>
+                <field name="previous_number" position="after">
+                        <field name="tipo_declaracion"/>
+                </field>
+                <group string="Declaración" position="after">
+                    <group string="Resultado" colspan="4" states="calculated,done,cancelled">
+                        <group string="Rentas sometidas a retención">
                             <field name="casilla_01"/>
-                            <field name="casilla_02" widget="monetary" options="{'currency_field': 'currency_id'}"/>
-                            <field name="casilla_03" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                            <field name="casilla_02" widget="monetary"
+                                   options="{'currency_field': 'currency_id'}"/>
+                            <button name="show_move_lines"
+                                    string="Show account move lines for base"
+                                    type="object" class="oe_link"
+                                    context="{'move_lines_base': True}"/>
+                            <separator/>
+                            <field name="casilla_03" widget="monetary"
+                                   options="{'currency_field': 'currency_id'}"/>
+                            <button name="show_move_lines"
+                                    string="Show account move lines for amount"
+                                    type="object" class="oe_link"
+                                    context="{'move_lines_cuota': True}"/>
+                            <separator/>
+                        </group>
+                        <group string="Rentas no sometidas a retención">
                             <field name="casilla_04"/>
-                            <field name="casilla_05" widget="monetary" options="{'currency_field': 'currency_id'}"/>
-                            <field name="casilla_06" widget="monetary" options="{'currency_field': 'currency_id'}"/>
-                            <field name="casilla_07"/>
+                            <field name="casilla_05" widget="monetary"
+                                   options="{'currency_field': 'currency_id'}"/>
+                        </group>
+                        <group string="Liquidación">
+                            <field name="casilla_06" widget="monetary"
+                                   options="{'currency_field': 'currency_id'}"/>
+                            <field name="casilla_07" widget="monetary"
+                                   options="{'currency_field': 'currency_id'}"/>
                         </group>
                     </group>
+                </group>
+                <group name="group_tax_lines" position="attributes">
+                    <attribute name="attrs">{'invisible': 1}</attribute>
+                </group>
             </field>
         </record>
 
@@ -38,9 +61,6 @@
                 <tree position="attributes">
                     <attribute name="string">Declaraciones AEAT 216</attribute>
                 </tree>
-                <field name="fiscalyear_id" position="after">
-                    <field name="period_id"/>
-                </field>
             </field>
         </record>
 

--- a/l10n_es_aeat_mod216/views/res_partner_view.xml
+++ b/l10n_es_aeat_mod216/views/res_partner_view.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="base_vat.view_partner_form"/>
             <field name="arch" type="xml">
                 <field name="last_reconciliation_date" position="after">
-                    <field name="is_resident"/>
+                    <field name="is_non_resident"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
Se mejoran los siguientes aspectos:
- Se permite selección por trimestres, eliminando la duplicidad de campos
- Se cambian las etiquetas de los campos para que sean las mismas que el Mod216 oficial
- Se calcula el resultado de la liquidación
- No se muestran las líneas de impuestos, éstos se refieren al modelo 303
- Se añaden botones/enlaces para ver los apuntes que se han tenido en cuenta para el cálculo de la base y de la cuota
- Se adapta el README a las convenciones OCA y se explica cómo sacar un modelo 216 paso a paso
- Se traduce de nuevo al Español
- Se modifica el campo `res.partner.is_resident`, pasándose a llamar `res.partner.is_non_resident` ya que ese nombre indica de manera más fiel el significado del campo. También se modifica la etiqueta asociada al campo
