### PR TITLE
[8.0][FIX] l10n_es_aeat_sii, wrong invoice filter

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.0.1",
+    "version": "8.0.2.1.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -708,6 +708,7 @@ class AccountInvoice(models.Model):
                 new_cr = RegistryManager.get(self.env.cr.dbname).cursor()
                 env = api.Environment(new_cr, self.env.uid, self.env.context)
                 invoice = env['account.invoice'].browse(self.id)
+                invoice.sii_send_failed = True
                 invoice.sii_send_error = fault
                 invoice.sii_return = fault
                 new_cr.commit()

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -143,7 +143,7 @@
                     <separator/>
                     <filter string="SII error"
                         domain="[('sii_send_failed', '=', True)]"
-                        context="{'group_by':'sii_send_failed'}"/>
+                        context="{'group_by':'sii_send_error'}"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
He modificado el filtro que agrupa las facturas según su error porque no estaba funcionando. Principalmente no funcionaba porque se estaba usando el campo `sii_send_failed`. En mi opinión creo que podríamos quitarle ya no se está utilizando en todos los casos que da error. Sin embargo el campo `sii_send_error` (que contiene el error) siempre que falla lleva contenido.

cc @pedrobaeza 