### PR TITLE
[FIX] l10n_es_aeat_*: Evitar problemas en campos related no readonly. Fixes #290

### DIFF
--- a/l10n_es_aeat_mod111/models/mod111.py
+++ b/l10n_es_aeat_mod111/models/mod111.py
@@ -204,7 +204,7 @@ class L10nEsAeatMod111Report(models.Model):
         'telemáticamente). A cumplimentar sólo en el caso de declaración '
         'complementaria.')
     currency_id = fields.Many2one(
-        comodel_name='res.currency', string='Moneda',
+        comodel_name='res.currency', string='Moneda', readonly=True,
         related='company_id.currency_id', store=True)
     tipo_declaracion = fields.Selection(
         [('I', 'Ingreso'), ('U', 'Domiciliación'),

--- a/l10n_es_aeat_mod115/models/mod115.py
+++ b/l10n_es_aeat_mod115/models/mod115.py
@@ -65,7 +65,7 @@ class L10nEsAeatMod115Report(models.Model):
         relation='mod115_account_move_line03_rel',
         column1='mod115', column2='account_move_line')
     currency_id = fields.Many2one(
-        comodel_name='res.currency', string='Moneda',
+        comodel_name='res.currency', string='Moneda', readonly=True,
         related='company_id.currency_id', store=True)
     tipo_declaracion = fields.Selection(
         selection=[('I', 'Ingreso'),

--- a/l10n_es_aeat_mod216/models/mod216.py
+++ b/l10n_es_aeat_mod216/models/mod216.py
@@ -75,7 +75,7 @@ class L10nEsAeatMod216Report(models.Model):
         relation='mod216_account_move_line_cuota_rel',
         column1='mod216', column2='account_move_line')
     currency_id = fields.Many2one(
-        'res.currency', string='Moneda',
+        'res.currency', string='Moneda', readonly=True,
         related='company_id.currency_id', store=True)
     tipo_declaracion = fields.Selection(
         [('I', 'Ingreso'), ('U', 'Domiciliación'),

--- a/l10n_es_aeat_mod296/models/mod296.py
+++ b/l10n_es_aeat_mod296/models/mod296.py
@@ -47,7 +47,7 @@ class L10nEsAeatMod296Report(models.Model):
         help='Casilla [04] Resumen de los datos incluidos en la declaración - '
              'Retenciones e ingresos a cuenta ingresados')
     currency_id = fields.Many2one(
-        comodel_name='res.currency', string='Moneda',
+        comodel_name='res.currency', string='Moneda', readonly=True,
         related='company_id.currency_id', store=True)
     lines296 = fields.One2many('l10n.es.aeat.mod296.report.line', 'mod296_id',
                                string="Lines")

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -83,7 +83,7 @@ class L10nEsAeatMod303Report(models.Model):
 
     currency_id = fields.Many2one(
         comodel_name='res.currency', string='Currency',
-        related='company_id.currency_id', store=True)
+        related='company_id.currency_id', store=True, readonly=True)
     number = fields.Char(default='303')
     export_config = fields.Many2one(default=_get_export_conf)
     company_partner_id = fields.Many2one('res.partner', string='Partner',


### PR DESCRIPTION
Cuando se tienen campos related, aunque el valor no se cambie, Odoo lanza una escritura en el objeto relacionado cada vez que se guarda el objeto principal. En el caso de la moneda asociada a la compañía, hace que aquellos usuarios que no tengan permiso para modificar la compañía (la mayoría), falle en la creación del modelo.
