### PR TITLE
[FIX] l10n_es_aeat_mod349: Remove check of names

### DIFF
--- a/l10n_es_aeat/models/aeat_report_tax_mapping.py
+++ b/l10n_es_aeat/models/aeat_report_tax_mapping.py
@@ -15,7 +15,7 @@ class L10nEsAeatReportTaxMapping(models.AbstractModel):
     tax_lines = fields.One2many(
         comodel_name='l10n.es.aeat.tax.line', inverse_name='res_id',
         domain=lambda self: [("model", "=", self._name)], auto_join=True,
-        ondelete="cascade", readonly=True)
+        readonly=True)
 
     @api.multi
     def calculate(self):
@@ -42,6 +42,11 @@ class L10nEsAeatReportTaxMapping(models.AbstractModel):
                     tax_lines.append(report._prepare_tax_line_vals(map_line))
                 report.tax_lines = [(0, 0, x) for x in tax_lines]
         return res
+
+    @api.multi
+    def unlink(self):
+        self.mapped('tax_lines').unlink()
+        return super(L10nEsAeatReportTaxMapping, self).unlink()
 
     @api.multi
     def _prepare_tax_line_vals(self, map_line):

--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -1,48 +1,13 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C)
-#        2004-2011: Pexego Sistemas Informáticos. (http://pexego.es)
-#        2013:      Top Consultant Software Creations S.L.
-#                   (http://www.topconsultant.es/)
-#        2014:      Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
-#                   Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-#
-#    Autores originales: Luis Manuel Angueira Blanco (Pexego)
-#                        Omar Castiñeira Saavedra(omar@pexego.es)
-#    Migración OpenERP 7.0: Ignacio Martínez y Miguel López.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2013 Top Consultant Software Creations S.L. (http://www.topconsultant.es/)
+# © 2014-2016 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 import re
 from openerp import models, fields, api, exceptions, _
 from openerp.addons.l10n_es_aeat_mod349.models.account_invoice \
     import OPERATION_KEYS
-
-
-# TODO: Quitarlo de aquí y pasarlo a l10n_es_aeat con sustituciones
-NAME_RESTRICTIVE_REGEXP = re.compile(
-    r"^[a-zA-Z0-9\sáÁéÉíÍóÓúÚñÑçÇäÄëËïÏüÜöÖ"
-    r"àÀèÈìÌòÒùÙâÂêÊîÎôÔûÛ\.,-_&'´\\:;:/]*$", re.UNICODE | re.X)
-
-
-def _check_valid_string(text_to_check):
-    """Checks if string fits with RegExp"""
-    if text_to_check and NAME_RESTRICTIVE_REGEXP.match(text_to_check):
-        return True
-    return False
 
 
 def _format_partner_vat(partner_vat=None, country=None):
@@ -233,34 +198,10 @@ class Mod349(models.Model):
                     _('Contact name (Full name) must have name and surname'))
 
     @api.multi
-    def _check_restrictive_names(self):
-        """Checks if names have not allowed characters and returns a message"""
-        for item in self:
-            if not _check_valid_string(item.contact_name):
-                raise exceptions.Warning(
-                    _("Name '%s' have not allowed characters.\nPlease, fix it "
-                      "before confirm the report") % item.contact_name)
-            # Check partner record partner names
-            for partner_record in item.partner_record_ids:
-                if not _check_valid_string(partner_record.partner_id.name):
-                    raise exceptions.Warning(
-                        _("Partner name '%s' in partner records is not valid "
-                          "due to incorrect characters") %
-                        partner_record.partner_id.name)
-            # Check partner refund partner names
-            for partner_refund in item.partner_refund_ids:
-                if not _check_valid_string(partner_refund.partner_id.name):
-                    raise exceptions.Warning(
-                        _("Partner name '%s' in refund lines is not valid due "
-                          "to incorrect characters") %
-                        partner_refund.partner_id.name)
-
-    @api.multi
     def button_confirm(self):
         """Checks if all the fields of the report are correctly filled"""
         self._check_names()
         self._check_report_lines()
-        self._check_restrictive_names()
         return super(Mod349, self).button_confirm()
 
     name = fields.Char(compute="_get_report_alias", string="Name")

--- a/l10n_es_aeat_mod349/wizard/export_mod349_to_boe.py
+++ b/l10n_es_aeat_mod349/wizard/export_mod349_to_boe.py
@@ -26,7 +26,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp import models, api, exceptions, _
+from openerp import api, fields, models, _
 
 
 class Mod349ExportToBoe(models.TransientModel):
@@ -158,13 +158,6 @@ class Mod349ExportToBoe(models.TransientModel):
         assert report, 'No AEAT 349 Report defined'
         assert partner_record, 'No Partner record defined'
         text = ''
-        try:
-            fiscal_year = int((report.fiscalyear_id.code or '')[:4])
-        except:
-            raise exceptions.Warning(
-                _('First four characters of fiscal year code must be numeric '
-                  'and contain the fiscal year number. Please, fix it and try '
-                  'again.'))
         # Formateo de algunos campos (debido a que pueden no ser correctos)
         # NIF : Se comprueba que no se incluya el código de pais
         company_vat = report.company_vat
@@ -172,7 +165,8 @@ class Mod349ExportToBoe(models.TransientModel):
             company_vat = report.company_vat[2:]
         text += '2'  # Tipo de registro
         text += '349'  # Modelo de declaración
-        text += self._formatNumber(fiscal_year, 4)  # Ejercicio
+        date_start = fields.Date.from_string(report.periods[:1].date_start)
+        text += self._formatNumber(date_start.year, 4)  # Ejercicio
         text += self._formatString(company_vat, 9)  # NIF del declarante
         text += 58 * ' '  # Blancos
         # NIF del operador intracomunitario


### PR DESCRIPTION
There's no need of a check about the name validity, because l10n_es_aeat
already transform all the exported strings to valid ASCII characters
(though unidecode), so I remove entirely this check.
