### PR TITLE
[8.0][IMP][l10n_es_aeat_mod340]  Added surcharge summaries (in summary invoices issued) and others improvements

### DIFF
--- a/l10n_es_aeat_mod340/__openerp__.py
+++ b/l10n_es_aeat_mod340/__openerp__.py
@@ -23,7 +23,7 @@
 
 {
     'name': 'Generación de fichero modelo 340 y libro de IVA',
-    'version': '8.0.2.4.1',
+    'version': '8.0.2.5.0',
     "author": "Spanish Localization Team,"
               # "Acysos S.L., "
               # "Ting, "
@@ -51,7 +51,6 @@
         'wizard/export_mod340_to_boe.xml',
         'views/mod340_view.xml',
         'security/ir.model.access.csv',
-        # 'views/res_partner_view.xml',
         'data/mod340_sequence.xml',
         'views/account_invoice_view.xml',
         'views/account_view.xml',

--- a/l10n_es_aeat_mod340/i18n/es.po
+++ b/l10n_es_aeat_mod340/i18n/es.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* l10n_es_aeat_mod340
+# 	* l10n_es_aeat_mod340
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-20 19:13+0000\n"
-"PO-Revision-Date: 2017-03-20 19:13+0000\n"
+"POT-Creation-Date: 2017-04-10 20:14+0000\n"
+"PO-Revision-Date: 2017-04-10 22:30+0200\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -54,7 +54,7 @@ msgstr "AEAT 340"
 #. module: l10n_es_aeat_mod340
 #: model:ir.ui.menu,name:l10n_es_aeat_mod340.menu_aeat_mod340_report
 msgid "AEAT 340 Model"
-msgstr "Declaración AEAT 340"
+msgstr "Modelo 340"
 
 #. module: l10n_es_aeat_mod340
 #: model:ir.model,name:l10n_es_aeat_mod340.model_l10n_es_aeat_mod340_calculate_records
@@ -446,6 +446,12 @@ msgid "ID"
 msgstr "ID"
 
 #. module: l10n_es_aeat_mod340
+#: view:l10n.es.aeat.mod340.issued:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_issued_form
+#: view:l10n.es.aeat.mod340.received:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_received_form
+msgid "Identification"
+msgstr "Identificación"
+
+#. module: l10n_es_aeat_mod340
 #: view:l10n.es.aeat.mod340.report:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_report_search
 msgid "In process"
 msgstr "En processo"
@@ -481,7 +487,7 @@ msgid "Invoice"
 msgstr "Factura"
 
 #. module: l10n_es_aeat_mod340
-#: code:addons/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py:276
+#: code:addons/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py:296
 #, python-format
 msgid "Invoice %s, Amount untaxed Lines %.2f do not correspond to AmountUntaxed on Invoice %.2f"
 msgstr "Factura %s, la base imposible de las líneas %.2f no se corresponde con la base imponible en la factura %.2f"
@@ -523,7 +529,7 @@ msgid "Issued invoice"
 msgstr "Facturas emitidas"
 
 #. module: l10n_es_aeat_mod340
-#: code:addons/l10n_es_aeat_mod340/models/mod340.py:284
+#: code:addons/l10n_es_aeat_mod340/models/mod340.py:270
 #: view:l10n.es.aeat.mod340.issued:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_issued_form
 #: view:l10n.es.aeat.mod340.issued:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_issued_tree
 #: view:l10n.es.aeat.mod340.report:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_form
@@ -574,7 +580,7 @@ msgid "LIBRO REGISTRO FACTURAS RECIBIDAS"
 msgstr "LIBRO REGISTRO FACTURAS RECIBIDAS"
 
 #. module: l10n_es_aeat_mod340
-#: code:addons/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py:89
+#: code:addons/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py:90
 #, python-format
 msgid "La siguiente empresa no tiene un pais relacionado: %s"
 msgstr "La siguiente empresa no tiene un pais relacionado: %s"
@@ -769,6 +775,11 @@ msgid "Partner"
 msgstr "Empresa"
 
 #. module: l10n_es_aeat_mod340
+#: view:l10n.es.aeat.mod340.received:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_received_form
+msgid "Payment"
+msgstr "Pago"
+
+#. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.intracomunitarias,payment_amount:0
 #: field:l10n.es.aeat.mod340.investment,payment_amount:0
 #: field:l10n.es.aeat.mod340.issued,payment_amount:0
@@ -848,7 +859,7 @@ msgid "Received invoice"
 msgstr "Facturas recibidas"
 
 #. module: l10n_es_aeat_mod340
-#: code:addons/l10n_es_aeat_mod340/models/mod340.py:288
+#: code:addons/l10n_es_aeat_mod340/models/mod340.py:274
 #: view:l10n.es.aeat.mod340.received:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_received_form
 #: view:l10n.es.aeat.mod340.received:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_received_tree
 #: view:l10n.es.aeat.mod340.report:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_form
@@ -891,6 +902,8 @@ msgid "Substitutive"
 msgstr "Sustitutiva"
 
 #. module: l10n_es_aeat_mod340
+#: view:l10n.es.aeat.mod340.issued:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_issued_form
+#: view:l10n.es.aeat.mod340.received:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_received_form
 #: view:l10n.es.aeat.mod340.report:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_form
 msgid "Summary"
 msgstr "Resumen"
@@ -934,6 +947,11 @@ msgstr "Numero de factura"
 #: field:l10n.es.aeat.mod340.report,support_type:0
 msgid "Support Type"
 msgstr "Tipo de soporte"
+
+#. module: l10n_es_aeat_mod340
+#: view:l10n.es.aeat.mod340.tax_line_issued:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_tax_line_issued_form
+msgid "Surcharge"
+msgstr "Recargo"
 
 #. module: l10n_es_aeat_mod340
 #: field:account.tax.code,surcharge_tax_id:0
@@ -1008,6 +1026,14 @@ msgid "Tax surcharge percentage"
 msgstr "Porcentaje de recargo"
 
 #. module: l10n_es_aeat_mod340
+#: view:l10n.es.aeat.mod340.issued:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_issued_form
+#: view:l10n.es.aeat.mod340.received:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_received_form
+#: view:l10n.es.aeat.mod340.tax_line_issued:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_tax_line_issued_form
+#: view:l10n.es.aeat.mod340.tax_line_received:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_tax_line_received_form
+msgid "Taxes"
+msgstr "Impuestos"
+
+#. module: l10n_es_aeat_mod340
 #: selection:l10n.es.aeat.mod340.report,support_type:0
 msgid "Telematics"
 msgstr "Telemática"
@@ -1025,17 +1051,6 @@ msgid "The 340 model field is different.\n"
 ""
 msgstr "El campo modelo 340 es diferente.\n"
 ""
-
-#. module: l10n_es_aeat_mod340
-#: help:l10n.es.aeat.mod340.report,number_records:0
-#: help:l10n.es.aeat.mod340.report,total:0
-#: help:l10n.es.aeat.mod340.report,total_rec:0
-#: help:l10n.es.aeat.mod340.report,total_sharetax:0
-#: help:l10n.es.aeat.mod340.report,total_sharetax_rec:0
-#: help:l10n.es.aeat.mod340.report,total_taxable:0
-#: help:l10n.es.aeat.mod340.report,total_taxable_rec:0
-msgid "The declaration will include partners with the total of operations over this limit"
-msgstr "La declaración incluirá las empresas cuya suma de operaciones supere este límite."
 
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py:107
@@ -1132,7 +1147,7 @@ msgstr "Total Impuestos"
 #: field:l10n.es.aeat.mod340.report,total_taxable:0
 #: field:l10n.es.aeat.mod340.report,total_taxable_rec:0
 msgid "Total Taxable"
-msgstr "Total"
+msgstr "Total base"
 
 #. module: l10n_es_aeat_mod340
 #: report:report mod340:0

--- a/l10n_es_aeat_mod340/models/mod340.py
+++ b/l10n_es_aeat_mod340/models/mod340.py
@@ -50,7 +50,7 @@ class L10nEsAeatMod340Report(orm.Model):
                 result[model.id]['total_taxable'] += issue.base_tax
                 result[model.id]['total_sharetax'] += issue.amount_tax
                 result[model.id]['total'] += issue.base_tax + \
-                    issue.amount_tax + issue.rec_amount_tax
+                    issue.amount_tax
             for issue in model.received:
                 result[model.id]['number_records'] += len(issue.tax_line_ids)
                 result[model.id]['total_taxable_rec'] += issue.base_tax
@@ -88,39 +88,25 @@ class L10nEsAeatMod340Report(orm.Model):
         'ean13': fields.char('Electronic Code VAT reverse charge', size=16),
         'total_taxable': fields.function(
             _get_number_records, method=True,
-            type='float', string='Total Taxable', multi='recalc',
-            help="The declaration will include partners with the total "
-            "of operations over this limit"),
+            type='float', string='Total Taxable', multi='recalc'),
         'total_sharetax': fields.function(
             _get_number_records, method=True,
-            type='float', string='Total Share Tax', multi='recalc',
-            help="The declaration will include partners with the total "
-            "of operations over this limit"),
+            type='float', string='Total Share Tax', multi='recalc'),
         'number_records': fields.function(
             _get_number_records, method=True,
-            type='integer', string='Records', multi='recalc',
-            help="The declaration will include partners with the total "
-            "of operations over this limit"),
+            type='integer', string='Records', multi='recalc'),
         'total': fields.function(
             _get_number_records, method=True,
-            type='float', string="Total", multi='recalc',
-            help="The declaration will include partners with the total "
-            "of operations over this limit"),
+            type='float', string="Total", multi='recalc'),
         'total_taxable_rec': fields.function(
             _get_number_records, method=True,
-            type='float', string='Total Taxable', multi='recalc',
-            help="The declaration will include partners with the total "
-            "of operations over this limit"),
+            type='float', string='Total Taxable', multi='recalc'),
         'total_sharetax_rec': fields.function(
             _get_number_records, method=True,
-            type='float', string='Total Share Tax', multi='recalc',
-            help="The declaration will include partners with the total "
-            "of operations over this limit"),
+            type='float', string='Total Share Tax', multi='recalc'),
         'total_rec': fields.function(
             _get_number_records, method=True,
-            type='float', string="Total", multi='recalc',
-            help="The declaration will include partners with the total "
-            "of operations over this limit"),
+            type='float', string="Total", multi='recalc'),
         'calculation_date': fields.date('Calculation date', readonly=True),
     }
 
