### PR TITLE
[8.0][IMP][l10n_es_aeat_mod347] Improve performance and allow adding additional records

### DIFF
--- a/l10n_es_aeat/wizard/export_to_boe.py
+++ b/l10n_es_aeat/wizard/export_to_boe.py
@@ -83,6 +83,7 @@ class L10nEsAeatReportExportToBoe(models.TransientModel):
             ur"[^a-zA-Z0-9\sáÁéÉíÍóÓúÚñÑçÇäÄëËïÏüÜöÖ"
             ur"àÀèÈìÌòÒùÙâÂêÊîÎôÔûÛ\.,-_&'´\\:;:/]", '', text,
             re.UNICODE | re.X)
+        name = re.sub(r'\s{2,}', ' ', name, re.UNICODE | re.X)
         return self._formatString(name, length, fill=fill, align=align)
 
     def _formatNumber(self, number, int_length, dec_length=0,

--- a/l10n_es_aeat/wizard/export_to_boe.py
+++ b/l10n_es_aeat/wizard/export_to_boe.py
@@ -78,6 +78,13 @@ class L10nEsAeatReportExportToBoe(models.TransientModel):
         # Return string
         return ascii_string
 
+    def _formatFiscalName(self, text, length, fill=' ', align='<'):
+        name = re.sub(
+            ur"[^a-zA-Z0-9\sáÁéÉíÍóÓúÚñÑçÇäÄëËïÏüÜöÖ"
+            ur"àÀèÈìÌòÒùÙâÂêÊîÎôÔûÛ\.,-_&'´\\:;:/]", '', text,
+            re.UNICODE | re.X)
+        return self._formatString(name, length, fill=fill, align=align)
+
     def _formatNumber(self, number, int_length, dec_length=0,
                       include_sign=False, positive_sign=' ',
                       negative_sign='N'):
@@ -150,13 +157,13 @@ class L10nEsAeatReportExportToBoe(models.TransientModel):
         # NIF del declarante
         text += self._formatString(report.company_vat, 9)
         # Apellidos y nombre o razón social del declarante
-        text += self._formatString(report.company_id.name, 40)
+        text += self._formatFiscalName(report.company_id.name, 40)
         # Tipo de soporte
         text += self._formatString(report.support_type, 1)
         # Persona de contacto (Teléfono)
         text += self._formatString(report.contact_phone, 9)
         # Persona de contacto (Apellidos y nombre)
-        text += self._formatString(report.contact_name, 40)
+        text += self._formatFiscalName(report.contact_name, 40)
         # Número identificativo de la declaración
         text += self._formatString(report.name, 13)
         # Declaración complementaria

--- a/l10n_es_aeat_mod347/README.rst
+++ b/l10n_es_aeat_mod347/README.rst
@@ -112,9 +112,9 @@ Contribuidores
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
@@ -122,4 +122,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/l10n_es_aeat_mod347/README.rst
+++ b/l10n_es_aeat_mod347/README.rst
@@ -107,6 +107,7 @@ Contribuidores
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Joaquín Gutierrez (http://gutierrezweb.es)
 * Comunitea (http://www.comunitea.com)
+* Antonio Espinosa <antonioea@antiun.com>
 
 Maintainer
 ----------

--- a/l10n_es_aeat_mod347/__init__.py
+++ b/l10n_es_aeat_mod347/__init__.py
@@ -1,27 +1,5 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+
 from . import models
 from . import wizard
-from openerp import SUPERUSER_ID
-
-
-def post_init_hook(cr, registry):
-    # Assign quarters on first time
-    period_obj = registry['account.period']
-    period_ids = period_obj.search(cr, SUPERUSER_ID, [])
-    period_obj.assign_quarter(cr, SUPERUSER_ID, period_ids)
+from .hooks import post_init_hook

--- a/l10n_es_aeat_mod347/__openerp__.py
+++ b/l10n_es_aeat_mod347/__openerp__.py
@@ -1,31 +1,16 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C)
-#        2004-2011:  Pexego Sistemas Informáticos. (http://pexego.es)
-#        2012:       NaN·Tic  (http://www.nan-tic.com)
-#        2013:       Acysos (http://www.acysos.com)
-#                    Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
-#        2014-2015:  Serv. Tecnol. Avanzados - Pedro M. Baeza
-#                    (http://www.serviciosbaeza.com)
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2012 NaN·Tic  (http://www.nan-tic.com)
+# © 2013 Acysos (http://www.acysos.com)
+# © 2013 Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+#             (http://www.serviciosbaeza.com)
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 {
     'name': "Modelo 347 AEAT",
-    'version': "8.0.1.3.1",
+    'version': "8.0.1.4.0",
     'author': "Pexego,"
               "ASR-OSS,"
               "NaN·tic,"
@@ -42,6 +27,7 @@
         'Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>',
         'Joaquín Gutierrez (http://gutierrezweb.es)',
         'Comunitea (http://www.comunitea.com)',
+        'Antonio Espinosa <antonioea@antiun.com>',
     ],
     'category': "Localisation/Accounting",
     'license': "AGPL-3",

--- a/l10n_es_aeat_mod347/hooks.py
+++ b/l10n_es_aeat_mod347/hooks.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+#             (http://www.serviciosbaeza.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import SUPERUSER_ID
+
+
+def post_init_hook(cr, registry):
+    # Assign quarters on first time
+    period_obj = registry['account.period']
+    period_ids = period_obj.search(cr, SUPERUSER_ID, [])
+    period_obj.assign_quarter(cr, SUPERUSER_ID, period_ids)

--- a/l10n_es_aeat_mod347/models/__init__.py
+++ b/l10n_es_aeat_mod347/models/__init__.py
@@ -1,20 +1,13 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2012 NaN·Tic  (http://www.nan-tic.com)
+# © 2013 Acysos (http://www.acysos.com)
+# © 2013 Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+#             (http://www.serviciosbaeza.com)
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import account_period
 from . import res_partner
 from . import account_invoice

--- a/l10n_es_aeat_mod347/models/__init__.py
+++ b/l10n_es_aeat_mod347/models/__init__.py
@@ -1,12 +1,4 @@
 # -*- coding: utf-8 -*-
-# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
-# © 2012 NaN·Tic  (http://www.nan-tic.com)
-# © 2013 Acysos (http://www.acysos.com)
-# © 2013 Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
-# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
-#             (http://www.serviciosbaeza.com)
-# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import account_period
 from . import res_partner

--- a/l10n_es_aeat_mod347/models/account_invoice.py
+++ b/l10n_es_aeat_mod347/models/account_invoice.py
@@ -1,36 +1,31 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2012 NaN·Tic  (http://www.nan-tic.com)
+# © 2013 Acysos (http://www.acysos.com)
+# © 2013 Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+#             (http://www.serviciosbaeza.com)
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import fields, models, api
 
 
 class AccountInvoice(models.Model):
     _inherit = 'account.invoice'
 
-    @api.one
-    @api.depends('cc_amount_untaxed', 'tax_line.amount')
-    def _get_amount_total_wo_irpf(self):
-        self.amount_total_wo_irpf = self.cc_amount_untaxed
-        for tax_line in self.tax_line:
-            if 'IRPF' not in tax_line.name:
-                self.amount_total_wo_irpf += tax_line.amount
+    @api.multi
+    @api.depends('cc_amount_untaxed',
+                 'tax_line', 'tax_line.amount')
+    def _compute_amount_total_wo_irpf(self):
+        for invoice in self:
+            invoice.amount_total_wo_irpf = invoice.cc_amount_untaxed
+            for tax_line in invoice.tax_line:
+                if 'IRPF' not in tax_line.name:
+                    invoice.amount_total_wo_irpf += tax_line.amount
 
     amount_total_wo_irpf = fields.Float(
-        compute="_get_amount_total_wo_irpf",
+        compute="_compute_amount_total_wo_irpf", store=True, readonly=True,
         string="Total amount without IRPF taxes")
     not_in_mod347 = fields.Boolean(
         "Not included in 347 report",

--- a/l10n_es_aeat_mod347/models/account_period.py
+++ b/l10n_es_aeat_mod347/models/account_period.py
@@ -1,20 +1,13 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2012 NaN·Tic  (http://www.nan-tic.com)
+# © 2013 Acysos (http://www.acysos.com)
+# © 2013 Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+#             (http://www.serviciosbaeza.com)
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import fields, api, models
 
 

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -379,7 +379,7 @@ class L10nEsAeatMod347Report(models.Model):
             if real_state_errors:
                 error += _("Real estate record errors:\n")
                 error += '\n'.join(real_state_errors)
-            if error:
+            if partner_errors or real_state_errors:
                 raise exceptions.ValidationError(error)
         return super(L10nEsAeatMod347Report, self).button_confirm()
 
@@ -729,7 +729,7 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
     @api.depends('state_code')
     def _compute_check_ok(self):
         for record in self:
-            record.check_ok = bool(record.partner_state_code)
+            record.check_ok = bool(record.state_code)
 
     report_id = fields.Many2one(
         comodel_name='l10n.es.aeat.mod347.report', string='AEAT 347 Report',

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -541,7 +541,7 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
                 record.partner_country_code and
                 record.partner_state_code and
                 record.partner_state_code.isdigit() and
-                (record.partner_vat or record.community_vat)
+                (record.partner_vat or record.partner_country_code != 'ES')
             )
 
     @api.model

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -1,22 +1,16 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-from openerp import fields, models, api, exceptions, _
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2012 NaN·Tic  (http://www.nan-tic.com)
+# © 2013 Acysos (http://www.acysos.com)
+# © 2013 Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+#             (http://www.serviciosbaeza.com)
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 import re
+from openerp import fields, models, api, exceptions, _
+from openerp.addons import decimal_precision as dp
 
 
 class L10nEsAeatMod347Report(models.Model):
@@ -26,17 +20,6 @@ class L10nEsAeatMod347Report(models.Model):
     _period_yearly = True
     _period_quarterly = False
     _period_monthly = False
-
-    @api.multi
-    def btn_list_records(self):
-        return {
-            'domain': "[('report_id','in'," + str(self.ids) + ")]",
-            'name': _("Partner records"),
-            'view_mode': 'tree,form',
-            'view_type': 'form',
-            'res_model': 'l10n.es.aeat.mod347.partner_record',
-            'type': 'ir.actions.act_window',
-        }
 
     def _get_default_address(self, partner):
         """Get the default invoice address of the partner"""
@@ -49,245 +32,289 @@ class L10nEsAeatMod347Report(models.Model):
         else:
             return None
 
-    @api.multi
-    def _calculate_partner_records(self, partners, periods):
-        """Search for invoices for the given partners, and check if exceeds
-        the limit. If so, it creates the partner record."""
-        self.ensure_one()
-        invoice_obj = self.env['account.invoice']
-        partner_record_obj = self.env['l10n.es.aeat.mod347.partner_record']
-        receivable_partner_record_id = False
-        # We will repeat the process for sales and purchases:
-        for invoice_type, refund_type in zip(('out_invoice', 'in_invoice'),
-                                             ('out_refund', 'in_refund')):
-            # CHECK THE SALE/PURCHASES INVOICE LIMIT
-            # (A and B operation keys)
-            # Search for invoices to this partner (with account moves).
-            invoices = invoice_obj.search(
-                [('partner_id.commercial_partner_id', 'in', partners.ids),
-                 ('type', '=', invoice_type),
-                 ('period_id', 'in', periods.ids),
-                 ('state', 'not in', ['draft', 'cancel']),
-                 ('not_in_mod347', '=', False)])
-            refunds = invoice_obj.search(
-                [('partner_id.commercial_partner_id', 'in', partners.ids),
-                 ('type', '=', refund_type),
-                 ('period_id', 'in', periods.ids),
-                 ('state', 'not in', ['draft', 'cancel']),
-                 ('not_in_mod347', '=', False)])
-            # Calculate the invoiced amount
-            # Remove IRPF tax for invoice amount
-            invoice_amount = sum(x.amount_total_wo_irpf for x in invoices)
-            refund_amount = sum(x.amount_total_wo_irpf for x in refunds)
-            total_amount = invoice_amount - refund_amount
-            # If the invoiced amount is greater than the limit
-            # we will add a partner record to the report.
-            if abs(total_amount) > self.operations_limit:
-                if invoice_type == 'out_invoice':
-                    operation_key = 'B'  # Note: B = Sale operations
-                else:
-                    assert invoice_type == 'in_invoice'
-                    operation_key = 'A'  # Note: A = Purchase operations
-                main_partner = partners[0]
-                address = self._get_default_address(main_partner)
-                # Get the partner data
-                if main_partner.vat:
-                    partner_country_code, partner_vat = (
-                        re.match(r"([A-Z]{0,2})(.*)",
-                                 main_partner.vat).groups())
-                else:
-                    partner_vat = ''
-                    partner_country_code = address.country_id.code
-                # Create the partner record
-                partner_record_id = partner_record_obj.create(
-                    {'report_id': self.id,
-                     'operation_key': operation_key,
-                     'partner_id': main_partner.id,
-                     'partner_vat': partner_vat,
-                     'representative_vat': '',
-                     'partner_state_code': address.state_id.code,
-                     'partner_country_code': partner_country_code,
-                     'invoice_record_ids': [(0, 0, {'invoice_id': x})
-                                            for x in (invoices.ids +
-                                                      refunds.ids)],
-                     'amount': total_amount})
-                if invoice_type == 'out_invoice':
-                    receivable_partner_record_id = partner_record_id
-        return receivable_partner_record_id
+    def _invoice_amount_get(self, invoices, refunds):
+        invoice_amount = sum(x.amount_total_wo_irpf for x in invoices)
+        refund_amount = sum(x.amount_total_wo_irpf for x in refunds)
+        amount = invoice_amount - refund_amount
+        if abs(amount) > self.operations_limit:
+            return amount
+        return 0
 
-    @api.multi
-    def _calculate_cash_records(self, partners, partner_record_id, periods):
-        """Search for payments received in cash from the given partners.
-        @param partner: Partner for generating cash records.
-        @param partner_ids: List of ids that corresponds to the same partner.
-        @param partner_record_id: Possible previously created 347 record for
-            the same partner.
+    def _cash_amount_get(self, moves):
+        amount = sum([line.credit for line in moves])
+        if abs(amount) > self.received_cash_limit:
+            return amount
+        return 0
+
+    def _cash_moves_group(self, moves):
+        cash_moves = {}
+        # Group cash move lines by origin operation fiscalyear
+        for move_line in moves:
+            # FIXME: ugly group by reconciliation invoices, because there
+            # isn't any direct relationship between payments and invoice
+            invoices = []
+            if move_line.reconcile_id:
+                for line in move_line.reconcile_id.line_id:
+                    if line.invoice:
+                        invoices.append(line.invoice)
+            elif move_line.reconcile_partial_id:
+                for line in move_line.reconcile_partial_id.line_partial_ids:
+                    if line.invoice:
+                        invoices.append(line.invoice)
+            # Remove duplicates
+            invoices = list(set(invoices))
+            if invoices:
+                invoice = invoices[0]
+                fy_id = invoice.period_id.fiscalyear_id.id
+                if fy_id not in cash_moves:
+                    cash_moves[fy_id] = [move_line]
+                else:
+                    cash_moves[fy_id].append(move_line)
+        return cash_moves
+
+    def _partner_record_a_create(self, data, vals):
+        """ Partner record type A: Adquisiciones de bienes y servicios
+            Create from income (from supplier) invoices
         """
-        self.ensure_one()
+        partner_record_obj = self.env['l10n.es.aeat.mod347.partner_record']
+        record = False
+        vals['operation_key'] = 'A'
+        invoices = data.get('in_invoices', self.env['account.invoice'])
+        refunds = data.get('in_refunds', self.env['account.invoice'])
+        amount = self._invoice_amount_get(invoices, refunds)
+        if amount:
+            vals['amount'] = amount
+            vals['invoice_record_ids'] = [
+                (0, 0, {'invoice_id': x})
+                for x in (invoices.ids + refunds.ids)]
+            record = partner_record_obj.create(vals)
+        return record
+
+    def _partner_record_b_create(self, data, vals):
+        """ Partner record type B: Entregas de bienes y servicios
+            Create from outcome (from customer) invoices and cash movements
+        """
         partner_record_obj = self.env['l10n.es.aeat.mod347.partner_record']
         cash_record_obj = self.env['l10n.es.aeat.mod347.cash_record']
-        move_line_obj = self.env['account.move.line']
-        # Get the cash journals (moves on these journals are considered cash)
-        cash_journals = self.env['account.journal'].search(
-            [('type', '=', 'cash')])
-        if not cash_journals:
-            return
-        receivable_ids = [x.property_account_receivable.id for x in partners]
-        cash_account_move_lines = move_line_obj.search(
-            [('partner_id.commercial_partner_id', 'in', partners.ids),
-             ('account_id', 'in', receivable_ids),
-             ('journal_id', 'in', cash_journals.ids),
-             ('period_id', 'in', periods.ids)])
-        # Calculate the cash amount in report fiscalyear
-        received_cash_amount = sum([line.credit for line in
-                                    cash_account_move_lines])
-        # Add the cash detail to the partner cash_move_fy_id if over limit
-        if received_cash_amount > self.received_cash_limit:
-            address = self._get_default_address(partners[0])
-            # Get the partner data
-            if partners.vat:
-                partner_country_code, partner_vat = (
-                    re.match(r"([A-Z]{0,2})(.*)", partners.vat).groups())
-            else:
-                partner_vat = ''
-                partner_country_code = address.country_id.code
-            cash_moves = {}
-            # Group cash move lines by origin operation fiscalyear
-            for move_line in cash_account_move_lines:
-                # FIXME: ugly group by reconciliation invoices, because there
-                # isn't any direct relationship between payments and invoice
-                invoices = []
-                if move_line.reconcile_id:
-                    for line in move_line.reconcile_id.line_id:
-                        if line.invoice:
-                            invoices.append(line.invoice)
-                elif move_line.reconcile_partial_id:
-                    line_ids = move_line.reconcile_partial_id.line_partial_ids
-                    for line in line_ids:
-                        if line.invoice:
-                            invoices.append(line.invoice)
-                invoices = list(set(invoices))
-                if invoices:
-                    invoice = invoices[0]
-                    cash_move_fy_id = invoice.period_id.fiscalyear_id.id
-                    if cash_move_fy_id not in cash_moves:
-                        cash_moves[cash_move_fy_id] = [move_line]
+        records = []
+        invoice_record = False
+        vals['operation_key'] = 'B'
+        invoices = data.get('out_invoices', self.env['account.invoice'])
+        refunds = data.get('out_refunds', self.env['account.invoice'])
+        moves = data.get('cash_moves', self.env['account.move.line'])
+        amount = self._invoice_amount_get(invoices, refunds)
+        if amount:
+            vals['amount'] = amount
+            vals['invoice_record_ids'] = [
+                (0, 0, {'invoice_id': x})
+                for x in (invoices.ids + refunds.ids)]
+            invoice_record = partner_record_obj.create(vals)
+            if invoice_record:
+                records.append(invoice_record)
+        if self._cash_amount_get(moves):
+            cash_moves = self._cash_moves_group(moves)
+            for fy_id in cash_moves.keys():
+                amount = self._cash_amount_get(cash_moves[fy_id])
+                if amount:
+                    if (fy_id != self.fiscalyear_id.id or not invoice_record):
+                        vals['amount'] = 0.0
+                        vals['cash_amount'] = amount
+                        vals['origin_fiscalyear_id'] = fy_id
+                        partner_record = partner_record_obj.create(vals)
+                        if partner_record:
+                            records.append(partner_record)
                     else:
-                        cash_moves[cash_move_fy_id].append(move_line)
-            for cash_move_fy_id in cash_moves.keys():
-                receivable_amount = sum([line.credit for line in
-                                         cash_moves[cash_move_fy_id]])
-                if receivable_amount > self.received_cash_limit:
-                    if (cash_move_fy_id != self.fiscalyear_id.id or
-                            not partner_record_id):
-                        # create partner cash_move_fy_id for cash operation in
-                        # different year to currently
-                        cash_partner_record_id = partner_record_obj.create(
-                            {'report_id': self.id,
-                             'operation_key': 'B',
-                             'partner_id': partners[0].id,
-                             'partner_vat': partner_vat,
-                             'representative_vat': '',
-                             'partner_state_code': address.state_id.code,
-                             'partner_country_code': partner_country_code,
-                             'amount': 0.0,
-                             'cash_amount': sum([line.credit for line in
-                                                 cash_moves[cash_move_fy_id]]),
-                             'origin_fiscalyear_id': cash_move_fy_id})
-                    else:
-                        partner_record_id.write(
-                            {'cash_amount': sum([line.credit for line in
-                                                 cash_moves[cash_move_fy_id]]),
-                             'origin_fiscalyear_id': cash_move_fy_id})
-                        cash_partner_record_id = partner_record_id
-                    for line in cash_moves[cash_move_fy_id]:
-                        cash_record_obj.create(
-                            {'partner_record_id': cash_partner_record_id.id,
-                             'move_line_id': line.id,
-                             'date': line.date,
-                             'amount': line.credit})
+                        invoice_record.write({
+                            'cash_amount': amount,
+                            'origin_fiscalyear_id': fy_id,
+                        })
+                        partner_record = invoice_record
+                    for line in cash_moves[fy_id]:
+                        cash_record_obj.create({
+                            'partner_record_id': partner_record.id,
+                            'move_line_id': line.id,
+                            'date': line.date,
+                            'amount': line.credit,
+                        })
+        return records
 
-    @api.multi
-    def calculate(self):
-        partner_obj = self.env['res.partner']
-        for report in self:
-            # Delete previous partner records
-            report.partner_record_ids.unlink()
-            # We will check every partner with not_in_mod347 flag unchecked
-            visited_partners = self.env['res.partner']
-            domain = [('not_in_mod347', '=', False), '|',
-                      ('parent_id', '=', False), ('is_company', '=', True)]
-            if report.only_supplier:
-                domain.append(('supplier', '=', True))
-            else:
-                domain.extend(['|',
-                               ('customer', '=', True),
-                               ('supplier', '=', True)])
-            for partner in partner_obj.search(domain):
-                if partner not in visited_partners:
-                    if partner.vat and report.group_by_vat:
-                        domain_group = list(domain)
-                        domain_group.append(('vat', '=', partner.vat))
-                        partners_grouped = partner_obj.search(
-                            domain_group)
-                    else:
-                        partners_grouped = partner
-                    visited_partners |= partners_grouped
-                    partner_record_id = report._calculate_partner_records(
-                        partners_grouped, report.periods)
-                    if partner.customer:
-                        report._calculate_cash_records(
-                            partners_grouped, partner_record_id,
-                            report.periods)
+    def _partner_records_create(self, data):
+        partner = data.get('partner')
+        address = self._get_default_address(partner)
+        partner_country_code, partner_vat = (
+            re.match(r"([A-Z]{0,2})(.*)", partner.vat or '').groups())
+        community_vat = ''
+        if not partner_country_code:
+            partner_country_code = address.country_id.code
+        partner_state_code = address.state_id.code
+        if partner_country_code != 'ES':
+            partner_vat = ''
+            community_vat = partner.vat
+            partner_state_code = 99
+        vals = {
+            'report_id': self.id,
+            'partner_id': partner.id,
+            'partner_vat': partner_vat,
+            'representative_vat': '',
+            'community_vat': community_vat,
+            'partner_state_code': partner_state_code,
+            'partner_country_code': partner_country_code,
+        }
+        # Create A record
+        self._partner_record_a_create(data, vals)
+        # Create B records
+        self._partner_record_b_create(data, vals)
         return True
 
-    @api.one
-    @api.depends('partner_record_ids', 'real_estate_record_ids')
-    def _get_totals(self):
+    def _invoices_search(self, partners):
+        invoice_obj = self.env['account.invoice']
+        partner_obj = self.env['res.partner']
+        domain = [
+            ('state', 'in', ['open', 'paid']),
+            ('period_id', 'in', self.periods.ids),
+            ('not_in_mod347', '=', False),
+            ('commercial_partner_id.not_in_mod347', '=', False),
+        ]
+        if self.only_supplier:
+            domain.append(('type', 'in', ('in_invoice', 'in_refund')))
+        key_field = 'id'
+        if self.group_by_vat:
+            key_field = 'vat'
+        groups = invoice_obj.read_group(
+            domain, ['commercial_partner_id'], ['commercial_partner_id'])
+        for group in groups:
+            partner = partner_obj.browse(group['commercial_partner_id'][0])
+            key_value = partner[key_field]
+            invoices = invoice_obj.search(group['__domain'])
+            in_invoices = invoices.filtered(
+                lambda x: x.type in 'in_invoice')
+            in_refunds = invoices.filtered(
+                lambda x: x.type in 'in_refund')
+            out_invoices = invoices.filtered(
+                lambda x: x.type in 'out_invoice')
+            out_refunds = invoices.filtered(
+                lambda x: x.type in 'out_refund')
+            if key_value not in partners:
+                partners[key_value] = {
+                    # Get first partner found when grouping by vat
+                    'partner': partner,
+                    'in_invoices': in_invoices,
+                    'in_refunds': in_refunds,
+                    'out_invoices': out_invoices,
+                    'out_refunds': out_refunds,
+                }
+            else:
+                # No need to check here if *_invoices exists,
+                # because this entry has been created in this method
+                partners[key_value]['in_invoices'] += in_invoices
+                partners[key_value]['in_refunds'] += in_refunds
+                partners[key_value]['out_invoices'] += out_invoices
+                partners[key_value]['out_refunds'] += out_refunds
+        return partners
+
+    def _cash_moves_search(self, partners):
+        partner_obj = self.env['res.partner']
+        move_line_obj = self.env['account.move.line']
+        cash_journals = self.env['account.journal'].search(
+            [('type', '=', 'cash')])
+        if not cash_journals or self.only_supplier:
+            return partners
+        domain = [
+            ('account_id.type', '=', 'receivable'),
+            ('journal_id', 'in', cash_journals.ids),
+            ('period_id', 'in', self.periods.ids),
+            ('partner_id.not_in_mod347', '=', False),
+        ]
+        groups = move_line_obj.read_group(
+            domain, ['partner_id'], ['partner_id'])
+        key_field = 'id'
+        if self.group_by_vat:
+            key_field = 'vat'
+        for group in groups:
+            partner = partner_obj.browse(group['partner_id'][0])
+            key_value = partner[key_field]
+            moves = move_line_obj.search(group['__domain'])
+            if key_value not in partners:
+                partners[key_value] = {
+                    # Get first partner found when grouping by vat
+                    'partner': partner,
+                    'cash_moves': moves,
+                }
+            else:
+                # Check here if cash_moves exists, maybe this entry
+                # has been created by _invoices_search
+                if partners[key_value].get('cash_moves'):
+                    partners[key_value]['cash_moves'] += moves
+                else:
+                    partners[key_value]['cash_moves'] = moves
+        return partners
+
+    @api.depends('partner_record_ids',
+                 'partner_record_ids.amount',
+                 'partner_record_ids.cash_amount',
+                 'partner_record_ids.real_estate_transmissions_amount')
+    def _get_partner_totals(self):
         """Calculates the total_* fields from the line values."""
-        self.total_partner_records = len(self.partner_record_ids)
-        self.total_amount = sum([x.amount for x in
-                                 self.partner_record_ids])
-        self.total_cash_amount = sum([x.cash_amount for x in
-                                      self.partner_record_ids])
-        self.total_real_estate_transmissions_amount = (
-            sum([x.real_estate_transmissions_amount for x in
-                 self.partner_record_ids]))
-        self.total_real_estate_amount = sum([x.amount for x in
-                                            self.real_estate_record_ids])
-        self.total_real_estate_records = len(self.real_estate_record_ids)
+        for record in self:
+            record.total_partner_records = len(record.partner_record_ids)
+            record.total_amount = (
+                sum([x.amount for x in record.partner_record_ids]))
+            record.total_cash_amount = (
+                sum([x.cash_amount for x in record.partner_record_ids]))
+            record.total_real_estate_transmissions_amount = (
+                sum([x.real_estate_transmissions_amount for x in
+                     record.partner_record_ids]))
+
+    @api.depends('real_estate_record_ids',
+                 'real_estate_record_ids.amount')
+    def _get_real_state_totals(self):
+        """Calculates the total_* fields from the line values."""
+        for record in self:
+            record.total_real_estate_amount = (
+                sum([x.amount for x in record.real_estate_record_ids]))
+            record.total_real_estate_records = (
+                len(record.real_estate_record_ids))
 
     number = fields.Char(default='347')
     group_by_vat = fields.Boolean(
         string='Group by VAT number', oldname='group_by_cif')
     only_supplier = fields.Boolean(string='Only Suppliers')
     operations_limit = fields.Float(
-        string='Invoiced Limit (1)', digits=(13, 2), default=3005.06,
+        string='Invoiced Limit (1)', digits=dp.get_precision('Account'),
+        default=3005.06,
         help="The declaration will include partners with the total of "
              "operations over this limit")
     received_cash_limit = fields.Float(
-        string='Received cash Limit (2)', digits=(13, 2), default=6000.00,
+        string='Received cash Limit (2)', digits=dp.get_precision('Account'),
+        default=6000.00,
         help="The declaration will show the total of cash operations over "
              "this limit")
     charges_obtp_limit = fields.Float(
-        string='Charges on behalf of third parties Limit (3)', digits=(13, 2),
+        string='Charges on behalf of third parties Limit (3)',
+        digits=dp.get_precision('Account'), default=300.51,
         help="The declaration will include partners from which we received "
-             "payments, on behalf of third parties, over this limit",
-        default=300.51)
+             "payments, on behalf of third parties, over this limit")
     total_partner_records = fields.Integer(
-        compute="_get_totals", string="Partners records")
+        compute="_get_partner_totals", store=True, readonly=True,
+        string="Partners records")
     total_amount = fields.Float(
-        compute="_get_totals", string="Amount")
+        compute="_get_partner_totals", store=True, readonly=True,
+        digits=dp.get_precision('Account'), string="Operations amount")
     total_cash_amount = fields.Float(
-        compute="_get_totals", string="Cash Amount")
+        compute="_get_partner_totals", store=True, readonly=True,
+        digits=dp.get_precision('Account'), string="Cash movements amount")
     total_real_estate_transmissions_amount = fields.Float(
-        compute="_get_totals", string="Real Estate Transmissions Amount",
+        compute="_get_partner_totals", store=True, readonly=True,
+        digits=dp.get_precision('Account'),
+        string="Real estate transmissions amount",
         oldname='total_real_state_transmissions_amount')
     total_real_estate_records = fields.Integer(
-        compute="_get_totals", string="Real estate records",
+        compute="_get_real_state_totals", store=True, readonly=True,
+        string="Real estate records",
         oldname='total_real_state_records')
     total_real_estate_amount = fields.Float(
-        compute="_get_totals", string="Real Estate Amount",
+        compute="_get_real_state_totals", store=True, readonly=True,
+        digits=dp.get_precision('Account'), string="Real estate amount",
         oldname='total_real_state_amount')
     partner_record_ids = fields.One2many(
         comodel_name='l10n.es.aeat.mod347.partner_record',
@@ -298,38 +325,79 @@ class L10nEsAeatMod347Report(models.Model):
         oldname='real_state_record_ids')
 
     @api.multi
+    def button_list_partner_records(self):
+        return {
+            'domain': "[('report_id','in'," + str(self.ids) + ")]",
+            'name': _("Partner records"),
+            'context': "{'default_report_id': %s}" % self.ids[0],
+            'view_mode': 'tree,form',
+            'view_type': 'form',
+            'res_model': 'l10n.es.aeat.mod347.partner_record',
+            'type': 'ir.actions.act_window',
+        }
+
+    @api.multi
+    def button_list_real_estate_records(self):
+        return {
+            'domain': "[('report_id','in'," + str(self.ids) + ")]",
+            'name': _("Real estate records"),
+            'context': "{'default_report_id': %s}" % self.ids[0],
+            'view_mode': 'tree,form',
+            'view_type': 'form',
+            'res_model': 'l10n.es.aeat.mod347.real_estate_record',
+            'type': 'ir.actions.act_window',
+        }
+
+    @api.multi
     def button_confirm(self):
         """Different check out in report"""
         for item in self:
             # Browse partner record lines to check if all are correct (all
             # fields filled)
+            partner_errors = []
             for partner_record in item.partner_record_ids:
-                if not partner_record.partner_state_code:
-                    raise exceptions.ValidationError(
-                        _("All partner state code field must be filled.\n"
-                          "Partner: %s (%s)") %
+                if not partner_record.check_ok:
+                    partner_errors.append(
+                        _("- %s (%s)") %
                         (partner_record.partner_id.name,
                          partner_record.partner_id.id))
-                if (not partner_record.partner_vat and
-                        not partner_record.community_vat):
-                    raise exceptions.ValidationError(
-                        _("All partner vat number field must be filled.\n"
-                          "Partner: %s (%s)") %
-                        (partner_record.partner_id.name,
-                         partner_record.partner_id.id))
-                if (partner_record.partner_state_code and
-                        not partner_record.partner_state_code.isdigit()):
-                    raise exceptions.ValidationError(
-                        _("All partner state code field must be numeric.\n"
-                          "Partner: %s (%s)") %
-                        (partner_record.partner_id.name,
-                         partner_record.partner_id.id))
+            real_state_errors = []
             for real_estate_record in item.real_estate_record_ids:
-                if not real_estate_record.state_code:
-                    raise exceptions.ValidationError(
-                        _("All real estate records state code field must be "
-                          "filled."))
+                if not real_estate_record.check_ok:
+                    real_state_errors.append(
+                        _("- %s (%s)") %
+                        (real_estate_record.partner_id.name,
+                         real_estate_record.partner_id.id))
+            error = _("Please review partner and real estate records, "
+                      "some of them are in red color:\n\n")
+            if partner_errors:
+                error += _("Partner record errors:\n")
+                error += '\n'.join(partner_errors)
+                error += '\n\n'
+            if real_state_errors:
+                error += _("Real estate record errors:\n")
+                error += '\n'.join(real_state_errors)
+            if error:
+                raise exceptions.ValidationError(error)
         return super(L10nEsAeatMod347Report, self).button_confirm()
+
+    @api.multi
+    def calculate(self):
+        def _automatic_filter(self):
+            return bool(self.invoice_record_ids or self.cash_record_ids)
+
+        for report in self:
+            # Delete previous partner records
+            report.partner_record_ids.filtered(_automatic_filter).unlink()
+            partners = {}
+            # Read invoices: normal and refunds
+            # We have to call _invoices_search always first
+            partners = report._invoices_search(partners)
+            # Read cash movements
+            partners = report._cash_moves_search(partners)
+            for k, v in partners.iteritems():
+                report._partner_records_create(v)
+        return True
 
     def __init__(self, pool, cr):
         self._aeat_number = '347'
@@ -341,38 +409,98 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
     _description = 'Partner Record'
     _rec_name = "partner_vat"
 
-    @api.one
-    @api.depends('invoice_record_ids.invoice_id.period_id.quarter')
-    def _get_quarter_totals(self):
-        self.first_quarter_real_estate_transmission_amount = 0
-        self.second_quarter_real_estate_transmission_amount = 0
-        self.third_quarter_real_estate_transmission_amount = 0
-        self.fourth_quarter_real_estate_transmission_amount = 0
-        invoices = self.invoice_record_ids.filtered(
-            lambda rec: rec.invoice_id.type in ('out_invoice', 'in_invoice'))
-        refunds = self.invoice_record_ids.filtered(
-            lambda rec: rec.invoice_id.type in ('out_refund', 'in_refund'))
-        self.first_quarter = (
-            sum(x.amount for x in invoices
-                if x.invoice_id.period_id.quarter == 'first') -
-            sum(x.amount for x in refunds
-                if x.invoice_id.period_id.quarter == 'first'))
-        self.second_quarter = (
-            sum(x.amount for x in invoices
-                if x.invoice_id.period_id.quarter == 'second') -
-            sum(x.amount for x in refunds
-                if x.invoice_id.period_id.quarter == 'second'))
-        self.third_quarter = (
-            sum(x.amount for x in invoices
-                if x.invoice_id.period_id.quarter == 'third') -
-            sum(x.amount for x in refunds
-                if x.invoice_id.period_id.quarter == 'third'))
-        self.fourth_quarter = (
-            sum(x.amount for x in invoices
-                if x.invoice_id.period_id.quarter == 'fourth') -
-            sum(x.amount for x in refunds
-                if x.invoice_id.period_id.quarter == 'fourth'))
+    @api.depends('invoice_record_ids',
+                 'invoice_record_ids.invoice_id.type',
+                 'invoice_record_ids.invoice_id.period_id.quarter',
+                 'manual_first_quarter', 'manual_second_quarter',
+                 'manual_third_quarter', 'manual_fourth_quarter')
+    def _get_quarter_invoice_totals(self):
+        def _invoices_normal(rec):
+            return rec.invoice_id.type in ('out_invoice', 'in_invoice')
 
+        def _invoices_refund(rec):
+            return rec.invoice_id.type in ('out_refund', 'in_refund')
+
+        def _invoices_sum(invoices, refunds, quarter):
+            return (
+                sum(x.amount for x in invoices
+                    if x.invoice_id.period_id.quarter == quarter) -
+                sum(x.amount for x in refunds
+                    if x.invoice_id.period_id.quarter == quarter))
+
+        for record in self:
+            # Invoices
+            if record.invoice_record_ids:
+                invoices = record.invoice_record_ids.filtered(_invoices_normal)
+                refunds = record.invoice_record_ids.filtered(_invoices_refund)
+                # Go to normal mode for getting invoice data
+                last_mode = self.env.all.mode
+                self.env.all.mode = False
+                first_quarter = _invoices_sum(invoices, refunds, 'first')
+                second_quarter = _invoices_sum(invoices, refunds, 'second')
+                third_quarter = _invoices_sum(invoices, refunds, 'third')
+                fourth_quarter = _invoices_sum(invoices, refunds, 'fourth')
+                # Return to current mode to save results
+                self.env.all.mode = last_mode
+                record.first_quarter = first_quarter
+                record.second_quarter = second_quarter
+                record.third_quarter = third_quarter
+                record.fourth_quarter = fourth_quarter
+            else:
+                record.first_quarter = record.manual_first_quarter
+                record.second_quarter = record.manual_second_quarter
+                record.third_quarter = record.manual_third_quarter
+                record.fourth_quarter = record.manual_fourth_quarter
+            # Totals
+            record.amount = sum([
+                record.first_quarter, record.second_quarter,
+                record.third_quarter, record.fourth_quarter])
+
+    @api.depends('cash_record_ids',
+                 'cash_record_ids.move_line_id.period_id.quarter')
+    def _get_quarter_cash_totals(self):
+        def _cash_moves_sum(records, quarter):
+            return (sum(x.amount for x in records
+                        if x.move_line_id.period_id.quarter == quarter))
+
+        for record in self:
+            # Cash
+            if record.cash_record_ids:
+                record.first_quarter_cash_amount = \
+                    _cash_moves_sum(record.cash_record_ids, 'first')
+                record.second_quarter_cash_amount = \
+                    _cash_moves_sum(record.cash_record_ids, 'second')
+                record.third_quarter_cash_amount = \
+                    _cash_moves_sum(record.cash_record_ids, 'third')
+                record.fourth_quarter_cash_amount = \
+                    _cash_moves_sum(record.cash_record_ids, 'fourth')
+            # Totals
+            record.cash_amount = sum([
+                record.first_quarter_cash_amount,
+                record.second_quarter_cash_amount,
+                record.third_quarter_cash_amount,
+                record.fourth_quarter_cash_amount])
+
+    @api.depends('first_quarter_real_estate_transmission_amount',
+                 'second_quarter_real_estate_transmission_amount',
+                 'third_quarter_real_estate_transmission_amount',
+                 'fourth_quarter_real_estate_transmission_amount')
+    def _get_quarter_real_state_totals(self):
+        for record in self:
+            # Totals
+            record.real_estate_transmissions_amount = sum([
+                record.first_quarter_real_estate_transmission_amount,
+                record.second_quarter_real_estate_transmission_amount,
+                record.third_quarter_real_estate_transmission_amount,
+                record.fourth_quarter_real_estate_transmission_amount])
+
+    @api.depends('invoice_record_ids', 'cash_record_ids')
+    def _compute_automatic(self):
+        for record in self:
+            record.automatic = bool(
+                record.invoice_record_ids or record.cash_record_ids)
+
+    # TODO: By now user must fill real estate transmission amounts manually
     @api.one
     def _get_real_estate_record_ids(self):
         """Get the real estate records from this record parent report for this
@@ -385,24 +513,36 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
                 [('report_id', '=', self.report_id.id),
                  ('partner_id', '=', self.partner_id.id)])
 
-    @api.one
-    def _set_real_estate_record_ids(self, vals):
-        """Set the real estate records from this record parent report for this
-        partner.
-        """
-        if vals:
-            real_estate_record_obj = self.env[
-                'l10n.es.aeat.mod347.real_estate_record']
-            for value in vals:
-                o_action, o_id, o_vals = value
-                rec = real_estate_record_obj.browse(o_id)
-                if o_action == 1:
-                    rec.write(o_vals)
-                elif o_action == 2:
-                    rec.unlink()
-                elif o_action == 0:
-                    rec.create(o_vals)
-        return True
+    # @api.one
+    # def _set_real_estate_record_ids(self, vals):
+    #     """Set the real estate records from this record parent report for
+    #     this partner.
+    #     """
+    #     if vals:
+    #         real_estate_record_obj = self.env[
+    #             'l10n.es.aeat.mod347.real_estate_record']
+    #         for value in vals:
+    #             o_action, o_id, o_vals = value
+    #             rec = real_estate_record_obj.browse(o_id)
+    #             if o_action == 1:
+    #                 rec.write(o_vals)
+    #             elif o_action == 2:
+    #                 rec.unlink()
+    #             elif o_action == 0:
+    #                 rec.create(o_vals)
+    #     return True
+
+    @api.multi
+    @api.depends('partner_country_code', 'partner_state_code', 'partner_vat',
+                 'community_vat')
+    def _compute_check_ok(self):
+        for record in self:
+            record.check_ok = (
+                record.partner_country_code and
+                record.partner_state_code and
+                record.partner_state_code.isdigit() and
+                (record.partner_vat or record.community_vat)
+            )
 
     @api.model
     def _default_record_id(self):
@@ -438,36 +578,105 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
     partner_country_code = fields.Char(string='Country Code', size=2)
     partner_state_code = fields.Char(string='State Code', size=2)
     first_quarter = fields.Float(
-        compute="_get_quarter_totals", string="First Quarter", digits=(13, 2))
+        compute="_get_quarter_invoice_totals", store=True, readonly=True,
+        string="First quarter operations", digits=dp.get_precision('Account'),
+        help="Total amount of first quarter in, out and refund invoices "
+             "for this partner")
+    manual_first_quarter = fields.Float(
+        string="First quarter operations", digits=dp.get_precision('Account'),
+        help="Total amount of first quarter in, out and refund invoices "
+             "for this partner")
     first_quarter_real_estate_transmission_amount = fields.Float(
-        compute="_get_quarter_totals", digits=(13, 2),
-        string="First Quarter Real Estate Transmission Amount",
-        oldname="first_quarter_real_state_transmission_amount")
+        string="First quarter real estate", digits=dp.get_precision('Account'),
+        oldname="first_quarter_real_state_transmission_amount",
+        help="Total amount of first quarter real estate transmissions "
+             "for this partner")
+    first_quarter_cash_amount = fields.Float(
+        compute="_get_quarter_cash_totals", store=True, readonly=True,
+        string="First quarter cash movements",
+        digits=dp.get_precision('Account'),
+        help="Total amount of first quarter cash movements "
+             "for this partner")
     second_quarter = fields.Float(
-        compute="_get_quarter_totals", string="Second Quarter", digits=(13, 2))
+        compute="_get_quarter_invoice_totals", store=True, readonly=True,
+        string="Second quarter operations", digits=dp.get_precision('Account'),
+        help="Total amount of second quarter in, out and refund invoices "
+             "for this partner")
+    manual_second_quarter = fields.Float(
+        string="Second quarter operations", digits=dp.get_precision('Account'),
+        help="Total amount of second quarter in, out and refund invoices "
+             "for this partner")
     second_quarter_real_estate_transmission_amount = fields.Float(
-        compute="_get_quarter_totals", digits=(13, 2),
-        string="Second Quarter Real Estate Transmission Amount",
-        oldname="second_quarter_real_state_transmission_amount")
+        string="Second quarter real estate",
+        digits=dp.get_precision('Account'),
+        oldname="second_quarter_real_state_transmission_amount",
+        help="Total amount of second quarter real estate transmissions "
+             "for this partner")
+    second_quarter_cash_amount = fields.Float(
+        compute="_get_quarter_cash_totals", store=True, readonly=True,
+        string="Second quarter cash movements",
+        digits=dp.get_precision('Account'),
+        help="Total amount of second quarter cash movements "
+             "for this partner")
     third_quarter = fields.Float(
-        compute="_get_quarter_totals", string="Third Quarter", digits=(13, 2))
+        compute="_get_quarter_invoice_totals", store=True, readonly=True,
+        string="Third quarter operations", digits=dp.get_precision('Account'),
+        help="Total amount of third quarter in, out and refund invoices "
+             "for this partner")
+    manual_third_quarter = fields.Float(
+        string="Third quarter operations", digits=dp.get_precision('Account'),
+        help="Total amount of third quarter in, out and refund invoices "
+             "for this partner")
     third_quarter_real_estate_transmission_amount = fields.Float(
-        compute="_get_quarter_totals", digits=(13, 2),
-        string="Third Quarter Real Estate Transmission Amount",
-        oldname="third_quarter_real_state_transmission_amount")
+        string="Third quarter real estate", digits=dp.get_precision('Account'),
+        oldname="third_quarter_real_state_transmission_amount",
+        help="Total amount of third quarter real estate transmissions "
+             "for this partner")
+    third_quarter_cash_amount = fields.Float(
+        compute="_get_quarter_cash_totals", store=True, readonly=True,
+        string="Third quarter cash movements",
+        digits=dp.get_precision('Account'),
+        help="Total amount of third quarter cash movements "
+             "for this partner")
     fourth_quarter = fields.Float(
-        compute="_get_quarter_totals", string="Fourth Quarter", digits=(13, 2))
+        compute="_get_quarter_invoice_totals", store=True, readonly=True,
+        string="Fourth quarter operations", digits=dp.get_precision('Account'),
+        help="Total amount of fourth quarter in, out and refund invoices "
+             "for this partner")
+    manual_fourth_quarter = fields.Float(
+        string="Fourth quarter operations", digits=dp.get_precision('Account'),
+        help="Total amount of fourth quarter in, out and refund invoices "
+             "for this partner")
     fourth_quarter_real_estate_transmission_amount = fields.Float(
-        compute="_get_quarter_totals", digits=(13, 2),
-        string="Fourth Quarter Real Estate Transmission Amount",
-        oldname="fourth_quarter_real_state_transmission_amount")
+        string="Fourth quarter real estate",
+        digits=dp.get_precision('Account'),
+        oldname="fourth_quarter_real_state_transmission_amount",
+        help="Total amount of fourth quarter real estate transmissions "
+             "for this partner")
+    fourth_quarter_cash_amount = fields.Float(
+        compute="_get_quarter_cash_totals", store=True, readonly=True,
+        string="Fourth quarter cash movements",
+        digits=dp.get_precision('Account'),
+        help="Total amount of fourth quarter cash movements "
+             "for this partner")
     amount = fields.Float(
-        string='Operations amount', digits=(13, 2))
+        compute="_get_quarter_invoice_totals", store=True, readonly=True,
+        string='Anual operations amount', digits=dp.get_precision('Account'),
+        help="Total amount of fiscal year in, out and refund invoices "
+             "for this partner")
     cash_amount = fields.Float(
-        string='Received cash amount', digits=(13, 2))
+        compute="_get_quarter_cash_totals", store=True, readonly=True,
+        string='Anual cash movements amount',
+        digits=dp.get_precision('Account'),
+        help="Total amount of fiscal year cash movements "
+             "for this partner")
     real_estate_transmissions_amount = fields.Float(
-        string='Real Estate Transmisions amount', digits=(13, 2),
-        oldname='real_state_transmissions_amount')
+        compute="_get_quarter_real_state_totals", store=True, readonly=True,
+        string='Real estate transmisions amount',
+        digits=dp.get_precision('Account'),
+        oldname='real_state_transmissions_amount',
+        help="Total amount of fiscal year real estate transmissions "
+             "for this partner")
     insurance_operation = fields.Boolean(
         string='Insurance Operation',
         help="Only for insurance companies. Set to identify insurance "
@@ -496,6 +705,7 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
     invoice_record_ids = fields.One2many(
         comodel_name='l10n.es.aeat.mod347.invoice_record',
         inverse_name='partner_record_id', string='Invoice records')
+    # TODO: By now user must fill real estate transmission amounts manually
     real_estate_record_ids = fields.One2many(
         compute="_get_real_estate_record_ids",
         # inverse="_set_real_estate_record_ids",
@@ -505,6 +715,12 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
     cash_record_ids = fields.One2many(
         comodel_name='l10n.es.aeat.mod347.cash_record',
         inverse_name='partner_record_id', string='Payment records')
+    automatic = fields.Boolean(
+        compute="_compute_automatic", store=True, readonly=True)
+    check_ok = fields.Boolean(
+        compute="_compute_check_ok", string='Record is OK',
+        store=True, readonly=True,
+        help='Checked if this record is OK')
 
     @api.multi
     @api.onchange('partner_id')
@@ -515,7 +731,7 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
         for record in self:
             if record.partner_id:
                 record.partner_vat = re.match(
-                    "(ES){0,1}(.*)", record.partner_id.vat).groups()[1]
+                    r'(ES)?(.*)', record.partner_id.vat or '').groups()[1]
                 record.partner_state_code = record.partner_id.state_id.code
                 record.partner_country_code = record.partner_id.country_id.code
 
@@ -541,6 +757,12 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
     def _default_representative_vat(self):
         return self.env.context.get('representative_vat', False)
 
+    @api.multi
+    @api.depends('state_code')
+    def _compute_check_ok(self):
+        for record in self:
+            record.check_ok = bool(record.partner_state_code)
+
     report_id = fields.Many2one(
         comodel_name='l10n.es.aeat.mod347.report', string='AEAT 347 Report',
         ondelete="cascade", select=1, default=_default_record_id)
@@ -552,15 +774,16 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
     representative_vat = fields.Char(
         string='L.R. VAT number', size=32, default=_default_representative_vat,
         help="Legal Representative VAT number")
-    amount = fields.Float(string='Amount', digits=(13, 2))
+    amount = fields.Float(
+        string='Amount', digits=dp.get_precision('Account'), required=True)
     situation = fields.Selection(
         selection=[('1', '1 - Spain but Basque Country and Navarra'),
                    ('2', '2 - Basque Country and Navarra'),
                    ('3', '3 - Spain, without catastral reference'),
                    ('4', '4 - Foreign')],
-        string='Real estate Situation')
+        string='Real estate Situation', required=True)
     reference = fields.Char(
-        string='Catastral Reference', size=25)
+        string='Catastral Reference', size=25, required=True)
     address_type = fields.Char(
         string='Address type', size=5)
     address = fields.Char(string='Address', size=50)
