### PR TITLE
[ADD] account_invoice_entry_date

### DIFF
--- a/account_invoice_entry_date/README.md
+++ b/account_invoice_entry_date/README.md
@@ -1,0 +1,40 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==========================
+Account Invoice entry Date
+==========================
+
+Este módulo, basado en el homónimo de la localización italiana, añade una fecha
+de contabilización a las facturas.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Paolo Chiara <p.chiara@isa.it>
+* Sergio Corato <info@icstools.it>
+* Ismael Calvo <ismael.calvo@factorlibre.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_invoice_entry_date/__init__.py
+++ b/account_invoice_entry_date/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/account_invoice_entry_date/__openerp__.py
+++ b/account_invoice_entry_date/__openerp__.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 FactorLibre - Ismael Calvo <ismael.calvo@factorlibre.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Account Invoice entry Date",
+    "summary": "Generic Modules/Accounting",
+    "version": "8.0.1.0.0",
+    "category": "",
+    "website": "https://odoo-community.org/",
+    "author": "ISA srl, "
+              "FactorLibre, "
+              "Odoo Italian Community, "
+              "Odoo Community Association (OCA)",
+    "contributors": [
+        "Ismael Calvo <ismael.calvo@factorlibre.com>"
+    ],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "external_dependencies": {},
+    "depends": [
+        'account',
+        'l10n_es_aeat_sii'
+    ],
+    "data": [
+        'views/account_view.xml'
+    ],
+    "demo": [],
+    "qweb": []
+}

--- a/account_invoice_entry_date/i18n/account_invoice_entry_date.pot
+++ b/account_invoice_entry_date/i18n/account_invoice_entry_date.pot
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_entry_date
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-12-02 08:40+0000\n"
+"PO-Revision-Date: 2014-12-02 08:40+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_entry_date
+#: model:ir.model,name:account_invoice_entry_date.model_account_invoice
+msgid "Invoice"
+msgstr ""
+
+#. module: account_invoice_entry_date
+#: help:account.invoice,registration_date:0
+msgid "Keep empty to use the current date"
+msgstr ""
+
+#. module: account_invoice_entry_date
+#: field:account.invoice,registration_date:0
+msgid "Registration Date"
+msgstr ""
+
+#. module: account_invoice_entry_date
+#: code:addons/account_invoice_entry_date/models/account.py:62
+#, python-format
+msgid "The invoice date cannot be later than the date of registration!"
+msgstr ""
+

--- a/account_invoice_entry_date/i18n/es.po
+++ b/account_invoice_entry_date/i18n/es.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * account_invoice_entry_date
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-12-02 08:40+0000\n"
+"PO-Revision-Date: 2014-12-02 08:40+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_entry_date
+#: model:ir.model,name:account_invoice_entry_date.model_account_invoice
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: account_invoice_entry_date
+#: help:account.invoice,registration_date:0
+msgid "Keep empty to use the current date"
+msgstr "Dejar vacío para usar la fecha actual"
+
+#. module: account_invoice_entry_date
+#: field:account.invoice,registration_date:0
+msgid "Registration Date"
+msgstr "Fecha de contabilización"
+
+#. module: account_invoice_entry_date
+#: code:addons/account_invoice_entry_date/models/account.py:62
+#, python-format
+msgid "The invoice date cannot be later than the date of registration!"
+msgstr "La fecha de factura no puede ser posterior que la de contabilización"
+

--- a/account_invoice_entry_date/i18n/it.po
+++ b/account_invoice_entry_date/i18n/it.po
@@ -1,0 +1,48 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_invoice_entry_date
+# 
+# Translators:
+# Hotellook, 2014
+# Paolo Valier, 2016
+# Paolo Valier, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: l10n-italy (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-27 13:17+0000\n"
+"PO-Revision-Date: 2016-08-17 18:49+0000\n"
+"Last-Translator: Paolo Valier\n"
+"Language-Team: Italian (http://www.transifex.com/oca/OCA-l10n-italy-8-0/language/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: account_invoice_entry_date
+#: code:addons/account_invoice_entry_date/models/account.py:92
+#, python-format
+msgid "Can't find a non special period for %s - %s (%s)"
+msgstr "Impossibile trovare un periodo non speciale per %s - %s (%s)"
+
+#. module: account_invoice_entry_date
+#: model:ir.model,name:account_invoice_entry_date.model_account_invoice
+msgid "Invoice"
+msgstr "Fattura"
+
+#. module: account_invoice_entry_date
+#: help:account.invoice,registration_date:0
+msgid "Keep empty to use the current date"
+msgstr "Lasciare vuoto per utilizzare la data corrente"
+
+#. module: account_invoice_entry_date
+#: field:account.invoice,registration_date:0
+msgid "Registration Date"
+msgstr "Data registrazione"
+
+#. module: account_invoice_entry_date
+#: code:addons/account_invoice_entry_date/models/account.py:85
+#, python-format
+msgid "The invoice date cannot be later than the date of registration!"
+msgstr "La data della fattura non può essere successiva alla data della registrazione!"

