### PR TITLE
[8.0] Sufijo variable por modo de pago SEPA

### DIFF
--- a/account_banking_sepa_bank_suffix/README.rst
+++ b/account_banking_sepa_bank_suffix/README.rst
@@ -1,0 +1,27 @@
+Account Banking Sepa - Sufijos variables por modo de pago y FSDD
+================================================================
+
+* Este módulo permite cambiar el sufijo de los identificadores sepa a través
+del modo de pago.
+* Este módulo permite establecer el prefijo FSDD en el identificador de un
+fichero sepa para el producto nicho de anticipo de crédito, antiguamente
+exportado en el cuaderno 58.
+
+Instalación
+===========
+
+Para instalar este módulo, es necesario tener disponible el módulo
+*account_banking_pain_base* del repositorio
+https://github.com/OCA/bank-payment
+
+Configuración
+=============
+
+* Se dispone de un campo sufijo en el modo de pago que si está establecido
+substituye al configurado en la compañía
+* Se dispone de un campo "Cobro financiado" en las ordenes de cobro que
+al guardarse añade el prefijo FSDD al nombre del la orden de cobro.
+
+Contributors
+------------
+* Omar Castiñeira Saavedra <omar@comunitea.com>

--- a/account_banking_sepa_bank_suffix/__init__.py
+++ b/account_banking_sepa_bank_suffix/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP - Account banking sepa bank suffix
+#    Copyright (C) 2016 Comunitea Servicios Tecnológicos.
+#    Omar Castiñeira Saavedra - omar@comunitea.com
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/account_banking_sepa_bank_suffix/__openerp__.py
+++ b/account_banking_sepa_bank_suffix/__openerp__.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP - Account banking sepa bank suffix
+#    Copyright (C) 2016 Comunitea Servicios Tecnológicos.
+#    Omar Castiñeira Saavedra - omar@comunitea.com
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Account Banking Sepa - Sufijos variables por modo de pago y FSDD",
+    "version": "8.0.0.0.0",
+    "author": "Comunitea,Odoo Community Association (OCA)",
+    "website": "http://www.comunitea.com",
+    "category": "Banking addons",
+    "description": """
+- Este módulo permite cambiar el sufijo de los identificadores sepa a través del modo de pago.
+- Este módulo permite establecer el prefijo FSDD en el identificador de un fichero sepa para el producto nicho de anticipo de crédito, antiguamente exportado en el cuaderno 58.
+    """,
+    "depends": [
+        "account_banking_pain_base"
+    ],
+    "demo": [],
+    "data": [
+        "views/payment_order_view.xml",
+        "views/payment_mode_view.xml"
+    ],
+    "installable": True,
+}

--- a/account_banking_sepa_bank_suffix/i18n/es.po
+++ b/account_banking_sepa_bank_suffix/i18n/es.po
@@ -1,0 +1,47 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#       * account_banking_sepa_bank_suffix
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-02-22 20:02+0000\n"
+"PO-Revision-Date: 2016-02-22 20:02+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_banking_sepa_bank_suffix
+#: model:ir.model,name:account_banking_sepa_bank_suffix.model_payment_mode
+msgid "Payment Mode"
+msgstr "Modo de pago"
+
+#. module: account_banking_sepa_bank_suffix
+#: field:payment.order,charge_financed:0
+msgid "Financed Charge"
+msgstr "Cobro financiado"
+
+#. module: account_banking_sepa_bank_suffix
+#: model:ir.model,name:account_banking_sepa_bank_suffix.model_payment_order
+msgid "Payment Order"
+msgstr "Orden de pago"
+
+#. module: account_banking_sepa_bank_suffix
+#: field:payment.mode,suffix:0
+msgid "Suffix"
+msgstr "Sufijo"
+
+#. module: account_banking_sepa_bank_suffix
+#: help:payment.mode,suffix:0
+msgid "Suffix for sepa identifiers with this payment mode. If not set it will use the company configuration."
+msgstr "Sufijo para identificadores sepa con este modo de pago. Si no se establece usará la configuración de la compañía."
+
+#. module: account_banking_sepa_bank_suffix
+#: code:addons/account_banking_sepa_bank_suffix/models/payment_mode.py:41
+#, python-format
+msgid "Suffix must be compound by 3 numbers"
+msgstr "El sufijo debe estar compuesto por 3 números"

--- a/account_banking_sepa_bank_suffix/models/__init__.py
+++ b/account_banking_sepa_bank_suffix/models/__init__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP - Account banking sepa bank suffix
+#    Copyright (C) 2016 Comunitea Servicios Tecnológicos.
+#    Omar Castiñeira Saavedra - omar@comunitea.com
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import payment_order
+from . import payment_mode
+from . import banking_export_pain

