### PR TITLE
[FIX] l10n_es: v5.4

### DIFF
--- a/l10n_es/README.rst
+++ b/l10n_es/README.rst
@@ -22,6 +22,14 @@ encuentra en la versión estándar de Odoo, por lo que es conveniente instalar
 Historial
 ---------
 
+* v5.4: Varias correcciones para el modelo 123 y para las rectificaciones:
+
+  * Códigos de impuestos de retenciones de venta movidos al modelo 200
+  * Creados códigos de impuestos para el modelo 123.
+  * Creados impuestos de reparto de dividendos y de préstamos.
+  * Creados códigos de impuesto para cada uno de los porcentajes y conceptos
+    de las rectificaciones.
+  * Incluida cuenta 4759.
 * v5.3: Añadido "IVA soportado no sujeto".
 * v5.2: Añadida retención 19,5% arrendamientos.
 * v5.1: Renombrado todo lo relacionado con arrendamientos para no incluir la

--- a/l10n_es/__openerp__.py
+++ b/l10n_es/__openerp__.py
@@ -1,37 +1,15 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (c) 2008-2010 Zikzakmedia S.L. (http://zikzakmedia.com)
-#                            Jordi Esteve <jesteve@zikzakmedia.com>
-#    Copyright (c) 2012-2013, Grupo OPENTIA (<http://opentia.com>)
-#                            Dpto. Consultoría <consultoria@opentia.es>
-#    Copyright (c) 2013-2015 Serv. Tecnol. Av. (http://www.serviciosbaeza.com)
-#                       Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-#    Copyright (c) 2015 FactorLibre (www.factorlibre.com)
-#                       Carlos Liébana <carlos.liebana@factorlibre.com>
-#                       Hugo Santos <hugo.santos@factorlibre.com>
-#    Copyright (c) 2015 GAFIC consultores (www.gafic.com)
-#                       Albert Cabedo <albert@gafic.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2008-2010 Jordi Esteve <jesteve@zikzakmedia.com>
+# Copyright 2012-2013, Dpto. Consultoría <consultoria@opentia.es>
+# Copyright 2013-2015 Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# Copyright 2015 Carlos Liébana <carlos.liebana@factorlibre.com>
+# Copyright 2015 Hugo Santos <hugo.santos@factorlibre.com>
+# Copyright 2015 Albert Cabedo <albert@gafic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": "Spanish Charts of Accounts (PGCE 2008)",
-    "version": "8.0.5.3.0",
+    "version": "8.0.5.4.0",
     "author": "Spanish Localization Team,"
               # "Zikzakmedia S.L.,"
               # "Grupo Opentia,"

--- a/l10n_es/data/account_account_common.xml
+++ b/l10n_es/data/account_account_common.xml
@@ -4324,6 +4324,22 @@
             <field name="name">Hacienda Pública, acreedora por subvenciones a reintegrar</field>
             <field name="user_type" ref="account.conf_account_type_tax"/>
         </record>
+        <record id="pgc_4759" model="account.account.template">
+            <field name="code">4759</field>
+            <field name="reconcile" eval="False"/>
+            <field name="parent_id" ref="pgc_475"/>
+            <field name="type">view</field>
+            <field name="name">Hacienda Pública, acreedor por otros conceptos</field>
+            <field name="user_type" ref="account.conf_account_type_tax"/>
+        </record>
+        <record id="pgc_4759_child" model="account.account.template">
+            <field name="code">4759</field>
+            <field name="reconcile" eval="False"/>
+            <field name="parent_id" ref="pgc_4759"/>
+            <field name="type">payable</field>
+            <field name="name">Hacienda Pública, acreedor por otros conceptos</field>
+            <field name="user_type" ref="account.conf_account_type_tax"/>
+        </record>
         <record id="pgc_476" model="account.account.template">
             <field name="code">476</field>
             <field name="reconcile" eval="False"/>

--- a/l10n_es/data/tax_codes_common.xml
+++ b/l10n_es/data/tax_codes_common.xml
@@ -94,6 +94,138 @@
       <field name="name">[15] Modificación bases y cuotas repercutido. Cuota.</field>
       <field name="sign">1.0</field>
     </record>
+    <record id="account_tax_code_template_MBYCRC21B" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC21B</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 21% (bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC21S" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC21S</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 21% (servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC21ISP" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC21ISP</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 21% (ISP).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC21IB" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC21IB</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 21% intracomunitaria (bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC21IBI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC21IBI</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 21% intracomunitaria (bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC21IS" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC21IS</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 21% intracomunitaria (servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC21E" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC21E</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 21% extracomunitaria.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC21ISN" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC21ISN</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 21% ISP nacional.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC10B" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC10B</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 10% (bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC10S" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC10S</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 10% (servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC10IB" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC10IB</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 10% intracomunitaria (bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC10IBI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC10IBI</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 10% intracomunitaria (bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC10IS" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC10IS</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 10% intracomunitaria (servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC10E" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC10E</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 10% extracomunitaria.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC10ISN" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC10ISN</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 10% ISP nacional.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC4B" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC4B</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 4% (bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC4S" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC4S</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 4% (servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC4IB" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC4IB</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 4% intracomunitaria (bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC4IBI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC4IBI</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 4% intracomunitaria (bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC4IS" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC4IS</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 4% intracomunitaria (servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC4E" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC4E</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 4% extracomunitaria.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCRC4ISN" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCRC"/>
+      <field name="code">MBYCRC4ISN</field>
+      <field name="name">Modificación bases y cuotas repercutido. Cuota 4% ISP nacional.</field>
+      <field name="sign">1.0</field>
+    </record>
     <record id="account_tax_code_template_REC05" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_ITDC"/>
       <field name="code">REC05</field>
@@ -116,6 +248,24 @@
       <field name="parent_id" ref="account_tax_code_template_ITDC"/>
       <field name="code">MBYCDRDERC</field>
       <field name="name">[26] Modificaciones bases y cuotas del recargo de equivalencia repercutido. Cuota.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCDRDERC05" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCDRDERC"/>
+      <field name="code">MBYCDRDERC05</field>
+      <field name="name">Modificaciones bases y cuotas del recargo de equivalencia repercutido. Cuota 0.5%.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCDRDERC014" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCDRDERC"/>
+      <field name="code">MBYCDRDERC014</field>
+      <field name="name">Modificaciones bases y cuotas del recargo de equivalencia repercutido. Cuota 1.4%.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_MBYCDRDERC52" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_MBYCDRDERC"/>
+      <field name="code">MBYCDRDERC52</field>
+      <field name="name">Modificaciones bases y cuotas del recargo de equivalencia repercutido. Cuota 5.2%.</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_ITADC" model="account.tax.code.template">
@@ -326,6 +476,204 @@
       <field name="parent_id" ref="account_tax_code_template_ITADC"/>
       <field name="code">RDDSC</field>
       <field name="name">[41] Rectificación de deducciones soportado. Cuota.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC21B" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC21B</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 21% (Bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC21BI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC21BI</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 21% (Bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC21S" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC21S</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 21% (Servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC21IB" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC21IB</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 21% intracomunitaria (Bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC21IBI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC21IBI</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 21% intracomunitaria (Bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC21IS" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC21IS</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 21% intracomunitaria (Servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC21EB" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC21EB</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 21% extracomunitaria (Bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC21EBI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC21EBI</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 21% extracomunitaria (Bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC21ES" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC21ES</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 21% extracomunitaria (Servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC21ISP" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC21ISP</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 21% ISP nacional.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC10B" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC10B</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 10% (Bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC10BI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC10BI</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 10% (Bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC10S" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC10S</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 10% (Servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC10IB" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC10IB</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 10% intracomunitaria (Bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC10IBI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC10IBI</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 10% intracomunitaria (Bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC10IS" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC10IS</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 10% intracomunitaria (Servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC10EB" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC10EB</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 10% extracomunitaria (Bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC10EBI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC10EBI</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 10% extracomunitaria (Bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC10ES" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC10ES</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 10% extracomunitaria (Servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC10ISP" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC10ISP</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 10% ISP nacional.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC4B" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC4B</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 4% (Bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC4BI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC4BI</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 4% (Bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC4S" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC4S</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 4% (Servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC4IB" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC4IB</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 4% intracomunitaria (Bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC4IBI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC4IBI</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 4% intracomunitaria (Bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC4IS" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC4IS</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 4% intracomunitaria (Servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC4EB" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC4EB</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 4% extracomunitaria (Bienes).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC4EBI" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC4EBI</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 4% extracomunitaria (Bienes de inversión).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC4ES" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC4ES</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 4% extracomunitaria (Servicios).</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSC4ISP" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSC4ISP</field>
+      <field name="name">Rectificación de deducciones soportado. Cuota 4% ISP nacional.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSCRE05" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSCRE05</field>
+      <field name="name">Rectificación de deducciones soportado. Recargo de equivalencia 0.5%.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSCRE014" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSCRE014</field>
+      <field name="name">Rectificación de deducciones soportado. Recargo de equivalencia 1.4%.</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RDDSCRE52" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RDDSC"/>
+      <field name="code">RDDSCRE52</field>
+      <field name="name">Rectificación de deducciones soportado. Recargo de equivalencia 5.2%.</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_CREAGYP12" model="account.tax.code.template">
@@ -1045,127 +1393,170 @@
     <record id="account_tax_code_template_123" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_root"/>
       <field name="code">123</field>
-      <field name="name">&lt;Mod. 123&gt; IRPF Retenciones a cuenta</field>
+      <field name="name">&lt;Mod. 123&gt; Otras retenciones</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RBI123" model="account.tax.code.template">
+      <field name="parent_id" ref="l10n_es.account_tax_code_template_123"/>
+      <field name="code">RBI123</field>
+      <field name="name">[02] Retenciones. Base Imponible</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RPPBI21" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RBI123"/>
+      <field name="code">RPPBI21</field>
+      <field name="name">Retenciones practicadas a préstamos. Base imponible (21%)</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RPRDBI19" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RBI123"/>
+      <field name="code">RPRDBI19</field>
+      <field name="name">Retenciones practicadas a reparto de dividendos. Base imponible (19%)</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RICC123" model="account.tax.code.template">
+      <field name="parent_id" ref="l10n_es.account_tax_code_template_123"/>
+      <field name="code">RICC123</field>
+      <field name="name">[03] Retenciones e ingresos a cuenta. Cuota</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RPPC21" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RICC123"/>
+      <field name="code">RPPC21</field>
+      <field name="name">Retenciones practicadas a préstamos. Cuota (21%)</field>
+      <field name="sign">1.0</field>
+    </record>
+    <record id="account_tax_code_template_RPRDC19" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_RICC123"/>
+      <field name="code">RPRDC19</field>
+      <field name="name">Retenciones practicadas a reparto de dividendos. Cuota (19%)</field>
+      <field name="sign">1.0</field>
+    </record>
+
+    <record id="account_tax_code_template_200" model="account.tax.code.template">
+      <field name="parent_id" ref="account_tax_code_template_root"/>
+      <field name="code">200</field>
+      <field name="name">&lt;Mod. 200&gt; Impuesto de sociedades</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACBI" model="account.tax.code.template">
-      <field name="parent_id" ref="account_tax_code_template_123"/>
+      <field name="parent_id" ref="account_tax_code_template_200"/>
       <field name="code">IRACBI</field>
-      <field name="name">[02] IRPF retenciones a cuenta. Base imponible</field>
+      <field name="name">Retenciones a cuenta. Base imponible</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACBI1" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_IRACBI"/>
       <field name="code">IRACBI1</field>
-      <field name="name">IRPF retenciones a cuenta. Base imponible (1%)</field>
+      <field name="name">Retenciones a cuenta. Base imponible (1%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACBI2" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_IRACBI"/>
       <field name="code">IRACBI2</field>
-      <field name="name">IRPF retenciones a cuenta. Base imponible (2%)</field>
+      <field name="name">Retenciones a cuenta. Base imponible (2%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACBI7" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_IRACBI"/>
       <field name="code">IRACBI7</field>
-      <field name="name">IRPF retenciones a cuenta. Base imponible (7%)</field>
+      <field name="name">Retenciones a cuenta. Base imponible (7%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACBI9" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_IRACBI"/>
       <field name="code">IRACBI9</field>
-      <field name="name">IRPF retenciones a cuenta. Base imponible (9%)</field>
+      <field name="name">Retenciones a cuenta. Base imponible (9%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACBI15" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_IRACBI"/>
       <field name="code">IRACBI15</field>
-      <field name="name">IRPF retenciones a cuenta. Base imponible (15%)</field>
+      <field name="name">Retenciones a cuenta. Base imponible (15%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACBI18" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_IRACBI"/>
       <field name="code">IRACBI18</field>
-      <field name="name">IRPF retenciones a cuenta. Base imponible (18%)</field>
+      <field name="name">Retenciones a cuenta. Base imponible (18%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACBI19" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_IRACBI"/>
       <field name="code">IRACBI19</field>
-      <field name="name">IRPF retenciones a cuenta. Base imponible (19%)</field>
+      <field name="name">Retenciones a cuenta. Base imponible (19%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACBI20" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_IRACBI"/>
       <field name="code">IRACBI20</field>
-      <field name="name">IRPF retenciones a cuenta. Base imponible (20%)</field>
+      <field name="name">Retenciones a cuenta. Base imponible (20%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACBI21" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_IRACBI"/>
       <field name="code">IRACBI21</field>
-      <field name="name">IRPF retenciones a cuenta. Base imponible (21%)</field>
+      <field name="name">Retenciones a cuenta. Base imponible (21%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_ITRACC" model="account.tax.code.template">
-      <field name="parent_id" ref="account_tax_code_template_123"/>
+      <field name="parent_id" ref="account_tax_code_template_200"/>
       <field name="code">ITRACC</field>
-      <field name="name">[03] IRPF total retenciones a cuenta. Cuota.</field>
+      <field name="name">[595] Retenciones e ingresos a cuenta / pagos a cuenta participaciones I.I.C.</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACC1" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_ITRACC"/>
       <field name="code">IRACC1</field>
-      <field name="name">IRPF retenciones a cuenta. Cuota (1%)</field>
+      <field name="name">Retenciones a cuenta. Cuota (1%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACC2" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_ITRACC"/>
       <field name="code">IRACC2</field>
-      <field name="name">IRPF retenciones a cuenta. Cuota (2%)</field>
+      <field name="name">Retenciones a cuenta. Cuota (2%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACC7" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_ITRACC"/>
       <field name="code">IRACC7</field>
-      <field name="name">IRPF retenciones a cuenta. Cuota (7%)</field>
+      <field name="name">Retenciones a cuenta. Cuota (7%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACC9" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_ITRACC"/>
       <field name="code">IRACC9</field>
-      <field name="name">IRPF retenciones a cuenta. Cuota (9%)</field>
+      <field name="name">Retenciones a cuenta. Cuota (9%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACC15" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_ITRACC"/>
       <field name="code">IRACC15</field>
-      <field name="name">IRPF retenciones a cuenta. Cuota (15%)</field>
+      <field name="name">Retenciones a cuenta. Cuota (15%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACC18" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_ITRACC"/>
       <field name="code">IRACC18</field>
-      <field name="name">IRPF retenciones a cuenta. Cuota (18%)</field>
+      <field name="name">Retenciones a cuenta. Cuota (18%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACC19" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_ITRACC"/>
       <field name="code">IRACC19</field>
-      <field name="name">IRPF retenciones a cuenta. Cuota (19%)</field>
+      <field name="name">Retenciones a cuenta. Cuota (19%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACC20" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_ITRACC"/>
       <field name="code">IRACC20</field>
-      <field name="name">IRPF retenciones a cuenta. Cuota (20%)</field>
+      <field name="name">Retenciones a cuenta. Cuota (20%)</field>
       <field name="sign">1.0</field>
     </record>
     <record id="account_tax_code_template_IRACC21" model="account.tax.code.template">
       <field name="parent_id" ref="account_tax_code_template_ITRACC"/>
       <field name="code">IRACC21</field>
-      <field name="name">IRPF retenciones a cuenta. Cuota (21%)</field>
+      <field name="name">Retenciones a cuenta. Cuota (21%)</field>
       <field name="sign">1.0</field>
     </record>
 

--- a/l10n_es/data/taxes_common.xml
+++ b/l10n_es/data/taxes_common.xml
@@ -57,7 +57,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">S_IVA21B</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC21B"/>
           <field name="type_tax_use">sale</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -75,7 +75,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">S_IVA21S</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC21S"/>
           <field name="type_tax_use">sale</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -93,7 +93,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">S_IVA21ISP</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC21ISP"/>
           <field name="type_tax_use">sale</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -112,7 +112,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_BC</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC21B"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -130,7 +130,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_SC</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC21S"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -157,7 +157,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_SP_IN_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC21IS"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -177,7 +177,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_SP_IN_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC21IS"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -207,7 +207,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_IC_BC_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC21IB"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -227,7 +227,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_IC_BC_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC21IB"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -256,7 +256,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_IC_BI_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC21IBI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -276,7 +276,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_IC_BI_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC21IBI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -296,7 +296,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_IBC</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC21EB"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -314,7 +314,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_IBI</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC21EBI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -359,7 +359,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_SP_EX_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC4E"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -379,7 +379,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_SP_EX_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC4ES"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -408,7 +408,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_SP_EX_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC10E"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -428,14 +428,14 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_SP_EX_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC10ES"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
           <field name="sequence" eval="20"/>
           <field name="base_code_id" ref="account_tax_code_template_OICBI10"/>
           <field name="ref_tax_sign" eval="-1.0"/>
-          <field name="name">IVA 10% Inversión del sujeto pasivo extracomunitario (3)</field>
+          <field name="name">IVA 10% Inversión del sujeto pasivo extracomunitario (2)</field>
           <field name="account_collected_id" ref="pgc_472_child"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
           <field name="tax_code_id" ref="account_tax_code_template_SOICC10"/>
@@ -457,7 +457,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_SP_EX_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC21E"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -477,7 +477,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_SP_EX_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC21ES"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -506,7 +506,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_IC_BC_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC4IB"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -526,7 +526,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_IC_BC_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC4IB"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -555,7 +555,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_IC_BI_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC4IBI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -575,7 +575,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_IC_BI_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC4IBI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -604,7 +604,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_IC_BC_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC10IB"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -624,7 +624,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_IC_BC_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC10IB"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -653,7 +653,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_IC_BI_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC10IBI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -673,7 +673,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_IC_BI_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC10IBI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -735,7 +735,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_IBC</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC4EB"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -753,7 +753,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_IBI</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC4EBI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -771,7 +771,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_IBC</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC10EB"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -789,7 +789,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_IBI</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC10EBI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -807,7 +807,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_BI</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC4BI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -825,7 +825,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_SC</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC4S"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -843,7 +843,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_BI</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC10BI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -861,7 +861,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA21_BI</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC21BI"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -879,7 +879,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_BC</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC10B"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -897,7 +897,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_BC</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC4B"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -915,7 +915,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_SC</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC10S"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -947,7 +947,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCDRDERBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">S_REQ05</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCDRDERC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCDRDERC05"/>
           <field name="type_tax_use">sale</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -965,7 +965,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">S_IVA4B</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC4B"/>
           <field name="type_tax_use">sale</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -983,7 +983,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">S_IVA10B</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC10B"/>
           <field name="type_tax_use">sale</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1017,7 +1017,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">S_IVA4S</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC4S"/>
           <field name="type_tax_use">sale</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1035,7 +1035,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">S_IVA10S</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC10S"/>
           <field name="type_tax_use">sale</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1053,7 +1053,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCDRDERBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">S_REQ014</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCDRDERC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCDRDERC014"/>
           <field name="type_tax_use">sale</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1071,7 +1071,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCDRDERBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">S_REQ52</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCDRDERC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCDRDERC52"/>
           <field name="type_tax_use">sale</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1398,7 +1398,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_REQ014</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSCRE014"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1416,7 +1416,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_REQ05</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSCRE05"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1434,7 +1434,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_REQ5.2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSCRE52"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1617,7 +1617,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_SP_IN_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC10IS"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1637,7 +1637,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA10_SP_IN_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC10IS"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1666,7 +1666,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_SP_IN_1</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC4IS"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1686,7 +1686,7 @@
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
           <field name="description">P_IVA4_SP_IN_2</field>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC4IS"/>
           <field name="type_tax_use">purchase</field>
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="base_sign" eval="1.0"/>
@@ -1831,7 +1831,7 @@
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC4ISP"/>
           <field name="ref_tax_sign" eval="-1.0"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
         </record>
@@ -1851,7 +1851,7 @@
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC4ISN"/>
           <field name="ref_tax_sign" eval="1.0"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
         </record>
@@ -1880,7 +1880,7 @@
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC10ISP"/>
           <field name="ref_tax_sign" eval="-1.0"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
         </record>
@@ -1900,7 +1900,7 @@
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC10ISN"/>
           <field name="ref_tax_sign" eval="1.0"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
         </record>
@@ -1929,7 +1929,7 @@
           <field name="account_paid_id" ref="pgc_472_child"/>
           <field name="ref_base_code_id" ref="account_tax_code_template_RDDSBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_RDDSC21ISP"/>
           <field name="ref_tax_sign" eval="-1.0"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
         </record>
@@ -1949,9 +1949,48 @@
           <field name="account_paid_id" ref="pgc_477_child"/>
           <field name="ref_base_code_id" ref="account_tax_code_template_MBYCRBI"/>
           <field name="ref_base_sign" eval="-1.0"/>
-          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC"/>
+          <field name="ref_tax_code_id" ref="account_tax_code_template_MBYCRC21ISN"/>
           <field name="ref_tax_sign" eval="1.0"/>
           <field name="chart_template_id" ref="account_chart_template_common"/>
         </record>
+
+    <record id="account_tax_template_p_rp21" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="description">P_RP21</field>
+        <field name="name">Retenciones 21% (préstamos)</field>
+        <field name="base_sign" eval="1.0"/>
+        <field name="base_code_id" ref="account_tax_code_template_RPPBI21"/>
+        <field name="tax_sign" eval="-1.0"/>
+        <field name="tax_code_id" ref="account_tax_code_template_RPPC21"/>
+        <field name="ref_base_sign" eval="-1.0"/>
+        <field name="ref_base_code_id" ref="account_tax_code_template_RPPBI21"/>
+        <field name="ref_tax_sign" eval="1.0"/>
+        <field name="ref_tax_code_id" ref="account_tax_code_template_RPPC21"/>
+        <field name="account_paid_id" ref="pgc_4751_child"/>
+        <field name="account_collected_id" ref="pgc_4751_child"/>
+        <field name="chart_template_id" ref="account_chart_template_common"/>
+        <field name="amount" eval="-0.21"/>
+        <field name="type">percent</field>
+    </record>
+
+    <record id="account_tax_template_p_rrD19" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="description">P_RRD19</field>
+        <field name="name">Retenciones 19% (reparto de dividendos)</field>
+        <field name="base_sign" eval="1.0"/>
+        <field name="base_code_id" ref="account_tax_code_template_RPRDBI19"/>
+        <field name="tax_sign" eval="-1.0"/>
+        <field name="tax_code_id" ref="account_tax_code_template_RPRDC19"/>
+        <field name="ref_base_sign" eval="-1.0"/>
+        <field name="ref_base_code_id" ref="account_tax_code_template_RPRDBI19"/>
+        <field name="ref_tax_sign" eval="1.0"/>
+        <field name="ref_tax_code_id" ref="account_tax_code_template_RPRDC19"/>
+        <field name="account_paid_id" ref="pgc_4751_child"/>
+        <field name="account_collected_id" ref="pgc_4751_child"/>
+        <field name="chart_template_id" ref="account_chart_template_common"/>
+        <field name="amount" eval="-0.19"/>
+        <field name="type">percent</field>
+    </record>
+
     </data>
 </openerp>

--- a/l10n_es_account_balance_report/data/balance_normal.xml
+++ b/l10n_es_account_balance_report/data/balance_normal.xml
@@ -1415,7 +1415,7 @@ http://www.mjusticia.gob.es/cs/Satellite/1292342988403
             <field name="template_id" ref="es_balance_normal"/>
             <field name="code">32560</field>
             <field name="name">6. Otras deudas con las Administraciones Públicas</field>
-            <field name="current_value">4750, 4751, 4758, 476, 477</field>
+            <field name="current_value">4750, 4751, 4758, 4759, 476, 477</field>
             <field name="parent_id" ref="es_balance_normal_32500"/> 
             <field name="sequence">134</field>
             <field name="css_class">l4</field>


### PR DESCRIPTION
- v5.4: Varias correcciones para el modelo 123 y para las rectificaciones:
  - Códigos de impuestos de retenciones de venta movidos al modelo 200
  - Creados códigos de impuestos para el modelo 123.
  - Creados impuestos de reparto de dividendos y de préstamos.
  - Creados códigos de impuesto para cada uno de los porcentajes y conceptos
    de las rectificaciones.
  - Incluida cuenta 4759.
