### PR TITLE
[FIX] aeat_mod_303. Corrección tipos de exportación

### DIFF
--- a/l10n_es_aeat_mod303/__openerp__.py
+++ b/l10n_es_aeat_mod303/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "AEAT modelo 303",
-    "version": "8.0.1.7.1",
+    "version": "8.0.1.8.0",
     'category': "Accounting & Finance",
     'author': "Guadaltech,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod303/__openerp__.py
+++ b/l10n_es_aeat_mod303/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "AEAT modelo 303",
-    "version": "8.0.1.7.0",
+    "version": "8.0.1.7.1",
     'category': "Accounting & Finance",
     'author': "Guadaltech,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
@@ -2187,7 +2187,7 @@
             <field name="export_config_id" ref="aeat_mod303_2017_sub03_export_config"/>
             <field name="name">Información adicional - B- Clave - Principal</field>
             <field name="fixed_value"/>
-            <field name="export_type">string</field>
+            <field name="export_type">integer</field>
             <field name="size">1</field>
             <field name="alignment">right</field>
         </record>
@@ -2207,7 +2207,7 @@
             <field name="export_config_id" ref="aeat_mod303_2017_sub03_export_config"/>
             <field name="name">Información adicional - B- Clave - Otras 1ª</field>
             <field name="fixed_value"/>
-            <field name="export_type">string</field>
+            <field name="export_type">integer</field>
             <field name="size">1</field>
             <field name="alignment">right</field>
         </record>
@@ -2227,7 +2227,7 @@
             <field name="export_config_id" ref="aeat_mod303_2017_sub03_export_config"/>
             <field name="name">Información adicional - B- Clave - Otras 2ª</field>
             <field name="fixed_value"/>
-            <field name="export_type">string</field>
+            <field name="export_type">integer</field>
             <field name="size">1</field>
             <field name="alignment">right</field>
         </record>
@@ -2247,7 +2247,7 @@
             <field name="export_config_id" ref="aeat_mod303_2017_sub03_export_config"/>
             <field name="name">Información adicional - B- Clave - Otras 3ª</field>
             <field name="fixed_value"/>
-            <field name="export_type">string</field>
+            <field name="export_type">integer</field>
             <field name="size">1</field>
             <field name="alignment">right</field>
         </record>
@@ -2267,7 +2267,7 @@
             <field name="export_config_id" ref="aeat_mod303_2017_sub03_export_config"/>
             <field name="name">Información adicional - B- Clave - Otras 4ª</field>
             <field name="fixed_value"/>
-            <field name="export_type">string</field>
+            <field name="export_type">integer</field>
             <field name="size">1</field>
             <field name="alignment">right</field>
         </record>
@@ -2287,7 +2287,7 @@
             <field name="export_config_id" ref="aeat_mod303_2017_sub03_export_config"/>
             <field name="name">Información adicional - B- Clave - Otras 5ª</field>
             <field name="fixed_value"/>
-            <field name="export_type">string</field>
+            <field name="export_type">integer</field>
             <field name="size">1</field>
             <field name="alignment">right</field>
         </record>


### PR DESCRIPTION
Cambiado valor de 'export_type' a 'integer' para las lineas de "Información adicional - B- Clave". El valor de estas posiciones debe ser numérico, según está definido por la AEAT, pero se había definido de tipo Alfanumérico y provoca un error al subir el fichero generado a la web de la AEAT.