### PR TITLE
l10n_es_aeat_mod303: Se añade la gestión del iva diferido en el 303

### DIFF
--- a/l10n_es_aeat_mod303/README.rst
+++ b/l10n_es_aeat_mod303/README.rst
@@ -4,7 +4,7 @@ Módulo para la presentación del modelo 303 (IVA - Autodeclaración) de la
 Agencia Española de Administración Tributaria.
 
 Instrucciones del modelo: http://goo.gl/pgVbXH
-Diseño de registros BOE: http://goo.gl/ediOFO
+Diseño de registros BOE en Excel: http://goo.gl/z4grco
 
 Incluye la exportación al formato BOE para su uso telemático.
 
@@ -29,6 +29,7 @@ Contribuidores
 * GuadalTech (http://www.guadaltech.es)
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * AvanzOSC (http://www.avanzosc.es)
+* Comunitea (http://www.comunitea.com)
 
 Maintainer
 ----------

--- a/l10n_es_aeat_mod303/__openerp__.py
+++ b/l10n_es_aeat_mod303/__openerp__.py
@@ -26,12 +26,13 @@
 
 {
     "name": "AEAT modelo 303",
-    "version": "8.0.1.5.0",
+    "version": "8.0.1.6.0",
     'category': "Accounting & Finance",
     'author': "Guadaltech,"
               "AvanzOSC,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
               "Antiun Ingeniería S.L.,"
+              "Comunitea,"
               "Odoo Community Association (OCA)",
     'website': "https://github.com/OCA/l10n-spain",
     "license": "AGPL-3",

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_data.xml
@@ -2392,7 +2392,7 @@
             <field name="sequence">47</field>
             <field name="export_config_id" ref="aeat_mod303_sub03_export_config"/>
             <field name="name">Resultado - IVA a la importación liquidado por la Aduana pendiente de ingreso [77]</field>
-            <field name="expression">${object.tax_lines.filtered(lambda r: r.field_number==33).amount}</field>
+            <field name="expression">${object.casilla_77}</field>
             <field name="fixed_value">0</field>
             <field name="export_type">float</field>
             <field name="apply_sign" eval="True"/>

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -56,12 +56,12 @@ class L10nEsAeatMod303Report(models.Model):
 
     @api.multi
     @api.depends('atribuible_estado', 'cuota_compensar',
-                 'regularizacion_anual')
+                 'regularizacion_anual', 'casilla_77')
     def _compute_casilla_69(self):
         for report in self:
             report.casilla_69 = (
-                report.atribuible_estado + report.cuota_compensar +
-                report.regularizacion_anual)
+                report.atribuible_estado + report.casilla_77 +
+                report.cuota_compensar + report.regularizacion_anual)
 
     @api.multi
     @api.depends('casilla_69', 'previous_result')
@@ -121,6 +121,15 @@ class L10nEsAeatMod303Report(models.Model):
         string="[69] Resultado", readonly=True, compute="_compute_casilla_69",
         help="Atribuible a la Administración [66] - Cuotas a compensar [67] + "
              "Regularización anual [68]""", store=True)
+    casilla_77 = fields.Float(
+        string="[77] Iva Diferido (Liquidado por aduana)",
+        help="Se hará constar el importe de las cuotas del Impuesto a la "
+             "importación incluidas en los documentos en los que conste la "
+             "liquidación practicada por la Administración recibidos en el "
+             "periodo de liquidación. Solamente podrá cumplimentarse esta "
+             "casilla cuando se cumplan los requisitos establecidos en el "
+             "artículo 74.1 del Reglamento del Impuesto sobre el Valor "
+             "Añadido. ")
     previous_result = fields.Float(
         string="[70] A deducir",
         help="Resultado de la anterior o anteriores declaraciones del mismo "

--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -66,6 +66,10 @@
                                    options="{'currency_field': 'currency_id'}"
                                    attrs="{'readonly': [('period_type', 'not in', ('4T', '12'))]}"
                                     />
+                            <field name="casilla_77"
+                                   widget="monetary"
+                                   options="{'currency_field': 'currency_id'}"
+                                    />
                             <field name="casilla_69"
                                    widget="monetary"
                                    options="{'currency_field': 'currency_id'}"


### PR DESCRIPTION
Hola,

Tenemos un cliente sujeto al iva diferido http://www.gecotex.es/el-iva-en-diferido-a-la-importacion-que-es-y-como-funciona/ esto les obliga a presentar el 303 mensualmente y a indicar en el 303 la cuota liquidada desde aduanas directamente, no tienen DUA, esta cuota no llega a figurar en la contabilidad  de la empresa ya que se encarga la propia aduana de presentarla, pero si obligan en el 303 a indicar el importe presentado en la casilla 77, este importe se rellena a mano consultándolo previamente en la sede electrónica de la AEAT.

Actualmente, esta casilla (77) se estaba cubriendo incorrectamente con el importe de la casilla 33 (Liquidación (3) - Regimen General - IVA Deducible -Por cuotas soportadas en las importaciones de bienes corrientes - Cuota [33]) pero aunque se exportaba no figuraba en el resultado por lo que supongo que no daría problemas, ahora se añadió un campo "Float" en el 303 que debe rellenarse a mano sólo para empresas sujetas al iva diferido y esta casilla afecta al resultado de la casilla 69 (Resultado) y esta por consiguiente a la casilla 71 (resultado de la liquidación) tal y como se puede ver en las instrucciones del modelo. http://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Declaraciones/Modelos_300_al_399/303/Instrucciones/instr_mod303.pdf

De paso he aprovechado para actualizar el enlace al diseño de registros ya que no funcionaba.

Un saludo