@@ -589,20 +812,23 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
     township_code = fields.Char(string='Township Code', size=5)
     state_code = fields.Char(string='State Code', size=2)
     postal_code = fields.Char(string='Postal code', size=5)
+    check_ok = fields.Boolean(
+        compute="_compute_check_ok", string='Record is OK',
+        store=True, readonly=True,
+        help='Checked if this record is OK')
 
     @api.onchange('partner_id')
     def on_change_partner_id(self):
         """Loads some partner data (vat) when the selected partner changes."""
-        if self.partner_id:
-            self.partner_vat = re.match("(ES){0,1}(.*)",
-                                        self.partner_id.vat).groups()[1]
-        else:
-            self.partner_vat = ''
+        for record in self:
+            record.partner_vat = re.match(
+                r'(ES)?(.*)', record.partner_id.vat or '').groups()[1]
 
 
 class L10nEsAeatMod347InvoiceRecord(models.Model):
     _name = 'l10n.es.aeat.mod347.invoice_record'
     _description = 'Invoice Record'
+    _order = 'date ASC, invoice_id ASC'
 
     @api.model
     def _default_partner_record(self):
@@ -615,16 +841,20 @@ class L10nEsAeatMod347InvoiceRecord(models.Model):
     invoice_id = fields.Many2one(
         comodel_name='account.invoice', string='Invoice', required=True,
         ondelete="cascade")
