### PR TITLE
[FIX] l10n_es_aeat_sii: Se redondea la base imponible en el caso de las exentas de clientes

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.5.2",
+    "version": "8.0.2.5.3",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -392,7 +392,7 @@ class AccountInvoice(models.Model):
         if taxes_to:
             sub = type_breakdown['PrestacionServicios']['Sujeta']
             sub['NoExenta']['DesgloseIVA']['DetalleIVA'] = taxes_to.values()
-        if 'Exenta' in tax_breakdown['Sujeta']:
+        if 'Sujeta' in tax_breakdown and 'Exenta' in tax_breakdown['Sujeta']:
             exempt_dict = tax_breakdown['Sujeta']['Exenta']
             exempt_dict['BaseImponible'] = \
                 float_round(exempt_dict['BaseImponible'], 2)

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1010,11 +1010,8 @@ class AccountInvoice(models.Model):
                     "ID": vat,
                 }
             }
-        elif gen_type == 3:
-            if country_code != 'ES':
-                id_type = '06' if vat == 'NO_DISPONIBLE' else '04'
-            else:
-                id_type = '06'
+        elif gen_type == 3 and country_code != 'ES':
+            id_type = '06' if vat == 'NO_DISPONIBLE' else '04'
             return {
                 "IDOtro": {
                     "CodigoPais": country_code,
@@ -1022,6 +1019,8 @@ class AccountInvoice(models.Model):
                     "ID": vat,
                 },
             }
+        elif gen_type == 3:
+            return {"NIF": vat[2:]}
 
     @api.multi
     def _get_sii_exempt_cause(self, product):

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1110,7 +1110,8 @@ class AccountInvoice(models.Model):
     @api.multi
     def _get_sii_sign(self):
         self.ensure_one()
-        return -1.0 if self.sii_refund_type == 'I' else 1.0
+        return -1.0 if self.sii_refund_type == 'I' and 'refund' in self.type \
+            else 1.0
 
 
 class AccountInvoiceLine(models.Model):

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -290,6 +290,7 @@ class AccountInvoice(models.Model):
         taxes_dict = {}
         taxes_f = {}
         taxes_to = {}
+        tax_breakdown = {}
         taxes_sfesb = self._get_sii_taxes_map(['SFESB'])
         taxes_sfesbe = self._get_sii_taxes_map(['SFESBE'])
         taxes_sfesisp = self._get_sii_taxes_map(['SFESISP'])

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -391,6 +391,10 @@ class AccountInvoice(models.Model):
         if taxes_to:
             sub = type_breakdown['PrestacionServicios']['Sujeta']
             sub['NoExenta']['DesgloseIVA']['DetalleIVA'] = taxes_to.values()
+        if 'Exenta' in tax_breakdown['Sujeta']:
+            exempt_dict = tax_breakdown['Sujeta']['Exenta']
+            exempt_dict['BaseImponible'] = \
+                float_round(exempt_dict['BaseImponible'], 2)
         # Ajustes finales breakdown
         # - DesgloseFactura y DesgloseTipoOperacion son excluyentes
         # - Ciertos condicionantes obligan DesgloseTipoOperacion


### PR DESCRIPTION
Las entregas intracomunitarias se declaran como exentas y al sumar todas sus lineas puede dar un número de más de dos decimales, por lo que se fuerza el redondeo.