### PR TITLE
Fix Mod. 111 error _get_tax_code_lines

### DIFF
--- a/l10n_es_aeat_mod111/__openerp__.py
+++ b/l10n_es_aeat_mod111/__openerp__.py
@@ -18,7 +18,7 @@
 
 {
     'name': 'AEAT modelo 111',
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.2.0',
     'category': "Localisation/Accounting",
     'author': "AvanzOSC,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza,"

--- a/l10n_es_aeat_mod111/models/mod111.py
+++ b/l10n_es_aeat_mod111/models/mod111.py
@@ -24,7 +24,7 @@ from openerp import fields, models, api, exceptions, _
 class L10nEsAeatMod111Report(models.Model):
 
     _description = 'AEAT 111 report'
-    _inherit = 'l10n.es.aeat.report'
+    _inherit = 'l10n.es.aeat.report.tax.mapping'
     _name = 'l10n.es.aeat.mod111.report'
 
     number = fields.Char(default='111')

--- a/l10n_es_aeat_mod115/__openerp__.py
+++ b/l10n_es_aeat_mod115/__openerp__.py
@@ -20,7 +20,7 @@
 
 {
     'name': 'AEAT modelo 115',
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.2.0',
     'category': "Localisation/Accounting",
     'author': "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod115/models/mod115.py
+++ b/l10n_es_aeat_mod115/models/mod115.py
@@ -24,7 +24,7 @@ from openerp import fields, models, api, _
 class L10nEsAeatMod115Report(models.Model):
 
     _description = 'AEAT 115 report'
-    _inherit = 'l10n.es.aeat.report'
+    _inherit = 'l10n.es.aeat.report.tax.mapping'
     _name = 'l10n.es.aeat.mod115.report'
 
     number = fields.Char(default='115')

--- a/l10n_es_aeat_mod216/__openerp__.py
+++ b/l10n_es_aeat_mod216/__openerp__.py
@@ -18,7 +18,7 @@
 
 {
     'name': 'AEAT modelo 216',
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.2.0',
     'category': "Localisation/Accounting",
     'author': "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod216/models/mod216.py
+++ b/l10n_es_aeat_mod216/models/mod216.py
@@ -24,7 +24,7 @@ from openerp import fields, models, api, _
 class L10nEsAeatMod216Report(models.Model):
 
     _description = 'AEAT 216 report'
-    _inherit = 'l10n.es.aeat.report'
+    _inherit = 'l10n.es.aeat.report.tax.mapping'
     _name = 'l10n.es.aeat.mod216.report'
 
     number = fields.Char(default='216')

--- a/l10n_es_aeat_mod296/__openerp__.py
+++ b/l10n_es_aeat_mod296/__openerp__.py
@@ -20,7 +20,7 @@
 
 {
     'name': 'AEAT modelo 296',
-    'version': '8.0.1.1.0',
+    'version': '8.0.1.2.0',
     'category': "Localisation/Accounting",
     'author': "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod296/models/mod296.py
+++ b/l10n_es_aeat_mod296/models/mod296.py
@@ -22,7 +22,7 @@ from openerp import fields, models, api
 class L10nEsAeatMod296Report(models.Model):
 
     _description = 'AEAT 296 report'
-    _inherit = 'l10n.es.aeat.report'
+    _inherit = 'l10n.es.aeat.report.tax.mapping'
     _name = 'l10n.es.aeat.mod296.report'
 
     number = fields.Char(default='296')


### PR DESCRIPTION
Solución al [8] Error en el Mod.111 #312
heredando el modelo 110 de la nueva clase l10n.es.aeat.report.tax.mapping
