### PR TITLE
[IMP] l10n_es_partner: Make name_search work

### DIFF
--- a/l10n_es_partner/__openerp__.py
+++ b/l10n_es_partner/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Adaptación de los clientes, proveedores y bancos para España",
-    "version": "8.0.1.5.1",
+    "version": "8.0.1.5.2",
     "author": "ZikZak,"
               "Acysos,"
               "Tecnativa,"

--- a/l10n_es_partner/data/l10n_es_partner_data.xml
+++ b/l10n_es_partner/data/l10n_es_partner_data.xml
@@ -5,7 +5,7 @@
 <data noupdate="1">
     <record id="comercial_name_pattern" model="ir.config_parameter">
         <field name="key">l10n_es_partner.name_pattern</field>
-        <field name="value">%(comercial_name)s (%(name)s)</field>
+        <field name="value">(%(comercial_name)s) %(name)s</field>
     </record>
 </data>
 </openerp>

--- a/l10n_es_partner/tests/test_l10n_es_partner.py
+++ b/l10n_es_partner/tests/test_l10n_es_partner.py
@@ -5,30 +5,35 @@
 from openerp.tests import common
 
 
-class TestL10nEsPartner(common.TransactionCase):
-    def setUp(self):
-        super(TestL10nEsPartner, self).setUp()
-        self.country_spain = self.env.ref('base.es')
-        self.bank = self.env['res.bank'].create({
+class TestL10nEsPartner(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestL10nEsPartner, cls).setUpClass()
+        # Make sure there's no commercial name on display_name field
+        cls.env['ir.config_parameter'].set_param(
+            'l10n_es_partner.name_pattern', '',
+        )
+        cls.country_spain = cls.env.ref('base.es')
+        cls.bank = cls.env['res.bank'].create({
             'name': 'BDE',
             'code': '1234',
             'lname': 'Banco de España',
             'vat': 'ES12345678Z',
             'website': 'www.bde.es',
         })
-        self.partner = self.env['res.partner'].create({
+        cls.partner = cls.env['res.partner'].create({
             'name': 'Empresa de prueba',
             'comercial': 'Nombre comercial',
             'vat': 'ES12345678Z',
         })
-        self.partner_bank = self.env['res.partner.bank'].create({
+        cls.partner_bank = cls.env['res.partner.bank'].create({
             'state': 'iban',
-            'partner_id': self.partner.id,
+            'partner_id': cls.partner.id,
             'acc_number': 'ES7620770024003102575766',
-            'country_id': self.country_spain.id,
+            'country_id': cls.country_spain.id,
         })
-        self.wizard = self.env['l10n.es.partner.import.wizard'].create({})
-        self.wizard_toponyms = self.env['config.es.toponyms'].create({
+        cls.wizard = cls.env['l10n.es.partner.import.wizard'].create({})
+        cls.wizard_toponyms = cls.env['config.es.toponyms'].create({
             'name': '',
             'state': 'both',
             'city_info': 'no'
@@ -73,6 +78,12 @@ class TestL10nEsPartner(common.TransactionCase):
 
     def test_name(self):
         self.env['ir.config_parameter'].set_param(
-            'l10n_es_partner.name_pattern', '%(comercial_name)s (%(name)s)')
-        self.assertEqual(self.partner.display_name,
-                         'Nombre comercial (Empresa de prueba)')
+            'l10n_es_partner.name_pattern', '%(comercial_name)s (%(name)s)',
+        )
+        partner2 = self.env['res.partner'].create({
+            'name': 'Empresa de prueba',
+            'comercial': 'Nombre comercial',
+        })
+        self.assertEqual(
+            partner2.display_name, 'Nombre comercial (Empresa de prueba)',
+        )


### PR DESCRIPTION
As Odoo overwrites name_search on res.partner in a non inheritable way,
we have to include explicitly name_search method and search first for
the partners with that commercial, and then the rest.