### PR TITLE
[FIX] l10n_es_aeat_mod347: Arreglado calculo de campos totales por trimestre

### DIFF
--- a/l10n_es_aeat_mod347/mod347.py
+++ b/l10n_es_aeat_mod347/mod347.py
@@ -434,18 +434,18 @@ class L10nEsAeatMod347PartnerRecord(orm.Model):
             result[record.id]['second_quarter'] = (
                 sum(x.amount for x in invoices
                     if x.invoice_id.period_id.quarter == 'second') -
-                sum(x.amount for x in refunds
-                    if x.invoice_id.period_id.quarter == 'second'))
+                abs(sum(x.amount for x in refunds
+                    if x.invoice_id.period_id.quarter == 'second')))
             result[record.id]['third_quarter'] = (
                 sum(x.amount for x in invoices
                     if x.invoice_id.period_id.quarter == 'third') -
-                sum(x.amount for x in refunds
-                    if x.invoice_id.period_id.quarter == 'third'))
+                abs(sum(x.amount for x in refunds
+                        if x.invoice_id.period_id.quarter == 'third')))
             result[record.id]['fourth_quarter'] = (
                 sum(x.amount for x in invoices
                     if x.invoice_id.period_id.quarter == 'fourth') -
-                sum(x.amount for x in refunds
-                    if x.invoice_id.period_id.quarter == 'fourth'))
+                abs(sum(x.amount for x in refunds
+                    if x.invoice_id.period_id.quarter == 'fourth')))
         return result
 
     def _get_lines(self, cr, uid, ids, context):


### PR DESCRIPTION
Este PR soluciona un problema con el cálculo de los importes totales del trimestre en el informe 347.

Resulta que si para un cliente tenemos por ejemplo en el primer trimestre
- Factura de cliente de 3500€
- Factura rectificativa de cliente de 500€
  Nos muestra como total del 347 para ese primer trimestre 4000€ cuando deberían mostrarse 3000€

Esto es debido a que los importes de las rectificativas se guardan como negativos en el resumen del 347, y al hacer el calculo está haciendo: Importe facturas - importe rectificativas y al ser este importe de rectificativas negativo se están sumando los importes.

Lo he solucionado mediante un abs en el importe de rectificativas de esa operación
