### PR TITLE
[8.0] Cambiado hardcodeo nombres de posición fiscal

### DIFF
--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -762,3 +762,22 @@ msgstr "Debe tener al menos una factura rectificada"
 msgid "or"
 msgstr "o"
 
+#. module: l10n_es_aeat_sii
+#: selection:account.fiscal.position,sii_partner_identification_type:0
+msgid "National"
+msgstr "Nacional"
+
+#. module: l10n_es_aeat_sii
+#: selection:account.fiscal.position,sii_partner_identification_type:0
+msgid "Export"
+msgstr "Exportación"
+
+#. module: l10n_es_aeat_sii
+#: selection:account.fiscal.position,sii_partner_identification_type:0
+msgid "Intracom"
+msgstr "Intracomunitario"
+
+#. module: l10n_es_aeat_sii
+#: field:account.fiscal.position,sii_partner_identification_type:0
+msgid "SII partner Identification Type"
+msgstr "SII Tipo de identifiación del cliente"

--- a/l10n_es_aeat_sii/models/account_fiscal_position.py
+++ b/l10n_es_aeat_sii/models/account_fiscal_position.py
@@ -5,9 +5,9 @@
 from openerp import fields, models, api
 
 SII_GEN_TYPE = [
-    ('1', 'National'),
-    ('2', 'Intracom'),
-    ('3', 'Export')
+    (1, 'National'),
+    (2, 'Intracom'),
+    (3, 'Export')
 ]
 
 class AccountFiscalPosition(models.Model):
@@ -56,5 +56,5 @@ class AccountFiscalPosition(models.Model):
     sii_partner_identification_type = fields.Selection(
         selection=SII_GEN_TYPE,
         string="SII partner Identification Type",
-        default="1",
+        default=1,
     )

--- a/l10n_es_aeat_sii/models/account_fiscal_position.py
+++ b/l10n_es_aeat_sii/models/account_fiscal_position.py
@@ -4,6 +4,7 @@
 
 from openerp import fields, models, api
 
+
 class AccountFiscalPosition(models.Model):
     _inherit = 'account.fiscal.position'
 

--- a/l10n_es_aeat_sii/models/account_fiscal_position.py
+++ b/l10n_es_aeat_sii/models/account_fiscal_position.py
@@ -4,6 +4,11 @@
 
 from openerp import fields, models, api
 
+SII_GEN_TYPE = [
+    ('1', 'National'),
+    ('2', 'Intracom'),
+    ('3', 'Export')
+]
 
 class AccountFiscalPosition(models.Model):
     _inherit = 'account.fiscal.position'
@@ -47,4 +52,9 @@ class AccountFiscalPosition(models.Model):
         string="SII Exempt Cause",
         selection='_get_selection_sii_exempt_cause',
         default=default_sii_exempt_cause,
+    )
+    sii_partner_identification_type = fields.Selection(
+        selection=SII_GEN_TYPE,
+        string="SII partner Identification Type",
+        default="1",
     )

--- a/l10n_es_aeat_sii/models/account_fiscal_position.py
+++ b/l10n_es_aeat_sii/models/account_fiscal_position.py
@@ -4,12 +4,6 @@
 
 from openerp import fields, models, api
 
-SII_GEN_TYPE = [
-    (1, 'National'),
-    (2, 'Intracom'),
-    (3, 'Export')
-]
-
 class AccountFiscalPosition(models.Model):
     _inherit = 'account.fiscal.position'
 
@@ -54,7 +48,6 @@ class AccountFiscalPosition(models.Model):
         default=default_sii_exempt_cause,
     )
     sii_partner_identification_type = fields.Selection(
-        selection=SII_GEN_TYPE,
+        selection=[('1', 'National'), ('2', 'Intracom'), ('3', 'Export')],
         string="SII partner Identification Type",
-        default=1,
     )

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -884,14 +884,18 @@ class AccountInvoice(models.Model):
         Returns:
             int: 1 (National), 2 (Intracom), 3 (Export)
         """
+        res = 1
         self.ensure_one()
         partner_identification = self.fiscal_position.sii_partner_identification_type
         if not partner_identification:
-            raise exceptions.Warning(
-                _("You dont set identification type on fiscal position. Please, "
-                  "set it and try again.")
-            )
-        return partner_identification
+            if self.fiscal_position.name == u'Régimen Intracomunitario':
+                res = 2
+            elif self.fiscal_position.name == \
+                    u'Régimen Extracomunitario / Canarias, Ceuta y Melilla':
+                res = 3
+        else:
+            res = partner_identification
+        return int(res)
 
 
     @api.multi

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -886,17 +886,16 @@ class AccountInvoice(models.Model):
         """
         res = 1
         self.ensure_one()