+    invoice_type = fields.Selection(related="invoice_id.type", readonly=True)
     date = fields.Date(
-        string='Date', related='invoice_id.date_invoice', store=True)
+        related='invoice_id.date_invoice', store=True, readonly=True,
+        string='Date')
     amount = fields.Float(
-        string='Amount', related="invoice_id.amount_total_wo_irpf", store=True)
+        related="invoice_id.amount_total_wo_irpf", store=True, readonly=True,
+        digits=dp.get_precision('Account'), string='Amount')
 
 
 class L10nEsAeatMod347CashRecord(models.Model):
     """Represents a payment record."""
     _name = 'l10n.es.aeat.mod347.cash_record'
     _description = 'Cash Record'
+    _order = 'date ASC, move_line_id ASC'
 
     @api.model
     def _default_partner_record(self):
@@ -638,4 +868,4 @@ class L10nEsAeatMod347CashRecord(models.Model):
         comodel_name='account.move.line', string='Account move line',
         required=True, ondelete="cascade")
     date = fields.Date(string='Date')
-    amount = fields.Float(string='Amount')
+    amount = fields.Float(string='Amount', digits=dp.get_precision('Account'))

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -699,7 +699,8 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
         for record in self:
             if record.partner_id:
                 record.partner_vat = re.match(
-                    r'(ES)?(.*)', record.partner_id.vat or '').groups()[1]
+                    r'^(?:ES)?(.*)', record.partner_id.vat or '',
+                    re.IGNORECASE).groups()[0]
                 record.partner_state_code = record.partner_id.state_id.code
                 record.partner_country_code = record.partner_id.country_id.code
 

