### PR TITLE
[8.0] account_balance_reporting: Pequeña corrección pero muy importante

### DIFF
--- a/account_balance_reporting/models/account_balance_reporting_report.py
+++ b/account_balance_reporting/models/account_balance_reporting_report.py
@@ -486,7 +486,7 @@ class AccountBalanceReportingLine(orm.Model):
                                     'date_from': report.previous_date_from,
                                     'date_to': report.previous_date_to
                                 })
-                        if line.report_id.check_filter == 'period':
+                        if line.report_id.check_filter == 'periods':
                             if fyear == 'current':
                                 ctx.update({
                                     'periods':


### PR DESCRIPTION
Hola,

Error tipográfico que impedía calcular correctamente los informe de balance con el filtro de periodos, siempre cogía el año fiscal completo. 
Los valores que admite el campo "check_filter" son "periods" y "date" y se estaba haciendo la comprobación para añadir los periodos al contexto, contra el valor "period" que no existe, por lo que nunca metía los periodos al contexto para calcular los saldos de las cuentas.

Un saludo.
