### PR TITLE
[FIX] l10n_es_aeat_*: Mejor herencia de impuestos

### DIFF
--- a/l10n_es_aeat/README.rst
+++ b/l10n_es_aeat/README.rst
@@ -23,10 +23,18 @@ Todos aquellos modelos que se especifiquen en los módulos adicionales y
 hereden el AEAT base, deberán definir una variable interna que se llame
 '_aeat_number' asignándole como valor, el número del modelo (130, 340, 347...).
 
+Para poder utilizar el motor genérico de cálculo de casillas por códigos de
+impuestos (como el 303), hay que heredar del modelo
+"l10n.es.aeat.report.tax.mapping" en lugar de "l10n.es.aeat.report". Para la
+vista, hay que añadir el campo a mano, ya que la herencia de vistas no permite
+una doble herencia de AbstractModel, pero lo que es la vista tree ya está
+definida.
+
 Para activar la creación del asiento de regularización en un modelo, hay que
 poner en el modelo correspondiente el campo allow_posting a True, y establecer
 en la configuración de impuestos los conceptos que se regularizarán con el
-flag "to_regularize".
+flag "to_regularize". Esto sólo es posible sobre los modelos que utilicen
+el cálculo de casillas por códigos de impuestos.
 
 Problemas conocidos / Hoja de ruta
 ==================================

--- a/l10n_es_aeat/__openerp__.py
+++ b/l10n_es_aeat/__openerp__.py
@@ -28,7 +28,7 @@
 ##############################################################################
 {
     'name': "AEAT Base",
-    'version': "8.0.1.4.0",
+    'version': "8.0.1.5.0",
     'author': "Pexego,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
               "AvanzOSC,"
@@ -54,7 +54,8 @@
         'data/aeat_partner.xml',
         'wizard/export_to_boe_wizard.xml',
         'views/aeat_menuitem.xml',
-        'views/aeat_view.xml',
+        'views/aeat_report_view.xml',
+        'views/aeat_report_tax_mapping_view.xml',
         'views/aeat_export_configuration_view.xml',
         'views/aeat_tax_code_mapping_view.xml'
     ],

