### PR TITLE
[8.0][IMP] Mod.340-Mejora en plantillas de impuestos y codigos de impuesto de inversión sujeto pasivo

### DIFF
--- a/l10n_es_aeat_mod340/__openerp__.py
+++ b/l10n_es_aeat_mod340/__openerp__.py
@@ -23,7 +23,7 @@
 
 {
     'name': 'Generación de fichero modelo 340 y libro de IVA',
-    'version': '8.0.2.3.0',
+    'version': '8.0.2.4.0',
     "author": "Spanish Localization Team,"
               # "Acysos S.L., "
               # "Ting, "

--- a/l10n_es_aeat_mod340/data/taxes_data.xml
+++ b/l10n_es_aeat_mod340/data/taxes_data.xml
@@ -101,6 +101,19 @@
         <record id="l10n_es.account_tax_code_template_AIBIBI21" model="account.tax.code.template">
             <field name="mod340" eval="True"/>
         </record>
+        <!-- INVERSION DEL SUJETO PASIVO -->
+        <record id="l10n_es.account_tax_code_template_OCIDSPEAIBI" model="account.tax.code.template">
+            <field name="mod340" eval="True"/>
+        </record>
+        <record id="l10n_es.account_tax_code_template_ONSOCIDSPQOEDAD" model="account.tax.code.template">
+            <field name="mod340" eval="True"/>
+        </record>
+        <record id="l10n_es.account_tax_code_template_VISP" model="account.tax.code.template">
+            <field name="mod340" eval="True"/>
+        </record>
+        <record id="l10n_es.account_tax_code_template_RDDSBI" model="account.tax.code.template">
+            <field name="mod340" eval="True"/>
+        </record>
         <!--Otros Códigos de Impuestos-->
         <record id="l10n_es.account_tax_code_template_EIDBYS" model="account.tax.code.template">
             <field name="mod340" eval="True"/>
@@ -108,6 +121,21 @@
         
         <record id="l10n_es.account_tax_code_template_EIDBYS" model="account.tax.code.template">
             <field name="mod340" eval="True"/>
+        </record>
+        
+        <!-- Impuestos incluidos en el Modelo 340 como inversion del sujeto pasivo
+        -->
+        <record id="l10n_es.account_tax_template_p_iva21_isp" model="account.tax.template">
+            <field name="is_340_reserve_charge" eval="True"/>
+        </record>
+        <record id="l10n_es.account_tax_template_s_iva0_isp" model="account.tax.template">
+            <field name="is_340_reserve_charge" eval="True"/>
+        </record>
+        <record id="l10n_es.account_tax_template_p_iva4_isp" model="account.tax.template">
+            <field name="is_340_reserve_charge" eval="True"/>
+        </record>
+        <record id="l10n_es.account_tax_template_p_iva10_isp" model="account.tax.template">
+            <field name="is_340_reserve_charge" eval="True"/>
         </record>
     </data>
 </openerp>

--- a/l10n_es_aeat_mod340/i18n/es.po
+++ b/l10n_es_aeat_mod340/i18n/es.po
@@ -1191,3 +1191,15 @@ msgstr "Emitida"
 msgid "open"
 msgstr "open"
 
+#. module: l10n_es_aeat_mod340
+#: field:account.tax.template,is_340_reserve_charge:0
+msgid "Include in mod340 as reserve charge"
+msgstr "Incluir en 340 como inversión del sujeto pasivo"
+
+#. module: l10n_es_aeat_mod340
+#: code:addons/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py:44
+#, python-format
+msgid "The field is 340 reverse charge is different.\n"
+""
+msgstr "El campo incluir en 340 como inversión del sujeto pasivo es diferente.\n"
+""

--- a/l10n_es_aeat_mod340/models/account.py
+++ b/l10n_es_aeat_mod340/models/account.py
@@ -44,6 +44,14 @@ class AccountTaxCode(orm.Model):
     }
 
 
+class AccountTaxTemplate(orm.Model):
+    _inherit = 'account.tax.template'
+
+    _columns = {
+        'is_340_reserve_charge': fields.boolean(
+            "Include in mod340 as reserve charge"),
+    }
+    
 class AccountTax(orm.Model):
     _inherit = 'account.tax'
 

--- a/l10n_es_aeat_mod340/models/account.py
+++ b/l10n_es_aeat_mod340/models/account.py
@@ -51,7 +51,8 @@ class AccountTaxTemplate(orm.Model):
         'is_340_reserve_charge': fields.boolean(
             "Include in mod340 as reserve charge"),
     }
-    
+
+
 class AccountTax(orm.Model):
     _inherit = 'account.tax'
 

--- a/l10n_es_aeat_mod340/views/account_view.xml
+++ b/l10n_es_aeat_mod340/views/account_view.xml
@@ -25,6 +25,17 @@
             </field>
         </record>
         
