### PR TITLE
l10n_es_aeat_mod347: Incorrecta selección de empresas para el cálculo

### DIFF
--- a/l10n_es_aeat_mod347/README.rst
+++ b/l10n_es_aeat_mod347/README.rst
@@ -106,6 +106,7 @@ Contribuidores
 * Acysos (http://www.acysos.com)
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Joaquín Gutierrez (http://gutierrezweb.es)
+* Comunitea (http://www.comunitea.com)
 
 Maintainer
 ----------

--- a/l10n_es_aeat_mod347/__openerp__.py
+++ b/l10n_es_aeat_mod347/__openerp__.py
@@ -25,7 +25,7 @@
 ##############################################################################
 {
     'name': "Modelo 347 AEAT",
-    'version': "8.0.1.3.0",
+    'version': "8.0.1.3.1",
     'author': "Pexego,"
               "ASR-OSS,"
               "NaN·tic,"
@@ -41,6 +41,7 @@
         'Acysos (http://www.acysos.com)',
         'Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>',
         'Joaquín Gutierrez (http://gutierrezweb.es)',
+        'Comunitea (http://www.comunitea.com)',
     ],
     'category': "Localisation/Accounting",
     'license': "AGPL-3",

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -64,13 +64,13 @@ class L10nEsAeatMod347Report(models.Model):
             # (A and B operation keys)
             # Search for invoices to this partner (with account moves).
             invoices = invoice_obj.search(
-                [('partner_id', 'child_of', partners.ids),
+                [('partner_id.commercial_partner_id', 'in', partners.ids),
                  ('type', '=', invoice_type),
                  ('period_id', 'in', periods.ids),
                  ('state', 'not in', ['draft', 'cancel']),
                  ('not_in_mod347', '=', False)])
             refunds = invoice_obj.search(
-                [('partner_id', 'child_of', partners.ids),
+                [('partner_id.commercial_partner_id', 'in', partners.ids),
                  ('type', '=', refund_type),
                  ('period_id', 'in', periods.ids),
                  ('state', 'not in', ['draft', 'cancel']),
@@ -134,7 +134,7 @@ class L10nEsAeatMod347Report(models.Model):
             return
         receivable_ids = [x.property_account_receivable.id for x in partners]
         cash_account_move_lines = move_line_obj.search(
-            [('partner_id', 'child_of', partners.ids),
+            [('partner_id.commercial_partner_id', 'in', partners.ids),
              ('account_id', 'in', receivable_ids),
              ('journal_id', 'in', cash_journals.ids),
              ('period_id', 'in', periods.ids)])
@@ -215,8 +215,8 @@ class L10nEsAeatMod347Report(models.Model):
             report.partner_record_ids.unlink()
             # We will check every partner with not_in_mod347 flag unchecked
             visited_partners = self.env['res.partner']
-            domain = [('not_in_mod347', '=', False),
-                      ('parent_id', '=', False)]
+            domain = [('not_in_mod347', '=', False), '|',
+                      ('parent_id', '=', False), ('is_company', '=', True)]
             if report.only_supplier:
                 domain.append(('supplier', '=', True))
             else:


### PR DESCRIPTION
Hola,

La selección que se hacía de empresas para el cálculo del 347 era [('parent_id', '=', False),('not_in_mod347', '=', False)] es decir, que no tengan padre y que no estén excluidas del 347, esto es incorrecto porque una empresa funcionando como grupo de empresas puede tener a varias empresas por debajo y con cada una tener que presentar registros individuales, porque tienen distinto cif se cambió el filtro de "sin padre" a que sean compañía, ahora queda: [('is_company', '=', True),('not_in_mod347', '=', False)]

Luego, una vez seleccionadas las empresas se estaban buscando sus facturas con [('partner_id','child_of', partner_ids),...] esto tampoco estaba correcto ya que debería de ser [('partner_id.commercial_partner_id','in', partner_ids),...] ya que sino, de nuevo en el caso de un grupo de empresas, la empresa padre estaría agrupando todas las facturas en un mismo cif, y puede que sean de distintos cifs.

Un saludo.
