### PR TITLE
[IMP] Sustituido campo 'reference' por 'supplier_invoice_number' como ref. de factura de proveedor en mod 340

### DIFF
--- a/l10n_es_aeat_mod340/__openerp__.py
+++ b/l10n_es_aeat_mod340/__openerp__.py
@@ -23,7 +23,7 @@
 
 {
     'name': 'Generación de fichero modelo 340 y libro de IVA',
-    'version': '8.0.2.1.0',
+    'version': '8.0.2.2.0',
     'author': "Acysos S.L., "
               "Ting, "
               "Nan-tic, "

--- a/l10n_es_aeat_mod340/i18n/es.po
+++ b/l10n_es_aeat_mod340/i18n/es.po
@@ -1,24 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat_mod340
-# 
-# Translators:
-# Alejandro Santana <alejandrosantana@anubia.es>, 2015
-# Oihane Crucelaegui <oihanecruce@gmail.com>, 2015
-# Pedro M. Baeza <pedro.baeza@gmail.com>, 2015
+#	* l10n_es_aeat_mod340
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-spain (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-05 19:24+0000\n"
-"PO-Revision-Date: 2015-11-05 11:42+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/es/)\n"
+"POT-Creation-Date: 2016-02-06 15:42+0000\n"
+"PO-Revision-Date: 2016-02-06 15:42+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_aeat_mod340
 #: selection:res.partner,vat_type:0
@@ -77,12 +72,14 @@ msgid "Account entry"
 msgstr "Entrada cuenta"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "Apellidos y nombre de contacto:"
 msgstr "Apellidos y nombre de contacto:"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "Base imponible"
 msgstr "Base imponible"
 
@@ -97,17 +94,19 @@ msgid "Base tax bill"
 msgstr "Base"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "CIF/NIF"
 msgstr "CIF/NIF"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "CIF/NIF del representante legal:"
 msgstr "CIF/NIF del representante legal:"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "CIF/NIF:"
 msgstr "CIF/NIF:"
 
@@ -157,7 +156,8 @@ msgid "Company CIF/NIF"
 msgstr "NIF de la compañía"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "Compañía:"
 msgstr "Compañía:"
 
@@ -216,12 +216,13 @@ msgid "Created on"
 msgstr "Creado el"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "Cuota impuesto"
 msgstr "Cuota impuesto"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Código electrónico autoliquidación IVA:"
 msgstr "Código electrónico autoliquidación IVA:"
 
@@ -266,7 +267,8 @@ msgid "Draft models"
 msgstr "Modelos en borrador"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "Ejercicio fiscal:"
 msgstr "Ejercicio fiscal:"
 
@@ -277,7 +279,8 @@ msgid "Electronic Code VAT reverse charge"
 msgstr "Código electrónico del modelo 340"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "Empresa"
 msgstr "Empresa"
 
@@ -297,17 +300,20 @@ msgid "Export config"
 msgstr "Plantilla de exportación"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "FACTURAS DE ENTRADA"
 msgstr "FACTURAS DE ENTRADA"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "FACTURAS DE SALIDA"
 msgstr "FACTURAS DE SALIDA"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "Fecha"
 msgstr "Fecha"
 
@@ -370,7 +376,8 @@ msgid "In process models"
 msgstr "Modelos en proceso"
 
 #. module: l10n_es_aeat_mod340
-#: field:account.tax.code,mod340:0 field:account.tax.code.template,mod340:0
+#: field:account.tax.code,mod340:0
+#: field:account.tax.code.template,mod340:0
 msgid "Include in mod340"
 msgstr "Incluir en el modelo 340"
 
@@ -386,9 +393,7 @@ msgstr "Factura"
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py:140
 #, python-format
-msgid ""
-"Invoice  %s, Amount untaxed Lines %.2f do not correspond to AmountUntaxed on"
-" Invoice %.2f"
+msgid "Invoice  %s, Amount untaxed Lines %.2f do not correspond to AmountUntaxed on Invoice %.2f"
 msgstr "Invoice  %s, Amount untaxed Lines %.2f do not correspond to AmountUntaxed on Invoice %.2f"
 
 #. module: l10n_es_aeat_mod340
@@ -449,7 +454,7 @@ msgid "L.R. VAT number"
 msgstr "NIF Representante legal"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "LIBRO DE IVA"
 msgstr "LIBRO DE IVA"
 
@@ -504,7 +509,7 @@ msgid "Legal Representative VAT number."
 msgstr "NIF del representante legal."
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "MODELO AEAT 340"
 msgstr "MODELO AEAT 340"
 
@@ -556,22 +561,23 @@ msgid "Number of tickets"
 msgstr "Número de tiques"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "Nº de factura"
 msgstr "Nº de factura"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "Número de factura"
 msgstr "Número de factura"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Número de la declaración anterior:"
 msgstr "Número de la declaración anterior:"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Número:"
 msgstr "Número:"
 
@@ -675,6 +681,11 @@ msgid "Summary"
 msgstr "Resumen"
 
 #. module: l10n_es_aeat_mod340
+#: field:l10n.es.aeat.mod340.received,supplier_invoice_number:0
+msgid "Supplier Invoice Number"
+msgstr "Ref. proveedor"
+
+#. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,support_type:0
 msgid "Support Type"
 msgstr "Tipo de soporte"
@@ -687,7 +698,7 @@ msgstr "Código impuesto"
 #. module: l10n_es_aeat_mod340
 #: model:ir.model,name:l10n_es_aeat_mod340.model_account_tax_code_template
 msgid "Tax Code Template"
-msgstr "Plantilla códigos de impuestos"
+msgstr "Plantilla de código de impuesto"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.tax_line_issued,tax_amount:0
@@ -726,7 +737,8 @@ msgid "Telematics"
 msgstr "Telemática"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "Teléfono de contacto:"
 msgstr "Teléfono de contacto:"
 
@@ -734,7 +746,9 @@ msgstr "Teléfono de contacto:"
 #: code:addons/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py:30
 #, python-format
 msgid "The 340 model field is different.\n"
+""
 msgstr "El campo modelo 340 es diferente.\n"
+""
 
 #. module: l10n_es_aeat_mod340
 #: help:l10n.es.aeat.mod340.report,number_records:0
@@ -744,9 +758,7 @@ msgstr "El campo modelo 340 es diferente.\n"
 #: help:l10n.es.aeat.mod340.report,total_sharetax_rec:0
 #: help:l10n.es.aeat.mod340.report,total_taxable:0
 #: help:l10n.es.aeat.mod340.report,total_taxable_rec:0
-msgid ""
-"The declaration will include partners with the total of operations over this"
-" limit"
+msgid "The declaration will include partners with the total of operations over this limit"
 msgstr "La declaración incluirá las empresas cuya suma de operaciones supere este límite."
 
 #. module: l10n_es_aeat_mod340
@@ -758,22 +770,18 @@ msgstr "El registro de tipo 1 tiene que tener 500 caracteres de longitud"
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py:259
 #, python-format
-msgid ""
-"The type 2 issued record must be 500 characters long for each Vat registry"
+msgid "The type 2 issued record must be 500 characters long for each Vat registry"
 msgstr "El registro de tipo 2 debe tener una longitud de 500 caracteres por cada registro de IVA"
 
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py:399
 #, python-format
-msgid ""
-"The type 2 received record must be 500 characters long for each Vat registry"
+msgid "The type 2 received record must be 500 characters long for each Vat registry"
 msgstr "El registro de tipo 2 debe tener una longitud de 500 caracteres por cada registro de IVA"
 
 #. module: l10n_es_aeat_mod340
 #: help:l10n.es.aeat.mod340.report,counterpart_account:0
-msgid ""
-"This account will be the counterpart for all the journal items that are "
-"regularized when posting the report."
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
 msgstr "Esta cuenta será la contrapartida para todos los elementos del diario que están regularizados al contabilizar el informe."
 
 #. module: l10n_es_aeat_mod340
@@ -788,12 +796,12 @@ msgid "Ticket Summary"
 msgstr "Resumen de tiques"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Tipo de declaración"
 msgstr "Tipo de declaración"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Tipo de soporte:"
 msgstr "Tipo de soporte:"
 
@@ -805,7 +813,8 @@ msgstr "Tipo de soporte:"
 #: view:l10n.es.aeat.mod340.received:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_received_tree
 #: field:l10n.es.aeat.mod340.received,total:0
 #: field:l10n.es.aeat.mod340.report,total:0
-#: field:l10n.es.aeat.mod340.report,total_rec:0 reportvat book:0
+#: field:l10n.es.aeat.mod340.report,total_rec:0
+#: report:vat book:0
 msgid "Total"
 msgstr "Total"
 
@@ -834,7 +843,8 @@ msgid "Total Taxable"
 msgstr "Total"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0
+#: report:vat book:0
 msgid "Total factura"
 msgstr "Total factura"
 
@@ -865,3 +875,9 @@ msgstr "get"
 #: selection:l10n.es.aeat.mod340.export_to_boe,state:0
 msgid "open"
 msgstr "open"
+
+#. module: l10n_es_aeat_mod340
+#: view:account.invoice:l10n_es_aeat_mod340.invoice_supplier_mod340_form
+msgid "{'required': True}"
+msgstr "{'required': True}"
+

--- a/l10n_es_aeat_mod340/migrations/8.0.2.2/post-migration.py
+++ b/l10n_es_aeat_mod340/migrations/8.0.2.2/post-migration.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Otherway Creatives S.L.
+#    Copyright (C) 2014-TODAY Otherway Creatives(<http://www.otherway.es>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import tools
+from base64 import b64decode, b64encode
+import hashlib, re, os, logging
+from datetime import datetime
+from openerp.tools.translate import _
+import pytz
+
+__name__ = u"Completamos el campo 'supplier_invoice_number' en las facturas"
+
+_logger = logging.getLogger(__name__)
+
+def update_supplier_invoice_number(cr, version):
+    
+    """
+    Completamos el campo 'supplier_invoice_number' en las facturas de 
+    proveedor que no lo tienen completado, con el valor del campo 'reference'
+    si está establecido o con el propio 'internal_number'
+    """
+    # Primero facturas emitidas
+    cr.execute("""select id, reference, invoice_number  
+        from account_invoice 
+        where supplier_invoice_number is null and type like 'in_invoice'  
+        ;""")
+    invoices = cr.fetchall()
+    for invoice in invoices:
+        invoice_id = invoice[0]
+        reference = invoice[1]
+        invoice_number = invoice[2]
+        
+        if reference and reference != '': 
+            cr.execute("""UPDATE account_invoice SET 
+            supplier_invoice_number = %s WHERE id = %s;""", 
+            (reference,invoice_id,))
+
+        elif invoice_number and invoice_number != '': 
+            cr.execute("""UPDATE account_invoice SET 
+            supplier_invoice_number = %s WHERE id = %s;""", 
+            (invoice_number,invoice_id,))
+
+    
+def migrate(cr, version):
+    if not version:
+        return
+    update_supplier_invoice_number(cr, version)
+
+
+
+
+
+

--- a/l10n_es_aeat_mod340/models/mod340.py
+++ b/l10n_es_aeat_mod340/models/mod340.py
@@ -168,6 +168,8 @@ class L10nEsAeatMod340Received(orm.Model):
         'tax_line_ids': fields.one2many(
             'l10n.es.aeat.mod340.tax_line_received', 'invoice_record_id',
             'Tax lines'),
+        'supplier_invoice_number': fields.related('invoice_id', 'supplier_invoice_number', 
+            type='char', string="Supplier Invoice Number", store=True),        
     }
 
 

--- a/l10n_es_aeat_mod340/models/mod340.py
+++ b/l10n_es_aeat_mod340/models/mod340.py
@@ -168,8 +168,11 @@ class L10nEsAeatMod340Received(orm.Model):
         'tax_line_ids': fields.one2many(
             'l10n.es.aeat.mod340.tax_line_received', 'invoice_record_id',
             'Tax lines'),
-        'supplier_invoice_number': fields.related('invoice_id', 'supplier_invoice_number', 
-            type='char', string="Supplier Invoice Number", store=True),        
+        'supplier_invoice_number': fields.related('invoice_id', 
+                                            'supplier_invoice_number', 
+                                            type='char', 
+                                            string="Supplier Invoice Number", 
+                                            store=True),        
     }
 
 

