### PR TITLE
[FIX] l10n_es_aeat_mod303: Añadir la cuenta bancaria en la exportación para devoluciones de IVA

### DIFF
--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
@@ -2166,6 +2166,7 @@
             <field name="sequence">25</field>
             <field name="export_config_id" ref="aeat_mod303_2017_sub03_export_config"/>
             <field name="name">Devolución. SWIFT-BIC</field>
+            <field name="expression">${object.partner_bank_id.bank_bic}</field>
             <field name="fixed_value"/>
             <field name="export_type">string</field>
             <field name="size">11</field>
@@ -2176,6 +2177,7 @@
             <field name="sequence">26</field>
             <field name="export_config_id" ref="aeat_mod303_2017_sub03_export_config"/>
             <field name="name">Domiciliación/Devolución - IBAN</field>
+            <field name="expression">${object.partner_bank_id and object.partner_bank_id.acc_number.replace(' ', '') or ''}</field>
             <field name="fixed_value"/>
             <field name="export_type">string</field>
             <field name="size">34</field>


### PR DESCRIPTION
AEAT ya no deja seleccionar la cuenta bancaria de devolución en el formulario de presentación.