--- a/account_invoice_entry_date/i18n/sl.po
+++ b/account_invoice_entry_date/i18n/sl.po
@@ -1,0 +1,47 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * account_invoice_entry_date
+# 
+# Translators:
+# Hotellook, 2014
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: l10n-italy (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-27 13:17+0000\n"
+"PO-Revision-Date: 2016-08-17 13:14+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>\n"
+"Language-Team: Slovenian (http://www.transifex.com/oca/OCA-l10n-italy-8-0/language/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: account_invoice_entry_date
+#: code:addons/account_invoice_entry_date/models/account.py:92
+#, python-format
+msgid "Can't find a non special period for %s - %s (%s)"
+msgstr "Ne posebnega obdobja za %s - %s (%s) ne najdem."
+
+#. module: account_invoice_entry_date
+#: model:ir.model,name:account_invoice_entry_date.model_account_invoice
+msgid "Invoice"
+msgstr "Račun"
+
+#. module: account_invoice_entry_date
+#: help:account.invoice,registration_date:0
+msgid "Keep empty to use the current date"
+msgstr "Pusti prazno za uporabo tekočega datuma"
+
+#. module: account_invoice_entry_date
+#: field:account.invoice,registration_date:0
+msgid "Registration Date"
+msgstr "Datum registracije"
+
+#. module: account_invoice_entry_date
+#: code:addons/account_invoice_entry_date/models/account.py:85
+#, python-format
+msgid "The invoice date cannot be later than the date of registration!"
+msgstr "Datum računa ne more biti kasnejši od datuma registracije!"

--- a/account_invoice_entry_date/models/__init__.py
+++ b/account_invoice_entry_date/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account

--- a/account_invoice_entry_date/models/account.py
+++ b/account_invoice_entry_date/models/account.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+# Copyright 2004-2010 ISA srl (<http://www.isa.it>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import time
+from openerp import fields, models
+from openerp.tools.translate import _
+from openerp.exceptions import Warning as UserError
+
+
+class AccountInvoice(models.Model):
+
+    _inherit = 'account.invoice'
+
+    registration_date = fields.Date(
+        'Registration Date',
+        states={
+            'paid': [('readonly', True)],
+            'open': [('readonly', True)],
+            'close': [('readonly', True)]
+        },
+        select=True,
+        help="Keep empty to use the current date",
+        copy=False)
+
+    def _get_period_from_dates(self, cr, uid, invoice):
+        period_model = self.pool['account.period']
+
+        date_start = invoice.registration_date or invoice.date_invoice \
+            or time.strftime('%Y-%m-%d')
+        date_stop = invoice.registration_date or invoice.date_invoice \
+            or time.strftime('%Y-%m-%d')
+
+        period_ids = period_model.search(cr, uid, [
+            ('date_start', '<=', date_start),
+            ('date_stop', '>=', date_stop),
+            ('company_id', '=', invoice.company_id.id),
+            ('special', '!=', True),
+        ])
+        if period_ids:
+            period_id = period_ids[0]
+        else:
+            period_id = False
+        return period_id, date_start, date_stop
+
+    def action_move_create(self, cr, uid, ids, context=None):
+
+        if not context:
+            context = {}
+
+        sequence_model = self.pool['ir.sequence']
+
+        for inv in self.browse(cr, uid, ids):
+            if inv.type in ('in_invoice', 'in_refund'):
+                date_invoice = inv.date_invoice
+                reg_date = inv.registration_date
+                if not inv.registration_date:
+                    if not inv.date_invoice:
+                        reg_date = time.strftime('%Y-%m-%d')
+                    else:
+                        reg_date = inv.date_invoice
+
+                if date_invoice and reg_date and date_invoice > reg_date:
+                    raise UserError(
+                        _("The invoice date cannot be later than"
+                          " the date of registration!"))
+
+                period_id, date_start, date_stop = self._get_period_from_dates(
+                    cr, uid, inv)
+                if not period_id:
+                    raise Warning(
+                        _("Can't find a non special period for %s - %s (%s)")
+                        % (date_start, date_stop, inv.company_id.name)
+                    )
+
+                invoice_values = {'registration_date': reg_date,
+                                  'period_id': period_id}
+
+                # ----- For in invoice or refund, force the sequence based on
+                #       registration date
+                if not inv.internal_number:
+                    period = self.pool['account.period'].browse(
+                        cr, uid, period_id, context)
+                    invoice_number_context = {
+                        'fiscalyear_id': period.fiscalyear_id.id}
+                    internal_number = sequence_model.next_by_id(
+                        cr, uid, inv.journal_id.sequence_id.id,
+                        invoice_number_context)
+                    invoice_values.update({'internal_number': internal_number})
+
+                self.write(cr, uid, [inv.id], invoice_values)
+
+        super(AccountInvoice, self).action_move_create(
+            cr, uid, ids, context=context)
+
+        account_move_model = self.pool['account.move']
+
+        for inv in self.browse(cr, uid, ids):
+            if inv.type in ('in_invoice', 'in_refund'):
+
+                mov_date = inv.registration_date or inv.date_invoice or \
+                    time.strftime('%Y-%m-%d')
+
+                account_move_model.write(
+                    cr, uid, [inv.move_id.id], {'state': 'draft'})
+
+                period_id, date_start, date_stop = self._get_period_from_dates(
+                    cr, uid, inv)
+
+                sql = (
+                    "update account_move_line "
+                    "set period_id = {}, date = '{}'"
+                    "where move_id = {}").format(
+                        period_id,
+                        mov_date,
+                        inv.move_id.id
+                )
+                cr.execute(sql)
+
+                account_move_model.write(
+                    cr, uid, [inv.move_id.id],
+                    {'period_id': period_id, 'date': mov_date})
+
+                account_move_model.write(
+                    cr, uid, [inv.move_id.id], {'state': 'posted'})
+
+        self._log_event(cr, uid, ids)
+        return True
+
+    def _get_account_registration_date(self):
+        return self.registration_date or fields.Date.today()

--- a/account_invoice_entry_date/models/account.py
+++ b/account_invoice_entry_date/models/account.py
@@ -2,8 +2,7 @@
 # Copyright 2004-2010 ISA srl (<http://www.isa.it>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import time
-from openerp import fields, models
+from openerp import models, fields, api
 from openerp.tools.translate import _
 from openerp.exceptions import Warning as UserError
 
@@ -23,109 +22,60 @@ class AccountInvoice(models.Model):
         help="Keep empty to use the current date",
         copy=False)
 