--- a/l10n_es_aeat/i18n/es.po
+++ b/l10n_es_aeat/i18n/es.po
@@ -1,24 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat
-# 
-# Translators:
-# Antonio Trueba, 2016
-# Carles Antolí <carlesantoli@hotmail.com>, 2015
-# Pedro M. Baeza <pedro.baeza@gmail.com>, 2015
+#	* l10n_es_aeat
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-spain (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-04 17:53+0000\n"
-"PO-Revision-Date: 2016-01-07 14:22+0000\n"
-"Last-Translator: Antonio Trueba\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/es/)\n"
+"POT-Creation-Date: 2016-02-11 16:07+0000\n"
+"PO-Revision-Date: 2016-02-11 16:07+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_aeat
 #: code:addons/l10n_es_aeat/wizard/export_to_boe.py:200
@@ -71,6 +66,7 @@ msgstr "Módulo base para declaraciones AEAT"
 
 #. module: l10n_es_aeat
 #: sql_constraint:l10n.es.aeat.report:0
+#: sql_constraint:l10n.es.aeat.report.tax.mapping:0
 msgid "AEAT report sequence must be unique"
 msgstr "La secuencia de la declaración AEAT debe ser única"
 
@@ -81,6 +77,7 @@ msgstr "Declaraciones AEAT"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,move_id:0
+#: field:l10n.es.aeat.report.tax.mapping,move_id:0
 msgid "Account entry"
 msgstr "Entrada cuenta"
 
@@ -142,6 +139,7 @@ msgstr "Calcular"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,calculation_date:0
+#: field:l10n.es.aeat.report.tax.mapping,calculation_date:0
 msgid "Calculation date"
 msgstr "Fecha de cálculo"
 
@@ -154,6 +152,7 @@ msgstr "Cancelar"
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: selection:l10n.es.aeat.report,state:0
+#: selection:l10n.es.aeat.report.tax.mapping,state:0
 msgid "Cancelled"
 msgstr "Cancelada"
 
@@ -170,11 +169,13 @@ msgstr "Cerrar"
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: field:l10n.es.aeat.report,company_id:0
+#: field:l10n.es.aeat.report.tax.mapping,company_id:0
 msgid "Company"
 msgstr "Compañía"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report,type:0
+#: selection:l10n.es.aeat.report.tax.mapping,type:0
 msgid "Complementary"
 msgstr "Complementaria"
 
@@ -215,13 +216,14 @@ msgstr "Datos de contacto"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,counterpart_account:0
+#: field:l10n.es.aeat.report.tax.mapping,counterpart_account:0
 msgid "Counterpart account"
 msgstr "Cuenta contrapartida"
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 msgid "Create move"
-msgstr "Crear movimiento"
+msgstr "Crear asiento"
 
 #. module: l10n_es_aeat
 #: field:aeat.mod.map.tax.code,create_uid:0
@@ -245,6 +247,7 @@ msgstr "Creado en"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report,support_type:0
+#: selection:l10n.es.aeat.report.tax.mapping,support_type:0
 msgid "DVD"
 msgstr "DVD"
 
@@ -255,12 +258,14 @@ msgstr "Declaración"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,number:0
+#: field:l10n.es.aeat.report.tax.mapping,number:0
 msgid "Declaration number"
 msgstr "Nº declaración"
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: selection:l10n.es.aeat.report,state:0
+#: selection:l10n.es.aeat.report.tax.mapping,state:0
 msgid "Done"
 msgstr "Realizada"
 
@@ -268,6 +273,7 @@ msgstr "Realizada"
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: selection:l10n.es.aeat.report,state:0
+#: selection:l10n.es.aeat.report.tax.mapping,state:0
 msgid "Draft"
 msgstr "Borrador"
 
@@ -301,11 +307,12 @@ msgstr "Exportar archivo AEAT BOE"
 #. module: l10n_es_aeat
 #: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_report_export_to_boe
 msgid "Export Report to BOE Format"
-msgstr "Exportar a formato BOE"
+msgstr "Exportar declaración al formato BOE"
 
 #. module: l10n_es_aeat
 #: model:ir.actions.act_window,name:l10n_es_aeat.action_aeat_export_config
 #: field:l10n.es.aeat.report,export_config:0
+#: field:l10n.es.aeat.report.tax.mapping,export_config:0
 msgid "Export config"
 msgstr "Configuración de exportación"
 
@@ -369,6 +376,7 @@ msgstr "Nombre de archivo"
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: field:l10n.es.aeat.report,fiscalyear_id:0
+#: field:l10n.es.aeat.report.tax.mapping,fiscalyear_id:0
 msgid "Fiscal year"
 msgstr "Ejercicio fiscal"
 
@@ -390,30 +398,30 @@ msgstr "Desde la fecha"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,contact_name:0
+#: field:l10n.es.aeat.report.tax.mapping,contact_name:0
 msgid "Full Name"
 msgstr "Nombre completo"
 
 #. module: l10n_es_aeat
-#: field:aeat.mod.map.tax.code,id:0 field:aeat.mod.map.tax.code.line,id:0
+#: field:aeat.mod.map.tax.code,id:0
+#: field:aeat.mod.map.tax.code.line,id:0
 #: field:aeat.model.export.config,id:0
-#: field:aeat.model.export.config.line,id:0 field:l10n.es.aeat.report,id:0
+#: field:aeat.model.export.config.line,id:0
+#: field:l10n.es.aeat.report,id:0
 #: field:l10n.es.aeat.report.export_to_boe,id:0
+#: field:l10n.es.aeat.report.tax.mapping,id:0
 #: field:l10n.es.aeat.tax.line,id:0
 msgid "ID"
 msgstr "ID"
 
 #. module: l10n_es_aeat
 #: help:aeat.model.export.config.line,repeat_expression:0
-msgid ""
-"If set, this expression will be used for getting the list of elements to "
-"iterate on"
+msgid "If set, this expression will be used for getting the list of elements to iterate on"
 msgstr "Si está establecida, esta expresión se usará para obtener una lista de los elementos por los que iterar"
 
 #. module: l10n_es_aeat
 #: help:aeat.model.export.config.line,conditional_expression:0
-msgid ""
-"If set, this expression will be used to evaluate if this line should be "
-"added"
+msgid "If set, this expression will be used to evaluate if this line should be added"
 msgstr "Si está establecida, esta expresión será usada para evaluar si la línea debe ser añadida"
 
 #. module: l10n_es_aeat
@@ -432,21 +440,25 @@ msgid "Informativas"
 msgstr "Informativas"
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:225
+#: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_report_tax_mapping
+msgid "Inheritable abstract model to add taxes by code mapping in any AEAT report"
+msgstr "Modelo abstracto heredable para añadir mapeo de impuestos por código en cualquier declaración de la AEAT"
+
+#. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_report.py:204
 #, python-format
-msgid ""
-"It seems that you have defined quarterly periods or periods in the middle of"
-" the month. This cannot be automatically handled. You should select manually"
-" the periods."
+msgid "It seems that you have defined quarterly periods or periods in the middle of the month. This cannot be automatically handled. You should select manually the periods."
 msgstr "Parece que ha definido periodos trimestrales o periodos en mitad del mes. Esto no se puede gestionar automáticamente, por lo que deberá seleccionar a mano los periodos."
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,journal_id:0
+#: field:l10n.es.aeat.report.tax.mapping,journal_id:0
 msgid "Journal"
 msgstr "Diario"
 
 #. module: l10n_es_aeat
 #: help:l10n.es.aeat.report,journal_id:0
+#: help:l10n.es.aeat.report.tax.mapping,journal_id:0
 msgid "Journal in which post the move."
 msgstr "Diario en el que publicar el movimiento."
 
@@ -457,6 +469,7 @@ msgstr "Apuntes contables"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,representative_vat:0
+#: field:l10n.es.aeat.report.tax.mapping,representative_vat:0
 msgid "L.R. VAT number"
 msgstr "NIF repr. legal"
 
@@ -487,6 +500,7 @@ msgstr "Izquierda"
 
 #. module: l10n_es_aeat
 #: help:l10n.es.aeat.report,representative_vat:0
+#: help:l10n.es.aeat.report.tax.mapping,representative_vat:0
 msgid "Legal Representative VAT number."
 msgstr "NIF del representante legal."
 
@@ -516,12 +530,19 @@ msgid "Mapping Lines"
 msgstr "Líneas de mapeo"
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.tax.line,model:0
+#: field:l10n.es.aeat.tax.line,model_id:0
+msgid "Model"
+msgstr "Modelo"
+
+#. module: l10n_es_aeat
 #: field:aeat.model.export.config,model_number:0
 msgid "Model number"
 msgstr "Nº modelo"
 
 #. module: l10n_es_aeat
 #: help:l10n.es.aeat.report,contact_name:0
+#: help:l10n.es.aeat.report.tax.mapping,contact_name:0
 msgid "Must have name and surname."
 msgstr "Debe tener apellidos y nombre."
 
@@ -540,6 +561,7 @@ msgstr "Carácter del signo negativo"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report,type:0
+#: selection:l10n.es.aeat.report.tax.mapping,type:0
 msgid "Normal"
 msgstr "Normal"
 
@@ -564,7 +586,7 @@ msgid "Odoo model"
 msgstr "Modelo Odoo"
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:447
+#: code:addons/l10n_es_aeat/models/aeat_report.py:328
 #, python-format
 msgid "Only reports in 'draft' or 'cancelled' state can be removed"
 msgstr "Sólo los informes en estado 'borrador' or 'cancelado' pueden ser eliminados"
@@ -581,24 +603,25 @@ msgstr "Otros parámetros"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,period_type:0
+#: field:l10n.es.aeat.report.tax.mapping,period_type:0
 msgid "Period type"
 msgstr "Tipo de periodo"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,periods:0
+#: field:l10n.es.aeat.report.tax.mapping,periods:0
 msgid "Period(s)"
 msgstr "Periodo(s)"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,contact_phone:0
+#: field:l10n.es.aeat.report.tax.mapping,contact_phone:0
 msgid "Phone"
 msgstr "Teléfono"
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
-msgid ""
-"Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el "
-"programa"
+msgid "Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el programa"
 msgstr "Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el programa"
 
 #. module: l10n_es_aeat
@@ -608,16 +631,19 @@ msgstr "Carácter del signo positivo"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report,state:0
+#: selection:l10n.es.aeat.report.tax.mapping,state:0
 msgid "Posted"
 msgstr "Contabilizado"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,previous_number:0
+#: field:l10n.es.aeat.report.tax.mapping,previous_number:0
 msgid "Previous declaration number"
 msgstr "Nº previo de declaración"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report,state:0
+#: selection:l10n.es.aeat.report.tax.mapping,state:0
 msgid "Processed"
 msgstr "Calculada"
 
@@ -632,7 +658,7 @@ msgid "Recalculate"
 msgstr "Recalcular"
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:357
+#: code:addons/l10n_es_aeat/models/aeat_report_tax_mapping.py:127
 #, python-format
 msgid "Regularization"
 msgstr "Regularización"
@@ -649,9 +675,13 @@ msgstr "Expresión de repetición"
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
-#: field:l10n.es.aeat.tax.line,report:0
 msgid "Report"
 msgstr "Declaración"
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.tax.line,res_id:0
+msgid "Resource ID"
+msgstr "ID del recurso"
 
 #. module: l10n_es_aeat
 #: selection:aeat.model.export.config.line,alignment:0
@@ -661,11 +691,12 @@ msgstr "Derecha"
 #. module: l10n_es_aeat
 #: field:aeat.model.export.config.line,sequence:0
 #: field:l10n.es.aeat.report,sequence:0
+#: field:l10n.es.aeat.report.tax.mapping,sequence:0
 msgid "Sequence"
 msgstr "Secuencia"
 
 #. module: l10n_es_aeat
-#: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
+#: view:l10n.es.aeat.tax.line:l10n_es_aeat.view_l10n_es_aeat_tax_line_tree
 msgid "Show journal items"
 msgstr "Mostrar apuntes contables"
 
@@ -675,11 +706,9 @@ msgid "Show move"
 msgstr "Ver movimiento"
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:185
+#: code:addons/l10n_es_aeat/models/aeat_report.py:164
 #, python-format
-msgid ""
-"Split fiscal years cannot be automatically handled. You should select "
-"manually the periods."
+msgid "Split fiscal years cannot be automatically handled. You should select manually the periods."
 msgstr "Los ejercicios fiscales separados no pueden ser gestionados automáticamente. Debe seleccionar manualmente los periodos."
 
 #. module: l10n_es_aeat
@@ -690,11 +719,13 @@ msgstr "Fecha de inicio"
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,state:0
 #: field:l10n.es.aeat.report.export_to_boe,state:0
+#: field:l10n.es.aeat.report.tax.mapping,state:0
 msgid "State"
 msgstr "Estado"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,type:0
+#: field:l10n.es.aeat.report.tax.mapping,type:0
 msgid "Statement Type"
 msgstr "Tipo de declaración"
 
@@ -706,11 +737,13 @@ msgstr "Sub-configuración"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report,type:0
+#: selection:l10n.es.aeat.report.tax.mapping,type:0
 msgid "Substitutive"
 msgstr "Sustitutiva"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,support_type:0
+#: field:l10n.es.aeat.report.tax.mapping,support_type:0
 msgid "Support Type"
 msgstr "Tipo de soporte"
 
@@ -738,13 +771,14 @@ msgid "Tax codes"
 msgstr "Códigos de impuesto"
 
 #. module: l10n_es_aeat
-#: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
-#: field:l10n.es.aeat.report,tax_lines:0
+#: field:l10n.es.aeat.report.tax.mapping,tax_lines:0
+#: view:l10n.es.aeat.tax.line:l10n_es_aeat.view_l10n_es_aeat_tax_line_tree
 msgid "Tax lines"
 msgstr "Líneas de impuestos"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report,support_type:0
+#: selection:l10n.es.aeat.report.tax.mapping,support_type:0
 msgid "Telematics"
 msgstr "Telemática"
 
@@ -756,24 +790,21 @@ msgid "The formated string must match the given length"
 msgstr "La cadena formateada debe satisfacer el tamaño dado."
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:292
+#: code:addons/l10n_es_aeat/models/aeat_report.py:260
 #, python-format
-msgid ""
-"There is no period defined for the report. Please set at least one period "
-"and try again."
+msgid "There is no period defined for the report. Please set at least one period and try again."
 msgstr "No hay periodo definido para el informe. Establezca un periodo y vuelva a intentarlo."
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:279
+#: code:addons/l10n_es_aeat/models/aeat_report.py:247
 #, python-format
 msgid "There's a missing previous declaration for the period %s."
-msgstr "Falta una declaración previa para el período %s."
+msgstr "No hay una declaración previa para el periodo %s."
 
 #. module: l10n_es_aeat
 #: help:l10n.es.aeat.report,counterpart_account:0
-msgid ""
-"This account will be the counterpart for all the journal items that are "
-"regularized when posting the report."
+#: help:l10n.es.aeat.report.tax.mapping,counterpart_account:0
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
 msgstr "Esta cuenta será la contrapartida para todos los elementos del diario que están regularizados al contabilizar el informe."
 
 #. module: l10n_es_aeat
@@ -793,6 +824,7 @@ msgstr "Para regularizar"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,company_vat:0
+#: field:l10n.es.aeat.report.tax.mapping,company_vat:0
 msgid "VAT number"
 msgstr "NIF"
 
@@ -819,10 +851,10 @@ msgid "Wrong aling option. It should be < or >"
 msgstr "Opción de alineamiento errónea. Debería ser < o >"
 
 #. module: l10n_es_aeat
-#: code:addons/l10n_es_aeat/models/aeat_report.py:394
+#: code:addons/l10n_es_aeat/models/aeat_report_tax_mapping.py:164
 #, python-format
 msgid "You must fill both journal and counterpart account."
-msgstr "Debe rellenar a la vez diario y cuenta de contrapartida."
+msgstr "Debe rellenar tanto el diario como la cuenta de contrapartida."
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
@@ -853,3 +885,4 @@ msgstr "o"
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
 msgid "para iniciar el proceso de exportación del archivo BOE de la AEAT."
 msgstr "para iniciar el proceso de exportación del archivo BOE de la AEAT."
+

--- a/l10n_es_aeat/migrations/8.0.1.5.0/post-migration.py
+++ b/l10n_es_aeat/migrations/8.0.1.5.0/post-migration.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# © 2016 - Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        UPDATE l10n_es_aeat_tax_line
+        SET model = 'l10n.es.aeat.mod303.report',
+            res_id = legacy_report_id
+        WHERE model is NULL
+        """)

--- a/l10n_es_aeat/migrations/8.0.1.5.0/pre-migration.py
+++ b/l10n_es_aeat/migrations/8.0.1.5.0/pre-migration.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# © 2016 - Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        ALTER TABLE l10n_es_aeat_tax_line
+        RENAME report TO legacy_report_id
+        """)

