### PR TITLE
[8.0][FIX] l10n_es_aeat_mod340: Correccion de calculo de records de facturas y de plantilla de codigos de impuesto

### DIFF
--- a/l10n_es_aeat_mod340/__openerp__.py
+++ b/l10n_es_aeat_mod340/__openerp__.py
@@ -23,7 +23,7 @@
 
 {
     'name': 'Generación de fichero modelo 340 y libro de IVA',
-    'version': '8.0.2.4.0',
+    'version': '8.0.2.5.0',
     "author": "Spanish Localization Team,"
               # "Acysos S.L., "
               # "Ting, "

--- a/l10n_es_aeat_mod340/data/taxes_data.xml
+++ b/l10n_es_aeat_mod340/data/taxes_data.xml
@@ -102,6 +102,12 @@
             <field name="mod340" eval="True"/>
         </record>
         <!-- INVERSION DEL SUJETO PASIVO -->
+        <record id="l10n_es.account_tax_code_template_OCIDSPEAIBI" model="account.tax.code.template">
+            <field name="mod340" eval="False"/>
+        </record>
+        <record id="l10n_es.account_tax_code_template_ONSOCIDSPQOEDAD" model="account.tax.code.template">
+            <field name="mod340" eval="False"/>
+        </record>
         <record id="l10n_es.account_tax_code_template_VISP" model="account.tax.code.template">
             <field name="mod340" eval="True"/>
         </record>

--- a/l10n_es_aeat_mod340/data/taxes_data.xml
+++ b/l10n_es_aeat_mod340/data/taxes_data.xml
@@ -102,12 +102,6 @@
             <field name="mod340" eval="True"/>
         </record>
         <!-- INVERSION DEL SUJETO PASIVO -->
-        <record id="l10n_es.account_tax_code_template_OCIDSPEAIBI" model="account.tax.code.template">
-            <field name="mod340" eval="True"/>
-        </record>
-        <record id="l10n_es.account_tax_code_template_ONSOCIDSPQOEDAD" model="account.tax.code.template">
-            <field name="mod340" eval="True"/>
-        </record>
         <record id="l10n_es.account_tax_code_template_VISP" model="account.tax.code.template">
             <field name="mod340" eval="True"/>
         </record>

--- a/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
+++ b/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
@@ -240,9 +240,9 @@ class L10nEsAeatMod340CalculateRecords(models.TransientModel):
             if tot_invoice != invoice.cc_amount_total:
                 values['total'] = tot_invoice
             if invoice.type in ['out_invoice', 'out_refund']:
-                invoices340.write(invoice_created)
+                invoice_created.write(values)
             if invoice.type in ['in_invoice', 'in_refund']:
-                invoices340_rec.write(invoice_created)
+                invoice_created.write(values)
             rec_tax_invoice = 0
             for surcharge in surcharge_taxes_lines:
                 rec_tax_percentage = round(surcharge.amount /


### PR DESCRIPTION
Se corrige un error en el código del cálculo de los records de factura del modelo 340 y se corrige la plantilla de códigos de impuesto, modificando dos códigos de impuestos marcados para incluir en el 340 y que no deben estarlo.