### PR TITLE
[8.0][FIX][l10n_es_aeat_mod349] Write partner using _formatFiscalName

### DIFF
--- a/l10n_es_aeat_mod349/wizard/export_mod349_to_boe.py
+++ b/l10n_es_aeat_mod349/wizard/export_mod349_to_boe.py
@@ -172,7 +172,7 @@ class Mod349ExportToBoe(models.TransientModel):
         # NIF del operador intracomunitario
         text += self._formatString(partner_record.partner_vat, 17)
         # Apellidos y nombre o razón social del operador intracomunitario
-        text += self._formatString(partner_record.partner_id.name, 40)
+        text += self._formatFiscalName(partner_record.partner_id.name, 40)
         # Clave de operación
         text += self._formatString(partner_record.operation_key, 1)
         # Base imponible (parte entera)
@@ -228,7 +228,7 @@ class Mod349ExportToBoe(models.TransientModel):
         # NIF del operador intracomunitario
         text += self._formatString(refund_record.partner_id.vat, 17)
         # Apellidos y nombre o razón social del operador intracomunitario
-        text += self._formatString(refund_record.partner_id.name, 40)
+        text += self._formatFiscalName(refund_record.partner_id.name, 40)
         # Clave de operación
         text += self._formatString(refund_record.operation_key, 1)
         text += 13 * ' '  # Blancos


### PR DESCRIPTION
En una mejora anterior añadimos el método `_formatFiscalName` para que al exportar en formato BOE no se escribirieran caracteres que son inválidos para la AEAT.

Ahora este modelo hace uso de este método para escribir el nombre de la operador intracomunitario. 

Este PR depende de https://github.com/OCA/l10n-spain/pull/317
