### PR TITLE
[IMP] l10n_es_aeat_mod349: Fiscal position onchange in new API

### DIFF
--- a/l10n_es_aeat_mod349/models/account_invoice.py
+++ b/l10n_es_aeat_mod349/models/account_invoice.py
@@ -141,13 +141,13 @@ class AccountInvoice(models.Model):
         return invoices, refunds
 
     @api.multi
-    def on_change_fiscal_position(self, fiscal_position, invoice_type):
+    @api.onchange('fiscal_position')
+    def onchange_fiscal_position_l10n_es_aeat_mod349(self):
         """Suggest an operation key when fiscal position changes."""
-        res = {'operation_key': False}
-        if fiscal_position and invoice_type:
-            fp = self.env['account.fiscal.position'].browse(fiscal_position)
-            res['operation_key'] = self._get_operation_key(fp, invoice_type)
-        return {'value': res}
+        for invoice in self:
+            if invoice.fiscal_position:
+                invoice.operation_key = self._get_operation_key(
+                    invoice.fiscal_position, invoice.type)
 
     @api.model
     def create(self, vals):

--- a/l10n_es_aeat_mod349/views/account_invoice_view.xml
+++ b/l10n_es_aeat_mod349/views/account_invoice_view.xml
@@ -6,23 +6,12 @@
         ### ACCOUNT INVOICE ###
         ################### -->
         <!-- #### Customer invoices #### -->
-        <!-- ### Inheritance to add an on_change method to fiscal_position field ### -->
-        <record id="view_customer_account_invoice_form__replace_fiscal_position" model="ir.ui.view">
-            <field name="name">Account invoice (customer) | replace 'fiscal position' field (form)</field>
-            <field name="model">account.invoice</field>
-            <field name="inherit_id" ref="account.invoice_form"/>
-            <field name="arch" type="xml">
-                <field name="fiscal_position" position="attributes">
-                    <attribute name="on_change">on_change_fiscal_position(fiscal_position, type)</attribute>
-                </field>
-            </field>
-        </record>
 
         <!-- ### Inheritance to add an on_change method to fiscal_position field ### -->
         <record id="view_customer_account_invoice_form__add_operation_key" model="ir.ui.view">
             <field name="name">Account invoice (customer) | add 'operation_key' field (form)</field>
             <field name="model">account.invoice</field>
-            <field name="inherit_id" ref="view_customer_account_invoice_form__replace_fiscal_position"/>
+            <field name="inherit_id" ref="account.invoice_form"/>
             <field name="arch" type="xml">
                 <field name="fiscal_position" position="after">
                     <field name="operation_key"/>
@@ -32,23 +21,12 @@
 
 
         <!-- #### Supplier invoices #### -->
-        <!-- ### Inheritance to add an on_change method to fiscal_position field ### -->
-        <record id="view_supplier_account_invoice_form__replace_fiscal_position" model="ir.ui.view">
-            <field name="name">Account invoice (supplier) | replace 'fiscal position' field (form)</field>
-            <field name="model">account.invoice</field>
-            <field name="inherit_id" ref="account.invoice_supplier_form"/>
-            <field name="arch" type="xml">
-                <field name="fiscal_position" position="attributes">
-                    <attribute name="on_change">on_change_fiscal_position(fiscal_position, type)</attribute>
-                </field>
-            </field>
-        </record>
 
         <!-- ### Inheritance to add an on_change method to fiscal_position field ### -->
         <record id="view_supplier_account_invoice_form__add_operation_key" model="ir.ui.view">
             <field name="name">Account invoice (supplier) | add 'operation_key' field (form)</field>
             <field name="model">account.invoice</field>
-            <field name="inherit_id" ref="view_supplier_account_invoice_form__replace_fiscal_position"/>
+            <field name="inherit_id" ref="account.invoice_supplier_form"/>
             <field name="arch" type="xml">
                 <field name="fiscal_position" position="after">
                     <field name="operation_key"/>


### PR DESCRIPTION
Para así tener compatibilidad con otros módulos que utilizan la nueva API de onchange, como el _invoice_fiscal_position_update_.

cc @rafaelbn @antespi 
