### PR TITLE
7.0 [FIX] l10n_es_aeat_mod347

### DIFF
--- a/l10n_es_aeat_mod347/mod347.py
+++ b/l10n_es_aeat_mod347/mod347.py
@@ -429,8 +429,8 @@ class L10nEsAeatMod347PartnerRecord(orm.Model):
             result[record.id]['first_quarter'] = (
                 sum(x.amount for x in invoices
                     if x.invoice_id.period_id.quarter == 'first') -
-                sum(x.amount for x in refunds
-                    if x.invoice_id.period_id.quarter == 'first'))
+                abs(sum(x.amount for x in refunds
+                    if x.invoice_id.period_id.quarter == 'first')))
             result[record.id]['second_quarter'] = (
                 sum(x.amount for x in invoices
                     if x.invoice_id.period_id.quarter == 'second') -


### PR DESCRIPTION
Arreglado calculo de campos totales en primer trimestre

En el PR https://github.com/OCA/l10n-spain/pull/287 Se habia quedado sin añadir el abs al primer trimestre, con esto se ha añadido y debería de funcionar correctamente para todos los trimestres
