### PR TITLE
[8.0][l10n_es_aeat_sii][IMP] Mejoras en la usabilidad

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.6.0",
+    "version": "8.0.2.7.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-09 17:00+0000\n"
-"PO-Revision-Date: 2017-07-09 17:00+0000\n"
+"POT-Creation-Date: 2017-07-09 17:24+0000\n"
+"PO-Revision-Date: 2017-07-09 17:24+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -109,6 +109,11 @@ msgstr "Por sustitución"
 #: view:l10n.es.aeat.sii.password:l10n_es_aeat_sii.l10n_es_sii_password_wizard_view
 msgid "Cancel"
 msgstr "Cancelar"
+
+#. module: l10n_es_aeat_sii
+#: view:account.invoice:l10n_es_aeat_sii.invoice_sii_form
+msgid "Cancel sending"
+msgstr "Cancelar envío"
 
 #. module: l10n_es_aeat_sii
 #: selection:account.invoice,sii_state:0
@@ -705,6 +710,12 @@ msgstr "Modo de envío"
 #. module: l10n_es_aeat_sii
 #: view:account.invoice:l10n_es_aeat_sii.invoice_sii_form
 #: view:account.invoice:l10n_es_aeat_sii.invoice_supplier_sii_form
+msgid "Send now"
+msgstr "Enviar ahora"
+
+#. module: l10n_es_aeat_sii
+#: view:account.invoice:l10n_es_aeat_sii.invoice_sii_form
+#: view:account.invoice:l10n_es_aeat_sii.invoice_supplier_sii_form
 msgid "Send to SII"
 msgstr "Enviar al SII"
 
@@ -736,7 +747,7 @@ msgstr "Estado"
 #. module: l10n_es_aeat_sii
 #: field:account.invoice.refund,supplier_invoice_number_refund:0
 msgid "Supplier Invoice Number"
-msgstr "Nº factura proveedor"
+msgstr "Nº de factura del proveedor"
 
 #. module: l10n_es_aeat_sii
 #: field:aeat.sii.map.lines,taxes:0
@@ -763,7 +774,7 @@ msgstr "La empresa no tiene un NIF establecido."
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:502
 #, python-format
 msgid "The supplier number invoice is required"
-msgstr "El número de factura del proveedor es obligatorio"
+msgstr "El nº de factura del proveedor es obligatorio"
 
 #. module: l10n_es_aeat_sii
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:493
@@ -799,25 +810,25 @@ msgid "With modifications not sent to SII"
 msgstr "Modificaciones no enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:937
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:938
 #, python-format
 msgid "You can not cancel this invoice because there is a job running!"
 msgstr "No puede cancelar una factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:904
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:908
 #, python-format
 msgid "You can not communicate the cancellation of this invoice at this moment because there is a job running!"
 msgstr "En este momento no puede comunicar la cancelación de esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:833
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:837
 #, python-format
 msgid "You can not communicate this invoice at this moment because there is a job running!"
 msgstr "En este momento no puede comunicar esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:952
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:953
 #, python-format
 msgid "You can not set to draft this invoice because there is a job running!"
 msgstr "En este momento no puede poner en borrador esta factura porque hay un trabajo ejecutándose!"
@@ -826,7 +837,7 @@ msgstr "En este momento no puede poner en borrador esta factura porque hay un tr
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:480
 #, python-format
 msgid "You can't make a supplier simplified invoice."
-msgstr "No puede realizar una facturas simplificada a un proveedor."
+msgstr "No puede realizar una factura simplificada a un proveedor."
 
 #. module: l10n_es_aeat_sii
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:157

--- a/l10n_es_aeat_sii/models/__init__.py
+++ b/l10n_es_aeat_sii/models/__init__.py
@@ -7,6 +7,7 @@ from . import aeat_sii
 from . import aeat_sii_mapping_registration_keys
 from . import aeat_sii_map
 from . import product_product
+from . import queue_job
 from . import account_fiscal_position
 from . import account_invoice
 from . import res_partner

--- a/l10n_es_aeat_sii/models/queue_job.py
+++ b/l10n_es_aeat_sii/models/queue_job.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from openerp import api, models
+
+
+class QueueJob(models.Model):
+    _inherit = 'queue.job'
+
+    @api.multi
+    def do_now(self):
+        self.sudo().write({'eta': 0})
+
+    @api.multi
+    def cancel_now(self):
+        self.sudo().filtered(
+            lambda x: x.state in ['pending', 'enqueued']
+        ).unlink()