--- a/l10n_es_aeat/models/__init__.py
+++ b/l10n_es_aeat/models/__init__.py
@@ -17,5 +17,6 @@
 ##############################################################################
 
 from . import aeat_report
+from . import aeat_report_tax_mapping
 from . import aeat_export_configuration
 from . import aeat_tax_code_mapping

--- a/l10n_es_aeat/models/aeat_report.py
+++ b/l10n_es_aeat/models/aeat_report.py
@@ -1,29 +1,10 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2004-2011
-#        Pexego Sistemas Informáticos. (http://pexego.es)
-#        Luis Manuel Angueira Blanco (Pexego)
-#    Copyright (C) 2013
-#        Ignacio Ibeas - Acysos S.L. (http://acysos.com)
-#        Migración a OpenERP 7.0
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 - Pexego Sistemas Informáticos - Luis Manuel Angueira Blanco
+# © 2013 - Acysos S.L. - Ignacio Ibeas (Migración a v7)
+# © 2014-2016 - Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import fields, models, api, exceptions, SUPERUSER_ID, _
-import openerp.addons.decimal_precision as dp
 from datetime import datetime
 import re
 
@@ -127,9 +108,6 @@ class L10nEsAeatReport(models.AbstractModel):
     periods = fields.Many2many(
         comodel_name='account.period', readonly=True, string="Period(s)",
         states={'draft': [('readonly', False)]})
