### PR TITLE
[FIX] Corrección de errores en modelo 347

### DIFF
--- a/l10n_es_aeat_mod347/mod347.py
+++ b/l10n_es_aeat_mod347/mod347.py
@@ -278,7 +278,7 @@ class L10nEsAeatMod347Report(orm.Model):
                                               context=context):
                 if partner.id not in visited_partners:
                     if partner.vat and report.group_by_cif:
-                        domain_group = domain.copy()
+                        domain_group = list(domain)
                         domain_group.append(('vat', '=', partner.vat))
                         partner_grouped_ids = partner_obj.search(
                             cr, uid, domain_group, context=context)
@@ -423,29 +423,29 @@ class L10nEsAeatMod347PartnerRecord(orm.Model):
                 'fourth_quarter_real_state_transmission_amount': 0,
             }
             invoices = [x for x in record.invoice_record_ids
-                        if x.type in ('out_invoice', 'in_invoice')]
+                        if x.invoice_id.type in ('out_invoice', 'in_invoice')]
             refunds = [x for x in record.invoice_record_ids
-                       if x.type in ('out_refund', 'in_refund')]
+                       if x.invoice_id.type in ('out_refund', 'in_refund')]
             result[record.id]['first_quarter'] = (
                 sum(x.amount for x in invoices
-                    if x.period_id.quarter == 'first') -
+                    if x.invoice_id.period_id.quarter == 'first') -
                 sum(x.amount for x in refunds
-                    if x.period_id.quarter == 'first'))
+                    if x.invoice_id.period_id.quarter == 'first'))
             result[record.id]['second_quarter'] = (
                 sum(x.amount for x in invoices
-                    if x.period_id.quarter == 'second') -
+                    if x.invoice_id.period_id.quarter == 'second') -
                 sum(x.amount for x in refunds
-                    if x.period_id.quarter == 'second'))
+                    if x.invoice_id.period_id.quarter == 'second'))
             result[record.id]['third_quarter'] = (
                 sum(x.amount for x in invoices
-                    if x.period_id.quarter == 'third') -
+                    if x.invoice_id.period_id.quarter == 'third') -
                 sum(x.amount for x in refunds
-                    if x.period_id.quarter == 'third'))
+                    if x.invoice_id.period_id.quarter == 'third'))
             result[record.id]['fourth_quarter'] = (
                 sum(x.amount for x in invoices
-                    if x.period_id.quarter == 'fourth') -
+                    if x.invoice_id.period_id.quarter == 'fourth') -
                 sum(x.amount for x in refunds
-                    if x.period_id.quarter == 'fourth'))
+                    if x.invoice_id.period_id.quarter == 'fourth'))
         return result
 
     def _get_lines(self, cr, uid, ids, context):


### PR DESCRIPTION
Corregida excepción "'list' object has no attribute 'copy'" que… se arrojaba al hacer un copy() de un list en el método 'calculate' del modelo 'L10nEsAeatMod347Report'. Cambiado por definición de nueva lista como list().

Corregido error en metodo _get_quarter_totals del modelo 'L10nEsAeatMod347PartnerRecord' que provocaba que los totales por periodo no se calcularan y aparecieran vacíos en el report generado imprimir el modelo 347. Intentaba obtener valor de campos 'type' y 'period_id' del modelo 'L10nEsAeatMod347InvoiceRecord' que no existen. Cambiado para obtener estos valores de los campos correspondientes del modelo account.invoice relacionado en el campo 'invoice_id' del modelo 'L10nEsAeatMod347InvoiceRecord'.
