### PR TITLE
Corregir menú inexistente

### DIFF
--- a/account_balance_reporting/i18n/es.po
+++ b/account_balance_reporting/i18n/es.po
@@ -534,7 +534,7 @@ msgstr "Mostrar apuntes contables"
 #. module: account_balance_reporting
 #: model:ir.ui.menu,name:account_balance_reporting.menu_spanish_financial_reports
 msgid "Spanish Financial Reports"
-msgstr "Informes Finacieros Españoles"
+msgstr "Informes Financieros Españoles"
 
 #. module: account_balance_reporting
 #: model:ir.model.fields,field_description:account_balance_reporting.field_account_balance_reporting_state

--- a/account_balance_reporting/views/account_balance_reporting_menu.xml
+++ b/account_balance_reporting/views/account_balance_reporting_menu.xml
@@ -8,7 +8,7 @@
 
     <menuitem id="menu_account_balance_reporting_templates"
               name="Financial Reports"
-              parent="account.menu_account_reports"
+              parent="account.menu_finance_configuration"
               action="action_view_account_balance_reporting_template"
     />
 


### PR DESCRIPTION
El menú de configuración de los Informes Financieros, no se mostraba por utilizar identificador inexistente como parent.
Corrección ortográfica.