### PR TITLE
[8.0][l10n_es_aeat_sii][FIX] Cálculo de descripción SII al crear facturas desde procesos automáticos y control cambio fecha factura de emitidas y recibidas

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.4.0",
+    "version": "8.0.2.5.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -8,10 +8,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-01 01:14+0000\n"
-"PO-Revision-Date: 2017-07-01 01:14+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"POT-Creation-Date: 2017-07-01 10:30+0000\n"
+"PO-Revision-Date: 2017-07-01 10:30+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -74,17 +74,8 @@ msgstr "Ya enviadas al SII. Incluye facturas canceladas"
 
 #. module: l10n_es_aeat_sii
 #: help:res.company,sii_header_customer:0
-msgid ""
-"An optional header description for customer invoices. Applied on all the SII"
-" description methods"
-msgstr ""
-
-#. module: l10n_es_aeat_sii
-#: help:res.company,sii_header_supplier:0
-msgid ""
-"An optional header description for supplier invoices. Applied on all the SII"
-" description methods"
-msgstr ""
+msgid "An optional header description for sale invoices. Applied on all the SII description methods"
+msgstr "Cabecera de la descripción opcional para facturas de cliente. Aplicado en todos los métodos de descripción de SII"
 
 #. module: l10n_es_aeat_sii
 #: selection:res.company,send_mode:0
@@ -403,7 +394,12 @@ msgid ""
 "- Manual (by default): It will be necessary to manually enter   the description on each invoice\n"
 "\n"
 "For all the options you can append a header text using the below fields 'SII Sale header' and 'SII Purchase header'"
-msgstr ""
+msgstr "Método para la descripción de las facturas para el SII. Puede ser uno de estos:\n"
+"- Automático: la descripción será la unión de la descripción de las líneas de la factura\n"
+"- Fijo: la descripción escrita en el campo de abajo 'Descripción SII'\n"
+"- Manual (por defecto): será necesario introducir manualmente la descripción en cada factura\n"
+"\n"
+"Para todas las opciones puede añadir un texto de cabecera usando los campos de abajo 'Cabecera de cliente para SII' y 'Cabecera de proveedor para SII'"
 
 #. module: l10n_es_aeat_sii
 #: field:aeat.sii.map,name:0
@@ -423,7 +419,7 @@ msgid "Never sent to SII"
 msgstr "Nunca enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:292
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:309
 #, python-format
 msgid "No VAT configured for the company '{}'"
 msgstr "La compañía '{}' no tiene ningún NIF establecido"
@@ -597,6 +593,11 @@ msgid "SII cancelled"
 msgstr "Anuladas SII"
 
 #. module: l10n_es_aeat_sii
+#: field:account.invoice,sii_description_computed:0
+msgid "SII computed description"
+msgstr "Descripción autocalculada para el SII"
+
+#. module: l10n_es_aeat_sii
 #: view:account.invoice:l10n_es_aeat_sii.view_account_invoice_sii_filter
 msgid "SII error"
 msgstr "Error SII"
@@ -703,19 +704,19 @@ msgid "The last attemp to sent to SII has failed"
 msgstr "El último intento de envío al SII ha fallado"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:485
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:502
 #, python-format
 msgid "The partner has not a VAT configured."
 msgstr "La empresa no tiene un NIF establecido."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:493
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:510
 #, python-format
 msgid "This company doesn't have SII enabled."
 msgstr "Esta compañía no tiene habilitado el SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:497
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:514
 #, python-format
 msgid "This invoice is not SII enabled."
 msgstr "Esta factura no está habilitada para el SII."
@@ -747,13 +748,13 @@ msgid "With modifications not sent to SII"
 msgstr "Modificaciones no enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:930
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:947
 #, python-format
 msgid "You can not cancel this invoice because there is a job running!"
 msgstr "No puede cancelar una factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:897
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:914
 #, python-format
 msgid ""
 "You can not communicate the cancellation of this invoice at this moment "
@@ -763,7 +764,7 @@ msgstr ""
 " un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:826
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:843
 #, python-format
 msgid ""
 "You can not communicate this invoice at this moment because there is a job "
@@ -773,7 +774,7 @@ msgstr ""
 "ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:945
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:962
 #, python-format
 msgid "You can not set to draft this invoice because there is a job running!"
 msgstr ""
@@ -781,7 +782,13 @@ msgstr ""
 "trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:195
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:192
+#, python-format
+msgid "You cannot change the invoice date of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct date"
+msgstr "No puede cambiar la fecha de factura de una factura enviada al SII. Debe cancelar la factura y crear una nueva con la fecha correcta"
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:209
 #, python-format
 msgid ""
 "You cannot change the supplier invoice number of an invoice already "
@@ -792,7 +799,7 @@ msgstr ""
 "al SII. Debe cancelar la factura y crear una nueva con el número correcto"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:188
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:202
 #, python-format
 msgid ""
 "You cannot change the supplier of an invoice already registered at the SII. "
