### PR TITLE
[8.0][FIX][l10n_es_aeat] Do not use hyphen in report sequence, only numbers

### DIFF
--- a/l10n_es_aeat/__openerp__.py
+++ b/l10n_es_aeat/__openerp__.py
@@ -28,7 +28,7 @@
 ##############################################################################
 {
     'name': "AEAT Base",
-    'version': "8.0.1.5.0",
+    'version': "8.0.1.6.0",
     'author': "Pexego,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
               "AvanzOSC,"

--- a/l10n_es_aeat/migrations/8.0.1.6.0/post-migration.py
+++ b/l10n_es_aeat/migrations/8.0.1.6.0/post-migration.py
@@ -15,3 +15,17 @@ def migrate(cr, version):
     for seq in sequences:
         seq.prefix = re.sub(r'-', '', seq.prefix)
         seq.padding = 13 - len(seq.prefix)
+
+    cr.execute(
+        """
+        SELECT table_schema, table_name
+        FROM information_schema.tables
+        WHERE table_schema='public' AND
+              table_name like 'l10n_es_aeat_%_report';
+        """)
+    for table_schema, table_name in cr.fetchall():
+        cr.execute(
+            """
+            ALTER TABLE %(table)s
+            DROP CONSTRAINT IF EXISTS %(table)s_sequence_uniq;
+            """ % {'table': table_name})

--- a/l10n_es_aeat/migrations/8.0.1.6.0/post-migration.py
+++ b/l10n_es_aeat/migrations/8.0.1.6.0/post-migration.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# © 2016 Antiun Ingenieria S.L. - Antonio Espinosa
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import re
+from openerp import SUPERUSER_ID
+from openerp.api import Environment
+
+
+def migrate(cr, version):
+    env = Environment(cr, SUPERUSER_ID, {})
+    sequences = env['ir.sequence'].search([
+        ('code', '=', 'aeat.sequence.type'),
+    ])
+    for seq in sequences:
+        seq.prefix = re.sub(r'-', '', seq.prefix)
+        seq.padding = 13 - len(seq.prefix)

--- a/l10n_es_aeat/models/aeat_report.py
+++ b/l10n_es_aeat/models/aeat_report.py
@@ -208,12 +208,14 @@ class L10nEsAeatReport(models.AbstractModel):
                     }
                 self.periods = period
 
-    @api.model
-    def create(self, values):
+    def _name_get(self):
         seq_obj = self.env['ir.sequence']
         sequence = "aeat%s-sequence" % self._model._aeat_number
-        seq = seq_obj.next_by_id(seq_obj.search([('name', '=', sequence)]).id)
-        values['name'] = seq
+        return seq_obj.next_by_id(seq_obj.search([('name', '=', sequence)]).id)
+
+    @api.model
+    def create(self, values):
+        values['name'] = self._name_get()
         return super(L10nEsAeatReport, self).create(values)
 
     @api.multi

--- a/l10n_es_aeat/models/aeat_report.py
+++ b/l10n_es_aeat/models/aeat_report.py
@@ -12,7 +12,7 @@ import re
 class L10nEsAeatReport(models.AbstractModel):
     _name = "l10n.es.aeat.report"
     _description = "AEAT report base module"
-    _rec_name = 'sequence'
+    _rec_name = 'name'
     _aeat_number = False
     _period_quarterly = True
     _period_monthly = True
@@ -95,7 +95,7 @@ class L10nEsAeatReport(models.AbstractModel):
          ('posted', 'Posted'),
          ('cancelled', 'Cancelled')], string='State', readonly=True,
         default='draft')
-    sequence = fields.Char(string="Sequence", size=16)
+    name = fields.Char(string="Report identifier", size=13, oldname='sequence')
     model = fields.Many2one(
         comodel_name="ir.model", compute='_compute_report_model')
     export_config = fields.Many2one(
@@ -121,8 +121,8 @@ class L10nEsAeatReport(models.AbstractModel):
         comodel_name="account.move", string="Account entry")
 
     _sql_constraints = [
-        ('sequence_uniq', 'unique(sequence)',
-         'AEAT report sequence must be unique'),
+        ('name_uniq', 'unique(name)',
+         'AEAT report identifier must be unique'),
     ]
 
     @api.one