-    tax_lines = fields.One2many(
-        comodel_name='l10n.es.aeat.tax.line', inverse_name='report',
-        readonly=True)
     allow_posting = fields.Boolean(compute="_compute_allow_posting")
     counterpart_account = fields.Many2one(
         comodel_name="account.account",
@@ -251,17 +229,6 @@ class L10nEsAeatReport(models.AbstractModel):
         return self.calculate()
 
     @api.multi
-    def _prepare_tax_line_vals(self, map_line):
-        self.ensure_one()
-        move_lines = self._get_tax_code_lines(
-            map_line.mapped('tax_codes.code'), periods=self.periods)
-        return {
-            'map_line': map_line.id,
-            'amount': sum(move_lines.mapped('tax_amount')),
-            'move_lines': [(6, 0, move_lines.ids)],
-        }
-
-    @api.multi
     def _get_previous_fiscalyear_reports(self, date):
         """Get the AEAT reports previous to the given date.
         :param date: Date for looking for previous reports.
@@ -291,26 +258,6 @@ class L10nEsAeatReport(models.AbstractModel):
                 raise exceptions.Warning(
                     _('There is no period defined for the report. Please set '
                       'at least one period and try again.'))
-            report.tax_lines.unlink()
-            # Buscar configuración de mapeo de impuestos
-            tax_code_map_obj = self.env['aeat.mod.map.tax.code']
-            date_start = min([fields.Date.from_string(x) for x in
-                              self.periods.mapped('date_start')])
-            date_stop = max([fields.Date.from_string(x) for x in
-                             self.periods.mapped('date_stop')])
-            tax_code_map = tax_code_map_obj.search(
-                [('model', '=', report.number),
-                 '|',
-                 ('date_from', '<=', date_start),
-                 ('date_from', '=', False),
-                 '|',
-                 ('date_to', '>=', date_stop),
-                 ('date_to', '=', False)], limit=1)
-            if tax_code_map:
-                tax_lines = []
-                for map_line in tax_code_map.map_lines:
-                    tax_lines.append(report._prepare_tax_line_vals(map_line))
-                report.tax_lines = [(0, 0, x) for x in tax_lines]
         return True
 
     @api.multi
@@ -329,78 +276,6 @@ class L10nEsAeatReport(models.AbstractModel):
             'ref': self.sequence,
             'company_id': self.company_id.id,
         }
-
-    @api.model
-    def _prepare_regularization_move_line(self, account_group):
-        return {
-            'name': account_group['account_id'][1],
-            'account_id': account_group['account_id'][0],
-            'debit': account_group['credit'],
-            'credit': account_group['debit'],
-        }
-
-    @api.multi
-    def _process_tax_line_regularization(self, tax_line):
-        self.ensure_one()
-        groups = self.env['account.move.line'].read_group(
-            [('id', 'in', tax_line.move_lines.ids)],
-            ['debit', 'credit', 'account_id'],
-            ['account_id'])
-        lines = []
-        for group in groups:
-            if group['debit']>0 and group['credit']>0:
-                new_group = group.copy()
-                group['debit'] = 0
-                new_group['credit']=0
-                lines.append(self._prepare_regularization_move_line(new_group))
-            lines.append(self._prepare_regularization_move_line(group))
-        return lines
-
-    @api.model
-    def _prepare_counterpart_move_line(self, account, debit, credit):
-        vals = {
-            'name': _('Regularization'),
-            'account_id': account.id,
-            'partner_id': self.env.ref('l10n_es_aeat.res_partner_aeat').id,
-        }
-        precision = self.env['decimal.precision'].precision_get('Account')
-        balance = round(debit - credit, precision)
-        vals['debit'] = 0.0 if debit > credit else -balance
-        vals['credit'] = balance if debit > credit else 0.0
-        return vals
-
-    @api.multi
-    def _prepare_regularization_extra_move_lines(self):
-        return []
-
-    @api.multi
-    def _prepare_regularization_move_lines(self):
-        """Prepare the list of dictionaries for the regularization move lines.
-        """
-        self.ensure_one()
-        lines = []
-        for tax_line in self.tax_lines.filtered('to_regularize'):
-            result = self._process_tax_line_regularization(tax_line)
-            # TODO: Ver si alguna vez se desglosa una cuenta en varias líneas
-            # y agrupar en consecuencia
-            lines += result
-        lines += self._prepare_regularization_extra_move_lines()
-        # Write counterpart with the remaining
-        debit = sum(x['debit'] for x in lines)
-        credit = sum(x['credit'] for x in lines)
-        lines.append(self._prepare_counterpart_move_line(
-            self.counterpart_account, debit, credit))
-        return lines
-
-    @api.one
-    def create_regularization_move(self):
-        if not self.counterpart_account or not self.journal_id:
-            raise exceptions.Warning(
-                _("You must fill both journal and counterpart account."))
-        move_vals = self._prepare_move_vals()
-        line_vals_list = self._prepare_regularization_move_lines()
-        move_vals['line_id'] = [(0, 0, x) for x in line_vals_list]
-        self.move_id = self.env['account.move'].create(move_vals)
 
     @api.multi
     def button_post(self):
@@ -454,7 +329,9 @@ class L10nEsAeatReport(models.AbstractModel):
         return super(L10nEsAeatReport, self).unlink()
 
     def init(self, cr):
-        if self._name != 'l10n.es.aeat.report':
+        # TODO: Poner en el _register_hook para evitar choque en multi BDs
+        if self._name not in ('l10n.es.aeat.report',
+                              'l10n.es.aeat.report.tax.mapping'):
             seq_obj = self.pool['ir.sequence']
             try:
                 aeat_num = getattr(self, '_aeat_number')
@@ -476,70 +353,3 @@ class L10nEsAeatReport(models.AbstractModel):
                 raise exceptions.Warning(
                     "Modelo no válido: %s. Debe declarar una variable "
                     "'_aeat_number'" % self._name)
-
-    # Helper functions
-    @api.multi
-    def _get_partner_domain(self):
-        return []
-
-    @api.multi
-    def _get_move_line_domain(self, codes, periods=None,
-                              include_children=True):
-        self.ensure_one()
-        tax_code_model = self.env['account.tax.code']
-        tax_codes = tax_code_model.search(
-            [('code', 'in', codes),
-             ('company_id', 'child_of', self.company_id.id)])
-        if include_children and tax_codes:
-            tax_codes = tax_code_model.search(
-                [('id', 'child_of', tax_codes.ids),
-                 ('company_id', 'child_of', self.company_id.id)])
-        if not periods:
-            periods = self.env['account.period'].search(
-                [('fiscalyear_id', '=', self.fiscalyear_id.id)])
-        move_line_domain = [('company_id', 'child_of', self.company_id.id),
-                            ('tax_code_id', 'child_of', tax_codes.ids),
-                            ('period_id', 'in', periods.ids)]
-        move_line_domain += self._get_partner_domain()
-        return move_line_domain
-
-    @api.model
-    def _get_tax_code_lines(self, codes, periods=None, include_children=True):
-        """
-        Get the move lines for the codes and periods associated
-        :param codes: List of strings for the tax codes
-        :param periods: Periods to include
-        :param include_children: True (default) if it also searches on
-          children tax codes.
-        :return: Move lines recordset that matches the criteria.
-        """
-        domain = self._get_move_line_domain(
-            codes, periods=periods, include_children=include_children)
-        return self.env['account.move.line'].search(domain)
-
-
-class L10nEsAeatTaxLine(models.Model):
-    _name = "l10n.es.aeat.tax.line"
-
-    report = fields.Many2one('l10n.es.aeat.report', required=True)
-    field_number = fields.Integer(
-        string="Field number", related="map_line.field_number",
-        store=True)
-    name = fields.Char(
-        string="Name", related="map_line.name", store=True)
-    amount = fields.Float(digits=dp.get_precision('Account'))
-    map_line = fields.Many2one(
-        comodel_name='aeat.mod.map.tax.code.line', required=True,
-        ondelete="cascade")
-    move_lines = fields.Many2many(
-        comodel_name='account.move.line', string='Journal items')
-    to_regularize = fields.Boolean(related='map_line.to_regularize')
-
-    def _get_move_line_act_window_dict(self):
-        return self.env.ref('account.action_tax_code_line_open').read()[0]
-
-    @api.multi
-    def get_calculated_move_lines(self):
-        res = self._get_move_line_act_window_dict()
-        res['domain'] = [('id', 'in', self.move_lines.ids)]
-        return res

--- a/l10n_es_aeat/models/aeat_report_tax_mapping.py
+++ b/l10n_es_aeat/models/aeat_report_tax_mapping.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+# © 2016 - Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, exceptions, fields, models, _
+import openerp.addons.decimal_precision as dp
+
+
+class L10nEsAeatReportTaxMapping(models.AbstractModel):
+    _name = "l10n.es.aeat.report.tax.mapping"
+    _inherit = "l10n.es.aeat.report"
+    _description = ("Inheritable abstract model to add taxes by code mapping "
+                    "in any AEAT report")
+
+    tax_lines = fields.One2many(
+        comodel_name='l10n.es.aeat.tax.line', inverse_name='res_id',
+        domain=lambda self: [("model", "=", self._name)], auto_join=True,
+        ondelete="cascade", readonly=True)
+
+    @api.multi
+    def calculate(self):
+        res = super(L10nEsAeatReportTaxMapping, self).calculate()
+        for report in self:
+            report.tax_lines.unlink()
+            # Buscar configuración de mapeo de impuestos
+            tax_code_map_obj = self.env['aeat.mod.map.tax.code']
+            date_start = min([fields.Date.from_string(x) for x in
+                              self.periods.mapped('date_start')])
+            date_stop = max([fields.Date.from_string(x) for x in
+                             self.periods.mapped('date_stop')])
+            tax_code_map = tax_code_map_obj.search(
+                [('model', '=', report.number),
+                 '|',
+                 ('date_from', '<=', date_start),
+                 ('date_from', '=', False),
+                 '|',
+                 ('date_to', '>=', date_stop),
+                 ('date_to', '=', False)], limit=1)
+            if tax_code_map:
+                tax_lines = []
+                for map_line in tax_code_map.map_lines:
+                    tax_lines.append(report._prepare_tax_line_vals(map_line))
+                report.tax_lines = [(0, 0, x) for x in tax_lines]
+        return res
+
+    @api.multi
+    def _prepare_tax_line_vals(self, map_line):
+        self.ensure_one()
+        move_lines = self._get_tax_code_lines(
+            map_line.mapped('tax_codes.code'), periods=self.periods)
+        return {
+            'model': self._name,
+            'res_id': self.id,
+            'map_line': map_line.id,
+            'amount': sum(move_lines.mapped('tax_amount')),
+            'move_lines': [(6, 0, move_lines.ids)],
+        }
+
+    @api.multi
+    def _get_partner_domain(self):
+        return []
+
+    @api.multi
+    def _get_move_line_domain(self, codes, periods=None,
+                              include_children=True):
+        self.ensure_one()
+        tax_code_model = self.env['account.tax.code']
+        tax_codes = tax_code_model.search(
+            [('code', 'in', codes),
+             ('company_id', 'child_of', self.company_id.id)])
+        if include_children and tax_codes:
+            tax_codes = tax_code_model.search(
+                [('id', 'child_of', tax_codes.ids),
+                 ('company_id', 'child_of', self.company_id.id)])
+        if not periods:
+            periods = self.env['account.period'].search(
+                [('fiscalyear_id', '=', self.fiscalyear_id.id)])
+        move_line_domain = [('company_id', 'child_of', self.company_id.id),
+                            ('tax_code_id', 'child_of', tax_codes.ids),
+                            ('period_id', 'in', periods.ids)]
+        move_line_domain += self._get_partner_domain()
+        return move_line_domain
+
+    @api.model
+    def _get_tax_code_lines(self, codes, periods=None, include_children=True):
+        """
+        Get the move lines for the codes and periods associated
+        :param codes: List of strings for the tax codes
+        :param periods: Periods to include
+        :param include_children: True (default) if it also searches on
+          children tax codes.
+        :return: Move lines recordset that matches the criteria.
+        """
+        domain = self._get_move_line_domain(
+            codes, periods=periods, include_children=include_children)
+        return self.env['account.move.line'].search(domain)
+
+    @api.model
+    def _prepare_regularization_move_line(self, account_group):
+        return {
+            'name': account_group['account_id'][1],
+            'account_id': account_group['account_id'][0],
+            'debit': account_group['credit'],
+            'credit': account_group['debit'],
+        }
+
+    @api.multi
+    def _process_tax_line_regularization(self, tax_line):
+        self.ensure_one()
+        groups = self.env['account.move.line'].read_group(
+            [('id', 'in', tax_line.move_lines.ids)],
+            ['debit', 'credit', 'account_id'],
+            ['account_id'])
+        lines = []
+        for group in groups:
+            if group['debit'] > 0 and group['credit'] > 0:
+                new_group = group.copy()
+                group['debit'] = 0
+                new_group['credit'] = 0
+                lines.append(self._prepare_regularization_move_line(new_group))
+            lines.append(self._prepare_regularization_move_line(group))
+        return lines
+
+    @api.model
+    def _prepare_counterpart_move_line(self, account, debit, credit):
+        vals = {
+            'name': _('Regularization'),
+            'account_id': account.id,
+            'partner_id': self.env.ref('l10n_es_aeat.res_partner_aeat').id,
+        }
+        precision = self.env['decimal.precision'].precision_get('Account')
+        balance = round(debit - credit, precision)
+        vals['debit'] = 0.0 if debit > credit else -balance
+        vals['credit'] = balance if debit > credit else 0.0
+        return vals
+
+    @api.multi
+    def _prepare_regularization_extra_move_lines(self):
+        return []
+
+    @api.multi
+    def _prepare_regularization_move_lines(self):
+        """Prepare the list of dictionaries for the regularization move lines.
+        """
+        self.ensure_one()
+        lines = []
+        for tax_line in self.tax_lines.filtered('to_regularize'):
+            result = self._process_tax_line_regularization(tax_line)
+            # TODO: Ver si alguna vez se desglosa una cuenta en varias líneas
+            # y agrupar en consecuencia
+            lines += result
+        lines += self._prepare_regularization_extra_move_lines()
+        # Write counterpart with the remaining
+        debit = sum(x['debit'] for x in lines)
+        credit = sum(x['credit'] for x in lines)
+        lines.append(self._prepare_counterpart_move_line(
+            self.counterpart_account, debit, credit))
+        return lines
+
+    @api.one
+    def create_regularization_move(self):
+        if not self.counterpart_account or not self.journal_id:
+            raise exceptions.Warning(
+                _("You must fill both journal and counterpart account."))
+        move_vals = self._prepare_move_vals()
+        line_vals_list = self._prepare_regularization_move_lines()
+        move_vals['line_id'] = [(0, 0, x) for x in line_vals_list]
+        self.move_id = self.env['account.move'].create(move_vals)
+
+
+class L10nEsAeatTaxLine(models.Model):
+    _name = "l10n.es.aeat.tax.line"
+
+    res_id = fields.Integer("Resource ID", index=True, required=True)
+    field_number = fields.Integer(
+        string="Field number", related="map_line.field_number",
+        store=True)
+    name = fields.Char(
+        string="Name", related="map_line.name", store=True)
+    amount = fields.Float(digits=dp.get_precision('Account'))
+    map_line = fields.Many2one(
+        comodel_name='aeat.mod.map.tax.code.line', required=True,
+        ondelete="cascade")
+    move_lines = fields.Many2many(
+        comodel_name='account.move.line', string='Journal items')
+    to_regularize = fields.Boolean(related='map_line.to_regularize')
+    model = fields.Char(index=True, readonly=True, required=True)
+    model_id = fields.Many2one(
+        comodel_name='ir.model', string='Model',
+        compute="_compute_model_id", store=True)
+
+    @api.multi
+    @api.depends("model")
+    def _compute_model_id(self):
+        for s in self:
+            s.model_id = self.env["ir.model"].search([("model", "=", s.model)])
+
+    def _get_move_line_act_window_dict(self):
+        return self.env.ref('account.action_tax_code_line_open').read()[0]
+
+    @api.multi
+    def get_calculated_move_lines(self):
+        res = self._get_move_line_act_window_dict()
+        res['domain'] = [('id', 'in', self.move_lines.ids)]
+        return res

--- a/l10n_es_aeat/views/aeat_report_tax_mapping_view.xml
+++ b/l10n_es_aeat/views/aeat_report_tax_mapping_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_l10n_es_aeat_tax_line_tree" model="ir.ui.view">
+            <field name="name">l10n.es.aeat.tax.line.tree</field>
+            <field name="model">l10n.es.aeat.tax.line</field>
+            <field name="arch" type="xml">
+                <tree string="Tax lines" editable="bottom">
+                    <field name="field_number"/>
+                    <field name="name"/>
+                    <field name="amount"/>
+                    <button name="get_calculated_move_lines"
+                            type="object"
+                            help="Show journal items"
+                            icon="gtk-find"/>
+                </tree>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/l10n_es_aeat/views/aeat_report_view.xml
+++ b/l10n_es_aeat/views/aeat_report_view.xml
@@ -97,23 +97,6 @@
                                         />
                             </group>
                         </group>
-                        <group string="Tax lines"
-                               name="group_tax_lines"
-                               colspan="4"
-                               attrs="{'invisible': ['|', ('tax_lines', '=', []), ('state', '=', 'draft')]}">
-                            <field name="tax_lines" nolabel="1">
-                                <!-- Se pone editable y el campo es readonly para evitar que se despliegue popup para evitar error por modelos cruzados -->
-                                <tree string="Tax lines" editable="bottom">
-                                    <field name="field_number"/>
-                                    <field name="name"/>
-                                    <field name="amount"/>
-                                    <button name="get_calculated_move_lines"
-                                            type="object"
-                                            help="Show journal items"
-                                            icon="gtk-find"/>
-                                </tree>
-                            </field>
-                        </group>
                     </sheet>
                 </form>
             </field>

--- a/l10n_es_aeat_mod111/views/mod111_view.xml
+++ b/l10n_es_aeat_mod111/views/mod111_view.xml
@@ -87,9 +87,6 @@
                     </group>
                 </group>
                 </group>
-                <group name="group_tax_lines" position="attributes">
-                    <attribute name="attrs">{'invisible': 1}</attribute>
-                </group>
             </field>
         </record>
 

--- a/l10n_es_aeat_mod115/views/mod115_view.xml
+++ b/l10n_es_aeat_mod115/views/mod115_view.xml
@@ -43,9 +43,6 @@
                         </group>
                     </group>
                 </group>
-                <group name="group_tax_lines" position="attributes">
-                    <attribute name="attrs">{'invisible': 1}</attribute>
-                </group>
             </field>
         </record>
 

--- a/l10n_es_aeat_mod216/views/mod216_view.xml
+++ b/l10n_es_aeat_mod216/views/mod216_view.xml
@@ -47,9 +47,6 @@
                         </group>
                     </group>
                 </group>
-                <group name="group_tax_lines" position="attributes">
-                    <attribute name="attrs">{'invisible': 1}</attribute>
-                </group>
             </field>
         </record>
 

--- a/l10n_es_aeat_mod296/views/mod296_view.xml
+++ b/l10n_es_aeat_mod296/views/mod296_view.xml
@@ -26,9 +26,6 @@
                         <field name="lines296" nolabel="1"/>
                     </group>
                 </group>
-                <group name="group_tax_lines" position="attributes">
-                    <attribute name="attrs">{'invisible': 1}</attribute>
-                </group>
             </field>
         </record>
 

--- a/l10n_es_aeat_mod303/__openerp__.py
+++ b/l10n_es_aeat_mod303/__openerp__.py
@@ -26,7 +26,7 @@
 
 {
     "name": "AEAT modelo 303",
-    "version": "8.0.1.3.0",
+    "version": "8.0.1.4.0",
     'category': "Accounting & Finance",
     'author': "Guadaltech,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod303/i18n/es.po
+++ b/l10n_es_aeat_mod303/i18n/es.po
@@ -1,22 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat_mod303
-# 
-# Translators:
-# Alejandro Santana <alejandrosantana@anubia.es>, 2015
+#	* l10n_es_aeat_mod303
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-spain (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-26 01:42+0000\n"
-"PO-Revision-Date: 2015-11-05 11:42+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/es/)\n"
+"POT-Creation-Date: 2016-02-11 16:13+0000\n"
+"PO-Revision-Date: 2016-02-11 16:13+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_aeat_mod303
 #: help:l10n.es.aeat.mod303.report,casilla_46:0
@@ -50,9 +47,7 @@ msgstr "Entrada cuenta"
 
 #. module: l10n_es_aeat_mod303
 #: help:l10n.es.aeat.mod303.report,casilla_69:0
-msgid ""
-"Atribuible a la Administración [66] - Cuotas a compensar [67] + "
-"Regularización anual [68]"
+msgid "Atribuible a la Administración [66] - Cuotas a compensar [67] + Regularización anual [68]"
 msgstr "Atribuible a la Administración [66] - Cuotas a compensar [67] + Regularización anual [68]"
 
 #. module: l10n_es_aeat_mod303
@@ -107,9 +102,7 @@ msgstr "Creado en"
 
 #. module: l10n_es_aeat_mod303
 #: help:l10n.es.aeat.mod303.report,cuota_compensar:0
-msgid ""
-"Cuota a compensar de periodos anteriores, en los que su declaración fue a "
-"devolver y se escogió la opción de compensación posterior"
+msgid "Cuota a compensar de periodos anteriores, en los que su declaración fue a devolver y se escogió la opción de compensación posterior"
 msgstr "Cuota a compensar de periodos anteriores, en los que su declaración fue a devolver y se escogió la opción de compensación posterior"
 
 #. module: l10n_es_aeat_mod303
@@ -144,12 +137,7 @@ msgstr "Borrador"
 
 #. module: l10n_es_aeat_mod303
 #: help:l10n.es.aeat.mod303.report,regularizacion_anual:0
-msgid ""
-"En la última autoliquidación del año (la del período 4T o mes 12) se hará "
-"constar, con el signo que corresponda, el resultado de la regularización "
-"anual conforme disponen las Leyes por las que se aprueban el Concierto "
-"Económico entre el Estado y la Comunidad Autónoma del País Vasco y el "
-"Convenio Económico entre el Estado y la Comunidad Foral de Navarra."
+msgid "En la última autoliquidación del año (la del período 4T o mes 12) se hará constar, con el signo que corresponda, el resultado de la regularización anual conforme disponen las Leyes por las que se aprueban el Concierto Económico entre el Estado y la Comunidad Autónoma del País Vasco y el Convenio Económico entre el Estado y la Comunidad Foral de Navarra."
 msgstr "En la última autoliquidación del año (la del período 4T o mes 12) se hará constar, con el signo que corresponda, el resultado de la regularización anual conforme disponen las Leyes por las que se aprueban el Concierto Económico entre el Estado y la Comunidad Autónoma del País Vasco y el Convenio Económico entre el Estado y la Comunidad Foral de Navarra."
 
 #. module: l10n_es_aeat_mod303
@@ -209,12 +197,7 @@ msgstr "Nombre del representante legal."
 
 #. module: l10n_es_aeat_mod303
 #: help:l10n.es.aeat.mod303.report,porcentaje_atribuible_estado:0
-msgid ""
-"Los sujetos pasivos que tributen conjuntamente a la Administración del "
-"Estado y a las Diputaciones Forales del País Vasco o a la Comunidad Foral de"
-" Navarra, consignarán en esta casilla el porcentaje del volumen de "
-"operaciones en territorio común. Los demás sujetos pasivos consignarán en "
-"esta casilla el 100%"
+msgid "Los sujetos pasivos que tributen conjuntamente a la Administración del Estado y a las Diputaciones Forales del País Vasco o a la Comunidad Foral de Navarra, consignarán en esta casilla el porcentaje del volumen de operaciones en territorio común. Los demás sujetos pasivos consignarán en esta casilla el 100%"
 msgstr "Los sujetos pasivos que tributen conjuntamente a la Administración del Estado y a las Diputaciones Forales del País Vasco o a la Comunidad Foral de Navarra, consignarán en esta casilla el porcentaje del volumen de operaciones en territorio común. Los demás sujetos pasivos consignarán en esta casilla el 100%"
 
 #. module: l10n_es_aeat_mod303
@@ -269,19 +252,17 @@ msgstr "Resultado"
 
 #. module: l10n_es_aeat_mod303
 #: help:l10n.es.aeat.mod303.report,previous_result:0
-msgid ""
-"Resultado de la anterior o anteriores declaraciones del mismo concepto, "
-"ejercicio y periodo"
+msgid "Resultado de la anterior o anteriores declaraciones del mismo concepto, ejercicio y periodo"
 msgstr "Resultado de la anterior o anteriores declaraciones del mismo concepto, ejercicio y periodo"
 
 #. module: l10n_es_aeat_mod303
-#: code:addons/l10n_es_aeat_mod303/models/mod303.py:198
+#: code:addons/l10n_es_aeat_mod303/models/mod303.py:187
 #, python-format
 msgid "Select an account for making the charge"
 msgstr "Seleccione una cuenta bancaria para realizar el cargo"
 
 #. module: l10n_es_aeat_mod303
-#: code:addons/l10n_es_aeat_mod303/models/mod303.py:200
+#: code:addons/l10n_es_aeat_mod303/models/mod303.py:189
 #, python-format
 msgid "Select an account for receiving the money"
 msgstr "Seleccione una cuenta bancaria para recibir el dinero"
@@ -293,9 +274,7 @@ msgstr "Secuencia"
 
 #. module: l10n_es_aeat_mod303
 #: help:l10n.es.aeat.mod303.report,compensate:0
-msgid ""
-"Si se marca, indicará que el importe a devolver se compensará en posteriores"
-" declaraciones"
+msgid "Si se marca, indicará que el importe a devolver se compensará en posteriores declaraciones"
 msgstr "Si se marca, indicará que el importe a devolver se compensará en posteriores declaraciones"
 
 #. module: l10n_es_aeat_mod303
@@ -319,6 +298,7 @@ msgid "Support Type"
 msgstr "Tipo de soporte"
 
 #. module: l10n_es_aeat_mod303
+#: view:l10n.es.aeat.mod303.report:l10n_es_aeat_mod303.view_l10n_es_aeat_mod303_report_form
 #: field:l10n.es.aeat.mod303.report,tax_lines:0
 msgid "Tax lines"
 msgstr "Líneas de impuestos"
@@ -330,9 +310,7 @@ msgstr "Telemática"
 
 #. module: l10n_es_aeat_mod303
 #: help:l10n.es.aeat.mod303.report,counterpart_account:0
-msgid ""
-"This account will be the counterpart for all the journal items that are "
-"regularized when posting the report."
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
 msgstr "Esta cuenta será la contrapartida para todos los elementos del diario que están regularizados al contabilizar el informe."
 
 #. module: l10n_es_aeat_mod303
@@ -389,3 +367,4 @@ msgstr "[70] A deducir"
 #: field:l10n.es.aeat.mod303.report,resultado_liquidacion:0
 msgid "[71] Result. liquidación"
 msgstr "[71] Result. liquidación"
+

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -1,25 +1,14 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see http://www.gnu.org/licenses/.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2013 - Guadaltech - Alberto Martín Cortada
+# © 2015 - AvanzOSC - Ainara Galdona
+# © 2014-2016 - Serv. Tecnol. Avanzados - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import models, fields, api, _
 
 
 class L10nEsAeatMod303Report(models.Model):
-    _inherit = "l10n.es.aeat.report"
+    _inherit = "l10n.es.aeat.report.tax.mapping"
     _name = "l10n.es.aeat.mod303.report"
     _description = "AEAT 303 Report"
 

--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -78,7 +78,7 @@
                         </group>
                     </group>
                     <group class="oe_subtotal_footer oe_right"
-                           attrs="{'invisible': ['|', ('tax_lines', '=', []), ('state', '=', 'draft')]}"
+                           attrs="{'invisible': [('state', '=', 'draft')]}"
                            colspan="2">
                         <field name="resultado_liquidacion"
                                class="oe_subtotal_footer_separator"
@@ -94,6 +94,12 @@
                                domain="[('partner_id', '=', company_partner_id)]"
                                attrs="{'invisible': [('result_type', 'not in', ('B', 'I')), ('compensate', '=', False)]}"
                                 />
+                    </group>
+                    <group string="Tax lines"
+                           name="group_tax_lines"
+                           colspan="4"
+                           attrs="{'invisible': [('state', '=', 'draft')]}">
+                        <field name="tax_lines" nolabel="1"/>
                     </group>
                 </group>
             </field>


### PR DESCRIPTION
El anterior método utilizado, al tener una clase y un many2one genérico,
no permitía poner los datos en múltiples modelos hijos, ya que se repetían
los IDs, y cogía los datos de un modelo en otros.

Con este nuevo sistema, se sigue utilizando una tabla, pero con doble
índice: el modelo y el ID, parecido a un campo reference, pero gestionado
por código propio en el método de cálculo.

El 303 está adaptado a este nuevo sistema, y se incluye un script de
migración que conserve los datos.
