### PR TITLE
[IMP] l10n_es_aeat_mod303. Tipo a compensar para resutlado negativo

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -141,7 +141,7 @@ class L10nEsAeatMod303Report(models.Model):
     result_type = fields.Selection(
         selection=[('I', 'A ingresar'),
                    ('D', 'A devolver'),
-                   ('C', 'A compensar')
+                   ('C', 'A compensar'),
                    ('N', 'Sin actividad/Resultado cero')],
         compute="_compute_result_type")
     compensate = fields.Boolean(
@@ -170,7 +170,10 @@ class L10nEsAeatMod303Report(models.Model):
         elif self.resultado_liquidacion > 0:
             self.result_type = 'I'
         else:
-            self.result_type = 'C'
+            if self.devolucion_mensual:
+                self.result_type = 'D'
+            else:
+                self.result_type = 'C'
 
     @api.onchange('period_type', 'fiscalyear_id')
     def onchange_period_type(self):

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -141,6 +141,7 @@ class L10nEsAeatMod303Report(models.Model):
     result_type = fields.Selection(
         selection=[('I', 'A ingresar'),
                    ('D', 'A devolver'),
+                   ('C', 'A compensar')
                    ('N', 'Sin actividad/Resultado cero')],
         compute="_compute_result_type")
     compensate = fields.Boolean(
@@ -169,7 +170,7 @@ class L10nEsAeatMod303Report(models.Model):
         elif self.resultado_liquidacion > 0:
             self.result_type = 'I'
         else:
-            self.result_type = 'D'
+            self.result_type = 'C'
 
     @api.onchange('period_type', 'fiscalyear_id')
     def onchange_period_type(self):


### PR DESCRIPTION
No se puede cargar el fichero en la página de la AEAT debido a que los resultaos negativos deben ser obligatoriamente a compensar salvo en la última declaración del año