### PR TITLE
[8.0][l10n_es_aeat_sii][FIX] Corregido error en anulación de facturas de proveedor

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.0.0",
+    "version": "8.0.2.0.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -560,7 +560,11 @@ class AccountInvoice(models.Model):
         # Uso condicional de IDOtro/NIF
         ident = self._get_sii_identifier()
         inv_dict['IDFactura']['IDEmisorFactura'].update(ident)
-        if not cancel:
+        if cancel:
+            inv_dict['IDFactura']['IDEmisorFactura'].update(
+                {'NombreRazon': self.partner_id.name[0:120]}
+            )
+        else:
             # Check if refund type is 'By differences'. Negative amounts!
             sign = -1.0 if self.sii_refund_type == 'I' else 1.0
             inv_dict["FacturaRecibida"] = {


### PR DESCRIPTION
Se debe incluir el dato NombreRazon al bloque IDEmisorFactura para las comunicaciones de anulación de facturas de proveedores. Se incluye para evitar errores en el envío.