--- a/l10n_es_aeat_mod347/models/res_partner.py
+++ b/l10n_es_aeat_mod347/models/res_partner.py
@@ -1,20 +1,13 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2012 NaN·Tic  (http://www.nan-tic.com)
+# © 2013 Acysos (http://www.acysos.com)
+# © 2013 Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+#             (http://www.serviciosbaeza.com)
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openerp import fields, models, api
 
 

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -3,14 +3,15 @@
     <data>
 
         <!-- ##########################################
-                   AEAT MODEL 347 PARTNER RECORD 
+                   AEAT MODEL 347 PARTNER RECORD
              ########################################## -->
         <!-- Tree view -->
         <record model="ir.ui.view" id="view_l10n_es_aeat_mod347_partner_record_tree">
             <field name="name">l10n.es.aeat.mod347.partner_record.tree</field>
             <field name="model">l10n.es.aeat.mod347.partner_record</field>
             <field name="arch" type="xml">
-                <tree string="Partner Records" colors="">
+                <tree string="Partner Records" colors="red:not check_ok">
+                    <field name="check_ok" invisible="1"/>
                     <field name="operation_key" select="1"/>
                     <field name="partner_vat" select="1"/>
                     <field name="partner_id" select="1"/>
@@ -28,8 +29,9 @@
             <field name="name">l10n.es.aeat.mod347.partner_record.form</field>
             <field name="model">l10n.es.aeat.mod347.partner_record</field>
             <field name="arch" type="xml">
-                <form string="Partner Record" version="7.0">
+                <form string="Partner Record">
                     <field name="report_id" invisible="1"/>
+                    <field name="automatic" invisible="1"/>
                     <notebook>
                         <page string="Partner info">
                             <group>
@@ -57,10 +59,20 @@
                             </group>
                             <group >
                                 <group>
-                                    <field name="first_quarter"/>
-                                    <field name="second_quarter"/>
-                                    <field name="third_quarter"/>
-                                    <field name="fourth_quarter"/>
+                                    <field name="first_quarter" attrs="{'invisible': [('automatic', '=', False)]}"/>
+                                    <field name="second_quarter" attrs="{'invisible': [('automatic', '=', False)]}"/>
+                                    <field name="third_quarter" attrs="{'invisible': [('automatic', '=', False)]}"/>
+                                    <field name="fourth_quarter" attrs="{'invisible': [('automatic', '=', False)]}"/>
+                                    <field name="manual_first_quarter" attrs="{'invisible': [('automatic', '=', True)]}"/>
+                                    <field name="manual_second_quarter" attrs="{'invisible': [('automatic', '=', True)]}"/>
+                                    <field name="manual_third_quarter" attrs="{'invisible': [('automatic', '=', True)]}"/>
+                                    <field name="manual_fourth_quarter" attrs="{'invisible': [('automatic', '=', True)]}"/>
+                                </group>
+                                <group>
+                                    <field name="first_quarter_cash_amount"/>
+                                    <field name="second_quarter_cash_amount"/>
+                                    <field name="third_quarter_cash_amount"/>
+                                    <field name="fourth_quarter_cash_amount"/>
                                 </group>
                                 <group>
                                     <field name="first_quarter_real_estate_transmission_amount"/>
@@ -82,17 +94,21 @@
                                 </group>
                             </group>
                         </page>
+                        <!-- TODO: By now these fields must be filled by user manually
                         <page string="Real estate info" attrs="{'invisible': [('bussiness_real_estate_rent','=',False)]}">
                             <field name="real_estate_record_ids" nolabel="1" context="{'report_id': report_id, 'partner_id': partner_id, 'partner_vat': partner_vat, 'representative_vat': representative_vat}"/>
                         </page>
+                        -->
                         <page string="Details">
+                            <div><strong>Leyend:</strong> <span style="color: blue;">Refund invoices</span> - Normal invoices</div>
                             <field name="invoice_record_ids" context="{'partner_record_id': active_id}" readonly="True">
-                                <tree string="Invoice records">
+                                <tree string="Invoice records" colors="blue:invoice_type in ('in_refund', 'out_refund');">
+                                    <field name="invoice_type" invisible="1"/>
                                     <field name="invoice_id" select="1"/>
                                     <field name="date" select="1"/>
                                     <field name="amount" select="1"/>
                                 </tree>
-                                <form string="Invoice record" version="7.0">
+                                <form string="Invoice record">
                                     <group>
                                         <field name="invoice_id" select="1" readonly="True"/>
                                         <field name="date" select="1" readonly="True"/>
@@ -108,7 +124,7 @@
                                     <field name="date" select="1"/>
                                     <field name="amount" select="1"/>
                                 </tree>
-                                <form string="Cash record" version="7.0">
+                                <form string="Cash record">
                                     <group>
                                         <field name="move_line_id" select="1" readonly="True"/>
                                         <field name="date" select="1" readonly="True"/>
@@ -123,7 +139,7 @@
                 </form>
             </field>
         </record>
-        
+
         <!-- Search view -->
         <record id="partner_record_search_view" model="ir.ui.view">
             <field name="name">l10n.es.aeat.mod347.partner_record.search</field>
@@ -133,6 +149,14 @@
                     <field name="partner_id" string="Partner" filter_domain="[('partner_id','ilike',self)]"/>
                     <field name="operation_key" string="Operation key" filter_domain="[('operation_key','ilike',self)]"/>
                     <field name="partner_vat" string="Record" filter_domain="['|',('partner_vat','ilike',self),('partner_id','ilike',self)]"/>
+                    <separator/>
+                    <filter name="invalid" string="Invalid records"
+                            domain="[('check_ok', '=', False)]"/>
+                    <separator/>
+                    <filter name="manual" string="Manual records"
+                            domain="[('automatic', '=', False)]"/>
+                    <filter name="automatic" string="Automatic records"
+                            domain="[('automatic', '=', True)]"/>
                     <separator/>
                     <group  expand='0' string='Group by...'>
                        <filter string='Operation key' domain="[]" context="{'group_by' : 'operation_key'}"/>
@@ -149,7 +173,8 @@
             <field name="name">l10n.es.aeat.mod347.real_estate_record.tree</field>
             <field name="model">l10n.es.aeat.mod347.real_estate_record</field>
             <field name="arch" type="xml">
-                <tree string="Real Estate Records" colors="">
+                <tree string="Real Estate Records" colors="red:not check_ok">
+                    <field name="check_ok" invisible="1"/>
                     <field name="partner_vat" select="1"/>
                     <field name="partner_id" select="1"/>
                     <field name="reference" select="2"/>
@@ -167,7 +192,7 @@
             <field name="name">l10n.es.aeat.mod347.real_estate_record.form</field>
             <field name="model">l10n.es.aeat.mod347.real_estate_record</field>
             <field name="arch" type="xml">
-                <form string="Real Estate Record" version="7.0">
+                <form string="Real Estate Record">
                     <field name="report_id" invisible="1"/>
                     <group string="Partner info">
                         <group>
@@ -207,7 +232,7 @@
                                 <field name="portal"/>
                                 <field name="door"/>
                             </group>
-                           
+
                         </group>
                         <group>
                             <field name="complement"/>
@@ -216,7 +241,7 @@
                             <group>
                                 <field name="city"/>
                                 <field name="state_code"/>
-                                
+
                             </group>
                             <group>
                                 <field name="township"/>
@@ -269,18 +294,27 @@
                                 <group string="Summary">
                                     <field name="total_partner_records"/>
                                     <field name="total_amount"/>
+                                    <field name="total_cash_amount"/>
+                                    <field name="total_real_estate_transmissions_amount"/>
                                     <field name="total_real_estate_records"/>
                                     <field name="total_real_estate_amount"/>
                                 </group>
                             </group>
                         </page>
                         <page string="Partner records">
-                        	<button name="btn_list_records" string="Open list in new window" type="object" class="oe_link oe_inline" colspan="1"/>
-                            <field name="partner_record_ids" nolabel="1" context="{'report_id': active_id}"
-                                   attrs="{'readonly': [('state', '!=', 'calculated')]}"/>
+                            <button name="button_list_partner_records"
+                                    string="Edit records"
+                                    type="object" colspan="1"/>
+                            <field name="partner_record_ids" nolabel="1"
+                                   context="{'report_id': active_id}"
+                                   readonly="True"/>
                         </page>
                         <page string="Real Estate records">
-                            <field name="real_estate_record_ids" nolabel="1" context="{'report_id': active_id}"
+                            <button name="button_list_real_estate_records"
+                                    string="Edit records"
+                                    type="object" colspan="1"/>
+                            <field name="real_estate_record_ids" nolabel="1"
+                                   context="{'report_id': active_id}"
                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"/>
                         </page>
                     </notebook>
@@ -298,7 +332,7 @@
             <p class="oe_view_nocontent_create">
                 Click to create a AEAT Model 347 Reports.
               </p><p>
-                Basado en la Orden EHA/3012/2008, de 20 de Octubre, por el que se aprueban 
+                Basado en la Orden EHA/3012/2008, de 20 de Octubre, por el que se aprueban
                 los diseños físicos y lógicos del 347.
               </p>
               </field>

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -31,7 +31,6 @@
             <field name="arch" type="xml">
                 <form string="Partner Record">
                     <field name="report_id" invisible="1"/>
-                    <field name="automatic" invisible="1"/>
                     <notebook>
                         <page string="Partner info">
                             <group>
@@ -59,14 +58,10 @@
                             </group>
                             <group >
                                 <group>
-                                    <field name="first_quarter" attrs="{'invisible': [('automatic', '=', False)]}"/>
-                                    <field name="second_quarter" attrs="{'invisible': [('automatic', '=', False)]}"/>
-                                    <field name="third_quarter" attrs="{'invisible': [('automatic', '=', False)]}"/>
-                                    <field name="fourth_quarter" attrs="{'invisible': [('automatic', '=', False)]}"/>
-                                    <field name="manual_first_quarter" attrs="{'invisible': [('automatic', '=', True)]}"/>
-                                    <field name="manual_second_quarter" attrs="{'invisible': [('automatic', '=', True)]}"/>
-                                    <field name="manual_third_quarter" attrs="{'invisible': [('automatic', '=', True)]}"/>
-                                    <field name="manual_fourth_quarter" attrs="{'invisible': [('automatic', '=', True)]}"/>
+                                    <field name="first_quarter"/>
+                                    <field name="second_quarter"/>
+                                    <field name="third_quarter"/>
+                                    <field name="fourth_quarter"/>
                                 </group>
                                 <group>
                                     <field name="first_quarter_cash_amount"/>
@@ -152,11 +147,6 @@
                     <separator/>
                     <filter name="invalid" string="Invalid records"
                             domain="[('check_ok', '=', False)]"/>
-                    <separator/>
-                    <filter name="manual" string="Manual records"
-                            domain="[('automatic', '=', False)]"/>
-                    <filter name="automatic" string="Automatic records"
-                            domain="[('automatic', '=', True)]"/>
                     <separator/>
                     <group  expand='0' string='Group by...'>
                        <filter string='Operation key' domain="[]" context="{'group_by' : 'operation_key'}"/>

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -296,14 +296,16 @@
                                    context="{'report_id': active_id}"
                                    readonly="True"/>
                         </page>
-                        <page string="Real Estate records">
+                        <!-- Disable Real State records, because you can not
+                             add manually a partner record related with it -->
+                        <!--page string="Real Estate records">
                             <button name="button_list_real_estate_records"
                                     string="Edit records"
                                     type="object" colspan="1"/>
                             <field name="real_estate_record_ids" nolabel="1"
                                    context="{'report_id': active_id}"
                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"/>
-                        </page>
+                        </page-->
                     </notebook>
                 </group>
             </field>

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -292,9 +292,6 @@
                             </group>
                         </page>
                         <page string="Partner records">
-                            <button name="button_list_partner_records"
-                                    string="Edit records"
-                                    type="object" colspan="1"/>
                             <field name="partner_record_ids" nolabel="1"
                                    context="{'report_id': active_id}"
                                    readonly="True"/>

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -10,7 +10,7 @@
             <field name="name">l10n.es.aeat.mod347.partner_record.tree</field>
             <field name="model">l10n.es.aeat.mod347.partner_record</field>
             <field name="arch" type="xml">
-                <tree string="Partner Records" colors="red:not check_ok">
+                <tree string="Partner Records" colors="red:check_ok==False;">
                     <field name="check_ok" invisible="1"/>
                     <field name="operation_key" select="1"/>
                     <field name="partner_vat" select="1"/>
@@ -173,7 +173,7 @@
             <field name="name">l10n.es.aeat.mod347.real_estate_record.tree</field>
             <field name="model">l10n.es.aeat.mod347.real_estate_record</field>
             <field name="arch" type="xml">
-                <tree string="Real Estate Records" colors="red:not check_ok">
+                <tree string="Real Estate Records" colors="red:check_ok==False;">
                     <field name="check_ok" invisible="1"/>
                     <field name="partner_vat" select="1"/>
                     <field name="partner_id" select="1"/>

--- a/l10n_es_aeat_mod347/wizard/__init__.py
+++ b/l10n_es_aeat_mod347/wizard/__init__.py
@@ -1,11 +1,3 @@
 # -*- coding: utf-8 -*-
-# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
-# © 2012 NaN·Tic  (http://www.nan-tic.com)
-# © 2013 Acysos (http://www.acysos.com)
-# © 2013 Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
-# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
-#             (http://www.serviciosbaeza.com)
-# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import export_mod347_to_boe

--- a/l10n_es_aeat_mod347/wizard/__init__.py
+++ b/l10n_es_aeat_mod347/wizard/__init__.py
@@ -1,18 +1,11 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2012 NaN·Tic  (http://www.nan-tic.com)
+# © 2013 Acysos (http://www.acysos.com)
+# © 2013 Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+#             (http://www.serviciosbaeza.com)
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import export_mod347_to_boe

--- a/l10n_es_aeat_mod347/wizard/export_mod347_to_boe.py
+++ b/l10n_es_aeat_mod347/wizard/export_mod347_to_boe.py
@@ -130,7 +130,7 @@ class L10nEsAeatMod347ExportToBoe(models.TransientModel):
         # NIF del representante legal
         text += self._formatString(partner_record.representative_vat, 9)
         # Apellidos y nombre, razón social o denominación del declarado
-        text += self._formatString(partner_record.partner_id.name, 40)
+        text += self._formatFiscalName(partner_record.partner_id.name, 40)
         # Tipo de hoja: Constante ‘D’.
         text += 'D'
         # Código provincia
@@ -257,7 +257,7 @@ class L10nEsAeatMod347ExportToBoe(models.TransientModel):
         # NIF del representante legal
         text += self._formatString(partner_record.representative_vat, 9)
         # Apellidos y nombre, razón social o denominación del declarado
-        text += self._formatString(partner_record.partner_id.name, 40)
+        text += self._formatFiscalName(partner_record.partner_id.name, 40)
         # Tipo de hoja: Constante ‘I’.
         text += 'I'
         # Blancos

--- a/l10n_es_aeat_mod347/wizard/export_mod347_to_boe.py
+++ b/l10n_es_aeat_mod347/wizard/export_mod347_to_boe.py
@@ -156,10 +156,10 @@ class L10nEsAeatMod347ExportToBoe(models.TransientModel):
         text += self._formatNumber(
             partner_record.real_estate_transmissions_amount, 13, 2, True)
         # Año de devengo de las operaciones en efectivo
+        year = fields.Date.from_string(
+            partner_record.origin_fiscalyear_id.date_start).year
         text += (partner_record.origin_fiscalyear_id and
-                 self._formatString(fields.Date.from_string(
-                     report.origin_fiscalyear_id.date_start).year, 4) or
-                 4 * '0')
+                 self._formatString(year, 4) or 4 * '0')
         # Importe de las operaciones del primer trimestre
         text += self._formatNumber(partner_record.first_quarter, 13, 2, True)
         # Importe percibido por transmisiones de inmuebles sujates a Iva Primer

--- a/l10n_es_aeat_mod347/wizard/export_mod347_to_boe.py
+++ b/l10n_es_aeat_mod347/wizard/export_mod347_to_boe.py
@@ -1,21 +1,14 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-from openerp import models, api, _
+# © 2004-2011 Pexego Sistemas Informáticos. (http://pexego.es)
+# © 2012 NaN·Tic  (http://www.nan-tic.com)
+# © 2013 Acysos (http://www.acysos.com)
+# © 2013 Joaquín Pedrosa Gutierrez (http://gutierrezweb.es)
+# © 2014-2015 Serv. Tecnol. Avanzados - Pedro M. Baeza
+#             (http://www.serviciosbaeza.com)
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, api, fields, _
 
 
 class L10nEsAeatMod347ExportToBoe(models.TransientModel):
@@ -128,7 +121,8 @@ class L10nEsAeatMod347ExportToBoe(models.TransientModel):
         # Modelo Declaración
         text += '347'
         # Ejercicio
-        text += self._formatString(report.fiscalyear_id.code, 4)
+        text += self._formatString(
+            fields.Date.from_string(report.fiscalyear_id.date_start).year, 4)
         # NIF del declarante
         text += self._formatString(report.company_vat, 9)
         # NIF del declarado
@@ -141,8 +135,13 @@ class L10nEsAeatMod347ExportToBoe(models.TransientModel):
         text += 'D'
         # Código provincia
         text += self._formatNumber(partner_record.partner_state_code, 2)
+        # Código de país
+        if partner_record.partner_state_code == '99':
+            text += self._formatString(partner_record.partner_country_code, 2)
+        else:
+            text += 2 * ' '
         # Blancos
-        text += 3 * ' '
+        text += 1 * ' '
         # Clave de operación
         text += self._formatString(partner_record.operation_key, 1)
         # Importe de las operaciones
@@ -158,8 +157,9 @@ class L10nEsAeatMod347ExportToBoe(models.TransientModel):
             partner_record.real_estate_transmissions_amount, 13, 2, True)
         # Año de devengo de las operaciones en efectivo
         text += (partner_record.origin_fiscalyear_id and
-                 self._formatString(partner_record.origin_fiscalyear_id.code,
-                                    4) or 4 * '0')
+                 self._formatString(fields.Date.from_string(
+                     report.origin_fiscalyear_id.date_start).year, 4) or
+                 4 * '0')
         # Importe de las operaciones del primer trimestre
         text += self._formatNumber(partner_record.first_quarter, 13, 2, True)
         # Importe percibido por transmisiones de inmuebles sujates a Iva Primer
@@ -248,7 +248,8 @@ class L10nEsAeatMod347ExportToBoe(models.TransientModel):
         # Modelo Declaración
         text += '347'
         # Ejercicio
-        text += self._formatString(report.fiscalyear_id.code, 4)
+        text += self._formatString(
+            fields.Date.from_string(report.fiscalyear_id.date_start).year, 4)
         # NIF del declarante
         text += self._formatString(report.company_vat, 9)
         # NIF del declarado


### PR DESCRIPTION
- Mejora el rendimiento al hacer el cálculo de los registros de empresa
- Permite crear nuevos registros de empresa, indicando manualmente la cantidad de las operaciones. Estos registros no se pierden al recalcular
- Calcula el campo `community_vat` para empresas UE no residentes
- Define el campo provincia a 99 cuando la empresa no es española
- Guarda todos los campos calculados para mejorar el rendimiento en caso de modificación de registros
- Sólo permite la edición de registros en la pantalla lista, para no recalcular todos los totales de los registros de empresa
- Otros cambios menores

Depende de:
- [x] https://github.com/OCA/account-financial-tools/pull/361
