### PR TITLE
[8.0][l10n_es_aeat_sii][IMP] Cambios para v0.7 pendientes y preparación para v1.0

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.2.1",
+    "version": "8.0.2.3.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/data/aeat_sii_mapping_registration_keys_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_mapping_registration_keys_data.xml
@@ -14,7 +14,7 @@
         </record>
         <record id="aeat_sii_mapping_registration_keys_03" model="aeat.sii.mapping.registration.keys">
             <field name="code">03</field>
-            <field name="name">Operaciones a las que se aplique el régimen especial de bienes usados, objetos de arte, antigüedades y objetos de colección (135-139 LIVA)</field>
+            <field name="name">Operaciones a las que se aplique el régimen especial de bienes usados, objetos de arte, antigüedades y objetos de colección</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_04" model="aeat.sii.mapping.registration.keys">
@@ -39,7 +39,7 @@
         </record>
         <record id="aeat_sii_mapping_registration_keys_08" model="aeat.sii.mapping.registration.keys">
             <field name="code">08</field>
-            <field name="name">Operaciones sujetas al IPSI  / IGIC</field>
+            <field name="name">Operaciones sujetas al IPSI / IGIC (Impuesto sobre la Producción, los Servicios y la Importación / Impuesto General Indirecto Canario)</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_09" model="aeat.sii.mapping.registration.keys">
@@ -69,12 +69,17 @@
         </record> 
         <record id="aeat_sii_mapping_registration_keys_14" model="aeat.sii.mapping.registration.keys">
             <field name="code">14</field>
-            <field name="name">Factura con IVA pendiente de devengo (certificaciones de obra cuyo destinatario sea una Administración Pública)</field>
+            <field name="name">Factura con IVA pendiente de devengo en certificaciones de obra cuyo destinatario sea una Administración Pública</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_15" model="aeat.sii.mapping.registration.keys">
             <field name="code">15</field>
-            <field name="name">Factura con IVA pendiente de devengo - operaciones de tracto sucesivo</field>
+            <field name="name">Factura con IVA pendiente de devengo en operaciones de tracto sucesivo</field>
+            <field name="type">sale</field>
+        </record>
+        <record id="aeat_sii_mapping_registration_keys_29" model="aeat.sii.mapping.registration.keys">
+            <field name="code">16</field>
+            <field name="name">Primer semestre 2017</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_16" model="aeat.sii.mapping.registration.keys">
@@ -84,12 +89,12 @@
         </record>
         <record id="aeat_sii_mapping_registration_keys_17" model="aeat.sii.mapping.registration.keys">
             <field name="code">02</field>
-            <field name="name">Operaciones por las que los empresarios satisfacen compensaciones REAGYP</field>
+            <field name="name">Operaciones por las que los empresarios satisfacen compensaciones en las adquisiciones a personas acogidas al Régimen especial de la agricultura, ganaderia y pesca</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_18" model="aeat.sii.mapping.registration.keys">
             <field name="code">03</field>
-            <field name="name">Operaciones a las que se aplique el régimen especial de bienes usados, objetos de arte, antigüedades y objetos de colección (135-139 LIVA)</field>
+            <field name="name">Operaciones a las que se aplique el régimen especial de bienes usados, objetos de arte, antigüedades y objetos de colección</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_19" model="aeat.sii.mapping.registration.keys">
@@ -114,7 +119,7 @@
         </record>
         <record id="aeat_sii_mapping_registration_keys_23" model="aeat.sii.mapping.registration.keys">
             <field name="code">08</field>
-            <field name="name">Operaciones sujetas al IPSI  / IGIC</field>
+            <field name="name">Operaciones sujetas al IPSI / IGIC (Impuesto sobre la Producción, los Servicios y la Importación / Impuesto General Indirecto Canario)</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_24" model="aeat.sii.mapping.registration.keys">
@@ -122,16 +127,6 @@
             <field name="name">Adquisiciones intracomunitarias de bienes y prestaciones de servicios</field>
             <field name="type">purchase</field>
         </record>
-        <record id="aeat_sii_mapping_registration_keys_25" model="aeat.sii.mapping.registration.keys">
-            <field name="code">10</field>
-            <field name="name">Compra de agencias viajes: operaciones de mediación en nombre y por cuenta ajena en los servicios de transporte prestados al destinatario de los servicios de acuerdo con el apartado 3 de la D.A.4ª RD1619/2012</field>
-            <field name="type">purchase</field>
-        </record>
-        <record id="aeat_sii_mapping_registration_keys_26" model="aeat.sii.mapping.registration.keys">
-            <field name="code">11</field>
-            <field name="name">Facturación de las prestaciones de servicios de agencias de viaje que actúan como mediadoras en nombre y por cuenta ajena (D.A.4ª RD1619/2012)</field>
-            <field name="type">purchase</field>
-        </record> 
         <record id="aeat_sii_mapping_registration_keys_27" model="aeat.sii.mapping.registration.keys">
             <field name="code">12</field>
             <field name="name">Operaciones de arrendamiento de local de negocio</field>
@@ -140,6 +135,11 @@
         <record id="aeat_sii_mapping_registration_keys_28" model="aeat.sii.mapping.registration.keys">
             <field name="code">13</field>
             <field name="name">Factura correspondiente a una importación (informada sin asociar a un DUA)</field>
+            <field name="type">purchase</field>
+        </record>
+        <record id="aeat_sii_mapping_registration_keys_30" model="aeat.sii.mapping.registration.keys">
+            <field name="code">14</field>
+            <field name="name">Primer semestre 2017</field>
             <field name="type">purchase</field>
         </record>
     </data>

