### PR TITLE
[IMP] l10n_es_aeat: Add tax amount to view

### DIFF
--- a/l10n_es_aeat/__openerp__.py
+++ b/l10n_es_aeat/__openerp__.py
@@ -28,7 +28,7 @@
 ##############################################################################
 {
     'name': "AEAT Base",
-    'version': "8.0.1.7.0",
+    'version': "8.0.1.8.0",
     'author': "Pexego,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
               "AvanzOSC,"
@@ -38,7 +38,8 @@
         'Ignacio Ibeas (Acysos S.L.)',
         'Ainara Galdona',
         'Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>',
-        'Santi Argüeso <santi@comunitea.com>'
+        'Santi Argüeso <santi@comunitea.com>',
+        'cubells <info@obertix.net>',
     ],
     'website': "https://github.com/OCA/l10n-spain",
     'category': "Accounting & Finance",
@@ -58,7 +59,8 @@
         'views/aeat_report_view.xml',
         'views/aeat_report_tax_mapping_view.xml',
         'views/aeat_export_configuration_view.xml',
-        'views/aeat_tax_code_mapping_view.xml'
+        'views/aeat_tax_code_mapping_view.xml',
+        'views/account_move_line_view.xml',
     ],
     'installable': True,
 }

--- a/l10n_es_aeat/models/aeat_report_tax_mapping.py
+++ b/l10n_es_aeat/models/aeat_report_tax_mapping.py
@@ -196,11 +196,15 @@ class L10nEsAeatTaxLine(models.Model):
         for s in self:
             s.model_id = self.env["ir.model"].search([("model", "=", s.model)])
 
-    def _get_move_line_act_window_dict(self):
-        return self.env.ref('account.action_tax_code_line_open').read()[0]
-
     @api.multi
     def get_calculated_move_lines(self):
-        res = self._get_move_line_act_window_dict()
-        res['domain'] = [('id', 'in', self.move_lines.ids)]
-        return res
+        view_id = self.env.ref('l10n_es_aeat.view_move_line_tree')
+        return {'type': 'ir.actions.act_window',
+                'name': _('Account Move Lines'),
+                'view_mode': 'tree,form',
+                'view_type': 'form',
+                'views': [(view_id.id, 'tree')],
+                'view_id': False,
+                'res_model': 'account.move.line',
+                'domain': [('id', 'in', self.move_lines.ids)]
+                }

--- a/l10n_es_aeat/views/account_move_line_view.xml
+++ b/l10n_es_aeat/views/account_move_line_view.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-        <record id="view_move_line_tree_tax_amount" model="ir.ui.view">
-            <field name="name">account.move.line.tax.amount.form</field>
+        <record id="view_move_line_tree" model="ir.ui.view">
             <field name="model">account.move.line</field>
             <field name="mode">primary</field>
             <field name="inherit_id" ref="account.view_move_line_tree"/>

--- a/l10n_es_aeat/views/account_move_line_view.xml
+++ b/l10n_es_aeat/views/account_move_line_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_move_line_tree_tax_amount" model="ir.ui.view">
+            <field name="name">account.move.line.tax.amount.form</field>
+            <field name="model">account.move.line</field>
+            <field name="inherit_id" ref="account.view_move_line_tree"/>
+            <field name="arch" type="xml">
+                <field name="credit" position="after">
+                    <field name="tax_amount" sum="Total"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/l10n_es_aeat/views/account_move_line_view.xml
+++ b/l10n_es_aeat/views/account_move_line_view.xml
@@ -4,6 +4,7 @@
         <record id="view_move_line_tree_tax_amount" model="ir.ui.view">
             <field name="name">account.move.line.tax.amount.form</field>
             <field name="model">account.move.line</field>
+            <field name="mode">primary</field>
             <field name="inherit_id" ref="account.view_move_line_tree"/>
             <field name="arch" type="xml">
                 <field name="credit" position="after">

--- a/l10n_es_aeat_mod111/models/mod111.py
+++ b/l10n_es_aeat_mod111/models/mod111.py
@@ -292,10 +292,14 @@ class L10nEsAeatMod111Report(models.Model):
             move_lines = self.move_lines_08.ids
         elif self.env.context.get('move_lines_09', False):
             move_lines = self.move_lines_09.ids
+        view_id = self.env.ref(
+            'l10n_es_aeat.view_move_line_tree_tax_amount')
         return {'type': 'ir.actions.act_window',
                 'name': _('Account Move Lines'),
                 'view_mode': 'tree,form',
                 'view_type': 'form',
+                'views': [(view_id.id, 'tree')],
+                'view_id': False,
                 'res_model': 'account.move.line',
                 'domain': [('id', 'in', move_lines)]
                 }

--- a/l10n_es_aeat_mod111/models/mod111.py
+++ b/l10n_es_aeat_mod111/models/mod111.py
@@ -292,8 +292,7 @@ class L10nEsAeatMod111Report(models.Model):
             move_lines = self.move_lines_08.ids
         elif self.env.context.get('move_lines_09', False):
             move_lines = self.move_lines_09.ids
-        view_id = self.env.ref(
-            'l10n_es_aeat.view_move_line_tree_tax_amount')
+        view_id = self.env.ref('l10n_es_aeat.view_move_line_tree')
         return {'type': 'ir.actions.act_window',
                 'name': _('Account Move Lines'),
                 'view_mode': 'tree,form',

--- a/l10n_es_aeat_mod115/models/mod115.py
+++ b/l10n_es_aeat_mod115/models/mod115.py
@@ -104,8 +104,7 @@ class L10nEsAeatMod115Report(models.Model):
             move_lines = self.move_lines_02.ids
         elif self.env.context.get('move_lines03', False):
             move_lines = self.move_lines_03.ids
-        view_id = self.env.ref(
-            'l10n_es_aeat.view_move_line_tree_tax_amount')
+        view_id = self.env.ref('l10n_es_aeat.view_move_line_tree')
         return {'type': 'ir.actions.act_window',
                 'name': _('Account Move Lines'),
                 'view_mode': 'tree,form',

--- a/l10n_es_aeat_mod115/models/mod115.py
+++ b/l10n_es_aeat_mod115/models/mod115.py
@@ -104,10 +104,14 @@ class L10nEsAeatMod115Report(models.Model):
             move_lines = self.move_lines_02.ids
         elif self.env.context.get('move_lines03', False):
             move_lines = self.move_lines_03.ids
+        view_id = self.env.ref(
+            'l10n_es_aeat.view_move_line_tree_tax_amount')
         return {'type': 'ir.actions.act_window',
                 'name': _('Account Move Lines'),
                 'view_mode': 'tree,form',
                 'view_type': 'form',
+                'views': [(view_id.id, 'tree')],
+                'view_id': False,
                 'res_model': 'account.move.line',
                 'domain': [('id', 'in', move_lines)]
                 }


### PR DESCRIPTION
Este cambio muestra el importe de la base o de la cuota en los modelos que heredan de él. 

Importante si se quiere filtrar, por ejemplo, qué cuota o qué base se aplica a cada empresa, no solamente el total del modelo.