@@ -802,19 +809,19 @@ msgstr ""
 "la factura y crear una nueva con el proveedor correcto"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:212
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:229
 #, python-format
 msgid "You cannot delete an invoice already registered at the SII."
 msgstr "No puede eliminar una factura enviada al SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:488
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:505
 #, python-format
 msgid "You have to select what account chart template use this company."
 msgstr "Debe seleccionar qué plan contable utiliza esta compañía"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:138
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:142
 #, python-format
 msgid "You must have at least one refunded invoice"
 msgstr "Debe tener al menos una factura rectificada"

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -74,8 +74,13 @@ msgstr "Ya enviadas al SII. Incluye facturas canceladas"
 
 #. module: l10n_es_aeat_sii
 #: help:res.company,sii_header_customer:0
-msgid "An optional header description for sale invoices. Applied on all the SII description methods"
+msgid "An optional header description for customer invoices. Applied on all the SII description methods"
 msgstr "Cabecera de la descripción opcional para facturas de cliente. Aplicado en todos los métodos de descripción de SII"
+
+#. module: l10n_es_aeat_sii
+#: help:res.company,sii_header_supplier:0
+msgid "An optional header description for supplier invoices. Applied on all the SII description methods"
+msgstr "Cabecera de la descripción opcional para facturas de proveedor. Aplicado en todos los métodos de descripción de SII"
 
 #. module: l10n_es_aeat_sii
 #: selection:res.company,send_mode:0
@@ -283,6 +288,10 @@ msgstr "Agrupar por..."
 #. module: l10n_es_aeat_sii
 #: field:aeat.sii.map,id:0 field:aeat.sii.map.lines,id:0
 #: field:aeat.sii.mapping.registration.keys,id:0 field:l10n.es.aeat.sii,id:0
+#: field:aeat.sii.map,id:0
+#: field:aeat.sii.map.lines,id:0
+#: field:aeat.sii.mapping.registration.keys,id:0
+#: field:l10n.es.aeat.sii,id:0
 #: field:l10n.es.aeat.sii.password,id:0
 msgid "ID"
 msgstr "ID"
@@ -419,7 +428,7 @@ msgid "Never sent to SII"
 msgstr "Nunca enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:309
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:304
 #, python-format
 msgid "No VAT configured for the company '{}'"
 msgstr "La compañía '{}' no tiene ningún NIF establecido"
@@ -534,7 +543,8 @@ msgid "SII Customer header"
 msgstr "Cabecera de cliente para SII"
 
 #. module: l10n_es_aeat_sii
-#: field:account.invoice,sii_description:0 field:res.company,sii_description:0
+#: field:account.invoice,sii_description:0
+#: field:res.company,sii_description:0
 msgid "SII Description"
 msgstr "Descripción SII"
 
@@ -704,19 +714,19 @@ msgid "The last attemp to sent to SII has failed"
 msgstr "El último intento de envío al SII ha fallado"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:502
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:497
 #, python-format
 msgid "The partner has not a VAT configured."
 msgstr "La empresa no tiene un NIF establecido."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:510
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:505
 #, python-format
 msgid "This company doesn't have SII enabled."
 msgstr "Esta compañía no tiene habilitado el SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:514
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:509
 #, python-format
 msgid "This invoice is not SII enabled."
 msgstr "Esta factura no está habilitada para el SII."
@@ -748,13 +758,13 @@ msgid "With modifications not sent to SII"
 msgstr "Modificaciones no enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:947
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:942
 #, python-format
 msgid "You can not cancel this invoice because there is a job running!"
 msgstr "No puede cancelar una factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:914
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:909
 #, python-format
 msgid ""
 "You can not communicate the cancellation of this invoice at this moment "
@@ -764,7 +774,7 @@ msgstr ""
 " un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:843
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:838
 #, python-format
 msgid ""
 "You can not communicate this invoice at this moment because there is a job "
@@ -774,7 +784,7 @@ msgstr ""
 "ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:962
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:957
 #, python-format
 msgid "You can not set to draft this invoice because there is a job running!"
 msgstr ""
@@ -782,13 +792,13 @@ msgstr ""
 "trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:192
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:205
 #, python-format
 msgid "You cannot change the invoice date of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct date"
 msgstr "No puede cambiar la fecha de factura de una factura enviada al SII. Debe cancelar la factura y crear una nueva con la fecha correcta"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:209
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:198
 #, python-format
 msgid ""
 "You cannot change the supplier invoice number of an invoice already "
@@ -799,7 +809,7 @@ msgstr ""
 "al SII. Debe cancelar la factura y crear una nueva con el número correcto"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:202
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:191
 #, python-format
 msgid ""
 "You cannot change the supplier of an invoice already registered at the SII. "
@@ -809,13 +819,13 @@ msgstr ""
 "la factura y crear una nueva con el proveedor correcto"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:229
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:224
 #, python-format
 msgid "You cannot delete an invoice already registered at the SII."
 msgstr "No puede eliminar una factura enviada al SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:505
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:500
 #, python-format
 msgid "You have to select what account chart template use this company."
 msgstr "Debe seleccionar qué plan contable utiliza esta compañía"

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -1,22 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat_sii
-# 
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
+#	* l10n_es_aeat_sii
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-01 10:30+0000\n"
-"PO-Revision-Date: 2017-07-01 10:30+0000\n"
+"POT-Creation-Date: 2017-07-01 14:24+0000\n"
+"PO-Revision-Date: 2017-07-01 14:24+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_aeat_sii
 #: view:res.company:l10n_es_aeat_sii.view_company_sii_form
