### PR TITLE
[8.0][FIX] l10n_es_aeat_mod340: Corrección cálculo total impuestos y total en resumen facturas emitidas

### DIFF
--- a/l10n_es_aeat_mod340/models/mod340.py
+++ b/l10n_es_aeat_mod340/models/mod340.py
@@ -48,9 +48,10 @@ class L10nEsAeatMod340Report(orm.Model):
             for issue in model.issued:
                 result[model.id]['number_records'] += len(issue.tax_line_ids)
                 result[model.id]['total_taxable'] += issue.base_tax
-                result[model.id]['total_sharetax'] += issue.amount_tax
+                result[model.id]['total_sharetax'] += issue.amount_tax + \
+                    issue.rec_amount_tax
                 result[model.id]['total'] += issue.base_tax + \
-                    issue.amount_tax
+                    issue.amount_tax + issue.rec_amount_tax
             for issue in model.received:
                 result[model.id]['number_records'] += len(issue.tax_line_ids)
                 result[model.id]['total_taxable_rec'] += issue.base_tax

--- a/l10n_es_aeat_mod340/report/mod340_report.rml
+++ b/l10n_es_aeat_mod340/report/mod340_report.rml
@@ -237,7 +237,7 @@
             <para style="P10">[[r.base_tax]]</para>
           </td>
           <td>
-            <para style="P10">[[r.amount_tax or '0']]</para>
+            <para style="P10">[[(r.amount_tax + r.rec_amount_tax) or '0']]</para>
           </td>
           <td>
             <para style="P10">[[r.total or '0']]</para>

--- a/l10n_es_aeat_mod340/report/vat_book.rml
+++ b/l10n_es_aeat_mod340/report/vat_book.rml
@@ -224,7 +224,7 @@
       <font color="white"> </font>
     </para>
 
-    <blockTable colWidths="53.0,40.0,53.0,140.0,62.0,134.0" repeatRows="1" style="Taula3">
+    <blockTable colWidths="53.0,40.0,53.0,140.0,62.0,183.0" repeatRows="1" style="Taula3">
       <tr>
         <td>
           <para style="Table Heading">Fecha factura</para>
@@ -242,7 +242,7 @@
           <para style="Table Heading">NIF</para>
         </td>
         <td>
-            <blockTable colWidths="56.0,29.0,49.0" repeatRows="1" style="TablaInterna">
+            <blockTable colWidths="56.0,29.0,49.0,49.0" repeatRows="1" style="TablaInterna">
                 <tr>
                     <td>
                       <para style="Table Heading">Base</para>
@@ -252,6 +252,9 @@
                     </td>
                     <td>
                       <para style="Table Heading">Cuota</para>
+                    </td>
+                    <td>
+                      <para style="Table Heading">Recargo</para>
                     </td>
                  </tr>
              </blockTable>
@@ -264,7 +267,7 @@
     </para>
     <section>
       <para style="P6">[[repeatIn(o.issued,'r')]]</para>
-      <blockTable colWidths="53.0,40.0,53.0,140.0,62.0,134.0" repeatRows="1" style="Taula4">
+      <blockTable colWidths="53.0,40.0,53.0,140.0,62.0,183.0" repeatRows="1" style="Taula4">
         <tr>
           <td>
             <para style="P11">[[ formatLang(r.invoice_id.date_invoice,date=True) ]]</para>
@@ -283,7 +286,7 @@
           </td>
           <td>
             <para style="P6">[[repeatIn(r.tax_line_ids,'l')]]</para>
-                <blockTable colWidths="56.0,29.0,49.0" repeatRows="1" style="TablaInterna">
+                <blockTable colWidths="56.0,29.0,49.0,49.0" repeatRows="1" style="TablaInterna">
                 <tr>
                     <td>
                         <para style="P10">[[formatLang(l.base_amount)]]</para>
@@ -293,6 +296,9 @@
                       </td>
                       <td>
                         <para style="P10">[[formatLang(l.tax_amount) or '0']]</para>
+                      </td>
+                      <td>
+                        <para style="P10">[[formatLang(l.rec_tax_amount) or '0']]</para>
                       </td>
                   </tr>
                 </blockTable>


### PR DESCRIPTION
Se corrige el cálculo de los campos 'total_sharetax' y 'total' para las facturas emitidas.
En mi pull request #485 se modificó para que no tuviese en cuenta el valor del recargo ya que este ya estaba incluido en la columna de impuestos. Esto era así en ese momento, debido a un error existente que sería corregido en el pull request #498 de @pedrorgil. 

Se incluye el valor del recargo también en los informes de "Libro de IVA" y "Modelo 340". En el primero añadiendo una columna y en el segundo sumándolo a la columna "Cuota Impuesto".

Aprovecho para comentar que en el pull request anterior #485 también había modificado alguna traducción que ahora vuelven a estar como antes. ¿Es debido a que lo debía haber hecho de otra forma?. No vuelvo a incluir aquí la traducción, salvo que me indiquéis lo contrario, por desconocimiento de como debería proceder.
