### PR TITLE
[8.0] Regla multicompany en los modelos 111,115,303

### DIFF
--- a/l10n_es_aeat_mod111/README.rst
+++ b/l10n_es_aeat_mod111/README.rst
@@ -57,6 +57,7 @@ Contribuidores
 * AvanzOSC (http://www.avanzosc.es)
 * Antonio Espinosa <antonioea@antiun.com>
 * RGB Consulting SL (http://www.rgbconsulting.com)
+* Daniel Rodriguez <drl.9319@gmail.com>
 
 Maintainer
 ----------

--- a/l10n_es_aeat_mod111/__openerp__.py
+++ b/l10n_es_aeat_mod111/__openerp__.py
@@ -30,6 +30,7 @@
     'license': 'AGPL-3',
     'depends': ['l10n_es_aeat'],
     'data': [
+        'data/multicompany_rule.xml',
         'data/aeat_export_mod111_data.xml',
         'views/mod111_view.xml',
         'security/ir.model.access.csv',

--- a/l10n_es_aeat_mod111/data/aeat_export_mod111_data.xml
+++ b/l10n_es_aeat_mod111/data/aeat_export_mod111_data.xml
@@ -467,7 +467,7 @@
             <field name="export_type">boolean</field>
             <field name="size">1</field>
             <field name="bool_yes">X</field>
-            <field name="bool_no"> </field>
+            <field name="bool_no"></field>
             <field name="alignment">left</field>
         </record>
 
@@ -489,7 +489,7 @@
             <field name="export_type">boolean</field>
             <field name="size">1</field>
             <field name="bool_yes">X</field>
-            <field name="bool_no"> </field>
+            <field name="bool_no"></field>
             <field name="alignment">left</field>
         </record>
 

--- a/l10n_es_aeat_mod111/data/multicompany_rule.xml
+++ b/l10n_es_aeat_mod111/data/multicompany_rule.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<openerp>
+  <data noupdate="1">
+    <record id="mod111_multicompany_rule_id" model="ir.rule">
+      <field name="name">AEAT Mod 111 multicompany rule</field>
+      <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+      <field name="perm_read">True</field>
+      <field name="perm_create">True</field>
+      <field name="perm_write">True</field>
+      <field name="perm_unlink">True</field>
+      <field name="model_id" ref="model_l10n_es_aeat_mod111_report" />
+    </record>
+  </data>
+</openerp>

--- a/l10n_es_aeat_mod115/README.rst
+++ b/l10n_es_aeat_mod115/README.rst
@@ -44,6 +44,7 @@ Contribuidores
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Ainara Galdona <ainaragaldona@avanzosc.es>
 * Antonio Espinosa <antonioea@antiun.com>
+* Daniel Rodriguez <drl.9319@gmail.com>
 
 Maintainer
 ----------

--- a/l10n_es_aeat_mod115/__openerp__.py
+++ b/l10n_es_aeat_mod115/__openerp__.py
@@ -31,6 +31,7 @@
     'license': 'AGPL-3',
     'depends': ['l10n_es_aeat'],
     'data': [
+        'data/multicompany_rule.xml',
         'data/aeat_export_mod115_2017_data.xml',
         'wizard/export_mod115_to_boe.xml',
         'views/mod115_view.xml',

--- a/l10n_es_aeat_mod115/data/multicompany_rule.xml
+++ b/l10n_es_aeat_mod115/data/multicompany_rule.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<openerp>
+  <data noupdate="1">
+    <record id="mod115_multicompany_rule_id" model="ir.rule">
+      <field name="name">AEAT Mod 115 multicompany rule</field>
+      <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+      <field name="perm_read">True</field>
+      <field name="perm_create">True</field>
+      <field name="perm_write">True</field>
+      <field name="perm_unlink">True</field>
+      <field name="model_id" ref="model_l10n_es_aeat_mod115_report" />
+    </record>
+  </data>
+</openerp>

--- a/l10n_es_aeat_mod303/__openerp__.py
+++ b/l10n_es_aeat_mod303/__openerp__.py
@@ -21,6 +21,7 @@
         "l10n_es_aeat",
     ],
     "data": [
+        "data/multicompany_rule.xml",
         "data/tax_code_map_mod303_data.xml",
         "data/aeat_export_mod303_data.xml",
         "data/aeat_export_mod303_2017_data.xml",

--- a/l10n_es_aeat_mod303/data/multicompany_rule.xml
+++ b/l10n_es_aeat_mod303/data/multicompany_rule.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<openerp>
+    <data noupdate="1">
+        <record id="mod303_multicompany_rule_id" model="ir.rule">
+            <field name="name">AEAT Mod 303 multicompany rule</field>
+            <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+            <field name="perm_read">True</field>
+            <field name="perm_create">True</field>
+            <field name="perm_write">True</field>
+            <field name="perm_unlink">True</field>
+            <field name="model_id" ref="model_l10n_es_aeat_mod303_report"/>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Se han añadido la regla de multicompañia para los modelos de la AEAT 111,115 y 303 y que se mezclaban los informes entre compañías.