--- a/l10n_es_aeat_mod340/report/mod340_report.rml
+++ b/l10n_es_aeat_mod340/report/mod340_report.rml
@@ -297,7 +297,7 @@
             <para style="P11">[[r.partner_vat]]</para>
           </td>
           <td>
-            <para style="P11">[[r.invoice_id.reference or '0']]</para>
+            <para style="P11">[[r.invoice_id.supplier_invoice_number or '0']]</para>
           </td>
           <td>
             <para style="P10">[[r.base_tax]]</para>

--- a/l10n_es_aeat_mod340/report/vat_book.rml
+++ b/l10n_es_aeat_mod340/report/vat_book.rml
@@ -359,7 +359,7 @@
             <para style="P11">[[r.partner_vat]]</para>
           </td>
           <td>
-            <para style="P11">[[r.invoice_id.reference or '0']]</para>
+            <para style="P11">[[r.invoice_id.supplier_invoice_number or '0']]</para>
           </td>
           <td>
             <para style="P10">[[r.base_tax]]</para>

--- a/l10n_es_aeat_mod340/views/account_invoice_view.xml
+++ b/l10n_es_aeat_mod340/views/account_invoice_view.xml
@@ -27,8 +27,8 @@
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_supplier_form"/>
             <field name="arch" type="xml">
