### PR TITLE
8.0 import geonames

### DIFF
--- a/l10n_es_toponyms/wizard/geonames_import.py
+++ b/l10n_es_toponyms/wizard/geonames_import.py
@@ -91,10 +91,10 @@ class BetterZipGeonamesImport(models.TransientModel):
     @api.model
     def select_or_create_state(
             self, row, country, code_row_index=4, name_row_index=3):
+        code_row_index = 6
+        name_row_index = 5
         if country.code == 'ES':
             # Replace state code
-            code_row_index = 6
-            name_row_index = 5
             row[code_row_index] = STATES_REPLACE_LIST[row[code_row_index]]
         return super(BetterZipGeonamesImport, self).select_or_create_state(
             row, country, code_row_index=code_row_index,

--- a/l10n_es_toponyms/wizard/geonames_import.py
+++ b/l10n_es_toponyms/wizard/geonames_import.py
@@ -96,6 +96,13 @@ class BetterZipGeonamesImport(models.TransientModel):
         if country.code == 'ES':
             # Replace state code
             row[code_row_index] = STATES_REPLACE_LIST[row[code_row_index]]
+
+        # Some country codes have more than 3 characters and the first three
+        # are the same. So, would only be loaded the first. Here we use the
+        # two last characters to differentiate them.
+        if country.code == 'GB' and row[code_row_index][:2] == 'E1':
+            row[code_row_index] = 'E{}'.format(row[code_row_index][-2:])
+
         return super(BetterZipGeonamesImport, self).select_or_create_state(
             row, country, code_row_index=code_row_index,
             name_row_index=name_row_index)


### PR DESCRIPTION
Hola:

Tras lo que comenté en el grupo de Odoo España: https://groups.google.com/forum/#!topic/openerp-spain-users/kfbVspfcBqI, propongo estos cambios en el módulo para cargar de forma correcta las provincias de todos los países y no solo las de España.

En la parte de UK, algunas provincias tienen un código de más de 3 caracteres. Los tres primeros coincides por lo que se solo carga la primera provincia de este tipo. Así que lo he modificado para que, en estos casos, tome los dos últimos números para diferenciar las provincias. 
![image](https://cloud.githubusercontent.com/assets/4852443/24411670/b545ce5e-13d6-11e7-886b-19782877b53b.png)
