### PR TITLE
[8.0][FIX] l10n_es_aeat_mod340: Field reference requerido desde workflow

### DIFF
--- a/l10n_es_aeat_mod340/__openerp__.py
+++ b/l10n_es_aeat_mod340/__openerp__.py
@@ -55,6 +55,7 @@
         'data/mod340_sequence.xml',
         'views/account_invoice_view.xml',
         'views/account_view.xml',
+        'views/account_workflow.xml',
         'data/taxes_data.xml',
     ],
     'installable': True,

--- a/l10n_es_aeat_mod340/models/account_invoice.py
+++ b/l10n_es_aeat_mod340/models/account_invoice.py
@@ -55,3 +55,14 @@ class AccountInvoice(orm.Model):
         if lines:
             return True
         return False
+
+
+    @api.multi
+    def check_reference_required(self):
+        if self.type == 'in_invoice':
+            if self.reference is False:
+                return False
+            else:
+                return True
+        else:
+            return True

--- a/l10n_es_aeat_mod340/views/account_workflow.xml
+++ b/l10n_es_aeat_mod340/views/account_workflow.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="account.t4" model="workflow.transition">
+            <field name="condition">check_reference_required()</field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
El field reference está como requerido en la vista pero al intentar validar un factura de proveedor desde la vista tree con la opción del botón más se puede continuar aunque el campo este vacío.
Con este fíx se soluciona ya que se comprueba en la condicion del workflow que el field reference tenga algun valor.
