### PR TITLE
[IMP] l10n_es_aeat_sii: Convertimos las facturas en otra divisa a € para enviar al SII

### DIFF
--- a/l10n_es_aeat_sii/README.rst
+++ b/l10n_es_aeat_sii/README.rst
@@ -81,7 +81,6 @@ Known issues / Roadmap
 * Asistente para consultar los documentos comunicados.
 * Libro de bienes de inversión (Libro anual se crea un módulo aparte).
 * Regímenes especiales de seguros y de agencias de viaje.
-* Imputar los importes en € cuando la factura está en otra divisa.
 * Comunicación de las facturas del primer semestre.
 
 Bug Tracker

--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.0.1",
+    "version": "8.0.2.1.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"
@@ -37,6 +37,7 @@
         "account_refund_original",
         "l10n_es_aeat",
         "connector",
+        "account_invoice_currency",
     ],
     "data": [
         "data/ir_config_parameter.xml",

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -508,7 +508,7 @@ class AccountInvoice(models.Model):
                     "NombreRazon": self.partner_id.name[0:120],
                 },
                 "TipoDesglose": self._get_sii_out_taxes(),
-                "ImporteTotal": self.amount_total * sign,
+                "ImporteTotal": self.cc_amount_total * sign,
             }
             exp_dict = inv_dict['FacturaExpedida']
             # Uso condicional de IDOtro/NIF
@@ -518,10 +518,11 @@ class AccountInvoice(models.Model):
                 if self.sii_refund_type == 'S':
                     exp_dict['ImporteRectificacion'] = {
                         'BaseRectificada': sum(
-                            self.mapped('origin_invoices_ids.amount_untaxed')
+                            self.
+                            mapped('origin_invoices_ids.cc_amount_untaxed')
                         ),
                         'CuotaRectificada': sum(
-                            self.mapped('origin_invoices_ids.amount_tax')
+                            self.mapped('origin_invoices_ids.cc_amount_tax')
                         ),
                     }
         return inv_dict
@@ -581,7 +582,7 @@ class AccountInvoice(models.Model):
                     "NombreRazon": self.partner_id.name[0:120],
                 },
                 "FechaRegContable": reg_date,
-                "ImporteTotal": self.amount_total * sign,
+                "ImporteTotal": self.cc_amount_total * sign,
                 "CuotaDeducible": float_round(tax_amount * sign, 2),
             }
             # Uso condicional de IDOtro/NIF
@@ -596,7 +597,8 @@ class AccountInvoice(models.Model):
                 if self.sii_refund_type == 'S':
                     rec_dict['ImporteRectificacion'] = {
                         'BaseRectificada': sum(
-                            self.mapped('origin_invoices_ids.amount_untaxed')
+                            self.
+                            mapped('origin_invoices_ids.cc_amount_untaxed')
                         ),
                         'CuotaRectificada': refund_tax_amount,
                     }
@@ -748,10 +750,6 @@ class AccountInvoice(models.Model):
                 ]
             )
         )
-        if any(x.currency_id != x.company_id.currency_id for x in invoices):
-            raise exceptions.Warning(
-                _('Invoices in other currency are not yet supported')
-            )
         if not invoices._cancel_invoice_jobs():
             raise exceptions.Warning(_(
                 'You can not communicate this invoice at this moment '
@@ -991,7 +989,14 @@ class AccountInvoiceLine(models.Model):
         obtain through this method, as it can be inherited in other modules
         for altering the expected amount according other criteria."""
         self.ensure_one()
-        return self.price_unit * (1 - (self.discount or 0.0) / 100.0)
+        price_unit = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
+        if self.invoice_id.currency_id != \
+                self.invoice_id.company_id.currency_id:
+            from_currency = self.invoice_id.currency_id.\
+                with_context(date=self.invoice_id.date_invoice)
+            price_unit = from_currency.\
+                compute(price_unit, self.invoice_id.company_id.currency_id)
+        return price_unit
 
     @api.multi
     def _get_sii_line_price_subtotal(self):

--- a/l10n_es_aeat_sii/security/ir.model.access.csv
+++ b/l10n_es_aeat_sii/security/ir.model.access.csv
@@ -5,5 +5,6 @@ access_model_aeat_sii_map_lines_admin,aeat.sii.map.lines admin,model_aeat_sii_ma
 access_model_aeat_sii_map_lines_aeat,aeat.sii.map.lines aeat,model_aeat_sii_map_lines,l10n_es_aeat.group_account_aeat,1,0,0,0
 access_model_aeat_sii_mapping_registration_keys_admin,aeat.sii.mapping.registration.keys admin,model_aeat_sii_mapping_registration_keys,base.group_system,1,1,1,1
 access_model_aeat_sii_mapping_registration_keys_aeat,aeat.sii.mapping.registration.keys aeat,model_aeat_sii_mapping_registration_keys,l10n_es_aeat.group_account_aeat,1,0,0,0
+access_model_aeat_sii_mapping_registration_keys_aeat_account,aeat.sii.mapping.registration.keys aeat,model_aeat_sii_mapping_registration_keys,account.group_account_invoice,1,0,0,0
 access_l10n_es_aeat_sii_admin,l10n.es.aeat.sii admin,model_l10n_es_aeat_sii,base.group_system,1,1,1,1
 access_l10n_es_aeat_sii_aeat,l10n.es.aeat.sii aeat,model_l10n_es_aeat_sii,l10n_es_aeat.group_account_aeat,1,0,0,0

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -132,7 +132,7 @@ class TestL10nEsAeatSii(common.TransactionCase):
                 },
                 'DescripcionOperacion': u'/',
                 'ClaveRegimenEspecialOTrascendencia': special_regime,
-                'ImporteTotal': self.invoice.amount_total,
+                'ImporteTotal': self.invoice.cc_amount_total,
             },
             'PeriodoImpositivo': {
                 'Periodo': str(self.invoice.period_id.code[:2]),
@@ -160,12 +160,12 @@ class TestL10nEsAeatSii(common.TransactionCase):
                         ],
                     },
                 },
-                "CuotaDeducible": self.invoice.amount_tax,
+                "CuotaDeducible": self.invoice.cc_amount_tax,
             })
         if invoice_type == 'R4':
             invoices = self.invoice.origin_invoices_ids
-            base_rectificada = sum(invoices.mapped('amount_untaxed'))
-            cuota_rectificada = sum(invoices.mapped('amount_tax'))
+            base_rectificada = sum(invoices.mapped('cc_amount_untaxed'))
+            cuota_rectificada = sum(invoices.mapped('cc_amount_tax'))
             res[expedida_recibida].update({
                 'TipoRectificativa': 'S',
                 'ImporteRectificacion': {


### PR DESCRIPTION
- En el caso en el que la moneda de la factura sea distinta a la moneda de la compañía, el precio unidad se convierte a la moneda de la compañía y se opera con este para presentarlo en el SII.
- En el caso que se usen los campos generales de importe de las facturas se cambian siempre por los del módulo account_invoice_currency
- Una pequeña corrección de permisos, ya que un usuario que podía crear facturas, con el permiso base de contabilidad ahora no podía ya que se le requerían permisos de administración o de responsable de AEAT