### PR TITLE
[8.0][l10n_es_aeat_sii][FIX] Eliminación de trabajos de conector al volver a borrador

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.0.1",
+    "version": "8.0.2.2.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-06-27 01:19+0000\n"
-"PO-Revision-Date: 2017-06-27 01:19+0000\n"
+"PO-Revision-Date: 2017-06-29 04:42+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -47,7 +47,6 @@ msgid "Aeat SII Map"
 msgstr "SII - Mapeo de impuestos"
 
 #. module: l10n_es_aeat_sii
-#: model:ir.model,name:l10n_es_aeat_sii.model_aeat_sii_map_line
 #: model:ir.model,name:l10n_es_aeat_sii.model_aeat_sii_map_lines
 msgid "Aeat SII Map Lines"
 msgstr "SII - Lineas de mapeo"
@@ -325,7 +324,7 @@ msgid "Invoice Refund"
 msgstr "Abono factura"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:749
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:753
 #, python-format
 msgid "Invoices in other currency are not yet supported"
 msgstr "Las facturas en otra moneda no están soportadas aún"
@@ -710,22 +709,28 @@ msgid "With modifications not sent to SII"
 msgstr "Modificaciones no enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:868
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:873
 #, python-format
 msgid "You can not cancel this invoice because there is a job running!"
 msgstr "No puede cancelar una factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:835
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:840
 #, python-format
 msgid "You can not communicate the cancellation of this invoice at this moment because there is a job running!"
 msgstr "En este momento no puede comunicar la cancelación de esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:752
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:756
 #, python-format
 msgid "You can not communicate this invoice at this moment because there is a job running!"
 msgstr "En este momento no puede comunicar esta factura porque hay un trabajo ejecutándose!"
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:888
+#, python-format
+msgid "You can not set to draft this invoice because there is a job running!"
+msgstr "En este momento no puede poner en borrador esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:155

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -691,19 +691,19 @@ class AccountInvoice(models.Model):
                 #     res = serv.SuministroLRDetOperacionIntracomunitaria(
                 #         header, invoices)
                 if res['EstadoEnvio'] == 'Correcto':
-                    self.sii_state = 'sent'
-                    self.sii_csv = res['CSV']
-                    self.sii_send_failed = False
+                    invoice.sii_state = 'sent'
+                    invoice.sii_csv = res['CSV']
+                    invoice.sii_send_failed = False
                 else:
-                    self.sii_send_failed = True
-                self.sii_return = res
+                    invoice.sii_send_failed = True
+                invoice.sii_return = res
                 send_error = False
                 res_line = res['RespuestaLinea'][0]
                 if res_line['CodigoErrorRegistro']:
                     send_error = u"{} | {}".format(
                         unicode(res_line['CodigoErrorRegistro']),
                         unicode(res_line['DescripcionErrorRegistro'])[:60])
-                self.sii_send_error = send_error
+                invoice.sii_send_error = send_error
             except Exception as fault:
                 new_cr = RegistryManager.get(self.env.cr.dbname).cursor()
                 env = api.Environment(new_cr, self.env.uid, self.env.context)
@@ -806,24 +806,25 @@ class AccountInvoice(models.Model):
                 #     res = serv.AnulacionLRDetOperacionIntracomunitaria(
                 #         header, invoices)
                 if res['EstadoEnvio'] == 'Correcto':
-                    self.sii_state = 'cancelled'
-                    self.sii_csv = res['CSV']
-                    self.sii_send_failed = False
+                    invoice.sii_state = 'cancelled'
+                    invoice.sii_csv = res['CSV']
+                    invoice.sii_send_failed = False
                 else:
-                    self.sii_send_failed = True
-                self.sii_return = res
+                    invoice.sii_send_failed = True
+                invoice.sii_return = res
                 send_error = False
                 res_line = res['RespuestaLinea'][0]
                 if res_line['CodigoErrorRegistro']:
                     send_error = u"{} | {}".format(
                         unicode(res_line['CodigoErrorRegistro']),
                         unicode(res_line['DescripcionErrorRegistro'])[:60])
-                self.sii_send_error = send_error
+                invoice.sii_send_error = send_error
             except Exception as fault:
                 new_cr = RegistryManager.get(self.env.cr.dbname).cursor()
                 env = api.Environment(new_cr, self.env.uid, self.env.context)
                 invoice = env['account.invoice'].browse(self.id)
                 invoice.sii_send_error = fault
+                invoice.sii_send_failed = True
                 invoice.sii_return = fault
                 new_cr.commit()
                 new_cr.close()
@@ -880,7 +881,7 @@ class AccountInvoice(models.Model):
             # without any SII communication.
             self.sii_state = 'cancelled'
         return res
-    
+
     @api.multi
     def action_cancel_draft(self):
         if not self._cancel_invoice_jobs():

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -880,6 +880,14 @@ class AccountInvoice(models.Model):
             # without any SII communication.
             self.sii_state = 'cancelled'
         return res
+    
+    @api.multi
+    def action_cancel_draft(self):
+        if not self._cancel_invoice_jobs():
+            raise exceptions.Warning(_(
+                'You can not set to draft this invoice because'
+                ' there is a job running!'))
+        return super(AccountInvoice, self).action_cancel_draft()
 
     @api.multi
     def _get_sii_gen_type(self):


### PR DESCRIPTION
Controlado el caso de que ayamos anulado una factura y que antes de ejecutarse el trabajo del conector  la volvamos a borrador. En este caso la factura estará en borrador pero el trabajo seguirá encolado, y debe eliminarse.