### PR TITLE
[8.0][FIX] l10n_es_aeat_sii: fix supplier number required

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -496,7 +496,7 @@ class AccountInvoice(models.Model):
             raise exceptions.Warning(
                 _("This invoice is not SII enabled.")
             )
-        if not self.supplier_number_invoice and self.type in ['in_invoice', 'in_refund']:
+        if not self.supplier_invoice_number and self.type in ['in_invoice', 'in_refund']:
             raise exceptions.Warning(
                 _("The supplier number invoice is required")
             )

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -496,7 +496,8 @@ class AccountInvoice(models.Model):
             raise exceptions.Warning(
                 _("This invoice is not SII enabled.")
             )
-        if not self.supplier_invoice_number and self.type in ['in_invoice', 'in_refund']:
+        if not self.supplier_invoice_number\
+                and self.type in ['in_invoice', 'in_refund']:
             raise exceptions.Warning(
                 _("The supplier number invoice is required")
             )
@@ -1050,7 +1051,9 @@ class AccountInvoice(models.Model):
             description=description, journal_id=journal_id,
         )
         sii_refund_type = self.env.context.get('sii_refund_type')
-        supplier_invoice_number_refund = self.env.context.get('supplier_invoice_number')
+        supplier_invoice_number_refund = self.env.context.get(
+            'supplier_invoice_number'
+        )
         if sii_refund_type:
             res['sii_refund_type'] = sii_refund_type
         if supplier_invoice_number_refund:

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1050,8 +1050,12 @@ class AccountInvoice(models.Model):
             description=description, journal_id=journal_id,
         )
         sii_refund_type = self.env.context.get('sii_refund_type')
+        supplier_invoice_number_refund = self.env.context.get('supplier_invoice_number')
         if sii_refund_type:
             res['sii_refund_type'] = sii_refund_type
+        if supplier_invoice_number_refund:
+            res['supplier_invoice_number'] = supplier_invoice_number_refund
+
         return res
 
     @api.multi

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -496,6 +496,10 @@ class AccountInvoice(models.Model):
             raise exceptions.Warning(
                 _("This invoice is not SII enabled.")
             )
+        if not self.supplier_number_invoice and self.type in ['in_invoice', 'in_refund']:
+            raise exceptions.Warning(
+                _("The supplier number invoice is required")
+            )
 
     @api.multi
     def _get_account_registration_date(self):

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -21,9 +21,6 @@
                                 ('state', 'not in', ['cancel']),
                                 ('sii_state', 'not in', ['sent','sent_modified'])]}" />
                 </button>
-                <field name="supplier_invoice_number" position="attributes">
-                    <attribute name="required">True</attribute>
-                </field>
                 <notebook position="inside">
                     <page string="SII" groups="account.group_account_manager"  attrs="{'invisible': [('sii_enabled', '=', False)]}">
                         <group string="SII Information">

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -21,6 +21,11 @@
                                 ('state', 'not in', ['cancel']),
                                 ('sii_state', 'not in', ['sent','sent_modified'])]}" />
                 </button>
+
+                <field name="supplier_invoice_number" position="attributes">
+                    <attribute name="attrs">{'required':[('state','not in',['open','paid','cancel'])]}</attribute>
+                </field>
+
                 <notebook position="inside">
                     <page string="SII" groups="account.group_account_manager"  attrs="{'invisible': [('sii_enabled', '=', False)]}">
                         <group string="SII Information">

--- a/l10n_es_aeat_sii/wizards/account_invoice_refund.py
+++ b/l10n_es_aeat_sii/wizards/account_invoice_refund.py
@@ -37,10 +37,14 @@ class AccountInvoiceRefund(models.TransientModel):
         string="Is Supplier Invoice Number Required?",
         default=_default_supplier_invoice_number_refund_required,
     )
-    supplier_invoice_number_refund = fields.Char(string="Supplier Invoice Number")
+    supplier_invoice_number_refund = fields.Char(
+        string="Supplier Invoice Number"
+    )
 
     @api.multi
     def compute_refund(self, mode='refund'):
-        obj = self.with_context(sii_refund_type=self.sii_refund_type,
-                                supplier_invoice_number=self.supplier_invoice_number_refund)
+        obj = self.with_context(
+            sii_refund_type=self.sii_refund_type,
+            supplier_invoice_number=self.supplier_invoice_number_refund
+        )
         return super(AccountInvoiceRefund, obj).compute_refund(mode)

--- a/l10n_es_aeat_sii/wizards/account_invoice_refund.py
+++ b/l10n_es_aeat_sii/wizards/account_invoice_refund.py
@@ -13,6 +13,13 @@ class AccountInvoiceRefund(models.TransientModel):
         )
         return any(invoices.mapped('company_id.sii_enabled'))
 