@@ -213,7 +213,7 @@ class L10nEsAeatReport(models.AbstractModel):
         seq_obj = self.env['ir.sequence']
         sequence = "aeat%s-sequence" % self._model._aeat_number
         seq = seq_obj.next_by_id(seq_obj.search([('name', '=', sequence)]).id)
-        values['sequence'] = seq
+        values['name'] = seq
         return super(L10nEsAeatReport, self).create(values)
 
     @api.multi
@@ -273,7 +273,7 @@ class L10nEsAeatReport(models.AbstractModel):
             'date': fields.Date.today(),
             'journal_id': self.journal_id.id,
             'period_id': self.env['account.period'].find().id,
-            'ref': self.sequence,
+            'ref': self.name,
             'company_id': self.company_id.id,
         }
 

--- a/l10n_es_aeat/models/aeat_report.py
+++ b/l10n_es_aeat/models/aeat_report.py
@@ -344,9 +344,9 @@ class L10nEsAeatReport(models.AbstractModel):
                                 'code': 'aeat.sequence.type',
                                 'number_increment': 1,
                                 'implementation': 'no_gap',
-                                'padding': 9,
+                                'padding': 13 - len(str(aeat_num)),
                                 'number_next_actual': 1,
-                                'prefix': aeat_num + '-'
+                                'prefix': aeat_num
                                 }
                     seq_obj.create(cr, SUPERUSER_ID, seq_vals)
             except:

--- a/l10n_es_aeat/models/aeat_report.py
+++ b/l10n_es_aeat/models/aeat_report.py
@@ -208,14 +208,14 @@ class L10nEsAeatReport(models.AbstractModel):
                     }
                 self.periods = period
 
-    def _name_get(self):
+    def _report_identifier_get(self):
         seq_obj = self.env['ir.sequence']
         sequence = "aeat%s-sequence" % self._model._aeat_number
         return seq_obj.next_by_id(seq_obj.search([('name', '=', sequence)]).id)
 
     @api.model
     def create(self, values):
-        values['name'] = self._name_get()
+        values['name'] = self._report_identifier_get()
         return super(L10nEsAeatReport, self).create(values)
 
     @api.multi

--- a/l10n_es_aeat/views/aeat_report_view.xml
+++ b/l10n_es_aeat/views/aeat_report_view.xml
@@ -7,7 +7,7 @@
             <field name="model">l10n.es.aeat.report</field>
             <field name="arch" type="xml">
                 <tree string="AEAT report">
-                    <field name="sequence"/>
+                    <field name="name"/>
                     <field name="fiscalyear_id"/>
                     <field name="period_type"/>
                     <field name="state"/>
@@ -54,7 +54,7 @@
                         <field name="model" invisible="1"/>
                         <h1>
                             <label string="Report "/>
-                            <field name="sequence" class="oe_inline" readonly="1"/>
+                            <field name="name" class="oe_inline" readonly="1"/>
                         </h1>
                         <group string="Declaración"
                                colspan="4"

--- a/l10n_es_aeat/wizard/export_to_boe.py
+++ b/l10n_es_aeat/wizard/export_to_boe.py
@@ -155,7 +155,7 @@ class L10nEsAeatReportExportToBoe(models.TransientModel):
         # Persona de contacto (Apellidos y nombre)
         text += self._formatString(report.contact_name, 40)
         # Número identificativo de la declaración
-        text += self._formatString(report.sequence, 13)
+        text += self._formatString(report.name, 13)
         # Declaración complementaria
         text += self._formatString(report.type, 2).replace('N', ' ')
         # Número identificativo de la declaración anterior

--- a/l10n_es_aeat_mod340/views/mod340_view.xml
+++ b/l10n_es_aeat_mod340/views/mod340_view.xml
@@ -9,13 +9,13 @@
                 <tree string="Model 340">
                     <field name="fiscalyear_id"/>
                     <field name="period_type"/>
-                    <field name="sequence"/>
+                    <field name="name"/>
                     <field name="type"/>
                     <field name="state" invisible="1"/>
                 </tree>
             </field>
         </record>
-    
+
         <record id="view_l10n_es_aeat_mod340_form" model="ir.ui.view">
             <field name="name">l10n_es.aeat.mod340.form</field>
             <field name="model">l10n.es.aeat.mod340.report</field>