@@ -95,12 +92,8 @@ msgstr "Automático"
 
 #. module: l10n_es_aeat_sii
 #: help:res.company,sii_method:0
-msgid ""
-"By default, the invoice is sent/queued in validation process. With manual "
-"method, there's a button to send the invoice."
-msgstr ""
-"Por defecto, la factura es enviada/encolada en el proceso de validación. Con"
-" el método manual, hay un botón para enviarla."
+msgid "By default, the invoice is sent/queued in validation process. With manual method, there's a button to send the invoice."
+msgstr "Por defecto, la factura es enviada/encolada en el proceso de validación. Con el método manual, hay un botón para enviarla."
 
 #. module: l10n_es_aeat_sii
 #: selection:account.invoice,sii_refund_type:0
@@ -139,12 +132,8 @@ msgstr "Plantilla de cuentas"
 
 #. module: l10n_es_aeat_sii
 #: help:res.company,use_connector:0
-msgid ""
-"Check it to use connector instead of sending the invoice directly when it's "
-"validated"
-msgstr ""
-"Márquela para utilizar el conector en lugar de enviar directamente la "
-"factura cuando es validada."
+msgid "Check it to use connector instead of sending the invoice directly when it's validated"
+msgstr "Márquela para utilizar el conector en lugar de enviar directamente la factura cuando es validada."
 
 #. module: l10n_es_aeat_sii
 #: field:aeat.sii.map.lines,code:0
@@ -180,7 +169,8 @@ msgid "Connector config"
 msgstr "Configuración del conector"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,create_uid:0 field:aeat.sii.map.lines,create_uid:0
+#: field:aeat.sii.map,create_uid:0
+#: field:aeat.sii.map.lines,create_uid:0
 #: field:aeat.sii.mapping.registration.keys,create_uid:0
 #: field:l10n.es.aeat.sii,create_uid:0
 #: field:l10n.es.aeat.sii.password,create_uid:0
@@ -188,7 +178,8 @@ msgid "Created by"
 msgstr "Creado por"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,create_date:0 field:aeat.sii.map.lines,create_date:0
+#: field:aeat.sii.map,create_date:0
+#: field:aeat.sii.map.lines,create_date:0
 #: field:aeat.sii.mapping.registration.keys,create_date:0
 #: field:l10n.es.aeat.sii,create_date:0
 #: field:l10n.es.aeat.sii.password,create_date:0
@@ -226,12 +217,13 @@ msgid "Description config"
 msgstr "Configuración de descripción"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,display_name:0 field:aeat.sii.map.lines,display_name:0
+#: field:aeat.sii.map,display_name:0
+#: field:aeat.sii.map.lines,display_name:0
 #: field:aeat.sii.mapping.registration.keys,display_name:0
 #: field:l10n.es.aeat.sii,display_name:0
 #: field:l10n.es.aeat.sii.password,display_name:0
 msgid "Display Name"
-msgstr "Nombre"
+msgstr "Nombre mostrado"
 
 #. module: l10n_es_aeat_sii
 #: selection:l10n.es.aeat.sii,state:0
@@ -240,7 +232,8 @@ msgstr "Borrador"
 
 #. module: l10n_es_aeat_sii
 #: field:account.fiscal.position,sii_enabled:0
-#: field:account.invoice,sii_enabled:0 field:res.company,sii_enabled:0
+#: field:account.invoice,sii_enabled:0
+#: field:res.company,sii_enabled:0
 msgid "Enable SII"
 msgstr "Activar SII"
 
@@ -286,8 +279,6 @@ msgid "Group By..."
 msgstr "Agrupar por..."
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,id:0 field:aeat.sii.map.lines,id:0
-#: field:aeat.sii.mapping.registration.keys,id:0 field:l10n.es.aeat.sii,id:0
 #: field:aeat.sii.map,id:0
 #: field:aeat.sii.map.lines,id:0
 #: field:aeat.sii.mapping.registration.keys,id:0
@@ -298,18 +289,12 @@ msgstr "ID"
 
 #. module: l10n_es_aeat_sii
 #: help:account.invoice,sii_send_failed:0
-msgid ""
-"Indicates that the last attempt to communicate this invoice to the SII has "
-"failed. See SII return for details"
-msgstr ""
-"Indica que el último intento de comunicar la factura al SII ha fallado. Ver "
-"el retorno SII para más detalles"
+msgid "Indicates that the last attempt to communicate this invoice to the SII has failed. See SII return for details"
+msgstr "Indica que el último intento de comunicar la factura al SII ha fallado. Ver el retorno SII para más detalles"
 
 #. module: l10n_es_aeat_sii
 #: help:account.invoice,sii_state:0
-msgid ""
-"Indicates the state of this invoice in relation with the presentation at the"
-" SII"
+msgid "Indicates the state of this invoice in relation with the presentation at the SII"
 msgstr "Indica el estado de esta factura en relación al registro en el SII"
 
 #. module: l10n_es_aeat_sii
@@ -332,7 +317,7 @@ msgstr "Línea de factura"
 #. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_account_invoice_refund
 msgid "Invoice Refund"
-msgstr "Abono factura"
+msgstr "Factura rectificativa"
 
 #. module: l10n_es_aeat_sii
 #: field:account.invoice.refund,sii_refund_type_required:0