+    def _default_supplier_invoice_number_refund_required(self):
+        invoices = self.env['account.invoice'].browse(
+            self.env.context.get('active_ids'),
+        ).filtered(lambda x: x.type == 'in_invoice')
+
+        return any(invoices.mapped('company_id.sii_enabled'))
+
     def _selection_sii_refund_type(self):
         return self.env['account.invoice'].fields_get(
             allfields=['sii_refund_type']
@@ -26,7 +33,14 @@ class AccountInvoiceRefund(models.TransientModel):
         selection=_selection_sii_refund_type, string="SII Refund Type",
     )
 
+    supplier_invoice_number_refund_required = fields.Boolean(
+        string="Is Supplier Invoice Number Required?",
+        default=_default_supplier_invoice_number_refund_required,
+    )
+    supplier_invoice_number_refund = fields.Char(string="Supplier Invoice Number")
+
     @api.multi
     def compute_refund(self, mode='refund'):
-        obj = self.with_context(sii_refund_type=self.sii_refund_type)
+        obj = self.with_context(sii_refund_type=self.sii_refund_type,
+                                supplier_invoice_number=self.supplier_invoice_number_refund)
         return super(AccountInvoiceRefund, obj).compute_refund(mode)

--- a/l10n_es_aeat_sii/wizards/account_invoice_refund.py
+++ b/l10n_es_aeat_sii/wizards/account_invoice_refund.py
@@ -38,13 +38,13 @@ class AccountInvoiceRefund(models.TransientModel):
         default=_default_supplier_invoice_number_refund_required,
     )
     supplier_invoice_number_refund = fields.Char(
-        string="Supplier Invoice Number"
+        string="Supplier Invoice Number",
     )
 
     @api.multi
     def compute_refund(self, mode='refund'):
         obj = self.with_context(
             sii_refund_type=self.sii_refund_type,
-            supplier_invoice_number=self.supplier_invoice_number_refund
+            supplier_invoice_number=self.supplier_invoice_number_refund,
         )
         return super(AccountInvoiceRefund, obj).compute_refund(mode)

--- a/l10n_es_aeat_sii/wizards/account_invoice_refund_views.xml
+++ b/l10n_es_aeat_sii/wizards/account_invoice_refund_views.xml
@@ -10,8 +10,14 @@
         <field name="arch" type="xml">
             <field name="description" position="before">
                 <field name="sii_refund_type_required" invisible="1"/>
+                <field name="supplier_invoice_number_refund_required" invisible="1" />
                 <field name="sii_refund_type"
-                       attrs="{'required': [('sii_refund_type_required', '=', True)], 'invisible': [('sii_refund_type_required', '=', False)]}"
+                       attrs="{'required': [('sii_refund_type_required', '=', True)],
+                       'invisible': [('sii_refund_type_required', '=', False)]}"
+                />
+                <field name="supplier_invoice_number_refund"
+                       attrs="{'required': [('supplier_invoice_number_refund_required', '=', True)],
+                       'invisible': [('supplier_invoice_number_refund_required', '=', False)]}"
                 />
             </field>
         </field>

--- a/l10n_es_aeat_sii/wizards/account_invoice_refund_views.xml
+++ b/l10n_es_aeat_sii/wizards/account_invoice_refund_views.xml
@@ -12,12 +12,10 @@
                 <field name="sii_refund_type_required" invisible="1"/>
                 <field name="supplier_invoice_number_refund_required" invisible="1" />
                 <field name="sii_refund_type"
-                       attrs="{'required': [('sii_refund_type_required', '=', True)],
-                       'invisible': [('sii_refund_type_required', '=', False)]}"
+                       attrs="{'required': [('sii_refund_type_required', '=', True)], 'invisible': [('sii_refund_type_required', '=', False)]}"
                 />
                 <field name="supplier_invoice_number_refund"
-                       attrs="{'required': [('supplier_invoice_number_refund_required', '=', True)],
-                       'invisible': [('supplier_invoice_number_refund_required', '=', False)]}"
+                       attrs="{'required': [('supplier_invoice_number_refund_required', '=', True)], 'invisible': [('supplier_invoice_number_refund_required', '=', False)]}"
                 />
             </field>
         </field>


### PR DESCRIPTION
Existe un bloqueo cuando se cancela una factura de proveedor por abono, el número es obligatorio, pero no hay opción a cambiarlo.

Lo he pasado a excepción, aunque habría que ver si se hace de forma más practica, pues ahora habría que cancelar dicha factura para introducir el número.