@@ -41,7 +41,7 @@
                                     <group string="Received invoices" colspan="2">
                                         <field name="total_taxable_rec" select ="2" readonly="1"/>
                                         <field name="total_sharetax_rec" select ="2" readonly="1"/>
-                                        <field name="total_rec" select="2" readonly="1"/>                                    
+                                        <field name="total_rec" select="2" readonly="1"/>
                                     </group>
                             </group>
                         </page>
@@ -49,17 +49,17 @@
                             <field name="issued" nolabel="1" />
                         </page>
                         <page string="Received invoice" >
-                            <field name="received" nolabel="1" /> 
+                            <field name="received" nolabel="1" />
                         </page>
                     </notebook>
                 </group>
              </field>
         </record>
         <!-- FIN Modelo 340 -->
-    
-    
+
+
         <!--Invoice Issued-->
-        
+
         <record id="view_l10n_es_aeat_mod340_invoice_issued_tree" model="ir.ui.view">
             <field name="name">l10n.es.aeat.mod340.issued.tree</field>
             <field name="model">l10n.es.aeat.mod340.issued</field>
@@ -73,10 +73,10 @@
                     <field name="base_tax" sum="Total Base" />
                     <field name="amount_tax" sum="Total Tax" />
                     <field name="total" sum="Total"/>
-                </tree>   
+                </tree>
             </field>
         </record>
-        
+
         <record id="view_l10n_es_aeat_mod340_invoice_issued_form" model="ir.ui.view">
             <field name="name">l10n.es.aeat.mod340.issued.form</field>
             <field name="model">l10n.es.aeat.mod340.issued</field>
@@ -95,12 +95,12 @@
                     <field name="total"/>
                     <newline />
                     <field name="tax_line_ids" />
-                </form>   
+                </form>
             </field>
         </record>
-    
+
         <!--Invoice Received-->
-        
+
         <record id="view_l10n_es_aeat_mod340_invoice_received_tree" model="ir.ui.view">
             <field name="name">l10n.es.aeat.mod340.received.tree</field>
             <field name="model">l10n.es.aeat.mod340.received</field>
@@ -113,10 +113,10 @@
                     <field name="base_tax" sum="Total Base"/>
                     <field name="amount_tax" sum="Total Tax"/>
                     <field name="total" sum="Total"/>
-                </tree>   
+                </tree>
             </field>
         </record>
-        
+
         <record id="view_l10n_es_aeat_mod340_invoice_received_form" model="ir.ui.view">
             <field name="name">l10n.es.aeat.mod340.received.form</field>
             <field name="model">l10n.es.aeat.mod340.received</field>
@@ -135,12 +135,12 @@
                     <field name="total"/>
                     <newline />
                     <field name="tax_line_ids" />
-                </form>   
+                </form>
             </field>
         </record>
-        
+
         <!--Vat Lines-->
-        
+
         <record id="view_l10n_es_aeat_mod340_tax_line_issued_form" model="ir.ui.view">
             <field name="name">l10n.es.aeat.mod340.tax_line_issued.form</field>
             <field name="model">l10n.es.aeat.mod340.tax_line_issued</field>
@@ -153,7 +153,7 @@
                 </form>
             </field>
         </record>
-        
+
         <record id="view_l10n_es_aeat_mod340_tax_line_received_form" model="ir.ui.view">
             <field name="name">l10n.es.aeat.mod340.tax_line_received.form</field>
             <field name="model">l10n.es.aeat.mod340.tax_line_received</field>
@@ -166,7 +166,7 @@
                 </form>
             </field>
         </record>
-    
+
         <record id="view_l10n_es_aeat_mod340_report_search" model="ir.ui.view">
             <field name="name">AEAT Model 340 (search)</field>
             <field name="model">l10n.es.aeat.mod340.report</field>


### PR DESCRIPTION
El formato de la AEAT para el campo `Número identificativo de la declaración` debe ser numérico y no soporta guiones. Extracto del BOE:

```
Se consignará el número identificativo correspondiente a
la declaración. Campo de contenido numérico de 13
posiciones.
```

Este PR genera correctamente las secuencias para todos los modelos de la AEAT y al actualizar modifica las secuencias ya creadas para que se generen correctamente. 

NOTA: No se cambian los números identificativos de declaraciones ya creadas.
