### PR TITLE
[FIX] l10n_es_partner: prevent imported res.bank data from being removed on update

### DIFF
--- a/l10n_es_partner/wizard/l10n_es_partner_wizard.py
+++ b/l10n_es_partner/wizard/l10n_es_partner_wizard.py
@@ -38,7 +38,7 @@ class L10nEsPartnerImportWizard(models.TransientModel):
         path = os.path.join('l10n_es_partner', 'wizard', 'data_banks.xml')
         with tools.file_open(path) as fp:
             tools.convert_xml_import(
-                self._cr, 'l10n_es_partner', fp, {}, 'init', noupdate=False)
+                self._cr, 'l10n_es_partner', fp, {}, 'init', noupdate=True)
         return res
 
     @api.multi
@@ -56,7 +56,7 @@ class L10nEsPartnerImportWizard(models.TransientModel):
             gen_bank_data_xml(src_file.name, dest_file.name)
             tools.convert_xml_import(
                 self._cr, 'l10n_es_partner', dest_file.name, {}, 'init',
-                noupdate=False)
+                noupdate=True)
         except:
             self.import_fail = True
             return {


### PR DESCRIPTION
As the data generated by `l10n.es.partner.import.wizard` is created using the flag `noupdate=False`, the subsequent update of the module is removing all the created data. This causes the Bank Accounts (`res.partner.bank`) to be silently losing their assigned Bank (res.bank).

Fixes issue #276.
