### PR TITLE
[FIX] l10n_es_aeat_sii: Se corrige la asignación de la clave de registro SII por la posición fiscal

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.1.0",
+    "version": "8.0.2.1.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -131,7 +131,8 @@ class AccountInvoice(models.Model):
     def create(self, vals):
         """Complete registration key for auto-generated invoices."""
         invoice = super(AccountInvoice, self).create(vals)
-        if invoice.fiscal_position and not invoice.sii_registration_key:
+        if vals.get('fiscal_position') and \
+                not vals.get('sii_registration_key'):
             invoice.onchange_fiscal_position_l10n_es_aeat_sii()
         return invoice
 
@@ -158,10 +159,9 @@ class AccountInvoice(models.Model):
                           "correct number")
                     )
         res = super(AccountInvoice, self).write(vals)
-        if vals.get('fiscal_position'):
-            self.filtered(
-                lambda x: x.fiscal_position and not x.sii_registration_key
-            ).onchange_fiscal_position_l10n_es_aeat_sii()
+        if vals.get('fiscal_position') and \
+                not vals.get('sii_registration_key'):
+            self.onchange_fiscal_position_l10n_es_aeat_sii()
         return res
 
     @api.multi


### PR DESCRIPTION
Dos pequeñas correcciones:

Respecto al create: pequeña corrección ya que si se crea la factura manualmente funcionaba bien porque rellena una por defecto y al cambiar la posición fiscal hace on_change, pero si se creaba desde albarán siempre ponía la clave 01 ya que es la por defecto y debe de poner la de la posición fiscal.

Respecto al write: pequeña corrección para el caso en el que se actualice la posición fiscal y no la clave, si se hace manualmente van a ir los dos campos en el vals en el caso de que se haga un write por código de la posición fiscal no actualizaría la clave y quedaría incorrecta.