-    def _get_period_from_dates(self, cr, uid, invoice):
-        period_model = self.pool['account.period']
-
-        date_start = invoice.registration_date or invoice.date_invoice \
-            or time.strftime('%Y-%m-%d')
-        date_stop = invoice.registration_date or invoice.date_invoice \
-            or time.strftime('%Y-%m-%d')
-
-        if invoice.period_id:
-            period_id = invoice.period_id.id
+    def _get_period_from_dates(self):
+        self.ensure_one()
+        if self.period_id:
+            period_id = self.period_id
         else:
-            period_ids = period_model.search(cr, uid, [
-                ('date_start', '<=', date_start),
-                ('date_stop', '>=', date_stop),
-                ('company_id', '=', invoice.company_id.id),
-                ('special', '!=', True),
-            ])
-            if period_ids:
-                period_id = period_ids[0]
-            else:
-                period_id = False
-        return period_id, date_start, date_stop
+            date = self.registration_date or self.date_invoice \
+                   or fields.Date.today()
+            period_id = self.env['account.period'].find(dt=date)
+        return period_id
 
-    def action_move_create(self, cr, uid, ids, context=None):
-
-        if not context:
-            context = {}
-
-        sequence_model = self.pool['ir.sequence']
-
-        for inv in self.browse(cr, uid, ids):
+    @api.multi
+    def action_move_create(self):
+        for inv in self:
             if inv.type in ('in_invoice', 'in_refund'):
                 date_invoice = inv.date_invoice
                 reg_date = inv.registration_date
                 if not inv.registration_date:
                     if not inv.date_invoice:
-                        reg_date = time.strftime('%Y-%m-%d')
+                        reg_date = fields.Date.today()
                     else:
                         reg_date = inv.date_invoice
-
                 if date_invoice and reg_date and date_invoice > reg_date:
                     raise UserError(
                         _("The invoice date cannot be later than"
                           " the date of registration!"))
-
-                period_id, date_start, date_stop = self._get_period_from_dates(
-                    cr, uid, inv)
-                if not period_id:
-                    raise Warning(
-                        _("Can't find a non special period for %s - %s (%s)")
-                        % (date_start, date_stop, inv.company_id.name)
-                    )
-
+                period_id = inv._get_period_from_dates()
                 invoice_values = {'registration_date': reg_date,
-                                  'period_id': period_id}
-
+                                  'period_id': period_id.id}
                 # ----- For in invoice or refund, force the sequence based on
                 #       registration date
                 if not inv.internal_number:
-                    period = self.pool['account.period'].browse(
-                        cr, uid, period_id, context)
+                    sequence_model = self.pool.get('ir.sequence')
                     invoice_number_context = {
-                        'fiscalyear_id': period.fiscalyear_id.id}
+                        'fiscalyear_id': period_id.fiscalyear_id.id
+                    }
                     internal_number = sequence_model.next_by_id(
-                        cr, uid, inv.journal_id.sequence_id.id,
-                        invoice_number_context)
+                        self._cr, self._uid, inv.journal_id.sequence_id.id,
+                        invoice_number_context
+                    )
                     invoice_values.update({'internal_number': internal_number})
+                inv.write(invoice_values)
 
-                self.write(cr, uid, [inv.id], invoice_values)
+        super(AccountInvoice, self).action_move_create()
 
-        super(AccountInvoice, self).action_move_create(
-            cr, uid, ids, context=context)
-
-        account_move_model = self.pool['account.move']
-
-        for inv in self.browse(cr, uid, ids):
+        for inv in self:
             if inv.type in ('in_invoice', 'in_refund'):
-
                 mov_date = inv.registration_date or inv.date_invoice or \
-                    time.strftime('%Y-%m-%d')
-
-                account_move_model.write(
-                    cr, uid, [inv.move_id.id], {'state': 'draft'})
-
-                period_id, date_start, date_stop = self._get_period_from_dates(
-                    cr, uid, inv)
-
-                sql = (
-                    "update account_move_line "
-                    "set period_id = {}, date = '{}'"
-                    "where move_id = {}").format(period_id,
-                                                 mov_date,
-                                                 inv.move_id.id)
-                cr.execute(sql)
-
-                account_move_model.write(
-                    cr, uid, [inv.move_id.id],
-                    {'period_id': period_id, 'date': mov_date})
-
-                account_move_model.write(
-                    cr, uid, [inv.move_id.id], {'state': 'posted'})
-
-        self._log_event(cr, uid, ids)
+                           fields.Date.today()
+                inv.move_id.button_cancel()
+                period_id = inv._get_period_from_dates()
+                inv.move_id.write(
+                    {'period_id': period_id.id, 'date': mov_date}
+                )
+                inv.move_id.button_validate()
         return True
 
     def _get_account_registration_date(self):

--- a/account_invoice_entry_date/models/account.py
+++ b/account_invoice_entry_date/models/account.py
@@ -66,16 +66,16 @@ class AccountInvoice(models.Model):
 
         super(AccountInvoice, self).action_move_create()
 
-        for inv in self:
-            if inv.type in ('in_invoice', 'in_refund'):
-                mov_date = inv.registration_date or inv.date_invoice or \
-                           fields.Date.today()
-                inv.move_id.button_cancel()
-                period_id = inv._get_period_from_dates()
-                inv.move_id.write(
-                    {'period_id': period_id.id, 'date': mov_date}
-                )
-                inv.move_id.button_validate()
+        # for inv in self:
+        #     if inv.type in ('in_invoice', 'in_refund'):
+        #         mov_date = inv.registration_date or inv.date_invoice or \
+        #                    fields.Date.today()
+        #         inv.move_id.button_cancel()
+        #         period_id = inv._get_period_from_dates()
+        #         inv.move_id.write(
+        #             {'period_id': period_id.id, 'date': mov_date}
+        #         )
+        #         inv.move_id.button_validate()
         return True
 
     def _get_account_registration_date(self):

--- a/account_invoice_entry_date/views/account_view.xml
+++ b/account_invoice_entry_date/views/account_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="invoice_tree_reg_date" model="ir.ui.view">
+            <field name="name">account.invoice.tree.reg_date</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_tree"/>
+            <field name="arch" type="xml">
+                <field name="date_invoice" position="after">
+                    <field name="registration_date"></field>
+                </field>
+            </field>
+        </record>
+
+        <record id="invoice_supplier_form_reg_date" model="ir.ui.view">
+            <field name="name">account.invoice.supplier.form.reg_date</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_supplier_form"/>
+            <field name="arch" type="xml">
+                <field name="date_invoice" position="after">
+                    <field name="registration_date"></field>
+                </field>
+            </field>
+        </record>
+
+     </data>
+</openerp>


### PR DESCRIPTION
Añado el módulo `account_invoice_entry_date` que es copia del que está en la localización italiana. Como se comentó en el issue https://github.com/OCA/l10n-spain/issues/412#issuecomment-310091960

No he cambiado nada en el código, solo he añadido las traducciones al español. No sé si habría que modificar algo.

La herencia de este módulo en el sii lo hago en la rama de acysos o aquí si se mergea esa.