-                <field name="reference" position="replace">
-                    <field name="reference" nolabel="1" required="1"/>
+                <field name="supplier_invoice_number" position="attributes">
+                    <attribute name="attrs">{'required': True}</attribute>
                 </field>
             </field>
         </record>

--- a/l10n_es_aeat_mod340/views/mod340_view.xml
+++ b/l10n_es_aeat_mod340/views/mod340_view.xml
@@ -110,6 +110,7 @@
                     <field name="partner_country_code"/>
                     <field name="partner_vat"/>
                     <field name="invoice_id"/>
+                    <field name="supplier_invoice_number"/>
                     <field name="base_tax" sum="Total Base"/>
                     <field name="amount_tax" sum="Total Tax"/>
                     <field name="total" sum="Total"/>
@@ -123,6 +124,7 @@
             <field name="arch" type="xml">
                 <form string="Received invoices">
                     <field name="invoice_id"/>
+                    <field name="supplier_invoice_number"/>
                     <newline/>
                     <field name="partner_id"/>
                     <field name="partner_vat"/>

--- a/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py
+++ b/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py
@@ -371,7 +371,7 @@ class L10nEsAeatMod340ExportToBoe(models.TransientModel):
             # Base imponible a coste.
             text += ' ' + self._formatNumber(0, 11, 2)
             # Identificación de la factura
-            text += self._formatString(invoice_received.invoice_id.reference,
+            text += self._formatString(invoice_received.invoice_id.supplier_invoice_number,
                                        40)
             # Número de registro
             sequence_obj = self.env['ir.sequence']


### PR DESCRIPTION
Se estaba utilizando el campo de factura 'reference' para mostrar el numero de factura de proveedor, cuando en account.invoice hay un campo llamado 'supplier_invoice_number' que precisamente se usa para almacenar el número de factura de proveedor. Hemos modificado este campo para que sea obligatorio al instalar el módulo, y hemos referenciado este campo en las vistas y en los reports.
