### PR TITLE
aeat mod 347 fix code errors in received cash amount

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -194,14 +194,13 @@ class L10nEsAeatMod347Report(models.Model):
                              'origin_fiscalyear_id': cash_move_fy_id})
                     else:
                         partner_record_obj.write(
-                            partner_record_id,
                             {'cash_amount': sum([line.credit for line in
                                                  cash_moves[cash_move_fy_id]]),
                              'origin_fiscalyear_id': cash_move_fy_id})
                         cash_partner_record_id = partner_record_id
                     for line in cash_moves[cash_move_fy_id]:
                         cash_record_obj.create(
-                            {'partner_record_id': cash_partner_record_id,
+                            {'partner_record_id': cash_partner_record_id.id,
                              'move_line_id': line.id,
                              'date': line.date,
                              'amount': line.credit})

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -193,7 +193,7 @@ class L10nEsAeatMod347Report(models.Model):
                                                  cash_moves[cash_move_fy_id]]),
                              'origin_fiscalyear_id': cash_move_fy_id})
                     else:
-                        partner_record_obj.write(
+                        partner_record_id.write(
                             {'cash_amount': sum([line.credit for line in
                                                  cash_moves[cash_move_fy_id]]),
                              'origin_fiscalyear_id': cash_move_fy_id})


### PR DESCRIPTION
When calculating 347 report, if there are cash received records the system gives the following error:

File "/opt/odoo/l10n-spain/l10n_es_aeat_mod347/models/mod347.py", line 200, in _calculate_cash_records
    'origin_fiscalyear_id': cash_move_fy_id})
  File "/opt/odoo/odoo/openerp/api.py", line 239, in wrapper
    return new_api(self, _args, *_kwargs)
TypeError: write() takes exactly 2 arguments (3 given)

Error fixed.