@@ -345,7 +330,8 @@ msgid "Is Test Environment?"
 msgstr "¿Es un entorno de pruebas?"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,__last_update:0 field:aeat.sii.map.lines,__last_update:0
+#: field:aeat.sii.map,__last_update:0
+#: field:aeat.sii.map.lines,__last_update:0
 #: field:aeat.sii.mapping.registration.keys,__last_update:0
 #: field:l10n.es.aeat.sii,__last_update:0
 #: field:l10n.es.aeat.sii.password,__last_update:0
@@ -353,7 +339,8 @@ msgid "Last Modified on"
 msgstr "Últ. modificación en"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,write_uid:0 field:aeat.sii.map.lines,write_uid:0
+#: field:aeat.sii.map,write_uid:0
+#: field:aeat.sii.map.lines,write_uid:0
 #: field:aeat.sii.mapping.registration.keys,write_uid:0
 #: field:l10n.es.aeat.sii,write_uid:0
 #: field:l10n.es.aeat.sii.password,write_uid:0
@@ -361,7 +348,8 @@ msgid "Last Updated by"
 msgstr "Últ. actualización por"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,write_date:0 field:aeat.sii.map.lines,write_date:0
+#: field:aeat.sii.map,write_date:0
+#: field:aeat.sii.map.lines,write_date:0
 #: field:aeat.sii.mapping.registration.keys,write_date:0
 #: field:l10n.es.aeat.sii,write_date:0
 #: field:l10n.es.aeat.sii.password,write_date:0
@@ -395,9 +383,9 @@ msgid "Method"
 msgstr "Método"
 
 #. module: l10n_es_aeat_sii
+#: help:account.invoice,sii_description_method:0
 #: help:res.company,sii_description_method:0
-msgid ""
-"Method for the SII invoices description, can be one of these:\n"
+msgid "Method for the SII invoices description, can be one of these:\n"
 "- Automatic: the description will be the join of the invoice   lines description\n"
 "- Fixed: the description write on the below field 'SII   Description'\n"
 "- Manual (by default): It will be necessary to manually enter   the description on each invoice\n"
@@ -428,7 +416,7 @@ msgid "Never sent to SII"
 msgstr "Nunca enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:304
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:271
 #, python-format
 msgid "No VAT configured for the company '{}'"
 msgstr "La compañía '{}' no tiene ningún NIF establecido"
@@ -543,12 +531,12 @@ msgid "SII Customer header"
 msgstr "Cabecera de cliente para SII"
 
 #. module: l10n_es_aeat_sii
-#: field:account.invoice,sii_description:0
 #: field:res.company,sii_description:0
 msgid "SII Description"
 msgstr "Descripción SII"
 
 #. module: l10n_es_aeat_sii
+#: field:account.invoice,sii_description_method:0
 #: field:res.company,sii_description_method:0
 msgid "SII Description Method"
 msgstr "Método de descripción de SII"
@@ -603,9 +591,9 @@ msgid "SII cancelled"
 msgstr "Anuladas SII"
 
 #. module: l10n_es_aeat_sii
-#: field:account.invoice,sii_description_computed:0
+#: field:account.invoice,sii_description:0
 msgid "SII computed description"
-msgstr "Descripción autocalculada para el SII"
+msgstr "SII computed description"
 
 #. module: l10n_es_aeat_sii
 #: view:account.invoice:l10n_es_aeat_sii.view_account_invoice_sii_filter
@@ -621,6 +609,11 @@ msgstr "Envío SII fallido"
 #: view:account.invoice:l10n_es_aeat_sii.view_account_invoice_sii_filter
 msgid "SII filters"
 msgstr "Filtros SII"
+
+#. module: l10n_es_aeat_sii
+#: field:account.invoice,sii_manual_description:0
+msgid "SII manual description"
+msgstr "Descripción manul SII"
 
 #. module: l10n_es_aeat_sii
 #: view:account.invoice:l10n_es_aeat_sii.view_account_invoice_sii_filter
@@ -701,12 +694,8 @@ msgstr "Impuestos"
 
 #. module: l10n_es_aeat_sii
 #: help:res.company,sii_description:0
-msgid ""
-"The description for invoices. Only when the filed SII Description Method is "
-"'fixed'."
-msgstr ""
-"La descripción para las facturas. Solo cuando el campo 'Método de "
-"descripción de SII' es 'fijo'."
+msgid "The description for invoices. Only used when the field SII Description Method is 'Fixed'."
+msgstr "La descripción para las facturas. Usada solo cuando el campo 'Método de descripción de SII' es 'Fijo'."
 
 #. module: l10n_es_aeat_sii
 #: view:account.invoice:l10n_es_aeat_sii.view_account_invoice_sii_filter
@@ -714,19 +703,19 @@ msgid "The last attemp to sent to SII has failed"
 msgstr "El último intento de envío al SII ha fallado"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:497
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:464
 #, python-format
 msgid "The partner has not a VAT configured."
 msgstr "La empresa no tiene un NIF establecido."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:505
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:472
 #, python-format
 msgid "This company doesn't have SII enabled."
 msgstr "Esta compañía no tiene habilitado el SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:509
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:476
 #, python-format
 msgid "This invoice is not SII enabled."
 msgstr "Esta factura no está habilitada para el SII."
