### PR TITLE
[8.0][FIX+IMP][l10n_es_aeat_mod347] Corrección obtención año devengo en fichero BOE y reducido el tiempo de cálculo del modelo 347.

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -420,9 +420,9 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
 
         def _invoices_sum(invoices, refunds, quarter):
             return (
-                sum(x.amount for x in invoices
+                sum(x.invoice_id.amount_total_wo_irpf for x in invoices
                     if x.invoice_id.period_id.quarter == quarter) -
-                sum(x.amount for x in refunds
+                sum(x.invoice_id.amount_total_wo_irpf for x in refunds
                     if x.invoice_id.period_id.quarter == quarter))
 
         for record in self:
@@ -815,7 +815,7 @@ class L10nEsAeatMod347InvoiceRecord(models.Model):
         related='invoice_id.date_invoice', store=True, readonly=True,
         string='Date')
     amount = fields.Float(
-        related="invoice_id.amount_total_wo_irpf", store=True, readonly=True,
+        related="invoice_id.amount_total_wo_irpf", readonly=True,
         digits=dp.get_precision('Account'), string='Amount')
 
 

--- a/l10n_es_aeat_mod347/wizard/export_mod347_to_boe.py
+++ b/l10n_es_aeat_mod347/wizard/export_mod347_to_boe.py
@@ -156,7 +156,7 @@ class L10nEsAeatMod347ExportToBoe(models.TransientModel):
         text += self._formatNumber(
             partner_record.real_estate_transmissions_amount, 13, 2, True)
         # Año de devengo de las operaciones en efectivo
-        year = fields.Date.from_string(
+        year = partner_record.origin_fiscalyear_id and fields.Date.from_string(
             partner_record.origin_fiscalyear_id.date_start).year
         text += (partner_record.origin_fiscalyear_id and
                  self._formatString(year, 4) or 4 * '0')


### PR DESCRIPTION
En la obtención del fichero BOE cuando intentaba obtener el año de devengo se producía el error:
AttributeError: 'NoneType' object has no attribute 'year'
si el campo origin_fiscalyear_id era nulo.

En el cálculo del modelo 347 el tiempo de proceso se disparaba exponencialmente al aumentar el número de facturas implicadas en los periodos a tratar, de tal forma que para más de 12000 facturas tardaba más de 12 horas (no se llegó a comprobar si terminaba después de ese tiempo). Ahora se necesita para el mismo cálculo entre 2 y 4 minutos. Los cambios requeridos eliminación de store=True y llamada a amount_total_wo_irpf por medio de invoice_id fueron la solución encontrada.