@@ -210,7 +196,7 @@ class L10nEsAeatMod340TaxLineIssued(orm.Model):
     _description = 'Mod340 vat lines issued'
     _columns = {
         'name': fields.char('Name', size=128, required=True, select=True),
-        'tax_percentage': fields.float('Tax percentage', digits=(0, 2)),
+        'tax_percentage': fields.float('Tax percentage', digits=(0, 4)),
         'tax_amount': fields.float('Tax amount', digits=(13, 2)),
         'base_amount': fields.float('Base tax bill', digits=(13, 2)),
         'invoice_record_id': fields.many2one('l10n.es.aeat.mod340.issued',
@@ -251,7 +237,7 @@ class L10nEsAeatMod340TaxSummary(models.Model):
     sum_base_amount = new_fields.Float(
         string='Summary base amount', digits=(13, 2),
     )
-    tax_percent = new_fields.Float('Tax percent', digits=(13, 2))
+    tax_percent = new_fields.Float('Tax percent', digits=(13, 4))
     mod340_id = new_fields.Many2one(
         comodel_name='l10n.es.aeat.mod340.report', string='Model 340',
         ondelete="cascade",

--- a/l10n_es_aeat_mod340/views/mod340_view.xml
+++ b/l10n_es_aeat_mod340/views/mod340_view.xml
@@ -103,17 +103,27 @@
                 <form string="Issued invoices">
                     <group>
                         <field name="invoice_id"/>
-                        <field name="partner_id"/>
-                        <field name="partner_vat"/>
-                        <field name="vat_type"/>
-                        <field name="representative_vat"/>
-                        <field name="partner_country_code"/>
-                        <field name="key_operation"/>
-                        <field name="base_tax" />
-                        <field name="amount_tax" />
-                        <field name="rec_amount_tax" />
-                        <field name="total"/>
-                        <field name="txt_exception" />
+                        <newline/>
+                        <group col="4" colspan="4" string="Identification">
+                            <field name="partner_id"/>
+                            <field name="partner_vat"/>
+                            <field name="vat_type"/>                    
+                            <field name="representative_vat"/>
+                            <field name="partner_country_code"/>
+                        <newline/>
+                        </group>
+                        <group col="4" colspan="4" string="Taxes">
+                            <field name="key_operation"/>
+                            <field name="base_tax" />
+                            <field name="amount_tax" />
+                            <field name="rec_amount_tax" />
+                            <newline/>
+                        </group>
+                        <group col="8" colspan="4" string="Summary">
+                            <field name="total"/>
+                            <field name="txt_exception" />
+                            <newline />
+                        </group>
                         <field name="tax_line_ids" />
                     </group>
                 </form>
@@ -166,19 +176,32 @@
                 <form string="Received invoices">
                     <group>
                         <field name="invoice_id"/>
-                        <field name="partner_id"/>
-                        <field name="partner_vat"/>
-                        <field name="vat_type"/>
-                        <field name="representative_vat"/>
-                        <field name="partner_country_code"/>
-                        <field name="key_operation"/>
-                        <field name="base_tax"/>
-                        <field name="amount_tax"/>
-                        <field name="date_payment"/>
-                        <field name="payment_amount"/>
-                        <field name="name_payment_method"/>
-                        <field name="total"/>
-                        <field name="exception" />
+                        <newline/>
+                        <group col="4" colspan="4" string="Identification">
+                            <field name="partner_id"/>
+                            <field name="partner_vat"/>
+                            <field name="vat_type"/>                                        
+                            <field name="representative_vat"/>
+                            <field name="partner_country_code"/>
+                            <newline/>
+                        </group>
+                         <group col="4" colspan="4" string="Taxes">
+                            <field name="key_operation"/>                    
+                            <field name="base_tax"/>
+                            <field name="amount_tax"/>
+                            <newline/>
+                        </group>
+                        <group col="8" colspan="4" string="Payment">
+                            <field name="date_payment"/>
+                            <field name="payment_amount"/>
+                            <field name="name_payment_method"/>
+                            <newline/>
+                        </group>
+                        <group col="8" colspan="4" string="Summary">
+                            <field name="total"/>
+                            <field name="exception" />
+                            <newline />
+                        </group>
                         <field name="tax_line_ids" />
                     </group>
                 </form>
@@ -192,12 +215,16 @@
             <field name="model">l10n.es.aeat.mod340.tax_line_issued</field>
             <field name="arch" type="xml">
                 <form string="Tax line issued">
-                    <field name="name"/>
-                    <field name="tax_percentage"/>
-                    <field name="tax_amount"/>
-                    <field name="base_amount"/>
-                    <field name="rec_tax_percentage"/>
-                    <field name="rec_tax_amount"/>
+                    <group string="Taxes">
+                        <field name="name"/>
+                        <field name="tax_percentage"/>
+                        <field name="tax_amount"/>
+                        <field name="base_amount"/>
+                    </group>
+                    <group string="Surcharge">
+                        <field name="rec_tax_percentage"/>
+                        <field name="rec_tax_amount"/>
+                    </group>
                 </form>
             </field>
         </record>
@@ -207,10 +234,12 @@
             <field name="model">l10n.es.aeat.mod340.tax_line_received</field>
             <field name="arch" type="xml">
                 <form string="Tax line received">
-                    <field name="name"/>
-                    <field name="tax_percentage"/>
-                    <field name="tax_amount"/>
-                    <field name="base_amount"/>
+                    <group string="Taxes">
+                        <field name="name"/>
+                        <field name="tax_percentage"/>
+                        <field name="tax_amount"/>
+                        <field name="base_amount"/>
+                    </group>
                 </form>
             </field>
         </record>

--- a/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
+++ b/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
@@ -260,6 +260,25 @@ class L10nEsAeatMod340CalculateRecords(models.TransientModel):
                         surcharge.base_code_id.surcharge_tax_id.id)
                 ]
                 issued_obj.search(domain).write(values)
+                # Se añade al resumen de facturas emitidas
+                # el detalle de los recargos de equivalencia
+                dic = tax_code_isu_totals
+                key = 'issued'
+                base_code = surcharge.base_code_id
+                if not dic.get(base_code):
+                    dic[base_code] = {
+                        'base': surcharge.base_amount,
+                        'tax': surcharge.amount * sign * cur_rate,
+                        'perc': rec_tax_percentage,
+                        key: invoice_created,
+                    }
+                else:
+                    dic[base_code]['base'] += surcharge.base_amount
+                    dic[base_code]['tax'] += (
+                        surcharge.amount * sign * cur_rate
+                    )
+                    dic[base_code][key] += invoice_created
+
             if invoice.type in ['out_invoice', 'out_refund']:
                 vals2 = {
                     'rec_amount_tax': rec_tax_invoice}


### PR DESCRIPTION
Se han hecho algunas mejoras y alguna corrección que considero sería interesante aplicar.
Resumiendo, los cambios realizados son:
* Se añade resumen de los impuestos de recargo de equivalencia en el resumen de facturas emitidas.
* Se corrige el cálculo del total en facturas emitidas (sumaba dos veces el recargo de equivalencia).
* Se cambia la precisión decimal en los campos de porcentaje a 4 (los porcentajes de impuestos en tanto por cien pueden tener 2 decimales, luego en tanto por 1 deberían tener 4).
* Alguna mejora menor en alguna vista.

Saludos,