--- a/l10n_es_aeat_sii/models/res_company.py
+++ b/l10n_es_aeat_sii/models/res_company.py
@@ -65,10 +65,11 @@ class ResCompany(models.Model):
 
     def _get_sii_eta(self):
         if self.send_mode == 'fixed':
-            offset = datetime.now(pytz.timezone(
-                self._context.get('tz'))).strftime('%z')
+            tz = self.env.context.get('tz', self.env.user.partner_id.tz)
+            offset = datetime.now(pytz.timezone(tz)).strftime('%z') if tz \
+                else '+00'
             hour_diff = int(offset[:3])
-            hour, minute = divmod(self.sent_time, 1)
+            hour, minute = divmod(self.sent_time * 60, 60)
             hour = int(hour - hour_diff)
             minute = int(minute)
             now = datetime.now()

--- a/l10n_es_aeat_sii/security/aeat_sii.xml
+++ b/l10n_es_aeat_sii/security/aeat_sii.xml
@@ -9,5 +9,12 @@
         <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
     </record>
 
+    <record id="queue_job_sii_rule" model="ir.rule">
+        <field name="name">Queue job AEAT SII visibility</field>
+        <field name="model_id" ref="connector.model_queue_job"/>
+        <field name="domain_force">[('channel', '=', 'root.invoice_validate_sii')]</field>
+        <field name="groups" eval="[(4, ref('l10n_es_aeat.group_account_aeat'))]"/>
+    </record>
+
 </data>
 </openerp>

--- a/l10n_es_aeat_sii/security/ir.model.access.csv
+++ b/l10n_es_aeat_sii/security/ir.model.access.csv
@@ -8,3 +8,4 @@ access_model_aeat_sii_mapping_registration_keys_aeat,aeat.sii.mapping.registrati
 access_model_aeat_sii_mapping_registration_keys_aeat_account,aeat.sii.mapping.registration.keys aeat,model_aeat_sii_mapping_registration_keys,account.group_account_invoice,1,0,0,0
 access_l10n_es_aeat_sii_admin,l10n.es.aeat.sii admin,model_l10n_es_aeat_sii,base.group_system,1,1,1,1
 access_l10n_es_aeat_sii_aeat,l10n.es.aeat.sii aeat,model_l10n_es_aeat_sii,l10n_es_aeat.group_account_aeat,1,0,0,0
+access_queue_job,access_queue_job aeat,connector.model_queue_job,l10n_es_aeat.group_account_aeat,1,0,0,0

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -27,22 +27,23 @@
                 </field>
 
                 <notebook position="inside">
-                    <page string="SII" groups="account.group_account_manager"  attrs="{'invisible': [('sii_enabled', '=', False)]}">
+                    <page string="SII" groups="account.group_account_invoice"  attrs="{'invisible': [('sii_enabled', '=', False)]}">
                         <group string="SII Information">
-                            <field name="sii_description" attrs="{'required': [('sii_enabled', '=', True)]}"/>
+                            <field name="sii_description_method" invisible="1"/>
+                            <field name="sii_description" attrs="{'required': [('sii_enabled', '=', True)], 'readonly': [('sii_description_method', '!=', 'manual')]}"/>
                             <field name="sii_refund_type"
                                    attrs="{'required': [('sii_enabled', '=', True),('type', 'in', ('out_refund','in_refund'))], 'invisible': [('type', 'not in', ('out_refund', 'in_refund'))]}"/>
                             <field name="sii_registration_key" domain="[('type', '=', 'purchase')]" attrs="{'required': [('sii_enabled', '=', True)]}"/>
                             <field name="sii_enabled" invisible="1"/>
                         </group>
-                        <group string="SII Result">
+                        <group string="SII Result" groups="l10n_es_aeat.group_account_aeat">
                             <field name="sii_state" />
                             <field name="sii_send_failed" attrs="{'invisible': [('sii_send_failed', '=', False)]}" />
                             <field name="sii_csv"/>
                             <field name="sii_return" />
                         </group>
 
-                        <group string="Connector Jobs">
+                        <group string="Connector Jobs" groups="l10n_es_aeat.group_account_aeat">
                             <field name="invoice_jobs_ids" nolabel="1"
                                    readonly="1">
                                 <tree>
@@ -80,7 +81,7 @@
                     />
                 </button>
                 <notebook position="inside">
-                    <page string="SII" groups="account.group_account_manager" attrs="{'invisible': [('sii_enabled', '=', False)]}">
+                    <page string="SII" groups="account.group_account_invoice" attrs="{'invisible': [('sii_enabled', '=', False)]}">
                         <group string="SII Information">
                             <field name="sii_description_method" invisible="1"/>
                             <field name="sii_description" attrs="{'required': [('sii_enabled', '=', True)], 'readonly': [('sii_description_method', '!=', 'manual')]}"/>
