### PR TITLE
Update account_asset.py

### DIFF
--- a/l10n_es_account_asset/account_asset.py
+++ b/l10n_es_account_asset/account_asset.py
@@ -100,7 +100,8 @@ class AccountAssetAsset(orm.Model):
             'Start Depreciation Date',
             readonly=True,
             states={'draft': [('readonly', False)]},
-            help="Only needed if not the same than purchase date"),
+            help="Only needed if not the same than purchase date. You must "
+                "indicate the 1th day of the month of new depreciation date"),
 
     }
 


### PR DESCRIPTION
Aclarar la fecha que se debe indicar para que se recoja correctamente el primer mes de depreciación. Si se indica un día posterior al día 1 de mes, la primera depreciación se pasa al mes siguiente:
![image](https://cloud.githubusercontent.com/assets/10234023/12868401/5a326120-cd06-11e5-9f3c-171aac123146.png)

Si se pone día 1:
![image](https://cloud.githubusercontent.com/assets/10234023/12868423/b32cc996-cd06-11e5-979e-bc8fca202de4.png)
