### PR TITLE
l10n_es_account_bank_statement_import_n43: Dos comprobaciones extra para obtener el partner en n43

### DIFF
--- a/l10n_es_account_bank_statement_import_n43/README.rst
+++ b/l10n_es_account_bank_statement_import_n43/README.rst
@@ -42,6 +42,7 @@ Contributors
 ------------
 
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Omar Castiñeira Saavedra <omar@comunitea.com>
 
 Maintainer
 ----------


### PR DESCRIPTION
Hola,

Se añaden dos comprobaciones extra para obtener el partner extraídas del n43 de Bankia Y Sabadell

Depende del PR 
- [ ] https://github.com/OCA/bank-statement-import/pull/64

Ya que sin el es imposible encontrar ninguna empresa en el n43.

Un saludo