@@ -89,14 +90,14 @@
                             <field name="sii_registration_key" domain="[('type', '=', 'sale')]" attrs="{'required': [('sii_enabled', '=', True)]}" widget="selection"/>
                             <field name="sii_enabled" invisible="1"/>
                         </group>
-                        <group string="SII Result">
+                        <group string="SII Result" groups="l10n_es_aeat.group_account_aeat">
                             <field name="sii_state" />
                             <field name="sii_send_failed" attrs="{'invisible': [('sii_send_failed', '=', False)]}" />
                             <field name="sii_csv"/>
                             <field name="sii_return" />
                         </group>
 
-                        <group string="Connector Jobs">
+                        <group string="Connector Jobs" groups="l10n_es_aeat.group_account_aeat">
                             <field name="invoice_jobs_ids" nolabel="1"
                                    readonly="1">
                                 <tree>

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -48,6 +48,7 @@
                                    readonly="1">
                                 <tree>
                                     <field name="date_created"/>
+                                    <field name="eta"/>
                                     <field name="date_done"/>
                                     <field name="state"/>
                                     <button type="object"
@@ -55,6 +56,12 @@
                                             string="Requeue"
                                             class="oe_highlight"
                                             attrs="{'invisible': [('state', '!=', 'failed')]}"/>
+                                    <button type="object"
+                                            name="do_now"
+                                            string="Send now"
+                                            class="oe_highlight"
+                                            attrs="{'invisible': [('state', '!=', 'pending'), ('eta', '!=', False)]}"
+                                    />
                                 </tree>
                             </field>
                         </group>
@@ -102,6 +109,7 @@
                                    readonly="1">
                                 <tree>
                                     <field name="date_created"/>
+                                    <field name="eta"/>
                                     <field name="date_done"/>
                                     <field name="state"/>
                                     <button type="object"
@@ -109,6 +117,20 @@
                                             string="Requeue"
                                             class="oe_highlight"
                                             attrs="{'invisible': [('state', '!=', 'failed')]}"/>
+                                     <button type="object"
+                                             name="cancel_now"
+                                             string="Cancel sending"
+                                             class="oe_highlight_cancel"
+                                             icon="gtk-stop"
+                                             attrs="{'invisible': [('state', 'not in', ['pending','enqueued'])]}"
+                                    />
+                                    <button type="object"
+                                            name="do_now"
+                                            string="Send now"
+                                            class="oe_highlight"
+                                            icon="gtk-go-forward"
+                                            attrs="{'invisible': ['|', ('state', '!=', 'pending'), ('eta', '=', False)]}"
+                                    />
                                 </tree>
                             </field>
                         </group>
@@ -125,7 +147,7 @@
                 <xpath expr="//group[@string='Group By']" position="before">
                     <group string="SII filters">
                         <filter name="sii_not_sent" string="SII not sent"
-                            domain="[('sii_state', '=', 'not_sent')]"
+                            domain="[('sii_state', '=', 'not_sent'), ('date_invoice', '>=', '2017-01-01')]"
                             help="Never sent to SII" />
                         <filter name="sii_sent" string="SII sent"
                             domain="[('sii_state', 'in', ['sent','cancelled','sent_modified','cancelled_modified'])]"


### PR DESCRIPTION
Añadidas varias mejoras de cara a usabilidad:
- Se cambia el permiso para ver la información SII del formulario de factura del grupo. Cambiada de 'Gestor Financiero' al grupo 'Cobros y pagos' de contabilidad. Creo que es coherente que quienes pueden crear y modificar facturas puedan ver y rellenar esta información, si no habrá casos en los que se les requiera un campo (por ejemplo el tipo de rectificativa) que no puedan ni ver.
- Se asigna permiso sólo al grupo 'Responsable AEAT' para ver el resultado del envío al SII y los trabajos del conector en el formulario de factura.
- Se corrige un error detectado en el formulario de facturas de proveedor, no se establecía readonly el campo 'Descripción SII' para el método de relleno 'auto'. Por error está sólo contemplado en el formulario de factura de cliente, no en las de proveedor.
- Correcciones en la programación de hora de envío para el conector por el método 'Hora fija'. Se evitan errores por no estar establecido 'tz' en el contexto (ahora se coge directamente del timezone del usuario) y se corrige la obtención de los minutos (que no estaba funcionando y obtenía la hora programada pero los minutos siempre eran 0).