-        partner_identification = self.fiscal_position.sii_partner_identification_type
-        if not partner_identification:
+        partner_ident = self.fiscal_position.sii_partner_identification_type
+        if not partner_ident:
             if self.fiscal_position.name == u'Régimen Intracomunitario':
                 res = 2
             elif self.fiscal_position.name == \
                     u'Régimen Extracomunitario / Canarias, Ceuta y Melilla':
                 res = 3
         else:
-            res = partner_identification
+            res = partner_ident
         return int(res)
-
 
     @api.multi
     def _get_sii_identifier(self):

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -884,18 +884,18 @@ class AccountInvoice(models.Model):
         Returns:
             int: 1 (National), 2 (Intracom), 3 (Export)
         """
-        res = 1
         self.ensure_one()
         partner_ident = self.fiscal_position.sii_partner_identification_type
-        if not partner_ident:
-            if self.fiscal_position.name == u'Régimen Intracomunitario':
-                res = 2
-            elif self.fiscal_position.name == \
-                    u'Régimen Extracomunitario / Canarias, Ceuta y Melilla':
-                res = 3
+        if partner_ident:
+            res = int(partner_ident)
+        elif self.fiscal_position.name == u'Régimen Intracomunitario':
+            res = 2
+        elif (self.fiscal_position.name ==
+                  u'Régimen Extracomunitario / Canarias, Ceuta y Melilla'):
+            res = 3
         else:
-            res = partner_ident
-        return int(res)
+            res = 1
+        return res
 
     @api.multi
     def _get_sii_identifier(self):

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -891,7 +891,7 @@ class AccountInvoice(models.Model):
         elif self.fiscal_position.name == u'Régimen Intracomunitario':
             res = 2
         elif (self.fiscal_position.name ==
-                  u'Régimen Extracomunitario / Canarias, Ceuta y Melilla'):
+              u'Régimen Extracomunitario / Canarias, Ceuta y Melilla'):
             res = 3
         else:
             res = 1

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -468,7 +468,7 @@ class AccountInvoice(models.Model):
         """Build dict with data to send to AEAT WS for invoice types:
         out_invoice and out_refund.
 
-        :param cancel: It indicates if the dictionary if for sending a
+        :param cancel: It indicates if the dictionary is for sending a
           cancellation of the invoice.
         :return: invoices (dict) : Dict XML with data for this invoice.
         """
@@ -885,13 +885,14 @@ class AccountInvoice(models.Model):
             int: 1 (National), 2 (Intracom), 3 (Export)
         """
         self.ensure_one()
-        if self.fiscal_position.name == u'Régimen Intracomunitario':
-            return 2
-        elif self.fiscal_position.name == \
-                u'Régimen Extracomunitario / Canarias, Ceuta y Melilla':
-            return 3
-        else:
-            return 1
+        partner_identification = self.fiscal_position.sii_partner_identification_type
+        if not partner_identification:
+            raise exceptions.Warning(
+                _("You dont set identification type on fiscal position. Please, "
+                  "set it and try again.")
+            )
+        return partner_identification
+
 
     @api.multi
     def _get_sii_identifier(self):

--- a/l10n_es_aeat_sii/views/account_fiscal_position_view.xml
+++ b/l10n_es_aeat_sii/views/account_fiscal_position_view.xml
@@ -20,6 +20,7 @@
                         <field name="sii_registration_key_purchase" attrs="{'invisible': [('sii_active', '!=', True)]}"/>
                         <field name="sii_no_taxable_cause" attrs="{'invisible': [('sii_active', '!=', True)]}"/>
                         <field name="sii_exempt_cause" attrs="{'invisible': [('sii_active', '!=', True)]}"/>
+                        <field name="sii_partner_identification_type" attrs="{'invisible': [('sii_active', '!=', True)]}"/>
                     </group>
                 </xpath>
             </field>


### PR DESCRIPTION
Ahora se puede seleccionar a nivel de posición fiscal el tipo de identificación que se espera para los clientes asociados. Esto nos da opción a cambiar los nombres de las posiciones fiscales según necesidad, y da libertad a quien no quiera hacerlo y usar el estándar.

Si es cierto que una vez aplicado, será necesario configurar las posiciones fiscales según necesidad, ya que por defecto se pondrá nacional.
El mínimo a configurar será (para estos casos):

1. Régimen nacional (ya estará ok, _National_)
2. Régimen Intracomunitario (Seleccionar _Intracom_)
3. Régimen Extracomunitario / Canarias, Ceuta y Melilla (Seleccionar _Export_)