+        <record id="view_tax_template_form_mod340" model="ir.ui.view">
+            <field name="name">account.tax.template.form.mod340</field>
+            <field name="model">account.tax.template</field>
+            <field name="inherit_id" ref="account.view_account_tax_template_form"/>
+            <field name="arch" type="xml">
+                <field name="price_include" position="after">
+                    <field name="is_340_reserve_charge"/>
+                </field>
+            </field>
+        </record>
+        
         <record id="view_account_tax_form_mod340" model="ir.ui.view">
             <field name="name">account.tax.form.mod340</field>
             <field name="model">account.tax</field>

--- a/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py
+++ b/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py
@@ -41,7 +41,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
         notes = super(WizardUpdateChartsAccounts, self)._is_different_tax(
             tax, tax_template, mapping_taxes,mapping_tax_codes, mapping_accounts)
         if tax.is_340_reserve_charge != tax_template.is_340_reserve_charge:
-            notes += _("El campo incluir en 340 como sujeto pasivo es diferente.\n")
+            notes += _("The field is 340 reverse charge is different.\n")
         return notes
 
     def _prepare_tax_vals(self, tax_template, mapping_tax_codes,

--- a/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py
+++ b/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py
@@ -35,11 +35,12 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             tax_code_template, mapping_tax_codes)
         res['mod340'] = tax_code_template.mod340
         return res
-    
+
     def _is_different_tax(self, tax, tax_template, mapping_taxes,
                           mapping_tax_codes, mapping_accounts):
         notes = super(WizardUpdateChartsAccounts, self)._is_different_tax(
-            tax, tax_template, mapping_taxes,mapping_tax_codes, mapping_accounts)
+            tax, tax_template, mapping_taxes, mapping_tax_codes, 
+            mapping_accounts)
         if tax.is_340_reserve_charge != tax_template.is_340_reserve_charge:
             notes += _("The field is 340 reverse charge is different.\n")
         return notes
@@ -47,6 +48,6 @@ class WizardUpdateChartsAccounts(models.TransientModel):
     def _prepare_tax_vals(self, tax_template, mapping_tax_codes,
                           mapping_taxes):
         res = super(WizardUpdateChartsAccounts, self)._prepare_tax_vals(
-            tax_template, mapping_tax_codes,mapping_taxes)
+            tax_template, mapping_tax_codes, mapping_taxes)
         res['is_340_reserve_charge'] = tax_template.is_340_reserve_charge
         return res

--- a/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py
+++ b/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py
@@ -39,7 +39,7 @@ class WizardUpdateChartsAccounts(models.TransientModel):
     def _is_different_tax(self, tax, tax_template, mapping_taxes,
                           mapping_tax_codes, mapping_accounts):
         notes = super(WizardUpdateChartsAccounts, self)._is_different_tax(
-            tax, tax_template, mapping_taxes, mapping_tax_codes, 
+            tax, tax_template, mapping_taxes, mapping_tax_codes,
             mapping_accounts)
         if tax.is_340_reserve_charge != tax_template.is_340_reserve_charge:
             notes += _("The field is 340 reverse charge is different.\n")

--- a/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py
+++ b/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py
@@ -35,3 +35,18 @@ class WizardUpdateChartsAccounts(models.TransientModel):
             tax_code_template, mapping_tax_codes)
         res['mod340'] = tax_code_template.mod340
         return res
+    
+    def _is_different_tax(self, tax, tax_template, mapping_taxes,
+                          mapping_tax_codes, mapping_accounts):
+        notes = super(WizardUpdateChartsAccounts, self)._is_different_tax(
+            tax, tax_template, mapping_taxes,mapping_tax_codes, mapping_accounts)
+        if tax.is_340_reserve_charge != tax_template.is_340_reserve_charge:
+            notes += _("El campo incluir en 340 como sujeto pasivo es diferente.\n")
+        return notes
+
+    def _prepare_tax_vals(self, tax_template, mapping_tax_codes,
+                          mapping_taxes):
+        res = super(WizardUpdateChartsAccounts, self)._prepare_tax_vals(
+            tax_template, mapping_tax_codes,mapping_taxes)
+        res['is_340_reserve_charge'] = tax_template.is_340_reserve_charge
+        return res


### PR DESCRIPTION
Añadida configuración correcta de las plantillas de impuestos y codigos de impuestos para la inversión del sujeto pasivo. Actualmente los impuestos y codigos de impuesto relacionados con la inversión del sujeto pasivo no se configuran correctamente para ser incluidos en el modelo 340. Se han añadido los codigos de impuesto que deben incluirse en el 340. Se ha creado un nuevo campo para la plantilla de impuestos que contemple si debe o no reflejarse en el 340 como inversión del sujeto pasivo, se han configurado los impuestos que deben tener este campo a 'True' en la plantilla y se ha tenido en cuenta este campo para la actualización de cuentas mediante el módulo account_chart_update.