### PR TITLE
[ADD] l10n_es_aeat_mod303, casilla 77

### DIFF
--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_data.xml
@@ -2392,6 +2392,7 @@
             <field name="sequence">47</field>
             <field name="export_config_id" ref="aeat_mod303_sub03_export_config"/>
             <field name="name">Resultado - IVA a la importación liquidado por la Aduana pendiente de ingreso [77]</field>
+            <field name="expression">${object.tax_lines.filtered(lambda r: r.field_number==33).amount}</field>
             <field name="fixed_value">0</field>
             <field name="export_type">float</field>
             <field name="apply_sign" eval="True"/>


### PR DESCRIPTION
Hola:

Proponemos este PR para añadir la casilla 77 al modelo 303. El valor de esta casilla es una copia de la casilla 33. He seguido las indicaciones de @albertgafic, seguramente él pueda explicar mejor el porqué de este funcionamiento.

Según la AEAT:
**Casilla 77**. "**IVA a la importación liquidado por la Aduana pendiente de ingreso**: Se
hará constar el importe de las cuotas del Impuesto a la importación incluidas en
los documentos en los que conste la liquidación practicada por la
Administración recibidos en el periodo de liquidación.

Solamente podrá cumplimentarse esta casilla cuando se cumplan los requisitos
establecidos en el artículo 74.1 del Reglamento del Impuesto sobre el Valor
Añadido.

Esta casilla se habilita para los periodos de liquidación iniciados a partir del 1
de febrero de 2015, puesto que el ejercicio de esta opción debió ejercerse
excepcionalmente para el ejercicio 2015 en el mes de enero."
