### PR TITLE
8.0 [FIX]. account_balance_reporting. Corrige error al propagar contexto …

### DIFF
--- a/account_balance_reporting/models/account_balance_reporting_report.py
+++ b/account_balance_reporting/models/account_balance_reporting_report.py
@@ -475,7 +475,7 @@ class AccountBalanceReportingLine(orm.Model):
                             ctx.update({
                                 'fiscalyear': report.previous_fiscalyear_id.id,
                             })
-                        if line.report_id.check_filter == 'date':
+                        if line.report_id.check_filter == 'dates':
                             if fyear == 'current':
                                 ctx.update({
                                     'date_from': report.current_date_from,
@@ -501,7 +501,10 @@ class AccountBalanceReportingLine(orm.Model):
                             cr, uid, [line.id], tmpl_value,
                             balance_mode=balance_mode, context=ctx)
                         if line.report_id.level:
-                            line._create_child_lines(tmpl_value, balance_mode,
+                            # changed for fix error propagating context
+                            self._create_child_lines(cr, uid, [line.id],
+                                                     tmpl_value,
+                                                     balance_mode,
                                                      fyear, context=ctx)
                     elif re.match(r'^[\+\-0-9a-zA-Z_\*\ ]*$', tmpl_value):
                         # Account concept codes separated by "+" => sum of the


### PR DESCRIPTION
…si se saca el informe  desglosando por cuentas.

Sin este cambio el saldo de las cuentas  sería el de la fecha de cálculo en vez del rango de períodos o fechas establecidos.

Se ha hecho con la API antigua, pero si hay una sugerencia de cómo corregirlo de otra forma más elegante, perfecto.
