### PR TITLE
[8.0] Libro iva qweb

### DIFF
--- a/l10n_es_aeat_mod340/README.rst
+++ b/l10n_es_aeat_mod340/README.rst
@@ -72,6 +72,7 @@ Créditos
 Contribuidores
 --------------
 
+* Daniel Rodriguez <drl.9319@gmail.com>
 * Ignacio Ibeas Izquierdo <ignacio@acysos.com>
 * Ting
 * NaN Projectes de Programari Lliure, S.L.

--- a/l10n_es_aeat_mod340/__openerp__.py
+++ b/l10n_es_aeat_mod340/__openerp__.py
@@ -25,6 +25,7 @@
     'name': 'Generación de fichero modelo 340 y libro de IVA',
     'version': '8.0.2.5.1',
     "author": "Spanish Localization Team,"
+              # "Praxya., "
               # "Acysos S.L., "
               # "Ting, "
               # "Nan-tic, "
@@ -47,6 +48,8 @@
         'l10n_es_aeat_mod349'
     ],
     'data': [
+        'report/report_paper_format.xml',
+        'report/vat_book_invoices_issued.xml',
         'report/report_view.xml',
         'wizard/export_mod340_to_boe.xml',
         'views/mod340_view.xml',

--- a/l10n_es_aeat_mod340/__openerp__.py
+++ b/l10n_es_aeat_mod340/__openerp__.py
@@ -49,8 +49,9 @@
     ],
     'data': [
         'report/report_paper_format.xml',
-        'report/vat_book_invoices_issued.xml',
         'report/report_view.xml',
+        'report/vat_book_invoices_issued.xml',
+        'report/vat_book_invoices_received.xml',
         'wizard/export_mod340_to_boe.xml',
         'views/mod340_view.xml',
         'security/ir.model.access.csv',

--- a/l10n_es_aeat_mod340/i18n/es.po
+++ b/l10n_es_aeat_mod340/i18n/es.po
@@ -1,27 +1,21 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat_mod340
-# 
-# Translators:
-# Alejandro Santana <alejandrosantana@anubia.es>, 2015
-# kikopeiro <francisco.peiro@factorlibre.com>, 2016
-# kikopeiro <francisco.peiro@factorlibre.com>, 2016
-# oihane <oihanecruce@gmail.com>, 2015
-# oihane <oihanecruce@gmail.com>, 2015
-# Pedro M. Baeza <pedro.baeza@gmail.com>, 2015
+# 	* l10n_es_aeat_mod340
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-spain (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-20 01:15+0000\n"
-"PO-Revision-Date: 2017-05-19 14:27+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/es/)\n"
+"POT-Creation-Date: 2017-06-09 11:09+0000\n"
+"PO-Revision-Date: 2017-06-09 13:16+0200\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
 "Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 1.8.7.1\n"
 
 #. module: l10n_es_aeat_mod340
 #: selection:res.partner,vat_type:0
@@ -62,7 +56,7 @@ msgstr "AEAT 340"
 #. module: l10n_es_aeat_mod340
 #: model:ir.ui.menu,name:l10n_es_aeat_mod340.menu_aeat_mod340_report
 msgid "AEAT 340 Model"
-msgstr "Declaración AEAT 340"
+msgstr "Modelo 340"
 
 #. module: l10n_es_aeat_mod340
 #: model:ir.model,name:l10n_es_aeat_mod340.model_l10n_es_aeat_mod340_calculate_records
@@ -72,7 +66,7 @@ msgstr "Modelo 340 - Calcular registros"
 #. module: l10n_es_aeat_mod340
 #: model:ir.actions.act_window,name:l10n_es_aeat_mod340.action_l10n_es_aeat_mod340_report
 msgid "AEAT model 340"
-msgstr "Declaración AEAT 340"
+msgstr "Modelo 340"
 
 #. module: l10n_es_aeat_mod340
 #: model:ir.model,name:l10n_es_aeat_mod340.model_account_account
@@ -84,7 +78,7 @@ msgstr "Cuenta"
 #: field:l10n.es.aeat.mod340.tax_line_received,tax_code_id:0
 #: field:l10n.es.aeat.mod340.tax_summary,tax_code_id:0
 msgid "Account Tax Code"
-msgstr "Código de impuesto"
+msgstr "Account Tax Code"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,move_id:0
@@ -94,12 +88,22 @@ msgstr "Entrada cuenta"
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,allow_posting:0
 msgid "Allow posting"
-msgstr "Permitir publicación"
+msgstr "Allow posting"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0 report:vat book:0
 msgid "Apellidos y nombre de contacto:"
 msgstr "Apellidos y nombre de contacto:"
+
+#. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+msgid "BOOK REGISTER OF INVOICES ISSUED"
+msgstr "LIBRO REGISTRO DE FACTURAS EMITIDAS"
+
+#. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "BOOK REGISTER OF INVOICES RECEIVED"
+msgstr "LIBRO REGISTRO FACTURAS RECIBIDAS"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,partner_bank_id:0
@@ -107,12 +111,14 @@ msgid "Bank account"
 msgstr "Cuenta bancaria"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
 msgid "Base"
 msgstr "Base"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Base imponible"
 msgstr "Base imponible"
 
@@ -127,7 +133,7 @@ msgid "Base tax bill"
 msgstr "Base"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "CIF/NIF"
 msgstr "CIF/NIF"
 
@@ -163,8 +169,16 @@ msgid "Clave tipo de NIF"
 msgstr "Clave tipo de NIF"
 
 #. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Code"
+msgstr "Código"
+
+#. module: l10n_es_aeat_mod340
 #: view:l10n.es.aeat.mod340.report:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_report_search
 #: field:l10n.es.aeat.mod340.report,company_id:0
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
 msgid "Company"
 msgstr "Compañía"
 
@@ -179,10 +193,16 @@ msgstr "NIF de la compañía"
 #. module: l10n_es_aeat_mod340
 #: help:l10n.es.aeat.mod340.report,partner_bank_id:0
 msgid "Company bank account used for the presentation"
-msgstr "Cuenta bancaria de la empresa utilizada para la presentación"
+msgstr "Company bank account used for the presentation"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Company:"
+msgstr "Compañía:"
+
+#. module: l10n_es_aeat_mod340
+#: report:report mod340:0 report:vat book:0
 msgid "Compañía:"
 msgstr "Compañía:"
 
@@ -195,6 +215,12 @@ msgstr "Complementaria"
 #: view:l10n.es.aeat.mod340.report:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_report_search
 msgid "Confirmed models"
 msgstr "Modelos confirmados"
+
+#. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Contact phone:"
+msgstr "Teléfono de contacto:"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,counterpart_account:0
@@ -243,22 +269,28 @@ msgid "Created on"
 msgstr "Creado el"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "Cuota"
 msgstr "Cuota"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Cuota impuesto"
 msgstr "Cuota impuesto"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Cuote"
+msgstr "Cuota"
+
+#. module: l10n_es_aeat_mod340
+#: report:vat book:0
 msgid "Código"
 msgstr "Código"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Código electrónico autoliquidación IVA:"
 msgstr "Código electrónico autoliquidación IVA:"
 
@@ -279,7 +311,7 @@ msgstr "Date"
 #: field:l10n.es.aeat.mod340.issued,date_invoice:0
 #: field:l10n.es.aeat.mod340.received,date_invoice:0
 msgid "Date Invoice"
-msgstr "Fecha de factura"
+msgstr "Fecha Factura"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.intracomunitarias,date_payment:0
@@ -310,8 +342,15 @@ msgstr "Número de declaración"
 #: field:l10n.es.aeat.mod340.tax_line_issued,display_name:0
 #: field:l10n.es.aeat.mod340.tax_line_received,display_name:0
 #: field:l10n.es.aeat.mod340.tax_summary,display_name:0
+#: field:report.l10n_es_aeat_mod340.tmp_report_vat_book_invoices_issued,display_name:0
+#: field:report.l10n_es_aeat_mod340.tmp_report_vat_book_invoices_received,display_name:0
 msgid "Display Name"
-msgstr "Nombre mostrado"
+msgstr "Display Name"
+
+#. module: l10n_es_aeat_mod340
+#: field:account.account,not_level_expand:0
+msgid "Don't show this account on financial reports level detail"
+msgstr "Don't show this account on financial reports level detail"
 
 #. module: l10n_es_aeat_mod340
 #: view:l10n.es.aeat.mod340.report:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_report_search
@@ -331,7 +370,7 @@ msgid "Draft models"
 msgstr "Modelos en borrador"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0 report:vat book:0
 msgid "Ejercicio fiscal:"
 msgstr "Ejercicio fiscal:"
 
@@ -342,7 +381,7 @@ msgid "Electronic Code VAT reverse charge"
 msgstr "Código electrónico del modelo 340"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0 report:vat book:0
 msgid "Empresa"
 msgstr "Empresa"
 
@@ -371,25 +410,25 @@ msgstr "Exportar a formato BOE"
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,export_config:0
 msgid "Export config"
-msgstr "Plantilla de exportación"
+msgstr "Export config"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "FACTURAS DE ENTRADA"
 msgstr "FACTURAS DE ENTRADA"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "FACTURAS DE SALIDA"
 msgstr "FACTURAS DE SALIDA"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0 report:vat book:0
 msgid "Fecha"
 msgstr "Fecha"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "Fecha factura"
 msgstr "Fecha factura"
 
@@ -404,6 +443,11 @@ msgid "File name"
 msgstr "Nombre de archivo"
 
 #. module: l10n_es_aeat_mod340
+#: field:wizard.update.charts.accounts,financial_report_ids:0
+msgid "Financial reports"
+msgstr "Financial reports"
+
+#. module: l10n_es_aeat_mod340
 #: field:account.invoice,first_ticket:0
 msgid "First ticket"
 msgstr "Primer tique"
@@ -414,6 +458,12 @@ msgid "Fiscal Year"
 msgstr "Año fiscal"
 
 #. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Fiscal Year:"
+msgstr "Ejercicio fiscal"
+
+#. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,fiscalyear_id:0
 msgid "Fiscal year"
 msgstr "Año fiscal"
@@ -421,7 +471,7 @@ msgstr "Año fiscal"
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,contact_name:0
 msgid "Full Name"
-msgstr "Nombre completo"
+msgstr "Full Name"
 
 #. module: l10n_es_aeat_mod340
 #: view:l10n.es.aeat.mod340.report:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_form
@@ -445,6 +495,8 @@ msgstr "Agrupar por"
 #: field:l10n.es.aeat.mod340.tax_line_issued,id:0
 #: field:l10n.es.aeat.mod340.tax_line_received,id:0
 #: field:l10n.es.aeat.mod340.tax_summary,id:0
+#: field:report.l10n_es_aeat_mod340.tmp_report_vat_book_invoices_issued,id:0
+#: field:report.l10n_es_aeat_mod340.tmp_report_vat_book_invoices_received,id:0
 msgid "ID"
 msgstr "ID"
 
@@ -453,6 +505,11 @@ msgstr "ID"
 #: view:l10n.es.aeat.mod340.received:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_received_form
 msgid "Identification"
 msgstr "Identificación"
+
+#. module: l10n_es_aeat_mod340
+#: help:account.account,not_level_expand:0
+msgid "If you mark this field, when expanding account balances by levels on financial reports, this account won't be shown. This only serves when displaying the account itself, but not when showing parent accounts, which will include this account balance as part of the result."
+msgstr "If you mark this field, when expanding account balances by levels on financial reports, this account won't be shown. This only serves when displaying the account itself, but not when showing parent accounts, which will include this account balance as part of the result."
 
 #. module: l10n_es_aeat_mod340
 #: view:l10n.es.aeat.mod340.report:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_report_search
@@ -492,15 +549,25 @@ msgstr "Factura"
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py:296
 #, python-format
-msgid ""
-"Invoice %s, Amount untaxed Lines %.2f do not correspond to AmountUntaxed on "
-"Invoice %.2f"
+msgid "Invoice %s, Amount untaxed Lines %.2f do not correspond to AmountUntaxed on Invoice %.2f"
 msgstr "Factura %s, la base imposible de las líneas %.2f no se corresponde con la base imponible en la factura %.2f"
+
+#. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Invoice date"
+msgstr "Fecha factura"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.tax_line_issued,invoice_record_id:0
 msgid "Invoice issued"
 msgstr "Facturas emitidas"
+
+#. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Invoice number"
+msgstr "Número factura"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.tax_line_received,invoice_record_id:0
@@ -575,17 +642,17 @@ msgid "L.R. VAT number"
 msgstr "NIF Representante legal"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "LIBRO DE IVA"
 msgstr "LIBRO DE IVA"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "LIBRO REGISTRO DE FACTURAS EMITIDAS"
 msgstr "LIBRO REGISTRO DE FACTURAS EMITIDAS"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "LIBRO REGISTRO FACTURAS RECIBIDAS"
 msgstr "LIBRO REGISTRO FACTURAS RECIBIDAS"
 
@@ -606,8 +673,10 @@ msgstr "La siguiente empresa no tiene un pais relacionado: %s"
 #: field:l10n.es.aeat.mod340.tax_line_issued,__last_update:0
 #: field:l10n.es.aeat.mod340.tax_line_received,__last_update:0
 #: field:l10n.es.aeat.mod340.tax_summary,__last_update:0
+#: field:report.l10n_es_aeat_mod340.tmp_report_vat_book_invoices_issued,__last_update:0
+#: field:report.l10n_es_aeat_mod340.tmp_report_vat_book_invoices_received,__last_update:0
 msgid "Last Modified on"
-msgstr "Última modificación en"
+msgstr "Last Modified on"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.calculate_records,write_uid:0
@@ -656,7 +725,7 @@ msgid "Legal Representative VAT number."
 msgstr "NIF del representante legal."
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "MODELO AEAT 340"
 msgstr "MODELO AEAT 340"
 
@@ -707,20 +776,20 @@ msgstr "Modelo 340"
 #. module: l10n_es_aeat_mod340
 #: help:l10n.es.aeat.mod340.report,contact_name:0
 msgid "Must have name and surname."
-msgstr "Debe tener nombre y apellido."
+msgstr "Must have name and surname."
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "NIF"
 msgstr "NIF"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "NIF del representante legal:"
 msgstr "NIF del representante legal:"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0 report:vat book:0
 msgid "NIF:"
 msgstr "NIF:"
 
@@ -741,27 +810,27 @@ msgid "Number of tickets"
 msgstr "Número de tiques"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "Nº de factura"
 msgstr "Nº de factura"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "Nº registro"
 msgstr "Nº registro"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0 report:vat book:0
 msgid "Número de factura"
 msgstr "Número de factura"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Número de la declaración anterior:"
 msgstr "Número de la declaración anterior:"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Número:"
 msgstr "Número:"
 
@@ -803,15 +872,21 @@ msgstr "Pagos"
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,period_type:0
 msgid "Period type"
-msgstr "Tipo de periodo"
+msgstr "Period type"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,periods:0
 msgid "Period(s)"
-msgstr "Periodo(s)"
+msgstr "Periodos"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Periods:"
+msgstr "Periodos:"
+
+#. module: l10n_es_aeat_mod340
+#: report:vat book:0
 msgid "Períodos:"
 msgstr "Períodos:"
 
@@ -842,19 +917,19 @@ msgid "Property Investment"
 msgstr "Inmovilizado"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "RESUMEN FACTURAS EMITIDAS"
 msgstr "RESUMEN FACTURAS EMITIDAS"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "RESUMEN FACTURAS RECIBIDAS"
 msgstr "RESUMEN FACTURAS RECIBIDAS"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "Recargo"
-msgstr ""
+msgstr "Recargo"
 
 #. module: l10n_es_aeat_mod340
 #: selection:l10n.es.aeat.mod340.tax_summary,summary_type:0
@@ -886,7 +961,7 @@ msgstr "Facturas recibidas"
 #: field:l10n.es.aeat.mod340.issued,record_number:0
 #: field:l10n.es.aeat.mod340.received,record_number:0
 msgid "Record number"
-msgstr "Nº registro"
+msgstr "Record number"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,number_records:0
@@ -894,9 +969,15 @@ msgid "Records"
 msgstr "Registros"
 
 #. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Registry"
+msgstr "Registro"
+
+#. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,name:0
 msgid "Report identifier"
-msgstr "Identificador de la declaración"
+msgstr "Report identifier"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.export_to_boe,state:0
@@ -937,6 +1018,16 @@ msgid "Summary base amount"
 msgstr "Resumen de base"
 
 #. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+msgid "Summary invoices issued"
+msgstr "Resumen de facturas emitidas"
+
+#. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Summary invoices received"
+msgstr "Resumen de facturas recibidas"
+
+#. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.tax_summary,sum_tax_amount:0
 msgid "Summary tax amount"
 msgstr "Resumen de impuestos"
@@ -963,14 +1054,21 @@ msgstr "Tipo de soporte"
 
 #. module: l10n_es_aeat_mod340
 #: view:l10n.es.aeat.mod340.tax_line_issued:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_tax_line_issued_form
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
 msgid "Surcharge"
-msgstr ""
+msgstr "Recargo"
 
 #. module: l10n_es_aeat_mod340
 #: field:account.tax.code,surcharge_tax_id:0
 #: field:account.tax.code.template,surcharge_tax_id:0
 msgid "Surcharge tax of"
 msgstr "Codigo de impuesto con recargo"
+
+#. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Surnames and name contact:"
+msgstr "Apellidos y nombre del contacto:"
 
 #. module: l10n_es_aeat_mod340
 #: model:ir.model,name:l10n_es_aeat_mod340.model_account_tax
@@ -1052,14 +1150,14 @@ msgid "Telematics"
 msgstr "Telemática"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0 reportvat book:0
+#: report:report mod340:0 report:vat book:0
 msgid "Teléfono de contacto:"
 msgstr "Teléfono de contacto:"
 
 #. module: l10n_es_aeat_mod340
 #: model:ir.model,name:l10n_es_aeat_mod340.model_account_tax_template
 msgid "Templates for Taxes"
-msgstr ""
+msgstr "Plantilla para los impuestos"
 
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py:30
@@ -1071,7 +1169,7 @@ msgstr "El campo modelo 340 es diferente.\n"
 #: code:addons/l10n_es_aeat_mod340/wizard/wizard_update_charts_accounts.py:45
 #, python-format
 msgid "The field is 340 reverse charge is different.\n"
-msgstr ""
+msgstr "The field is 340 reverse charge is different.\n"
 
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py:107
@@ -1088,29 +1186,25 @@ msgstr "El registro de tipo 1 tiene que tener 500 caracteres de longitud"
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py:337
 #, python-format
-msgid ""
-"The type 2 issued record must be 500 characters long for each Vat registry"
+msgid "The type 2 issued record must be 500 characters long for each Vat registry"
 msgstr "El registro de tipo 2 debe tener una longitud de 500 caracteres por cada registro de IVA"
 
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py:491
 #, python-format
-msgid ""
-"The type 2 received record must be 500 characters long for each Vat registry"
+msgid "The type 2 received record must be 500 characters long for each Vat registry"
 msgstr "El registro de tipo 2 debe tener una longitud de 500 caracteres por cada registro de IVA"
 
 #. module: l10n_es_aeat_mod340
 #: help:l10n.es.aeat.mod340.report,counterpart_account:0
-msgid ""
-"This account will be the counterpart for all the journal items that are "
-"regularized when posting the report."
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
 msgstr "Esta cuenta será la contrapartida para todos los elementos del diario que están regularizados al contabilizar el informe."
 
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py:54
 #, python-format
 msgid "This company doesn't have NIF"
-msgstr "Esta compañía no tiene NIF"
+msgstr "This company doesn't have NIF"
 
 #. module: l10n_es_aeat_mod340
 #: field:account.invoice,is_ticket_summary:0
@@ -1118,17 +1212,17 @@ msgid "Ticket Summary"
 msgstr "Resumen de tiques"
 
 #. module: l10n_es_aeat_mod340
-#: reportvat book:0
+#: report:vat book:0
 msgid "Tipo"
 msgstr "Tipo"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Tipo de declaración"
 msgstr "Tipo de declaración"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Tipo de soporte:"
 msgstr "Tipo de soporte:"
 
@@ -1140,7 +1234,9 @@ msgstr "Tipo de soporte:"
 #: view:l10n.es.aeat.mod340.received:l10n_es_aeat_mod340.view_l10n_es_aeat_mod340_invoice_received_tree
 #: field:l10n.es.aeat.mod340.received,total:0
 #: field:l10n.es.aeat.mod340.report,total:0
-#: field:l10n.es.aeat.mod340.report,total_rec:0 reportvat book:0
+#: field:l10n.es.aeat.mod340.report,total_rec:0 report:vat book:0
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
 msgid "Total"
 msgstr "Total"
 
@@ -1174,7 +1270,7 @@ msgid "Total Taxable"
 msgstr "Total"
 
 #. module: l10n_es_aeat_mod340
-#: reportreport mod340:0
+#: report:report mod340:0
 msgid "Total factura"
 msgstr "Total factura"
 
@@ -1192,9 +1288,37 @@ msgid "Total tax"
 msgstr "Total impuestos"
 
 #. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Type"
+msgstr "Tipo"
+
+#. module: l10n_es_aeat_mod340
+#: field:wizard.update.charts.accounts,update_financial_reports:0
+msgid "Update financial report accounts"
+msgstr "Update financial report accounts"
+
+#. module: l10n_es_aeat_mod340
+#: help:wizard.update.charts.accounts,update_financial_reports:0
+msgid "Update the financial reports mapping the accounts"
+msgstr "Update the financial reports mapping the accounts"
+
+#. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "VAT"
+msgstr "NIF"
+
+#. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.report,company_vat:0
 msgid "VAT number"
 msgstr "NIF"
+
+#. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "VAT:"
+msgstr "NIF:"
 
 #. module: l10n_es_aeat_mod340
 #: model:ir.actions.report.xml,name:l10n_es_aeat_mod340.vat_book
@@ -1202,12 +1326,32 @@ msgid "Vat Book"
 msgstr "Libro de IVA"
 
 #. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_issued_document
+msgid "Vat Book invoices issued"
+msgstr "Libro de IVA facturas emitidas"
+
+#. module: l10n_es_aeat_mod340
+#: view:website:l10n_es_aeat_mod340.report_vat_book_invoices_received_document
+msgid "Vat Book invoices received"
+msgstr "Libro de IVA facturas recibidas"
+
+#. module: l10n_es_aeat_mod340
+#: model:ir.actions.report.xml,name:l10n_es_aeat_mod340.report_vat_book_invoices_issued
+msgid "Vat book invoices issued"
+msgstr "Libro de IVA facturas emitidas"
+
+#. module: l10n_es_aeat_mod340
+#: model:ir.actions.report.xml,name:l10n_es_aeat_mod340.report_vat_book_invoices_received
+msgid "Vat book invoices received"
+msgstr "Libro de IVA facturas recibidas"
+
+#. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.intracomunitarias,vat_type:0
 #: field:l10n.es.aeat.mod340.investment,vat_type:0
 #: field:l10n.es.aeat.mod340.issued,vat_type:0
 #: field:l10n.es.aeat.mod340.received,vat_type:0
 msgid "Vat type"
-msgstr "Tipo de NIF"
+msgstr "Vat type"
 
 #. module: l10n_es_aeat_mod340
 #: code:addons/l10n_es_aeat_mod340/wizard/export_mod340_to_boe.py:104

--- a/l10n_es_aeat_mod340/models/__init__.py
+++ b/l10n_es_aeat_mod340/models/__init__.py
@@ -20,3 +20,4 @@ from . import account_invoice
 from . import account
 from . import res_partner
 from . import mod340
+from . import vat_book_invoices_issued

--- a/l10n_es_aeat_mod340/models/__init__.py
+++ b/l10n_es_aeat_mod340/models/__init__.py
@@ -21,3 +21,4 @@ from . import account
 from . import res_partner
 from . import mod340
 from . import vat_book_invoices_issued
+from . import vat_book_invoices_received

--- a/l10n_es_aeat_mod340/models/vat_book_invoices_issued.py
+++ b/l10n_es_aeat_mod340/models/vat_book_invoices_issued.py
@@ -1,0 +1,18 @@
+#-*- coding:utf-8 -*-
+
+from openerp.osv import osv
+from openerp.report import report_sxw
+
+
+class vat_book_invoices_issued_report(report_sxw.rml_parse):
+
+    def __init__(self, cr, uid, name, context):
+        super(vat_book_invoices_issued_report, self).__init__(
+            cr, uid, name, context)
+
+
+class wrapped_vat_book_invoices_issued(osv.AbstractModel):
+    _name = 'report.l10n_es_aeat_mod340.tmp_report_vat_book_invoices_issued'
+    _inherit = 'report.abstract_report'
+    _template = 'l10n_es_aeat_mod340.tmp_report_vat_book_invoices_issued'
+    _wrapped_report_class = vat_book_invoices_issued_report

--- a/l10n_es_aeat_mod340/models/vat_book_invoices_received.py
+++ b/l10n_es_aeat_mod340/models/vat_book_invoices_received.py
@@ -1,0 +1,18 @@
+#-*- coding:utf-8 -*-
+
+from openerp.osv import osv
+from openerp.report import report_sxw
+
+
+class vat_book_invoices_received_report(report_sxw.rml_parse):
+
+    def __init__(self, cr, uid, name, context):
+        super(vat_book_invoices_received_report, self).__init__(
+            cr, uid, name, context)
+
+
+class wrapped_vat_book_invoices_received(osv.AbstractModel):
+    _name = 'report.l10n_es_aeat_mod340.tmp_report_vat_book_invoices_received'
+    _inherit = 'report.abstract_report'
+    _template = 'l10n_es_aeat_mod340.tmp_report_vat_book_invoices_received'
+    _wrapped_report_class = vat_book_invoices_received_report

--- a/l10n_es_aeat_mod340/report/report_paper_format.xml
+++ b/l10n_es_aeat_mod340/report/report_paper_format.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+      	<record id="paperformat_lowmargin_lowfooter" model="report.paperformat">
+            <field name="name">European A4 low margin and footer</field>
+      	    <field name="default" eval="True" />
+      	    <field name="format">custom</field>
+      	    <field name="page_height">298</field>
+      	    <field name="page_width">210</field>
+      	    <field name="orientation">Portrait</field>
+      	    <field name="margin_top">10</field>
+      	    <field name="margin_bottom">10</field>
+      	    <field name="margin_left">10</field>
+      	    <field name="margin_right">10</field>
+      	    <field name="header_line" eval="False" />
+      	    <field name="header_spacing">0</field>
+      	    <field name="dpi">90</field>
+      	</record>
+
+    </data>
+</openerp>

--- a/l10n_es_aeat_mod340/report/report_view.xml
+++ b/l10n_es_aeat_mod340/report/report_view.xml
@@ -18,6 +18,17 @@
             rml="l10n_es_aeat_mod340/report/vat_book.rml"
             auto="True"
             header="False" />
+
+
+        <report
+            id="report_vat_book_invoices_issued"
+            model="l10n.es.aeat.mod340.report"
+            string="Vat book invoices issued"
+            report_type="qweb-pdf"
+            name="l10n_es_aeat_mod340.tmp_report_vat_book_invoices_issued"
+            file="l10n_es_aeat_mod340.tmp_report_vat_book_invoices_issued"
+            attachment_use="False"
+        />
+
     </data>
 </openerp>
-

--- a/l10n_es_aeat_mod340/report/report_view.xml
+++ b/l10n_es_aeat_mod340/report/report_view.xml
@@ -30,5 +30,15 @@
             attachment_use="False"
         />
 
+        <report
+            id="report_vat_book_invoices_received"
+            model="l10n.es.aeat.mod340.report"
+            string="Vat book invoices received"
+            report_type="qweb-pdf"
+            name="l10n_es_aeat_mod340.tmp_report_vat_book_invoices_received"
+            file="l10n_es_aeat_mod340.tmp_report_vat_book_invoices_received"
+            attachment_use="False"
+        />
+
     </data>
 </openerp>

--- a/l10n_es_aeat_mod340/report/vat_book_invoices_issued.xml
+++ b/l10n_es_aeat_mod340/report/vat_book_invoices_issued.xml
@@ -86,7 +86,7 @@
               </div>
 
               <div class="col-xs-12 text-center" id="vat_book_kind">
-                <h4>BOOK REGISTER OF BILLS ISSUED</h4>
+                <h4>BOOK REGISTER OF INVOICES ISSUED</h4>
               </div>
 
               <div class="col-xs-12" id="detail_div">

--- a/l10n_es_aeat_mod340/report/vat_book_invoices_issued.xml
+++ b/l10n_es_aeat_mod340/report/vat_book_invoices_issued.xml
@@ -89,79 +89,127 @@
                 <h4>BOOK REGISTER OF BILLS ISSUED</h4>
               </div>
 
-              <table class="table table-condensed" id="detail_table">
-                  <thead>
-                      <tr>
-                          <td id="detail_invoice_date">Invoice date</td>
-                          <td id="detail_registry">Registry</td>
-                          <td id="detail_invoice_number">Invoice number</td>
-                          <td id="detail_company">Company</td>
-                          <td id="detail_vat">VAT</td>
-                          <td id="detail_base">Base</td>
-                          <td id="detail_type">Type</td>
-                          <td id="detail_cuote">Cuote</td>
-                          <td id="detail_surcharge">Surcharge</td>
-                      </tr>
-                  </thead>
-                  <tbody>
-                      <tr t-foreach="o.issued" t-as="l">
-                          <td id="data_invoice_date">
-                           <span t-field="l.invoice_id.date_invoice"/>
-                          </td>
-                          <td id="data_registry">
-                            <span t-field="l.record_number"/>
-                          </td>
-                          <td id="data_invoice_number">
-                            <span t-field="l.invoice_id.number"/>
-                          </td>
-                          <td id="data_company">
-                            <span t-field="l.partner_id.name"/>
-                          </td>
-                          <td id="data_vat">
-                              <span t-field="l.partner_vat"/>
-                          </td>
-                          <t t-set="number_taxes" t-value="0" />
-                          <t t-foreach="l.tax_line_ids" t-as="tax">
+              <div class="col-xs-12" id="detail_div">
+                <table class="table table-condensed" id="detail_table">
+                    <thead>
+                        <tr>
+                            <td id="detail_invoice_date">Invoice date</td>
+                            <td id="detail_registry">Registry</td>
+                            <td id="detail_invoice_number">Invoice number</td>
+                            <td id="detail_company">Company</td>
+                            <td id="detail_vat">VAT</td>
+                            <td id="detail_base">Base</td>
+                            <td id="detail_type">Type</td>
+                            <td id="detail_cuote">Cuote</td>
+                            <td id="detail_surcharge">Surcharge</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr t-foreach="o.issued" t-as="l">
+                            <td id="data_invoice_date">
+                             <span t-field="l.invoice_id.date_invoice"/>
+                            </td>
+                            <td id="data_registry">
+                              <span t-field="l.record_number"/>
+                            </td>
+                            <td id="data_invoice_number">
+                              <span t-field="l.invoice_id.number"/>
+                            </td>
+                            <td id="data_company">
+                              <span t-field="l.partner_id.name"/>
+                            </td>
+                            <td id="data_vat">
+                                <span t-field="l.partner_vat"/>
+                            </td>
+                            <t t-set="number_taxes" t-value="0" />
+                            <t t-foreach="l.tax_line_ids" t-as="tax">
 
-                            <t t-if="number_taxes != 0">
-                              <tr>
-                                <td colspan="5">
-                                </td>
-                                <td id="data_base_tax_hight">
-                                  <span t-esc="formatLang(tax.base_amount)"/>
-                                </td>
-                                <td id="data_type_tax_hight">
-                                    <span t-esc="tax.tax_percentage * 100"/>
-                                </td>
-                                <td id="data_cuote_tax_hight">
-                                    <span t-esc="formatLang(tax.tax_amount)"/>
-                                </td>
-                                <td id="data_surcharg_tax_hight">
-                                    <span t-esc="formatLang(tax.rec_tax_amount)"/>
-                                </td>
-                              </tr>
-                            </t>
-
-                            <t t-if="number_taxes == 0">
-                                <td id="data_base_first_tax">
+                              <t t-if="number_taxes != 0">
+                                <tr>
+                                  <td colspan="5">
+                                  </td>
+                                  <td id="data_base_tax_hight">
                                     <span t-esc="formatLang(tax.base_amount)"/>
-                                </td>
-                                <td id="data_type_first_tax">
-                                    <span t-esc="tax.tax_percentage * 100"/>
-                                </td>
-                                <td id="data_cuote_first_tax">
-                                    <span t-esc="formatLang(tax.tax_amount)"/>
-                                </td>
-                                <td id="data_surcharg_first_tax">
-                                  <span t-esc="formatLang(tax.rec_tax_amount)"/>
-                                </td>
-                            </t>
+                                  </td>
+                                  <td id="data_type_tax_hight">
+                                      <span t-esc="tax.tax_percentage * 100"/>
+                                  </td>
+                                  <td id="data_cuote_tax_hight">
+                                      <span t-esc="formatLang(tax.tax_amount)"/>
+                                  </td>
+                                  <td id="data_surcharg_tax_hight">
+                                      <span t-esc="formatLang(tax.rec_tax_amount)"/>
+                                  </td>
+                                </tr>
+                              </t>
 
-                            <t t-set="number_taxes" t-value="number_taxes + 1" />
-                          </t>
-                      </tr>
-                  </tbody>
-              </table>
+                              <t t-if="number_taxes == 0">
+                                  <td id="data_base_first_tax">
+                                      <span t-esc="formatLang(tax.base_amount)"/>
+                                  </td>
+                                  <td id="data_type_first_tax">
+                                      <span t-esc="tax.tax_percentage * 100"/>
+                                  </td>
+                                  <td id="data_cuote_first_tax">
+                                      <span t-esc="formatLang(tax.tax_amount)"/>
+                                  </td>
+                                  <td id="data_surcharg_first_tax">
+                                    <span t-esc="formatLang(tax.rec_tax_amount)"/>
+                                  </td>
+                              </t>
+
+                              <t t-set="number_taxes" t-value="number_taxes + 1" />
+                            </t>
+                        </tr>
+                    </tbody>
+                </table> <!-- end detail_table -->
+              </div> <!-- end detail div -->
+
+              <div class="col-xs-12" id="title_sumary_invoices">
+                <h4>Summary invoices issued</h4>
+              </div>
+              <div class="col-xs-12" id="div_sumary_invoices">
+                <table class="table table-condensed" id="table_sumary_invoices">
+                    <thead>
+                        <tr>
+                            <td class="text-center" id="sumary_code">Code</td>
+                            <td class="text-center" id="sumary_base">Base</td>
+                            <td class="text-center" id="sumary_cuote">Cuote</td>
+                            <td class="text-center" id="sumary_type">Type</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr t-foreach="o.summary_issued" t-as="s">
+                            <td class="text-center" id="data_sumary_code">
+                             <span t-field="s.tax_code_id.name"/>
+                            </td>
+                            <td class="text-center" id="data_sumary_base">
+                                <span t-esc="formatLang(s.sum_base_amount) or '0'"/>
+                            </td>
+                            <td class="text-center" id="data_sumary_cuote">
+                                <span t-esc="formatLang(s.sum_tax_amount) or '0'"/>
+                            </td>
+                            <td class="text-center" id="data_sumary_type">
+                                <span t-esc="formatLang(s.tax_percent * 100) or '0'"/>
+                            </td>
+                        </tr>
+                        <tr id="total_sumary">
+                            <td class="text-right" id="total_sumary_code">
+                             <strong>Total</strong>
+                            </td>
+                            <td class="text-center" id="total_sumary_base">
+                                <span t-esc="formatLang(o.total_taxable)"/>
+                            </td>
+                            <td class="text-center" id="total_sumary_cuote">
+                                <span t-esc="formatLang(o.total_sharetax)"/>
+                            </td>
+                            <td class="text-center" id="total_sumary_type">
+                                <span t-esc="formatLang(o.total)"/>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+              </div>
 
         </div>
       </div> <!-- Close div page -->

--- a/l10n_es_aeat_mod340/report/vat_book_invoices_issued.xml
+++ b/l10n_es_aeat_mod340/report/vat_book_invoices_issued.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+<template id="report_vat_book_invoices_issued_document">
+    <t t-call="report.html_container">
+
+        <div class="page">
+            <style type="text/css">
+               .detail_table {
+                   width:100%;
+                   margin-top: 2%;
+               }
+               .td_detail_table{
+                  width: 50%;
+                  padding-right: 5%;
+               }
+           </style>
+            <div class="row">
+
+              <div class="col-xs-12 text-center" id="title">
+                  <h3>Vat Book invoices issued</h3>
+              </div>
+
+              <div class="col-xs-12 text-center" id="fiscal_periods_div">
+                  <table class="detail_table" id="fiscal_periods_table">
+                      <tbody class="invoice_tbody">
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               Company:
+                              </td>
+                              <td class="td_detail_table">
+                                  <span t-field="o.company_id"/>
+                              </td>
+                          </tr>
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               Fiscal Year:
+                              </td>
+                              <td class="td_detail_table">
+                                  <span t-field="o.fiscalyear_id"/>
+                              </td>
+                          </tr>
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               Periods:
+                              </td>
+                              <td class="td_detail_table">
+                                <t t-foreach="o.periods" t-as="period">
+                                  <span t-field="period.name"/>
+                                </t>
+                              </td>
+                          </tr>
+                      </tbody>
+                  </table>
+              </div>
+
+              <div class="col-xs-12 text-center" id="vat_book_contact_div">
+                  <table class="detail_table" id="vat_book_contact_table">
+                      <tbody class="invoice_tbody">
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               VAT:
+                              </td>
+                              <td class="td_detail_table">
+                                  <span t-field="o.company_vat"/>
+                              </td>
+                          </tr>
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               Contact phone:
+                              </td>
+                              <td class="td_detail_table">
+                                  <span t-field="o.contact_phone"/>
+                              </td>
+                          </tr>
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               Surnames and name contact:
+                              </td>
+                              <td class="td_detail_table">
+                                <span t-field="o.contact_name"/>
+                              </td>
+                          </tr>
+                      </tbody>
+                  </table>
+              </div>
+
+              <div class="col-xs-12 text-center" id="vat_book_kind">
+                <h4>BOOK REGISTER OF BILLS ISSUED</h4>
+              </div>
+
+              <table class="table table-condensed" id="detail_table">
+                  <thead>
+                      <tr>
+                          <td id="detail_invoice_date">Invoice date</td>
+                          <td id="detail_registry">Registry</td>
+                          <td id="detail_invoice_number">Invoice number</td>
+                          <td id="detail_company">Company</td>
+                          <td id="detail_vat">VAT</td>
+                          <td id="detail_base">Base</td>
+                          <td id="detail_type">Type</td>
+                          <td id="detail_cuote">Cuote</td>
+                          <td id="detail_total">Total</td>
+                          <td id="detail_surcharge">Surcharge</td>
+                      </tr>
+                  </thead>
+                  <tbody>
+                      <tr t-foreach="o.issued" t-as="l">
+                          <td id="data_invoice_date">
+                           <span t-field="l.invoice_id.date_invoice"/>
+                          </td>
+                          <td id="data_registry">
+                            <span t-field="l.record_number"/>
+                          </td>
+                          <td id="data_invoice_number">
+                            <span t-field="l.invoice_id.number"/>
+                          </td>
+                          <td id="data_company">
+                            <span t-field="l.partner_id.name"/>
+                          </td>
+                          <td id="data_vat">
+                              <span t-field="l.partner_vat"/>
+                          </td>
+                          <t t-foreach="l.tax_line_ids" t-as="tax">
+                            <tr>
+                              <td id="data_base">
+                                  <span t-field="tax.base_amount"/>
+                              </td>
+                              <td id="data_type">
+                                  <span t-field="tax.tax_percentage"/>
+                              </td>
+                              <td id="data_cuote">
+                                  <span t-field="tax.tax_amount"/>
+                              </td>
+                              <td id="data_total">
+                                  <!-- <span t-field="tax.total"/> -->
+                              </td>
+                              <td id="data_surcharg">
+                                  <span t-field="tax.rec_tax_amount"/>
+                              </td>
+                            </tr>
+                          </t>
+                      </tr>
+                  </tbody>
+              </table>
+
+        </div>
+      </div> <!-- Close div page -->
+
+    </t>
+</template>
+
+<template id="tmp_report_vat_book_invoices_issued">
+    <t t-call="report.html_container">
+        <t t-foreach="doc_ids" t-as="doc_id">
+            <t t-raw="translate_doc(doc_id, doc_model, 'company_id.partner_id.lang', 'l10n_es_aeat_mod340.report_vat_book_invoices_issued_document')"/>
+        </t>
+    </t>
+</template>
+
+<record id="l10n_es_aeat_mod340.report_vat_book_invoices_issued" model="ir.actions.report.xml">
+    <field name="paperformat_id" ref="l10n_es_aeat_mod340.paperformat_lowmargin_lowfooter"></field>
+</record>
+
+</data>
+</openerp>

--- a/l10n_es_aeat_mod340/report/vat_book_invoices_issued.xml
+++ b/l10n_es_aeat_mod340/report/vat_book_invoices_issued.xml
@@ -100,7 +100,6 @@
                           <td id="detail_base">Base</td>
                           <td id="detail_type">Type</td>
                           <td id="detail_cuote">Cuote</td>
-                          <td id="detail_total">Total</td>
                           <td id="detail_surcharge">Surcharge</td>
                       </tr>
                   </thead>
@@ -121,24 +120,44 @@
                           <td id="data_vat">
                               <span t-field="l.partner_vat"/>
                           </td>
+                          <t t-set="number_taxes" t-value="0" />
                           <t t-foreach="l.tax_line_ids" t-as="tax">
-                            <tr>
-                              <td id="data_base">
-                                  <span t-field="tax.base_amount"/>
-                              </td>
-                              <td id="data_type">
-                                  <span t-field="tax.tax_percentage"/>
-                              </td>
-                              <td id="data_cuote">
-                                  <span t-field="tax.tax_amount"/>
-                              </td>
-                              <td id="data_total">
-                                  <!-- <span t-field="tax.total"/> -->
-                              </td>
-                              <td id="data_surcharg">
-                                  <span t-field="tax.rec_tax_amount"/>
-                              </td>
-                            </tr>
+
+                            <t t-if="number_taxes != 0">
+                              <tr>
+                                <td colspan="5">
+                                </td>
+                                <td id="data_base_tax_hight">
+                                  <span t-esc="formatLang(tax.base_amount)"/>
+                                </td>
+                                <td id="data_type_tax_hight">
+                                    <span t-esc="tax.tax_percentage * 100"/>
+                                </td>
+                                <td id="data_cuote_tax_hight">
+                                    <span t-esc="formatLang(tax.tax_amount)"/>
+                                </td>
+                                <td id="data_surcharg_tax_hight">
+                                    <span t-esc="formatLang(tax.rec_tax_amount)"/>
+                                </td>
+                              </tr>
+                            </t>
+
+                            <t t-if="number_taxes == 0">
+                                <td id="data_base_first_tax">
+                                    <span t-esc="formatLang(tax.base_amount)"/>
+                                </td>
+                                <td id="data_type_first_tax">
+                                    <span t-esc="tax.tax_percentage * 100"/>
+                                </td>
+                                <td id="data_cuote_first_tax">
+                                    <span t-esc="formatLang(tax.tax_amount)"/>
+                                </td>
+                                <td id="data_surcharg_first_tax">
+                                  <span t-esc="formatLang(tax.rec_tax_amount)"/>
+                                </td>
+                            </t>
+
+                            <t t-set="number_taxes" t-value="number_taxes + 1" />
                           </t>
                       </tr>
                   </tbody>

--- a/l10n_es_aeat_mod340/report/vat_book_invoices_received.xml
+++ b/l10n_es_aeat_mod340/report/vat_book_invoices_received.xml
@@ -86,7 +86,7 @@
               </div>
 
               <div class="col-xs-12 text-center" id="vat_book_kind">
-                <h4>BOOK REGISTER OF BILLS ISSUED</h4>
+                <h4>BOOK REGISTER OF INVOICES RECEIVED</h4>
               </div>
 
               <div class="col-xs-12" id="detail_div">
@@ -101,19 +101,18 @@
                             <td id="detail_base">Base</td>
                             <td id="detail_type">Type</td>
                             <td id="detail_cuote">Cuote</td>
-                            <td id="detail_surcharge">Surcharge</td>
                         </tr>
                     </thead>
                     <tbody>
-                        <tr t-foreach="o.issued" t-as="l">
+                        <tr t-foreach="o.received" t-as="l">
                             <td id="data_invoice_date">
-                             <span t-field="l.invoice_id.date_invoice"/>
+                             <span t-esc="formatLang(l.invoice_id.date_invoice,date=True)"/>
                             </td>
                             <td id="data_registry">
                               <span t-field="l.record_number"/>
                             </td>
                             <td id="data_invoice_number">
-                              <span t-field="l.invoice_id.number"/>
+                              <span t-esc="l.invoice_id.reference or l.invoice_id.number or ''"/>
                             </td>
                             <td id="data_company">
                               <span t-field="l.partner_id.name"/>
@@ -137,9 +136,6 @@
                                   <td id="data_cuote_tax_hight">
                                       <span t-esc="formatLang(tax.tax_amount)"/>
                                   </td>
-                                  <td id="data_surcharg_tax_hight">
-                                      <span t-esc="formatLang(tax.rec_tax_amount)"/>
-                                  </td>
                                 </tr>
                               </t>
 
@@ -153,9 +149,6 @@
                                   <td id="data_cuote_first_tax">
                                       <span t-esc="formatLang(tax.tax_amount)"/>
                                   </td>
-                                  <td id="data_surcharg_first_tax">
-                                    <span t-esc="formatLang(tax.rec_tax_amount)"/>
-                                  </td>
                               </t>
 
                               <t t-set="number_taxes" t-value="number_taxes + 1" />
@@ -166,7 +159,7 @@
               </div> <!-- end detail div -->
 
               <div class="col-xs-12" id="title_sumary_invoices">
-                <h4>Summary invoices issued</h4>
+                <h4>Summary invoices received</h4>
               </div>
               <div class="col-xs-12" id="div_sumary_invoices">
                 <table class="table table-condensed" id="table_sumary_invoices">
@@ -179,7 +172,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr t-foreach="o.summary_issued" t-as="s">
+                        <tr t-foreach="o.summary_received" t-as="s">
                             <td class="text-center" id="data_sumary_code">
                              <span t-field="s.tax_code_id.name"/>
                             </td>
@@ -198,13 +191,13 @@
                              <strong>Total</strong>
                             </td>
                             <td class="text-center" id="total_sumary_base">
-                                <span t-esc="formatLang(o.total_taxable)"/>
+                                <span t-esc="formatLang(o.total_taxable_rec)"/>
                             </td>
                             <td class="text-center" id="total_sumary_cuote">
-                                <span t-esc="formatLang(o.total_sharetax)"/>
+                                <span t-esc="formatLang(o.total_sharetax_rec)"/>
                             </td>
                             <td class="text-center" id="total_sumary_type">
-                                <span t-esc="formatLang(o.total)"/>
+                                <span t-esc="formatLang(o.total_rec)"/>
                             </td>
                         </tr>
                     </tbody>

--- a/l10n_es_aeat_mod340/report/vat_book_invoices_received.xml
+++ b/l10n_es_aeat_mod340/report/vat_book_invoices_received.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+<template id="report_vat_book_invoices_received_document">
+    <t t-call="report.html_container">
+
+        <div class="page">
+            <style type="text/css">
+               .detail_table {
+                   width:100%;
+                   margin-top: 2%;
+               }
+               .td_detail_table{
+                  width: 50%;
+                  padding-right: 5%;
+               }
+           </style>
+            <div class="row">
+
+              <div class="col-xs-12 text-center" id="title">
+                  <h3>Vat Book invoices received</h3>
+              </div>
+
+              <div class="col-xs-12 text-center" id="fiscal_periods_div">
+                  <table class="detail_table" id="fiscal_periods_table">
+                      <tbody class="invoice_tbody">
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               Company:
+                              </td>
+                              <td class="td_detail_table">
+                                  <span t-field="o.company_id"/>
+                              </td>
+                          </tr>
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               Fiscal Year:
+                              </td>
+                              <td class="td_detail_table">
+                                  <span t-field="o.fiscalyear_id"/>
+                              </td>
+                          </tr>
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               Periods:
+                              </td>
+                              <td class="td_detail_table">
+                                <t t-foreach="o.periods" t-as="period">
+                                  <span t-field="period.name"/>
+                                </t>
+                              </td>
+                          </tr>
+                      </tbody>
+                  </table>
+              </div>
+
+              <div class="col-xs-12 text-center" id="vat_book_contact_div">
+                  <table class="detail_table" id="vat_book_contact_table">
+                      <tbody class="invoice_tbody">
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               VAT:
+                              </td>
+                              <td class="td_detail_table">
+                                  <span t-field="o.company_vat"/>
+                              </td>
+                          </tr>
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               Contact phone:
+                              </td>
+                              <td class="td_detail_table">
+                                  <span t-field="o.contact_phone"/>
+                              </td>
+                          </tr>
+                          <tr>
+                              <td class="text-right td_detail_table">
+                               Surnames and name contact:
+                              </td>
+                              <td class="td_detail_table">
+                                <span t-field="o.contact_name"/>
+                              </td>
+                          </tr>
+                      </tbody>
+                  </table>
+              </div>
+
+              <div class="col-xs-12 text-center" id="vat_book_kind">
+                <h4>BOOK REGISTER OF BILLS ISSUED</h4>
+              </div>
+
+              <div class="col-xs-12" id="detail_div">
+                <table class="table table-condensed" id="detail_table">
+                    <thead>
+                        <tr>
+                            <td id="detail_invoice_date">Invoice date</td>
+                            <td id="detail_registry">Registry</td>
+                            <td id="detail_invoice_number">Invoice number</td>
+                            <td id="detail_company">Company</td>
+                            <td id="detail_vat">VAT</td>
+                            <td id="detail_base">Base</td>
+                            <td id="detail_type">Type</td>
+                            <td id="detail_cuote">Cuote</td>
+                            <td id="detail_surcharge">Surcharge</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr t-foreach="o.issued" t-as="l">
+                            <td id="data_invoice_date">
+                             <span t-field="l.invoice_id.date_invoice"/>
+                            </td>
+                            <td id="data_registry">
+                              <span t-field="l.record_number"/>
+                            </td>
+                            <td id="data_invoice_number">
+                              <span t-field="l.invoice_id.number"/>
+                            </td>
+                            <td id="data_company">
+                              <span t-field="l.partner_id.name"/>
+                            </td>
+                            <td id="data_vat">
+                                <span t-field="l.partner_vat"/>
+                            </td>
+                            <t t-set="number_taxes" t-value="0" />
+                            <t t-foreach="l.tax_line_ids" t-as="tax">
+
+                              <t t-if="number_taxes != 0">
+                                <tr>
+                                  <td colspan="5">
+                                  </td>
+                                  <td id="data_base_tax_hight">
+                                    <span t-esc="formatLang(tax.base_amount)"/>
+                                  </td>
+                                  <td id="data_type_tax_hight">
+                                      <span t-esc="tax.tax_percentage * 100"/>
+                                  </td>
+                                  <td id="data_cuote_tax_hight">
+                                      <span t-esc="formatLang(tax.tax_amount)"/>
+                                  </td>
+                                  <td id="data_surcharg_tax_hight">
+                                      <span t-esc="formatLang(tax.rec_tax_amount)"/>
+                                  </td>
+                                </tr>
+                              </t>
+
+                              <t t-if="number_taxes == 0">
+                                  <td id="data_base_first_tax">
+                                      <span t-esc="formatLang(tax.base_amount)"/>
+                                  </td>
+                                  <td id="data_type_first_tax">
+                                      <span t-esc="tax.tax_percentage * 100"/>
+                                  </td>
+                                  <td id="data_cuote_first_tax">
+                                      <span t-esc="formatLang(tax.tax_amount)"/>
+                                  </td>
+                                  <td id="data_surcharg_first_tax">
+                                    <span t-esc="formatLang(tax.rec_tax_amount)"/>
+                                  </td>
+                              </t>
+
+                              <t t-set="number_taxes" t-value="number_taxes + 1" />
+                            </t>
+                        </tr>
+                    </tbody>
+                </table> <!-- end detail_table -->
+              </div> <!-- end detail div -->
+
+              <div class="col-xs-12" id="title_sumary_invoices">
+                <h4>Summary invoices issued</h4>
+              </div>
+              <div class="col-xs-12" id="div_sumary_invoices">
+                <table class="table table-condensed" id="table_sumary_invoices">
+                    <thead>
+                        <tr>
+                            <td class="text-center" id="sumary_code">Code</td>
+                            <td class="text-center" id="sumary_base">Base</td>
+                            <td class="text-center" id="sumary_cuote">Cuote</td>
+                            <td class="text-center" id="sumary_type">Type</td>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr t-foreach="o.summary_issued" t-as="s">
+                            <td class="text-center" id="data_sumary_code">
+                             <span t-field="s.tax_code_id.name"/>
+                            </td>
+                            <td class="text-center" id="data_sumary_base">
+                                <span t-esc="formatLang(s.sum_base_amount) or '0'"/>
+                            </td>
+                            <td class="text-center" id="data_sumary_cuote">
+                                <span t-esc="formatLang(s.sum_tax_amount) or '0'"/>
+                            </td>
+                            <td class="text-center" id="data_sumary_type">
+                                <span t-esc="formatLang(s.tax_percent * 100) or '0'"/>
+                            </td>
+                        </tr>
+                        <tr id="total_sumary">
+                            <td class="text-right" id="total_sumary_code">
+                             <strong>Total</strong>
+                            </td>
+                            <td class="text-center" id="total_sumary_base">
+                                <span t-esc="formatLang(o.total_taxable)"/>
+                            </td>
+                            <td class="text-center" id="total_sumary_cuote">
+                                <span t-esc="formatLang(o.total_sharetax)"/>
+                            </td>
+                            <td class="text-center" id="total_sumary_type">
+                                <span t-esc="formatLang(o.total)"/>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+              </div>
+
+        </div>
+      </div> <!-- Close div page -->
+
+    </t>
+</template>
+
+<template id="tmp_report_vat_book_invoices_received">
+    <t t-call="report.html_container">
+        <t t-foreach="doc_ids" t-as="doc_id">
+            <t t-raw="translate_doc(doc_id, doc_model, 'company_id.partner_id.lang', 'l10n_es_aeat_mod340.report_vat_book_invoices_received_document')"/>
+        </t>
+    </t>
+</template>
+
+<record id="l10n_es_aeat_mod340.report_vat_book_invoices_received" model="ir.actions.report.xml">
+    <field name="paperformat_id" ref="l10n_es_aeat_mod340.paperformat_lowmargin_lowfooter"></field>
+</record>
+
+</data>
+</openerp>


### PR DESCRIPTION
Se ha pasado el libro de IVA a QWEB, separando en facturas emitidas y recibidas tal y como la mayoría de clientes piden. Se ha introducido id a todos los elementos para que sea fácil heredar los reports.
@rubencabrera @jesuspablo @carlosap92 