### PR TITLE
[8.0] 349 Separar lineas por tipo de producto

### DIFF
--- a/l10n_es_aeat_mod349/README.rst
+++ b/l10n_es_aeat_mod349/README.rst
@@ -75,6 +75,7 @@ Contributors
 * Ignacio Martínez (Top Consultant)
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Antonio Espinosa <antonioea@antiun.com>
+* Daniel Rodriguez <drl.9319@gmail.com>
 
 Maintainer
 ----------

--- a/l10n_es_aeat_mod349/__openerp__.py
+++ b/l10n_es_aeat_mod349/__openerp__.py
@@ -28,6 +28,7 @@
     "version": "8.0.2.2.0",
     "author": "Pexego, "
               "Top Consultant, "
+              "Praxya, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
               "Antiun Ingeniería S.L.,"
               "Odoo Community Association (OCA)",

--- a/l10n_es_aeat_mod349/i18n/es.po
+++ b/l10n_es_aeat_mod349/i18n/es.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * l10n_es_aeat_mod349
-# 
+#
 # Translators:
 # Alejandro Santana <alejandrosantana@anubia.es>, 2015
 msgid ""
@@ -695,6 +695,26 @@ msgstr "Tipo de soporte"
 #: report:report_l10n_es_aeat_mod349.report:0
 msgid "Support type:"
 msgstr "Tipo de soporte:"
+
+#. module: l10n_es_aeat_mod349
+#: field:l10n.es.aeat.mod349.partner_record,total_consumable_storable_amount:0
+msgid "Total operation Consumable and Storable products"
+msgstr "Total operacion productos consumibles y almacenables"
+
+#. module: l10n_es_aeat_mod349
+#: field:l10n.es.aeat.mod349.partner_record,total_service_amount:0
+msgid "Total operation service products"
+msgstr "Total operacion productos servicio"
+
+#. module: l10n_es_aeat_mod349
+#: report:report_l10n_es_aeat_mod349.report:0
+msgid "Consu. Sto. amount"
+msgstr "Consu. Alma. total"
+
+#. module: l10n_es_aeat_mod349
+#: report:report_l10n_es_aeat_mod349.report:0
+msgid "Service Amount"
+msgstr "Servicio Total"
 
 #. module: l10n_es_aeat_mod349
 #: selection:account.invoice,operation_key:0

--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -56,8 +56,8 @@ class Mod349(models.Model):
         sum_debit = 0
         sum_credit_service_amount = 0
         sum_debit_service_amount = 0
-        sum_credit_consumable_storable_amount = 0
-        sum_debit_consumable_storable_amount = 0
+        sum_credit_consumable_amount = 0
+        sum_debit_consumable_amount = 0
         for invoice in invoices:
             if invoice.type not in ('in_refund', 'out_refund'):
                 sum_credit += invoice.cc_amount_untaxed
@@ -71,10 +71,10 @@ class Mod349(models.Model):
                         sum_debit_service_amount += line.price_subtotal
                 elif line.product_id.type in ['consu', 'product']:
                     if invoice.type not in ('in_refund', 'out_refund'):
-                        sum_credit_consumable_storable_amount +=\
+                        sum_credit_consumable_amount +=\
                             line.price_subtotal
                     elif invoice.type in ('in_refund', 'out_refund'):
-                        sum_debit_consumable_storable_amount +=\
+                        sum_debit_consumable_amount +=\
                             line.price_subtotal
         invoice_created = rec_obj.create(
             {'report_id': self.id,
@@ -87,8 +87,7 @@ class Mod349(models.Model):
              'total_service_amount':
                 sum_credit_service_amount - sum_debit_service_amount,
              'total_consumable_storable_amount':
-                sum_credit_consumable_storable_amount - \
-                    sum_debit_consumable_storable_amount,
+                sum_credit_consumable_amount - sum_debit_consumable_amount,
              })
         # Creation of partner detail lines
         detail_obj = self.env['l10n.es.aeat.mod349.partner_record_detail']

--- a/l10n_es_aeat_mod349/report/mod349_report.rml
+++ b/l10n_es_aeat_mod349/report/mod349_report.rml
@@ -111,7 +111,7 @@
     <story>
         [[repeatIn(objects,'report')]]
         [[setLang(user.context_lang)]]
-        <blockTable colWidths="19cm" style="SeparatorTable">
+        <blockTable colWidths="20cm" style="SeparatorTable">
             <tr><td><para style="Separator"></para></td></tr>
             <tr><td><para style="SeparatorHeader">AEAT 349 MODEL</para></td></tr>
             <tr><td><para style="Separator"></para></td></tr>
