### PR TITLE
[8.0]Modificación para evitar facturas de anticipo en el modelo 349.

### DIFF
--- a/l10n_es_aeat_mod349/README.rst
+++ b/l10n_es_aeat_mod349/README.rst
@@ -7,6 +7,24 @@ Operaciones Intracomunitarias)
 Basado en la Orden EHA/769/2010 por el que se aprueban los diseños físicos y
 lógicos del 349.
 
+Según el Artículo 76 de la Ley del IVA,
+En las adquisiciones intracomunitarias de bienes, el impuesto se devengará en
+el momento en que se consideren efectuadas las entregas de bienes similares de
+conformidad con lo dispuesto en el artículo 75 de esta Ley.
+
+No se deben de tener en cuenta las facturas de anticipo en el modelo 349.
+
+Para ello se ha creado un checkbox en las cuentas, para marcar aquellas que no
+se deben de incluir en el modelo 349 y en los cálculos de los importes y el
+detalle de registros a incluir en el modelo, se tiene en cuenta que no
+pertenezcan a las cuentas marcadas y se calcula el total a partir del
+sumatorio de las bases de tax_line, para poder efectuar el filtrado de las
+cuentas.
+
+Por defecto se marcan como no incluibles las cuentas hijas de la 438 (Anticipos
+de Clientes) y las cuentas hijas de la 407 (Anticipos de proveedores).
+
+
 De acuerdo con la normativa de la Hacienda Española, están obligados a
 presentar el modelo 349:
 

--- a/l10n_es_aeat_mod349/__openerp__.py
+++ b/l10n_es_aeat_mod349/__openerp__.py
@@ -25,7 +25,7 @@
 
 {
     "name": "Modelo 349 AEAT",
-    "version": "8.0.2.2.0",
+    "version": "8.0.2.2.1",
     "author": "Pexego, "
               "Top Consultant, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
@@ -46,6 +46,7 @@
         "views/account_fiscal_position_view.xml",
         "views/account_invoice_view.xml",
         "views/mod349_view.xml",
+        "views/account_account_view.xml",
         "report/mod349_report.xml",
         "security/ir.model.access.csv",
         "security/mod_349_security.xml",

--- a/l10n_es_aeat_mod349/migrations/8.0.2.2.0/post-migration.py
+++ b/l10n_es_aeat_mod349/migrations/8.0.2.2.0/post-migration.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# © 2017 Punt Sistemes, S.L.U.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+
+    cr.execute(
+        """
+        UPDATE account_account
+        SET not_in_mod349 = True
+        WHERE code like '407%' OR code like '438%';
+        """)

--- a/l10n_es_aeat_mod349/models/__init__.py
+++ b/l10n_es_aeat_mod349/models/__init__.py
@@ -18,4 +18,5 @@
 
 from . import account_fiscal_position
 from . import account_invoice
+from . import account_account
 from . import mod349

--- a/l10n_es_aeat_mod349/models/account_account.py
+++ b/l10n_es_aeat_mod349/models/account_account.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+
+from openerp import models, fields
+
+
+class ccountAccount(models.Model):
+
+    _inherit = 'account.account'
+
+    not_in_mod349 = fields.Boolean(string='Not in mod349')

--- a/l10n_es_aeat_mod349/views/account_account_view.xml
+++ b/l10n_es_aeat_mod349/views/account_account_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_account_account_form__add_mod349" model="ir.ui.view">
+            <field name="name">account.account.form.add.mod349</field>
+            <field name="model">account.account</field>
+            <field name="inherit_id" ref="account.view_account_form"/>
+            <field name="arch" type="xml">
+                <field name="reconcile" position="after">
+                    <field name="not_in_mod349"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Según el Artículo 76 de la Ley del IVA,
En las adquisiciones intracomunitarias de bienes, el impuesto se devengará en el momento en que se consideren efectuadas las entregas de bienes similares de conformidad con lo dispuesto en el artículo 75 de esta Ley.

No se deben de tener en cuenta las facturas de anticipo en el modelo 349.

Para ello se ha creado un checkbox en las cuentas, para marcar aquellas que no se deben de incluir en el modelo 349 y en los cálculos de los importes y el detalle de registros a incluir en el modelo, se tiene en cuenta que no pertenezcan a las cuentas marcadas y se calcula el total a partir del sumatorio de las bases de tax_line, para poder efectuar el filtrado de las cuentas.