### PR TITLE
8.0 l10n es aeat mod111 boe export

### DIFF
--- a/l10n_es_aeat_mod111/README.rst
+++ b/l10n_es_aeat_mod111/README.rst
@@ -56,6 +56,7 @@ Contribuidores
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * AvanzOSC (http://www.avanzosc.es)
 * Antonio Espinosa <antonioea@antiun.com>
+* Juan Formoso <jfv@anubia.es> (http://www.anubia.es)
 
 Maintainer
 ----------

--- a/l10n_es_aeat_mod111/__openerp__.py
+++ b/l10n_es_aeat_mod111/__openerp__.py
@@ -25,11 +25,13 @@
               "Antiun Ingeniería S.L.,"
               "MálagaTIC,"
               "G. Vermon,"
+              "Anubía Soluciones en la Nube, SL,"
               "Odoo Community Association (OCA)",
     'website': "https://github.com/OCA/l10n-spain",
     'license': 'AGPL-3',
     'depends': ['l10n_es_aeat'],
     'data': [
+        'data/aeat_export_mod111_data.xml',
         'wizard/export_mod111_to_boe.xml',
         'views/mod111_view.xml',
         'security/ir.model.access.csv'],

--- a/l10n_es_aeat_mod111/data/aeat_export_mod111_data.xml
+++ b/l10n_es_aeat_mod111/data/aeat_export_mod111_data.xml
@@ -1,0 +1,714 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="0">
+
+        <!--  SUB-111-01  -->
+        <record id="aeat_mod111_sub01_export_config" model="aeat.model.export.config">
+            <field name="name">Exportación modelo 111 2014 - Régimen general/simplificado</field>
+            <field name="model_number">111</field>
+        </record>
+
+        <!--  Apertura: constantes y datos  -->
+        <record id="aeat_mod111_sub01_export_line_01" model="aeat.model.export.config.line">
+            <field name="sequence">1</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Constante: &lt;T</field>
+            <field name="fixed_value">&lt;T</field>
+            <field name="export_type">string</field>
+            <field name="size">2</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_02" model="aeat.model.export.config.line">
+            <field name="sequence">2</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Modelo: 111</field>
+            <field name="fixed_value">111</field>
+            <field name="export_type">string</field>
+            <field name="size">3</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_03" model="aeat.model.export.config.line">
+            <field name="sequence">3</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Constante: 01</field>
+            <field name="fixed_value">01</field>
+            <field name="export_type">string</field>
+            <field name="size">2</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_04" model="aeat.model.export.config.line">
+            <field name="sequence">4</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Constante: 000</field>
+            <field name="fixed_value">000</field>
+            <field name="export_type">string</field>
+            <field name="size">3</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_05" model="aeat.model.export.config.line">
+            <field name="sequence">5</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Constante: &gt;</field>
+            <field name="fixed_value">&gt;</field>
+            <field name="export_type">string</field>
+            <field name="size">1</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_06" model="aeat.model.export.config.line">
+            <field name="sequence">6</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Reservado para la Administración: Rellenar con blancos</field>
+            <field name="fixed_value"/>
+            <field name="export_type">string</field>
+            <field name="size">1</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_07" model="aeat.model.export.config.line">
+            <field name="sequence">7</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Tipo de declaración</field>
+            <field name="expression">${object.tipo_declaracion}</field>
+            <field name="export_type">string</field>
+            <field name="size">1</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_08" model="aeat.model.export.config.line">
+            <field name="sequence">8</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Identificación: NIF</field>
+            <field name="expression">${object.company_vat}</field>
+            <field name="export_type">string</field>
+            <field name="size">9</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_09" model="aeat.model.export.config.line">
+            <field name="sequence">9</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Identificación: Apellidos o Razón social</field>
+            <field name="expression">${object.company_id.name}</field>
+            <field name="export_type">string</field>
+            <field name="size">60</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_10" model="aeat.model.export.config.line">
+            <field name="sequence">10</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Identificación: Nombre</field>
+            <field name="expression">${object.company_id.name}</field>
+            <field name="export_type">string</field>
+            <field name="size">20</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_11" model="aeat.model.export.config.line">
+            <field name="sequence">11</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Devengo: Ejercicio</field>
+            <field name="expression">${object.fiscalyear_id.date_start[:4]}</field>
+            <field name="export_type">string</field>
+            <field name="size">4</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_12" model="aeat.model.export.config.line">
+            <field name="sequence">12</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Devengo: Periodo</field>
+            <field name="expression">${object.period_type}</field>
+            <field name="export_type">string</field>
+            <field name="size">2</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <!--  I. Rendimientos del trabajo  -->
+        <record id="aeat_mod111_sub01_export_line_13" model="aeat.model.export.config.line">
+            <field name="sequence">13</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos del trabajo - Rendimientos dinerarios - Número de perceptores [01]</field>
+            <field name="expression">${object.casilla_01}</field>
+            <field name="export_type">integer</field>
+            <field name="size">8</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_14" model="aeat.model.export.config.line">
+            <field name="sequence">14</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos del trabajo - Rendimientos dinerarios - Importe de las percepciones [02]</field>
+            <field name="expression">${object.casilla_02}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_15" model="aeat.model.export.config.line">
+            <field name="sequence">15</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos del trabajo - Rendimientos dinerarios - Importe de las retenciones [03]</field>
+            <field name="expression">${object.casilla_03}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_16" model="aeat.model.export.config.line">
+            <field name="sequence">16</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos del trabajo - Rendimientos en especie - Número de perceptores [04]</field>
+            <field name="expression">${object.casilla_04}</field>
+            <field name="export_type">integer</field>
+            <field name="size">8</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_17" model="aeat.model.export.config.line">
+            <field name="sequence">17</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos del trabajo - Rendimientos en especie - Valor percepciones en especie [05]</field>
+            <field name="expression">${object.casilla_05}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_18" model="aeat.model.export.config.line">
+            <field name="sequence">18</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos del trabajo - Rendimientos en especie - Importe de los ingresos a cuenta [06]</field>
+            <field name="expression">${object.casilla_06}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <!--  II. Rendimientos de actividades económicas  -->
+        <record id="aeat_mod111_sub01_export_line_19" model="aeat.model.export.config.line">
+            <field name="sequence">19</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos de actividades económicas - Rendimientos dinerarios - Número de perceptores [07]</field>
+            <field name="expression">${object.casilla_07}</field>
+            <field name="export_type">integer</field>
+            <field name="size">8</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_20" model="aeat.model.export.config.line">
+            <field name="sequence">20</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos de actividades económicas - Rendimientos dinerarios - Importe de las percepciones [08]</field>
+            <field name="expression">${object.casilla_08}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_21" model="aeat.model.export.config.line">
+            <field name="sequence">21</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos de actividades económicas - Rendimientos dinerarios - Importe de las retenciones [09]</field>
+            <field name="expression">${object.casilla_09}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_22" model="aeat.model.export.config.line">
+            <field name="sequence">22</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos de actividades económicas - Rendimientos en especie - Número de perceptores [10]</field>
+            <field name="expression">${object.casilla_10}</field>
+            <field name="export_type">integer</field>
+            <field name="size">8</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_23" model="aeat.model.export.config.line">
+            <field name="sequence">23</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos de actividades económicas - Rendimientos en especie - Valor percepciones en especie [11]</field>
+            <field name="expression">${object.casilla_11}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_24" model="aeat.model.export.config.line">
+            <field name="sequence">24</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Rendimientos de actividades económicas - Rendimientos en especie - Importe de los ingresos a cuenta [12]</field>
+            <field name="expression">${object.casilla_12}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <!--  III. Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias  -->
+        <record id="aeat_mod111_sub01_export_line_25" model="aeat.model.export.config.line">
+            <field name="sequence">25</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Rendimientos dinerarios - Número de perceptores [13]</field>
+            <field name="expression">${object.casilla_13}</field>
+            <field name="export_type">integer</field>
+            <field name="size">8</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_26" model="aeat.model.export.config.line">
+            <field name="sequence">26</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Rendimientos dinerarios - Importe de las percepciones [14]</field>
+            <field name="expression">${object.casilla_14}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_27" model="aeat.model.export.config.line">
+            <field name="sequence">27</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Rendimientos dinerarios - Importe de las retenciones [15]</field>
+            <field name="expression">${object.casilla_15}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_28" model="aeat.model.export.config.line">
+            <field name="sequence">28</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Rendimientos en especie - Número de perceptores [16]</field>
+            <field name="expression">${object.casilla_16}</field>
+            <field name="export_type">integer</field>
+            <field name="size">8</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_29" model="aeat.model.export.config.line">
+            <field name="sequence">29</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Rendimientos en especie - Valor percepciones en especie [17]</field>
+            <field name="expression">${object.casilla_17}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_30" model="aeat.model.export.config.line">
+            <field name="sequence">30</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Premios por la participación en juegos, concursos, rifas o combinaciones aleatorias - Rendimientos en especie - Importe de los ingresos a cuenta [18]</field>
+            <field name="expression">${object.casilla_18}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <!--  IV. Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en los montes públicos  -->
+        <record id="aeat_mod111_sub01_export_line_31" model="aeat.model.export.config.line">
+            <field name="sequence">31</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en los montes públicos - Rendimientos dinerarios - Número de perceptores [19]</field>
+            <field name="expression">${object.casilla_19}</field>
+            <field name="export_type">integer</field>
+            <field name="size">8</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_32" model="aeat.model.export.config.line">
+            <field name="sequence">32</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en los montes públicos - Rendimientos dinerarios - Importe de las percepciones [20]</field>
+            <field name="expression">${object.casilla_20}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_33" model="aeat.model.export.config.line">
+            <field name="sequence">33</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en los montes públicos - Rendimientos dinerarios - Importe de las retenciones [21]</field>
+            <field name="expression">${object.casilla_21}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_34" model="aeat.model.export.config.line">
+            <field name="sequence">34</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en los montes públicos - Rendimientos en especie - Número de perceptores [22]</field>
+            <field name="expression">${object.casilla_22}</field>
+            <field name="export_type">integer</field>
+            <field name="size">8</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_35" model="aeat.model.export.config.line">
+            <field name="sequence">35</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en los montes públicos - Rendimientos en especie - Valor percepciones en especie [23]</field>
+            <field name="expression">${object.casilla_23}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_36" model="aeat.model.export.config.line">
+            <field name="sequence">36</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Ganancias patrimoniales derivadas de los aprovechamientos forestales de los vecinos en los montes públicos - Rendimientos en especie - Importe de los ingresos a cuenta [24]</field>
+            <field name="expression">${object.casilla_24}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <!--  V. Contraprestaciones por la cesión de derechos de imagen, ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto  -->
+        <record id="aeat_mod111_sub01_export_line_37" model="aeat.model.export.config.line">
+            <field name="sequence">37</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Contraprestaciones por la cesión de derechos de imagen, ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Rendimientos dinerarios/en especie - Número de perceptores [25]</field>
+            <field name="expression">${object.casilla_25}</field>
+            <field name="export_type">integer</field>
+            <field name="size">8</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_38" model="aeat.model.export.config.line">
+            <field name="sequence">38</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Contraprestaciones por la cesión de derechos de imagen, ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Rendimientos dinerarios/en especie - Contraprestaciones satisfechas [26]</field>
+            <field name="expression">${object.casilla_26}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_39" model="aeat.model.export.config.line">
+            <field name="sequence">39</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Contraprestaciones por la cesión de derechos de imagen, ingresos a cuenta previstos en el artículo 92.8 de la Ley del Impuesto - Rendimientos dinerarios/en especie - Importe de los ingresos a cuenta [27]</field>
+            <field name="expression">${object.casilla_27}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <!--  Total liquidación  -->
+        <record id="aeat_mod111_sub01_export_line_40" model="aeat.model.export.config.line">
+            <field name="sequence">40</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Total liquidación - Suma de las retenciones e ingresos a cuenta [28]</field>
+            <field name="expression">${object.casilla_28}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_41" model="aeat.model.export.config.line">
+            <field name="sequence">41</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Total liquidación - Resultado a ingresar de la anterior o anteriores autoliquidaciones por el mismo concepto, ejercicio y período [29]</field>
+            <field name="expression">${object.casilla_29}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_42" model="aeat.model.export.config.line">
+            <field name="sequence">42</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Total liquidación - Resultado a ingresar [30]</field>
+            <field name="expression">${object.casilla_30}</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">float</field>
+            <field name="apply_sign" eval="True"/>
+            <field name="size">17</field>
+            <field name="decimal_size">2</field>
+            <field name="alignment">right</field>
+        </record>
+
+        <!--  A cumplimentar sólo en el caso de declaración complementaria  -->
+        <record id="aeat_mod111_sub01_export_line_43" model="aeat.model.export.config.line">
+            <field name="sequence">43</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Indicador de página complementaria</field>
+            <field name="expression">${object.tipo_declaracion == 'C'}</field>
+            <field name="export_type">boolean</field>
+            <field name="size">1</field>
+            <field name="bool_yes">X</field>
+            <field name="bool_no"> </field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_44" model="aeat.model.export.config.line">
+            <field name="sequence">44</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Número de justificante de la declaración anterior</field>
+            <field name="expression">${object.previous_number}</field>
+            <field name="export_type">string</field>
+            <field name="size">14</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <!--  Ingreso  -->
+        <record id="aeat_mod111_sub01_export_line_45" model="aeat.model.export.config.line">
+            <field name="sequence">45</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">IBAN</field>
+            <field name="expression">${object.iban_number}</field>
+            <field name="export_type">string</field>
+            <field name="size">24</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_sub01_export_line_46" model="aeat.model.export.config.line">
+            <field name="sequence">46</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Reservado para la Administración: Rellenar con blancos</field>
+            <field name="fixed_value"/>
+            <field name="export_type">string</field>
+            <field name="size">412</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <!--  Cierre: constantes  -->
+        <record id="aeat_mod111_sub01_export_line_47" model="aeat.model.export.config.line">
+            <field name="sequence">47</field>
+            <field name="export_config_id" ref="aeat_mod111_sub01_export_config"/>
+            <field name="name">Indicador de fin de registro: &lt;/T11101&gt;</field>
+            <field name="fixed_value">&lt;/T11101000&gt;</field>
+            <field name="export_type">string</field>
+            <field name="size">12</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <!--  MAIN-111  -->
+        <record id="aeat_mod111_main_export_config" model="aeat.model.export.config">
+            <field name="name">Exportación modelo 111 2014-actualidad</field>
+            <field name="date_start">2014-01-01</field>
+            <field name="model_number">111</field>
+            <field name="model" ref="l10n_es_aeat_mod111.model_l10n_es_aeat_mod111_report"/>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_01" model="aeat.model.export.config.line">
+            <field name="sequence">1</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Constante: &lt;T</field>
+            <field name="fixed_value">&lt;T</field>
+            <field name="export_type">string</field>
+            <field name="size">2</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_02" model="aeat.model.export.config.line">
+            <field name="sequence">2</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Modelo: 111</field>
+            <field name="fixed_value">111</field>
+            <field name="export_type">string</field>
+            <field name="size">3</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_03" model="aeat.model.export.config.line">
+            <field name="sequence">3</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Constante: 0</field>
+            <field name="fixed_value">0</field>
+            <field name="export_type">string</field>
+            <field name="size">1</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_04" model="aeat.model.export.config.line">
+            <field name="sequence">4</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Ejercicio devengo: AAAA</field>
+            <field name="expression">${object.fiscalyear_id.date_start[:4]}</field>
+            <field name="export_type">string</field>
+            <field name="size">4</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_05" model="aeat.model.export.config.line">
+            <field name="sequence">5</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Periodo: PP</field>
+            <field name="expression">${object.period_type}</field>
+            <field name="export_type">string</field>
+            <field name="size">2</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_06" model="aeat.model.export.config.line">
+            <field name="sequence">6</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Constante: 0000&gt;</field>
+            <field name="fixed_value">0000&gt;</field>
+            <field name="export_type">string</field>
+            <field name="size">5</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_07" model="aeat.model.export.config.line">
+            <field name="sequence">7</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Constante: &lt;AUX&gt;</field>
+            <field name="fixed_value">&lt;AUX&gt;</field>
+            <field name="export_type">string</field>
+            <field name="size">5</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_08" model="aeat.model.export.config.line">
+            <field name="sequence">8</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Reservado para la Administración: Rellenar con blancos</field>
+            <field name="fixed_value"/>
+            <field name="export_type">string</field>
+            <field name="size">70</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_09" model="aeat.model.export.config.line">
+            <field name="sequence">9</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Versión del Programa: </field>
+            <field name="fixed_value">8.0</field>
+            <field name="export_type">string</field>
+            <field name="size">4</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_10" model="aeat.model.export.config.line">
+            <field name="sequence">10</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Reservado para la Administración: Rellenar con blancos</field>
+            <field name="fixed_value"/>
+            <field name="export_type">string</field>
+            <field name="size">4</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_11" model="aeat.model.export.config.line">
+            <field name="sequence">11</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">NIF Empresa Desarrollo</field>
+            <field name="fixed_value">Odoo</field>
+            <field name="export_type">string</field>
+            <field name="size">9</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_12" model="aeat.model.export.config.line">
+            <field name="sequence">12</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Reservado para la Administración: Rellenar con blancos</field>
+            <field name="fixed_value"/>
+            <field name="export_type">string</field>
+            <field name="size">213</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_13" model="aeat.model.export.config.line">
+            <field name="sequence">13</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Constante: &lt;/AUX&gt;</field>
+            <field name="fixed_value">&lt;/AUX&gt;</field>
+            <field name="export_type">string</field>
+            <field name="size">6</field>
+            <field name="alignment">left</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_14" model="aeat.model.export.config.line">
+            <field name="sequence">14</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Régimen general/simplificado</field>
+            <field name="conditional_expression">True</field>
+            <field name="sub_config" ref="aeat_mod111_sub01_export_config"/>
+            <field name="export_type">subconfig</field>
+        </record>
+
+        <record id="aeat_mod111_main_export_line_15" model="aeat.model.export.config.line">
+            <field name="sequence">15</field>
+            <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
+            <field name="name">Constante. &lt;/T1110+Ejercicio+periodo+0000&gt;</field>
+            <field name="expression">&lt;/T1110${object.fiscalyear_id.date_start[:4]}${object.period_type}0000&gt;</field>
+            <field name="export_type">string</field>
+            <field name="size">18</field>
+            <field name="alignment">left</field>
+        </record>
+        
+    </data>
+</openerp>

--- a/l10n_es_aeat_mod111/models/mod111.py
+++ b/l10n_es_aeat_mod111/models/mod111.py
@@ -226,6 +226,19 @@ class L10nEsAeatMod111Report(models.Model):
         comodel_name='account.move.line',
         relation='mod111_account_move_line09_rel',
         column1='mod111', column2='account_move_line')
+    iban = fields.Many2one(
+        comodel_name='res.partner.bank',
+        string='IBAN')
+    iban_number = fields.Char(
+        compute='_compute_iban_number',
+        string='IBAN')
+
+    @api.multi
+    @api.depends('iban')
+    def _compute_iban_number(self):
+        for report in self:
+            if report.iban and report.iban.acc_number:
+                report.iban_number = report.iban.acc_number.replace(' ', '')
 
     @api.one
     @api.constrains('codigo_electronico_anterior', 'previous_number')

--- a/l10n_es_aeat_mod111/views/mod111_view.xml
+++ b/l10n_es_aeat_mod111/views/mod111_view.xml
@@ -16,9 +16,11 @@
                     <field name="contact_mobile_phone"/>
                 </field>
                 <field name="previous_number" position="after">
-                        <field name="tipo_declaracion"/>
-                        <field name="codigo_electronico_anterior" attrs="{'invisible': [('type','==','N')]}"/>
-                        <field name="colegio_concertado"/>
+                    <field name="tipo_declaracion"/>
+                    <field name="iban" domain="[('company_id', '=', 1), ('state', '=', 'iban'), ('acc_country_id', '=', 69)]"/>
+                    <field name="iban_number" invisible="1"/>
+                    <field name="codigo_electronico_anterior" attrs="{'invisible': [('type','==','N')]}"/>
+                    <field name="colegio_concertado"/>
                 </field>
                 <field name="previous_number" position="attributes">
                     <attribute name="attrs">{'invisible': [('type','==','N')]}</attribute>


### PR DESCRIPTION
Módulo `l10n_es_aeat_mod111` modificado para poder exportar a BOE. Con la exportación se puede descargar un archivo de texto que luego puede ser importado en el formulario de la página de la Agencia Tributaria, al igual que ya se puede hacer con otros modelos.