@@ -121,7 +121,7 @@
         <!--
         ### REPORT INFO ###
         -->
-        <blockTable colWidths="4cm,15cm" style="ReportInfo" id="ReportInfo">
+        <blockTable colWidths="4cm,16cm" style="ReportInfo" id="ReportInfo">
             <tr>
                 <td><para style="ReportInfoDetail">Partner </para></td>
                 <td><para style="ReportInfo">[[report.company_id.name]]</para></td>
@@ -143,28 +143,32 @@
         <!--
         ### PARTER RECORD LINES ###
         -->
-        <blockTable colWidths="19cm" style="SeparatorTable">
+        <blockTable colWidths="20cm" style="SeparatorTable">
             <tr><td><para style="Separator">PARTNER RECORD LINES</para></td></tr>
         </blockTable>
 
-        <blockTable colWidths="8cm,2.5cm,3cm,3cm,2.5cm" style="DetailLineTable">
+        <blockTable colWidths="7cm,2cm,2cm,3cm,2cm,2cm,2cm" style="DetailLineTable">
             <tr>
                 <td><para style="DetailLine">Partner</para></td>
                 <td><para style="DetailLine">Op.Key</para></td>
                 <td><para style="DetailLine">Country</para></td>
                 <td><para style="DetailLine">VAT</para></td>
+                <td><para style="DetailLine">Service Amount</para></td>
+                <td><para style="DetailLine">Consu. Sto. amount</para></td>
                 <td><para style="DetailLine">Op.Amount</para></td>
             </tr>
         </blockTable>
 
         <section>
             [[repeatIn(report.partner_record_ids, 'partner_record')]]
-            <blockTable colWidths="8cm,2.5cm,3cm,3cm,2.5cm" style="DataLineTable">
+            <blockTable colWidths="7cm,2cm,2cm,3cm,2cm,2cm,2cm" style="DataLineTable">
                 <tr>
                     <td><para style="DataLine">[[partner_record.partner_id.name or '-----']]</para></td>
                     <td><para style="DataLineCenter">[[partner_record.operation_key or '-']]</para></td>
                     <td><para style="DataLine">[[partner_record.country_id.name or '-----']]</para></td>
                     <td><para style="DataLine">[[partner_record.partner_vat or '-----']]</para></td>
+                    <td><para style="DataLineRight">[[partner_record.total_service_amount and formatLang(partner_record.total_service_amount) or 0.0]] [[report.company_id.currency_id.code]]</para></td>
+                    <td><para style="DataLineRight">[[partner_record.total_consumable_storable_amount and formatLang(partner_record.total_consumable_storable_amount) or 0.0]] [[report.company_id.currency_id.code]]</para></td>
                     <td><para style="DataLineRight">[[partner_record.total_operation_amount and formatLang(partner_record.total_operation_amount) or 0.0]] [[report.company_id.currency_id.code]]</para></td>
                 </tr>
             </blockTable>

--- a/l10n_es_aeat_mod349/views/mod349_view.xml
+++ b/l10n_es_aeat_mod349/views/mod349_view.xml
@@ -47,9 +47,9 @@
                     <field name="country_id"/>
                     <field name="partner_vat"/>
                     <field name="partner_id"/>
-                    <field name="total_operation_amount"/>
                     <field name="total_service_amount"/>
                     <field name="total_consumable_storable_amount"/>
+                    <field name="total_operation_amount"/>
                 </tree>
             </field>
         </record>
@@ -67,6 +67,8 @@
                                 <field name="partner_id"/>
                                 <field name="country_id"/>
                                 <field name="partner_vat" on_change="onchange_format_partner_vat(partner_vat,country_id)"/>
+                                <field name="total_service_amount"/>
+                                <field name="total_consumable_storable_amount"/>
                                 <field name="total_operation_amount"/>
                             </group>
                         </page>

--- a/l10n_es_aeat_mod349/views/mod349_view.xml
+++ b/l10n_es_aeat_mod349/views/mod349_view.xml
@@ -48,6 +48,8 @@
                     <field name="partner_vat"/>
                     <field name="partner_id"/>
                     <field name="total_operation_amount"/>
+                    <field name="total_service_amount"/>
+                    <field name="total_consumable_storable_amount"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
Se han separado las lineas de "registros de empresa" del 349, para obtener el total en productos de tipo servicio y el total en productos de tipo almacenable y consumible.

Me seria de gran ayuda si algún contable pudiera verificar que los datos son correctos.

Gracias.