### PR TITLE
[8.0][IMP] l10n_es_aeat_sii: varios controles del VAT

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.5.0",
+    "version": "8.0.2.5.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"


### PR DESCRIPTION
* Solo se comprueba que tenga VAT en el caso de regimen nacional
* En caso de extracomunitarias pero con código de pais ES solo acepta
  IDType=07
* Mandar 'NO_DISPONIBLE' en caso de que no haya VAT