### PR TITLE
[8.0][FIX] l10n_es_aeat_mod216:fix period_id field

### DIFF
--- a/l10n_es_aeat_mod216/__openerp__.py
+++ b/l10n_es_aeat_mod216/__openerp__.py
@@ -18,7 +18,7 @@
 
 {
     'name': 'AEAT modelo 216',
-    'version': '8.0.1.3.0',
+    'version': '8.0.1.3.1',
     'category': "Localisation/Accounting",
     'author': "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod216/wizard/export_mod216_to_boe.py
+++ b/l10n_es_aeat_mod216/wizard/export_mod216_to_boe.py
@@ -39,9 +39,7 @@ class L10nEsAeatMod216ExportToBoe(models.TransientModel):
         res += self._formatString(
             fields.Date.from_string(report.fiscalyear_id.date_start).year, 4)
         # Devengado. Periodo: "01" ... "12" o "1T" … "4T"
-        res += self._formatString(
-            fields.Date.from_string(report.period_id.date_start).month, 2,
-            fill='0', align='>')
+        res += self._formatString(report.period_type,2)
         # Tipo y cierre
         res += self._formatString('0000>', 5)
         return res
@@ -70,9 +68,7 @@ class L10nEsAeatMod216ExportToBoe(models.TransientModel):
         res += self._formatString('0', 1)
         res += self._formatString(
             fields.Date.from_string(report.fiscalyear_id.date_start).year, 4)
-        res += self._formatString(
-            fields.Date.from_string(report.period_id.date_start).month, 2,
-            fill='0', align='>')
+        res += self._formatString(report.period_type,2)
         res += self._formatString('0000>', 5)
         # Fin de registro Constante CRLF(Hexadecimal 0D0A, Decimal 1310)
         res += '\x0A\x0D'
@@ -104,9 +100,7 @@ class L10nEsAeatMod216ExportToBoe(models.TransientModel):
         res += self._formatString(
             fields.Date.from_string(report.fiscalyear_id.date_start).year, 4)
         # Devengado. Periodo: "01" ... "12" o "1T" … "4T"
-        res += self._formatString(
-            fields.Date.from_string(report.period_id.date_start).month, 2,
-            fill='0', align='>')
+        res += self._formatString(report.period_type,2)
         return res
 
     @api.multi

--- a/l10n_es_aeat_mod216/wizard/export_mod216_to_boe.py
+++ b/l10n_es_aeat_mod216/wizard/export_mod216_to_boe.py
@@ -39,7 +39,7 @@ class L10nEsAeatMod216ExportToBoe(models.TransientModel):
         res += self._formatString(
             fields.Date.from_string(report.fiscalyear_id.date_start).year, 4)
         # Devengado. Periodo: "01" ... "12" o "1T" … "4T"
-        res += self._formatString(report.period_type,2)
+        res += self._formatString(report.period_type, 2)
         # Tipo y cierre
         res += self._formatString('0000>', 5)
         return res
@@ -68,7 +68,7 @@ class L10nEsAeatMod216ExportToBoe(models.TransientModel):
         res += self._formatString('0', 1)
         res += self._formatString(
             fields.Date.from_string(report.fiscalyear_id.date_start).year, 4)
-        res += self._formatString(report.period_type,2)
+        res += self._formatString(report.period_type, 2)
         res += self._formatString('0000>', 5)
         # Fin de registro Constante CRLF(Hexadecimal 0D0A, Decimal 1310)
         res += '\x0A\x0D'
@@ -100,7 +100,7 @@ class L10nEsAeatMod216ExportToBoe(models.TransientModel):
         res += self._formatString(
             fields.Date.from_string(report.fiscalyear_id.date_start).year, 4)
         # Devengado. Periodo: "01" ... "12" o "1T" … "4T"
-        res += self._formatString(report.period_type,2)
+        res += self._formatString(report.period_type, 2)
         return res
 
     @api.multi


### PR DESCRIPTION
When exporting to file in several functions the field 'period_id'
does not exist, I have replaced it with the period_type field.