--- a/account_banking_sepa_bank_suffix/models/banking_export_pain.py
+++ b/account_banking_sepa_bank_suffix/models/banking_export_pain.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP - Account banking sepa bank suffix
+#    Copyright (C) 2016 Comunitea Servicios Tecnológicos.
+#    Omar Castiñeira Saavedra - omar@comunitea.com
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class BankingExportPain(models.AbstractModel):
+    _inherit = 'banking.export.pain'
+
+    @api.model
+    def generate_initiating_party_block(self, parent_node, gen_args):
+        res = super(BankingExportPain, self).\
+            generate_initiating_party_block(parent_node, gen_args)
+
+        if self.payment_order_ids[0].mode.suffix:
+            other_id_code = parent_node.xpath('//InitgPty/Id/OrgId/Othr/Id')
+            if other_id_code:
+                initiating_party_identifier =\
+                    self.payment_order_ids[0].company_id.\
+                    initiating_party_identifier
+                other_id_code[0].text = initiating_party_identifier[:-3] + \
+                    self.payment_order_ids[0].mode.suffix
+
+        return res
+
+    @api.model
+    def generate_creditor_scheme_identification(
+            self, parent_node, identification, identification_label,
+            eval_ctx, scheme_name_proprietary, gen_args):
+
+        res = super(BankingExportPain, self).\
+            generate_creditor_scheme_identification(parent_node,
+                                                    identification,
+                                                    identification_label,
+                                                    eval_ctx,
+                                                    scheme_name_proprietary,
+                                                    gen_args)
+        if self.payment_order_ids[0].mode.suffix:
+            other_id_code = parent_node.\
+                xpath('//PrvtId/Othr/Id')
+            if other_id_code:
+                sepa_creditor_identifier = self.\
+                    _prepare_field(identification_label, identification,
+                                   eval_ctx, gen_args=gen_args)
+                other_id_code[0].text = sepa_creditor_identifier[:4] + \
+                    self.payment_order_ids[0].mode.suffix + \
+                    sepa_creditor_identifier[7:]
+
+        return res

--- a/account_banking_sepa_bank_suffix/models/payment_mode.py
+++ b/account_banking_sepa_bank_suffix/models/payment_mode.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP - Account banking sepa bank suffix
+#    Copyright (C) 2016 Comunitea Servicios Tecnológicos.
+#    Omar Castiñeira Saavedra - omar@comunitea.com
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api, exceptions, _
+
+
+class PaymentMode(models.Model):
+
+    _inherit = "payment.mode"
+
+    suffix = fields.Char("Suffix", size=3, help='Suffix for sepa identifiers '
+                                                'with this payment mode. If '
+                                                'not set it will use the '
+                                                'company configuration.')
+
+    @api.one
+    @api.constrains('suffix')
+    def _check_suffix_format(self):
+        if self.suffix:
+            if len(self.suffix) != 3 or not self.suffix.isdigit():
+                raise exceptions.\
+                    Warning(_("Suffix must be compound by 3 numbers"))

--- a/account_banking_sepa_bank_suffix/models/payment_order.py
+++ b/account_banking_sepa_bank_suffix/models/payment_order.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP - Account banking sepa bank suffix
+#    Copyright (C) 2016 Comunitea Servicios Tecnológicos.
+#    Omar Castiñeira Saavedra - omar@comunitea.com
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api, fields
+
+
+class PaymentOrder(models.Model):
+
+    _inherit = "payment.order"
+
+    charge_financed = fields.Boolean('Financed Charge')
+
+    @api.model
+    def create(self, vals):
+        res = super(PaymentOrder, self).create(vals)
+        if vals.get('charge_financed', False):
+            res.reference = u"FSDD" + res.reference
+        return res
+
+    @api.multi
+    def write(self, vals):
+        res = super(PaymentOrder, self).write(vals)
+        if 'charge_financed' in vals:
+            for po in self:
+                if not vals['charge_financed'] and 'FSDD' in po.reference:
+                    po.reference = po.reference.replace("FSDD", "")
+                elif vals['charge_financed'] and 'FSDD' not in po.reference:
+                    po.reference = u"FSDD" + po.reference
+        return res

--- a/account_banking_sepa_bank_suffix/views/payment_mode_view.xml
+++ b/account_banking_sepa_bank_suffix/views/payment_mode_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_payment_mode_form_add_suffix" model="ir.ui.view">
+            <field name="name">add.suffix.in.payment.mode.form</field>
+            <field name="model">payment.mode</field>
+            <field name="inherit_id" ref="account_banking_payment_export.view_payment_mode_form_inherit"/>
+            <field name="arch" type="xml">
+                <field name="type" position="after">
+                    <field name="suffix"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/account_banking_sepa_bank_suffix/views/payment_order_view.xml
+++ b/account_banking_sepa_bank_suffix/views/payment_order_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_payment_order_form_add_fsdd" model="ir.ui.view">
+            <field name="name">account.payment.order.form.add.fsdd</field>
+            <field name="model">payment.order</field>
+            <field name="inherit_id" ref="account_payment.view_payment_order_form" />
+            <field name="arch" type="xml">
+                <field name="mode" position="after">
+                    <field name="charge_financed" attrs="{'invisible': [('payment_order_type', '!=', 'debit')]}"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Hola,

Es tema que se viene hablando desde hace tiempo en la listas https://groups.google.com/forum/#!topic/openerp-spain-users/i614B0u28tk y en algún issue https://github.com/OCA/bank-payment/issues/224 y lo hemos implantado para un cliente que tenía este problema, para las remesas con anticipo de crédito por ejemplo, el antiguo cuaderno 58 hay bancos que requieren que el sufijo del indtificador sepa sea distinto al por defecto, también hay el caso de que un cliente trabaja con varios bancos y en cada uno le piden un sufijo distinto, con este módulo se permite poner el sufijo a nivel de modo de pago y se está establecido, se reemplaza directamente en la exportación de los ficheros SEPA sino sigue comportándose como hasta ahora, además de esta funcionalidad se añade un checkbox "Cobro financiado" en las ordenes de cobro que añade el prefijo FSDD al identificador de la remesa, esta es la propuesta oficial de SEPA para notificar los anticipos de crédito.

No se si es el sitio ideal para este módulo, pero como se comentaba en el issue enlazado es un comportamiento de España, ya me decís; si lo subimos aquí podemos mirar de cambiarle el nombre al módulo.

Un saludo
