### PR TITLE
[8.0][FIX] l10n_es_partner search args length error

### DIFF
--- a/l10n_es_partner/models/l10n_es_partner.py
+++ b/l10n_es_partner/models/l10n_es_partner.py
@@ -138,7 +138,7 @@ class ResPartner(models.Model):
         implicitly for name_search()"""
         if args and args[0][0] == 'name':
             args = expression.normalize_domain(args)
-            exp = args[0]
+            exp = args[1]
             args = ['|', ('comercial', exp[1], exp[2])] + args
         return super(ResPartner, self).search(
             args, offset=offset, limit=limit, order=order, count=count,


### PR DESCRIPTION
Un simple ejemplo linea 139 la variable `args` tiene este valor 
`[['name', 'ilike', 'Demo proveedor'], ['supplier', '=', True]]`
Después de normalizar el domain `args` tiene
`['&', ['name', 'ilike', 'Demo proveedor'], ['supplier', '=', True]]`
Por lo tanto si hacemos `exp = args[0]` nos traemos `&` y no lo esperado
`['name', 'ilike', 'Demo proveedor']`