@@ -758,80 +747,61 @@ msgid "With modifications not sent to SII"
 msgstr "Modificaciones no enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:942
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:909
 #, python-format
 msgid "You can not cancel this invoice because there is a job running!"
 msgstr "No puede cancelar una factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:909
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:876
 #, python-format
-msgid ""
-"You can not communicate the cancellation of this invoice at this moment "
-"because there is a job running!"
-msgstr ""
-"En este momento no puede comunicar la cancelación de esta factura porque hay"
-" un trabajo ejecutándose!"
+msgid "You can not communicate the cancellation of this invoice at this moment because there is a job running!"
+msgstr "En este momento no puede comunicar la cancelación de esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:838
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:805
 #, python-format
-msgid ""
-"You can not communicate this invoice at this moment because there is a job "
-"running!"
-msgstr ""
-"En este momento no puede comunicar esta factura porque hay un trabajo "
-"ejecutándose!"
+msgid "You can not communicate this invoice at this moment because there is a job running!"
+msgstr "En este momento no puede comunicar esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:957
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:924
 #, python-format
 msgid "You can not set to draft this invoice because there is a job running!"
-msgstr ""
-"En este momento no puede poner en borrador esta factura porque hay un "
-"trabajo ejecutándose!"
+msgstr "En este momento no puede poner en borrador esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:205
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:157
 #, python-format
 msgid "You cannot change the invoice date of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct date"
 msgstr "No puede cambiar la fecha de factura de una factura enviada al SII. Debe cancelar la factura y crear una nueva con la fecha correcta"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:198
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:174
 #, python-format
-msgid ""
-"You cannot change the supplier invoice number of an invoice already "
-"registered at the SII. You must cancel the invoice and create a new one with"
-" the correct number"
-msgstr ""
-"No puede cambiar el número de factura del proveedor de una factura enviada "
-"al SII. Debe cancelar la factura y crear una nueva con el número correcto"
+msgid "You cannot change the supplier invoice number of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct number"
+msgstr "No puede cambiar el número de factura del proveedor de una factura enviada al SII. Debe cancelar la factura y crear una nueva con el número correcto"
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:167
+#, python-format
+msgid "You cannot change the supplier of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct supplier"
+msgstr "No puede cambiar el proveedor de una factura enviada al SII. Debe cancelar la factura y crear una nueva con el proveedor correcto"
 
 #. module: l10n_es_aeat_sii
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:191
-#, python-format
-msgid ""
-"You cannot change the supplier of an invoice already registered at the SII. "
-"You must cancel the invoice and create a new one with the correct supplier"
-msgstr ""
-"No puede cambiar el proveedor de una factura enviada al SII. Debe cancelar "
-"la factura y crear una nueva con el proveedor correcto"
-
-#. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:224
 #, python-format
 msgid "You cannot delete an invoice already registered at the SII."
 msgstr "No puede eliminar una factura enviada al SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:500
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:467
 #, python-format
 msgid "You have to select what account chart template use this company."
 msgstr "Debe seleccionar qué plan contable utiliza esta compañía"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:142
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:123
 #, python-format
 msgid "You must have at least one refunded invoice"
 msgstr "Debe tener al menos una factura rectificada"
@@ -839,39 +809,35 @@ msgstr "Debe tener al menos una factura rectificada"
 #. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
 msgid "[E1] Art. 20: Operaciones interiores exentas"
-msgstr ""
+msgstr "[E1] Art. 20: Operaciones interiores exentas"
 
 #. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
 msgid "[E2] Art. 21: Exenciones en las exportaciones de bienes"
-msgstr ""
+msgstr "[E2] Art. 21: Exenciones en las exportaciones de bienes"
 
 #. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
-msgid ""
-"[E3] Art. 22: Exenciones en las operaciones asimiladas a las exportaciones"
-msgstr ""
+msgid "[E3] Art. 22: Exenciones en las operaciones asimiladas a las exportaciones"
+msgstr "[E3] Art. 22: Exenciones en las operaciones asimiladas a las exportaciones"
 
 #. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
-msgid ""
-"[E4] Art. 23 y 24: Exenciones relativas a regímenes aduaneros y fiscales. "
-"Exenciones zonas francas, depósitos francos y otros depósitos."
-msgstr ""
+msgid "[E4] Art. 23 y 24: Exenciones relativas a regímenes aduaneros y fiscales. Exenciones zonas francas, depósitos francos y otros depósitos."
+msgstr "[E4] Art. 23 y 24: Exenciones relativas a regímenes aduaneros y fiscales. Exenciones zonas francas, depósitos francos y otros depósitos."
 
 #. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
-msgid ""
-"[E5] Art. 25: Exenciones en las entregas de bienes destinados a otro estado "
-"miembro."
-msgstr ""
+msgid "[E5] Art. 25: Exenciones en las entregas de bienes destinados a otro estado miembro."
+msgstr "[E5] Art. 25: Exenciones en las entregas de bienes destinados a otro estado miembro."
 
 #. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
 msgid "[E6] Otros"
