### PR TITLE
[8.0][FIX] l10n_es_aeat_sii: en caso de que no haya descripción no deja guardar

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.5.1",
+    "version": "8.0.2.5.2",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1062,7 +1062,7 @@ class AccountInvoice(models.Model):
                     description += ' - '.join(
                         invoice.mapped('invoice_line.name')
                     )
-            invoice.sii_description = description[:500]
+            invoice.sii_description = description[:500] or '/'
 
     @api.multi
     def _inverse_sii_description(self):


### PR DESCRIPTION
Reportado por un cliente que crean la cabecera de la factura y luego en facturación se encargan de rellenar las líneas, no le permitía meter solo la cabecera de la factura.