### PR TITLE
[FIX] l10n_es: root account for account_chart_update

### DIFF
--- a/l10n_es/data/account_chart_template_post.xml
+++ b/l10n_es/data/account_chart_template_post.xml
@@ -16,16 +16,19 @@
         <record id="account_chart_template_full" model="account.chart.template">
             <field name="tax_code_root_id" ref="account_tax_code_template_root"/>
             <field name="bank_account_view_id" ref="pgc_572"/>
+            <field name="account_root_id" ref="pgc_0"/>
         </record>
         
         <record id="account_chart_template_pymes" model="account.chart.template">
             <field name="tax_code_root_id" ref="account_tax_code_template_root"/>
             <field name="bank_account_view_id" ref="pgc_572"/>
+            <field name="account_root_id" ref="pgc_0"/>
         </record>
         
         <record id="account_chart_template_assoc" model="account.chart.template">
             <field name="tax_code_root_id" ref="account_tax_code_template_root"/>
             <field name="bank_account_view_id" ref="pgc_572"/>
+            <field name="account_root_id" ref="pgc_0"/>
         </record>
         
     </data>


### PR DESCRIPTION
account_chart_update doesn't recognize correctly all template accounts without having
this set, because it doesn't navigate to parent template charts.