-msgstr ""
+msgstr "[E6] Otros"
 
 #. module: l10n_es_aeat_sii
 #: view:l10n.es.aeat.sii.password:l10n_es_aeat_sii.l10n_es_sii_password_wizard_view
 msgid "or"
 msgstr "o"
+

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -62,7 +62,7 @@ class AccountInvoice(models.Model):
         method_desc = company.sii_description_method
         header_customer = company.sii_header_customer
         header_supplier = company.sii_header_supplier
-        description = ''
+        description = '/'
         if inv_type in ['out_invoice', 'out_refund'] and header_customer:
             description = header_customer
         elif inv_type in ['in_invoice', 'in_refund'] and header_supplier:
@@ -91,6 +91,10 @@ class AccountInvoice(models.Model):
 
     sii_description = fields.Text(
         string='SII Description', default=_default_sii_description,
+    )
+    sii_description_computed = fields.Text(
+        string='SII computed description', compute="_compute_sii_description",
+        default=False, store=True,
     )
     sii_state = fields.Selection(
         selection=SII_STATES, string="SII send state", default='not_sent',
@@ -149,7 +153,7 @@ class AccountInvoice(models.Model):
             else:
                 key = invoice.fiscal_position.sii_registration_key_purchase
             invoice.sii_registration_key = key
-
+    
     @api.onchange('invoice_line')
     def _onchange_invoice_line_l10n_es_aeat_sii(self):
         for invoice in self:
@@ -161,8 +165,8 @@ class AccountInvoice(models.Model):
             if description:
                 description += ' | '
             description += ' - '.join(invoice.mapped('invoice_line.name'))
-            invoice.sii_description = description[:500]
-
+        invoice.sii_description = description[:500]
+    
     @api.model
     def create(self, vals):
         """Complete registration key for auto-generated invoices."""
@@ -170,6 +174,9 @@ class AccountInvoice(models.Model):
         if vals.get('fiscal_position') and \
                 not vals.get('sii_registration_key'):
             invoice.onchange_fiscal_position_l10n_es_aeat_sii()
+        if vals.get('invoice_line') and \
+                not vals.get('sii_description'):
+            invoice._onchange_invoice_line_l10n_es_aeat_sii()
         return invoice
 
     @api.multi
@@ -201,6 +208,9 @@ class AccountInvoice(models.Model):
         if vals.get('fiscal_position') and \
                 not vals.get('sii_registration_key'):
             self.onchange_fiscal_position_l10n_es_aeat_sii()
+        if vals.get('invoice_line') and \
+                not vals.get('sii_description'):
+            self._onchange_invoice_line_l10n_es_aeat_sii()
         return res
 
     @api.multi
@@ -1013,6 +1023,31 @@ class AccountInvoice(models.Model):
         self.ensure_one()
         return self.fiscal_position.sii_no_taxable_cause or \
             'ImportePorArticulos7_14_Otros'
+
+    @api.multi
+    @api.depends('invoice_line', 'invoice_line.name')
+    def _compute_sii_description(self):
+        """Compute the invoice description for SII when changes are made
+        over invoice lines. This is necessary when a process creates or 
+        modifies an invoice line in an invoice but not using the 'create' nor
+        'write' methods of account.invoice model but the account.invoice.line
+        ones, in these cases the description wont me calculated when
+        description mode is set to 'auto'"""  
+        for invoice in self:
+            description = invoice.sii_description
+            if invoice.company_id.sii_description_method == 'auto':
+                description = self.with_context(
+                    type=invoice.type, force_company=invoice.company_id.id,
+                )._default_sii_description()
+                if invoice.invoice_line:
+                    description += ' | '
+                    description += ' - '.join(invoice.mapped(
+                        'invoice_line.name'
+                    ))
+                    description = description[:500] if description else \
+                        False
+            invoice.write({'sii_description': description})
+            invoice.sii_description_computed = description
 
     @api.multi
     @api.depends('company_id', 'company_id.sii_enabled',

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -52,28 +52,6 @@ SII_START_DATE = '2017-07-01'
 class AccountInvoice(models.Model):
     _inherit = 'account.invoice'
 
-    def _default_sii_description(self):
-        context = self.env.context
-        inv_type = context.get('type')
-        if context.get('force_company'):
-            company = self.env['res.company'].browse(context['force_company'])
-        else:
-            company = self.env.user.company_id
-        method_desc = company.sii_description_method
-        header_customer = company.sii_header_customer
-        header_supplier = company.sii_header_supplier
-        description = '/'
-        if inv_type in ['out_invoice', 'out_refund'] and header_customer:
-            description = header_customer
-        elif inv_type in ['in_invoice', 'in_refund'] and header_supplier:
-            description = header_supplier
-        if method_desc in ['fixed']:
-            fixed_desc = company.sii_description
-            if fixed_desc and description:
-                description += ' | '
-            description += fixed_desc
-        return description[0:500]
-
     def _default_sii_refund_type(self):
         inv_type = self.env.context.get('type')
         return 'S' if inv_type in ['out_refund', 'in_refund'] else False
@@ -89,12 +67,15 @@ class AccountInvoice(models.Model):
                 [('code', '=', '01'), ('type', '=', 'sale')], limit=1)
         return key
 
-    sii_description = fields.Text(
-        string='SII Description', default=_default_sii_description,
+    sii_manual_description = fields.Text(
+        string='SII manual description', size=500, copy=False,
     )
-    sii_description_computed = fields.Text(
+    sii_description_method = fields.Selection(
+        related='company_id.sii_description_method', readonly=True,
+    )
+    sii_description = fields.Text(
         string='SII computed description', compute="_compute_sii_description",
-        default=False, store=True,
+        store=True, inverse='_inverse_sii_description',
     )
     sii_state = fields.Selection(
         selection=SII_STATES, string="SII send state", default='not_sent',
@@ -153,20 +134,7 @@ class AccountInvoice(models.Model):
             else:
                 key = invoice.fiscal_position.sii_registration_key_purchase
             invoice.sii_registration_key = key
-    
-    @api.onchange('invoice_line')
-    def _onchange_invoice_line_l10n_es_aeat_sii(self):
-        for invoice in self:
-            if invoice.company_id.sii_description_method != 'auto':
-                continue
-            description = self.with_context(
-                type=invoice.type, force_company=invoice.company_id.id,
-            )._default_sii_description()
-            if description:
-                description += ' | '
-            description += ' - '.join(invoice.mapped('invoice_line.name'))
-        invoice.sii_description = description[:500]
-    
+
     @api.model
     def create(self, vals):
         """Complete registration key for auto-generated invoices."""
@@ -174,9 +142,6 @@ class AccountInvoice(models.Model):
         if vals.get('fiscal_position') and \
                 not vals.get('sii_registration_key'):
             invoice.onchange_fiscal_position_l10n_es_aeat_sii()
-        if vals.get('invoice_line') and \
-                not vals.get('sii_description'):
-            invoice._onchange_invoice_line_l10n_es_aeat_sii()
         return invoice
 
     @api.multi
@@ -215,9 +180,6 @@ class AccountInvoice(models.Model):
         if vals.get('fiscal_position') and \
                 not vals.get('sii_registration_key'):
             self.onchange_fiscal_position_l10n_es_aeat_sii()
-        if vals.get('invoice_line') and \
-                not vals.get('sii_description'):
-            self._onchange_invoice_line_l10n_es_aeat_sii()
         return res
 
     @api.multi
@@ -567,7 +529,7 @@ class AccountInvoice(models.Model):
                 "ClaveRegimenEspecialOTrascendencia": (
                     self.sii_registration_key.code
                 ),
-                "DescripcionOperacion": self.sii_description[0:500],
+                "DescripcionOperacion": self.sii_description,
                 "Contraparte": {
                     "NombreRazon": (
                         self.partner_id.commercial_partner_id.name[0:120]
@@ -644,7 +606,7 @@ class AccountInvoice(models.Model):
                 "ClaveRegimenEspecialOTrascendencia": (
                     self.sii_registration_key.code
                 ),
-                "DescripcionOperacion": self.sii_description[0:500],
+                "DescripcionOperacion": self.sii_description,
                 "DesgloseFactura": desglose_factura,
                 "Contraparte": {
                     "NombreRazon": (
@@ -1032,29 +994,34 @@ class AccountInvoice(models.Model):
             'ImportePorArticulos7_14_Otros'
 
     @api.multi
-    @api.depends('invoice_line', 'invoice_line.name')
+    @api.depends('invoice_line', 'invoice_line.name', 'company_id',
+                 'sii_manual_description')
     def _compute_sii_description(self):
-        """Compute the invoice description for SII when changes are made
-        over invoice lines. This is necessary when a process creates or 
-        modifies an invoice line in an invoice but not using the 'create' nor
-        'write' methods of account.invoice model but the account.invoice.line
-        ones, in these cases the description wont me calculated when
-        description mode is set to 'auto'"""  
         for invoice in self:
-            description = invoice.sii_description
-            if invoice.company_id.sii_description_method == 'auto':
-                description = self.with_context(
-                    type=invoice.type, force_company=invoice.company_id.id,
-                )._default_sii_description()
+            if invoice.type in ['out_invoice', 'out_refund']:
+                description = invoice.company_id.sii_header_customer or ''
+            else:  # supplier invoices
+                description = invoice.company_id.sii_header_supplier or ''
+            method = invoice.company_id.sii_description_method
+            if method == 'fixed':
+                description += (invoice.company_id.sii_description or '/')
+            elif method == 'manual':
+                description = (
+                    invoice.sii_manual_description or description or '/'
+                )
+            else:  # auto method
                 if invoice.invoice_line:
-                    description += ' | '
-                    description += ' - '.join(invoice.mapped(
-                        'invoice_line.name'
-                    ))
-                    description = description[:500] if description else \
-                        False
-            invoice.write({'sii_description': description})
-            invoice.sii_description_computed = description
+                    if description:
+                        description += ' | '
+                    description += ' - '.join(
+                        invoice.mapped('invoice_line.name')
+                    )
+            invoice.sii_description = description[:500]
+
+    @api.multi
+    def _inverse_sii_description(self):
+        for invoice in self:
+            invoice.sii_manual_description = invoice.sii_description
 
     @api.multi
     @api.depends('company_id', 'company_id.sii_enabled',

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -185,8 +185,15 @@ class AccountInvoice(models.Model):
         VAT/ID Otro and the supplier invoice number. Cannot let change these
         values in a SII registered supplier invoice"""
         for invoice in self:
-            if (invoice.type in ['in_invoice', 'in refund'] and
-                    invoice.sii_state != 'not_sent'):
+            if invoice.sii_state == 'not_sent':
+                continue
+            if 'date_invoice' in vals:
+                raise exceptions.Warning(
+                    _("You cannot change the invoice date of an invoice "
+                      "already registered at the SII. You must cancel the "
+                      "invoice and create a new one with the correct date")
+                )
+            if (invoice.type in ['in_invoice', 'in refund']):
                 if 'partner_id' in vals:
                     correct_partners = invoice.partner_id.commercial_partner_id
                     correct_partners |= correct_partners.child_ids

--- a/l10n_es_aeat_sii/models/res_company.py
+++ b/l10n_es_aeat_sii/models/res_company.py
@@ -29,15 +29,15 @@ class ResCompany(models.Model):
              "For all the options you can append a header text using the "
              "below fields 'SII Sale header' and 'SII Purchase header'")
     sii_description = fields.Char(
-        string="SII Description",
-        help="The description for invoices. Only when the filed SII "
-             "Description Method is 'fixed'.")
+        string="SII Description", size=500,
+        help="The description for invoices. Only used when the field SII "
+             "Description Method is 'Fixed'.")
     sii_header_customer = fields.Char(
-        string="SII Customer header",
+        string="SII Customer header", size=500,
         help="An optional header description for customer invoices. "
              "Applied on all the SII description methods")
     sii_header_supplier = fields.Char(
-        string="SII Supplier header",
+        string="SII Supplier header", size=500,
         help="An optional header description for supplier invoices. "
              "Applied on all the SII description methods")
     chart_template_id = fields.Many2one(

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -76,6 +76,7 @@ class TestL10nEsAeatSii(common.TransactionCase):
             'tax_sign': 1,
         })
         self.period = self.env['account.period'].find()
+        self.env.user.company_id.sii_description_method = 'manual'
         self.invoice = self.env['account.invoice'].create({
             'partner_id': self.partner.id,
             'date_invoice': fields.Date.today(),
@@ -92,7 +93,7 @@ class TestL10nEsAeatSii(common.TransactionCase):
                     'quantity': 1,
                     'invoice_line_tax_id': [(6, 0, self.tax.ids)],
                 })],
-            'sii_description': u'/',
+            'sii_manual_description': '/',
         })
 
     def _open_invoice(self):
@@ -227,3 +228,32 @@ class TestL10nEsAeatSii(common.TransactionCase):
         self.invoice.journal_id.update_posted = True
         with self.assertRaises(exceptions.Warning):
             self.invoice.action_cancel()
+
+    def test_sii_description(self):
+        company = self.invoice.company_id
+        company.write({
+            'sii_header_customer': 'Test customer header',
+            'sii_header_supplier': 'Test supplier header',
+            'sii_description': ' | Test description',
+            'sii_description_method': 'fixed',
+        })
+        invoice_temp = self.invoice.copy()
+        self.assertEqual(
+            invoice_temp.sii_description,
+            'Test customer header | Test description',
+        )
+        invoice_temp = self.invoice.copy({'type': 'in_invoice'})
+        self.assertEqual(
+            invoice_temp.sii_description,
+            'Test supplier header | Test description',
+        )
+        company.sii_description_method = 'manual'
+        invoice_temp = self.invoice.copy()
+        self.assertEqual(invoice_temp.sii_description, 'Test customer header')
+        invoice_temp.sii_description = 'Other thing'
+        self.assertEqual(invoice_temp.sii_description, 'Other thing')
+        company.sii_description_method = 'auto'
+        invoice_temp = self.invoice.copy()
+        self.assertEqual(
+            invoice_temp.sii_description, 'Test customer header | Test line',
+        )

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -80,10 +80,11 @@
                 <notebook position="inside">
                     <page string="SII" groups="account.group_account_manager" attrs="{'invisible': [('sii_enabled', '=', False)]}">
                         <group string="SII Information">
-                            <field name="sii_description" attrs="{'required': [('sii_enabled', '=', True)]}"/>
+                            <field name="sii_description_method" invisible="1"/>
+                            <field name="sii_description" attrs="{'required': [('sii_enabled', '=', True)], 'readonly': [('sii_description_method', '!=', 'manual')]}"/>
                             <field name="sii_refund_type"
                                    attrs="{'required': [('sii_enabled', '=', True),('type', 'in', ('out_refund','in_refund'))], 'invisible': [('type', 'not in', ('out_refund','in_refund'))]}"/>
-                            <field name="sii_registration_key" domain="[('type', '=', 'sale')]" attrs="{'required': [('sii_enabled', '=', True)]}"/>
+                            <field name="sii_registration_key" domain="[('type', '=', 'sale')]" attrs="{'required': [('sii_enabled', '=', True)]}" widget="selection"/>
                             <field name="sii_enabled" invisible="1"/>
                         </group>
                         <group string="SII Result">


### PR DESCRIPTION
Al crear facturas desde ventas, compras, albaranes etc. no se calcula la descripción SII, al igual que pasaba con la posición fiscal y clave de la factura. Se añade control en el create y en el write para cubrir estos casos y que siempre se calcule la descripción SII.