--- a/l10n_es_aeat_sii/data/ir_config_parameter.xml
+++ b/l10n_es_aeat_sii/data/ir_config_parameter.xml
@@ -13,44 +13,39 @@
             <field name="value">/opt/certificates/privateKey.pem</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
-        <record id="config_parameter_sii_version" model="ir.config_parameter" forcecreate="True">
-            <field name="key">l10n_es_aeat_sii.version</field>
-            <field name="value">0.7</field>
-            <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
-        </record>
         <record id="config_parameter_sii_wsdl_out" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_out</field>
-            <field name="value">http://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/V_07/SuministroFactEmitidas.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroFactEmitidas.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_in" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_in</field>
-            <field name="value">http://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/V_07/SuministroFactRecibidas.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroFactRecibidas.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_pi" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_pi</field>
-            <field name="value">http://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/V_07/SuministroBienesInversion.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroBienesInversion.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_ic" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_ic</field>
-            <field name="value">http://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/V_07/SuministroOpIntracomunitarias.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroOpIntracomunitarias.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_pr" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_pr</field>
-            <field name="value">http://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/V_07/SuministroCobrosEmitidas.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroCobrosEmitidas.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
-        <record id="config_parameter_sii_wsdl_prm" model="ir.config_parameter" forcecreate="True">
-            <field name="key">l10n_es_aeat_sii.wsdl_prm</field>
-            <field name="value">http://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/V_07/SuministroCobrosMetalico.wsdl</field>
+        <record id="config_parameter_sii_wsdl_ott" model="ir.config_parameter" forcecreate="True">
+            <field name="key">l10n_es_aeat_sii.wsdl_ott</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroOpTrascendTribu.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_ps" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_ps</field>
-            <field name="value">http://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/V_07/SuministroPagosRecibidas.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroPagosRecibidas.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
     </data>

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -98,6 +98,7 @@ class TestL10nEsAeatSii(common.TransactionCase):
     def _open_invoice(self):
         self.invoice.company_id.write({
             'sii_enabled': True,
+            'sii_test': True,
             'use_connector': True,
             'chart_template_id': self.env.ref(
                 'l10n_es.account_chart_template_pymes').id,

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -17,7 +17,7 @@
                     <button type="object" string="Send cancellation to SII"
                             name="cancel_sii"
                             groups="l10n_es_aeat.group_account_aeat"
-                            attrs="{'invisible': ['|','|','|',('sii_enabled', '=', False),
+                            attrs="{'invisible': ['|','|',('sii_enabled', '=', False),
                                 ('state', 'not in', ['cancel']),
                                 ('sii_state', 'not in', ['sent','sent_modified'])]}" />
                 </button>
@@ -74,7 +74,7 @@
                     <button type="object" string="Send cancellation to SII"
                             name="cancel_sii"
                             groups="l10n_es_aeat.group_account_aeat"
-                            attrs="{'invisible': ['|','|','|',('sii_enabled', '=', False), ('state', 'not in', ['cancel']), ('sii_state', 'not in', ['sent','sent_modified'])]}"
+                            attrs="{'invisible': ['|','|',('sii_enabled', '=', False), ('state', 'not in', ['cancel']), ('sii_state', 'not in', ['sent','sent_modified'])]}"
                     />
                 </button>
                 <notebook position="inside">


### PR DESCRIPTION
Realizadas modificaciones para completar algunos aspectos aún no cubiertos de la versión 0.7 y adaptación de parámetros de configuración para la versión 1.0:
- Se ha modificado el texto de algunas claves de registro para adaptarlos a las actualmente publicadas por la AEAT
- Se han añadido las claves de registro correspondientes al primer semestre de 2017 para facturas emitidas y recibidas
- Se han eliminado dos claves de registro eliminadas por la AEAT en la versión 0.7
- Se ha cambiado el valor de la variable SII_VERSION a '1.0'
- Se han modificado en los parámetros del sistema las URL de los WSDL de SII conforme a los publicados por la AEAT. Son funcionales tanto en entorno de pruebas como de producción. La versión 0.7 es admitida hasta el día 30 de Junio sólo para el entorno de pruebas (en producción debe ser la 1.0), a partir del día 1 de Julio la versión debe ser la 1.0 para ambos entornos.
- Se ha eliminado el parámetro del sistema 'l10n_es_aeat_sii.version' ya que no tiene sentido en configuración. La versión está hardcodeada en account_invoice.py y no debe poder ser configurable por el usuario.
- Se ha contemplado un nueva opción para el campo <TipoNoExenta> que la AEAT añadió en la versión 0.7, la opción (S3) que debe utilizarse cuando la factura tiene una parte sujeta sin inversión de sujeto pasivo y otra sujeta con inversión de sujeto pasivo.
- Se ha añadido control (provisionalmente) en los envíos para evitar que por error un usuario envíe una factura del primer semestre al entorno de producción, comprobándolo por el período de la factura. El formato que ahora se genera no está adaptado para facturas del primer semestre ya que es algo distinto (hay campos que deben tener un valor fijo por defecto, como la descripción que debe ser "Registro del primer semestre" o la CuotaDeducible que debe ser 0). Auque he realziado pruebas de envío contra la de pruebas con clave de registro del primer semestre y no me ha dado error, no se si en producción pasará igual o si, aún no dando el error, la factura estará mal comunicada (no tiene la clave correcta o los valores por defecto exigidos). Por eso de momento (he añadido un TODO) se evita que se envíen si no se está contra el entorno de pruebas. Cuando se adapte el formato de envío y dedidamos cómo abordar el tema de la comunicación de las facturas del primer semestre (wizard o similar) lo podemos quitar o modificar según veamos.
