### PR TITLE
[8.0][IMP] l10n_es_aeat_sii: Facturas simplificadas con facturas normales

### DIFF
--- a/l10n_es_aeat_sii/README.rst
+++ b/l10n_es_aeat_sii/README.rst
@@ -109,6 +109,7 @@ Contributors
 * Jordi Tolsà <jordi@studio73.es>
 * Ismael Calvo <ismael.calvo@factorlibre.es>
 * Omar Castiñeira - Comunitea S.L. <omar@comunitea.com>
+* Juanjo Algaz <jalgaz@gmail.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 
 Maintainer

--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.5.3",
+    "version": "8.0.2.6.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"
@@ -53,7 +53,8 @@
         "security/ir.model.access.csv",
         "security/aeat_sii.xml",
         "views/product_view.xml",
-        "views/account_fiscal_position_view.xml"
+        "views/account_fiscal_position_view.xml",
+        "views/res_partner_views.xml",
     ],
     "post_init_hook": "add_key_to_existing_invoices",
 }

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -1,23 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat_sii
-# 
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
-# Pedro Rodríguez <pedro@otherway.es>, 2017
+#	* l10n_es_aeat_sii
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-07 00:09+0000\n"
-"PO-Revision-Date: 2017-07-07 00:09+0000\n"
-"Last-Translator: Pedro Rodríguez <pedro@otherway.es>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"POT-Creation-Date: 2017-07-09 17:00+0000\n"
+"PO-Revision-Date: 2017-07-09 17:00+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_aeat_sii
 #: view:res.company:l10n_es_aeat_sii.view_company_sii_form
@@ -75,21 +71,13 @@ msgstr "Ya enviadas al SII. Incluye facturas canceladas"
 
 #. module: l10n_es_aeat_sii
 #: help:res.company,sii_header_customer:0
-msgid ""
-"An optional header description for customer invoices. Applied on all the SII"
-" description methods"
-msgstr ""
-"Cabecera de la descripción opcional para facturas de cliente. Aplicado en "
-"todos los métodos de descripción de SII"
+msgid "An optional header description for customer invoices. Applied on all the SII description methods"
+msgstr "Cabecera de la descripción opcional para facturas de cliente. Aplicado en todos los métodos de descripción de SII"
 
 #. module: l10n_es_aeat_sii
 #: help:res.company,sii_header_supplier:0
-msgid ""
-"An optional header description for supplier invoices. Applied on all the SII"
-" description methods"
-msgstr ""
-"Cabecera de la descripción opcional para facturas de proveedor. Aplicado en "
-"todos los métodos de descripción de SII"
+msgid "An optional header description for supplier invoices. Applied on all the SII description methods"
+msgstr "Cabecera de la descripción opcional para facturas de proveedor. Aplicado en todos los métodos de descripción de SII"
 
 #. module: l10n_es_aeat_sii
 #: selection:res.company,send_mode:0
@@ -104,12 +92,8 @@ msgstr "Automático"
 
 #. module: l10n_es_aeat_sii
 #: help:res.company,sii_method:0
-msgid ""
-"By default, the invoice is sent/queued in validation process. With manual "
-"method, there's a button to send the invoice."
-msgstr ""
-"Por defecto, la factura es enviada/encolada en el proceso de validación. Con"
-" el método manual, hay un botón para enviarla."
+msgid "By default, the invoice is sent/queued in validation process. With manual method, there's a button to send the invoice."
+msgstr "Por defecto, la factura es enviada/encolada en el proceso de validación. Con el método manual, hay un botón para enviarla."
 
 #. module: l10n_es_aeat_sii
 #: selection:account.invoice,sii_refund_type:0
@@ -148,12 +132,13 @@ msgstr "Plantilla de cuentas"
 
 #. module: l10n_es_aeat_sii
 #: help:res.company,use_connector:0
-msgid ""
-"Check it to use connector instead of sending the invoice directly when it's "
-"validated"
-msgstr ""
-"Márquela para utilizar el conector en lugar de enviar directamente la "
-"factura cuando es validada."
+msgid "Check it to use connector instead of sending the invoice directly when it's validated"
+msgstr "Márquela para utilizar el conector en lugar de enviar directamente la factura cuando es validada."
+
+#. module: l10n_es_aeat_sii
+#: help:res.partner,sii_simplified_invoice:0
+msgid "Checking this mark, invoices done to this partner will be sent to SII as simplified invoices."
+msgstr "Marcando esta casilla, las facturas realizadas a esta empresa serán enviadas al SII como facturas simplificadas."
 
 #. module: l10n_es_aeat_sii
 #: field:aeat.sii.map.lines,code:0
@@ -189,7 +174,8 @@ msgid "Connector config"
 msgstr "Configuración del conector"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,create_uid:0 field:aeat.sii.map.lines,create_uid:0
+#: field:aeat.sii.map,create_uid:0
+#: field:aeat.sii.map.lines,create_uid:0
 #: field:aeat.sii.mapping.registration.keys,create_uid:0
 #: field:l10n.es.aeat.sii,create_uid:0
 #: field:l10n.es.aeat.sii.password,create_uid:0
@@ -197,7 +183,8 @@ msgid "Created by"
 msgstr "Creado por"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,create_date:0 field:aeat.sii.map.lines,create_date:0
+#: field:aeat.sii.map,create_date:0
+#: field:aeat.sii.map.lines,create_date:0
 #: field:aeat.sii.mapping.registration.keys,create_date:0
 #: field:l10n.es.aeat.sii,create_date:0
 #: field:l10n.es.aeat.sii.password,create_date:0
@@ -235,7 +222,8 @@ msgid "Description config"
 msgstr "Configuración de descripción"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,display_name:0 field:aeat.sii.map.lines,display_name:0
+#: field:aeat.sii.map,display_name:0
+#: field:aeat.sii.map.lines,display_name:0
 #: field:aeat.sii.mapping.registration.keys,display_name:0
 #: field:l10n.es.aeat.sii,display_name:0
 #: field:l10n.es.aeat.sii.password,display_name:0
@@ -249,7 +237,9 @@ msgstr "Borrador"
 
 #. module: l10n_es_aeat_sii
 #: field:account.fiscal.position,sii_enabled:0
-#: field:account.invoice,sii_enabled:0 field:res.company,sii_enabled:0
+#: field:account.invoice,sii_enabled:0
+#: field:res.company,sii_enabled:0
+#: field:res.partner,sii_enabled:0
 msgid "Enable SII"
 msgstr "Activar SII"
 
@@ -300,26 +290,22 @@ msgid "Group By..."
 msgstr "Agrupar por..."
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,id:0 field:aeat.sii.map.lines,id:0
-#: field:aeat.sii.mapping.registration.keys,id:0 field:l10n.es.aeat.sii,id:0
+#: field:aeat.sii.map,id:0
+#: field:aeat.sii.map.lines,id:0
+#: field:aeat.sii.mapping.registration.keys,id:0
+#: field:l10n.es.aeat.sii,id:0
 #: field:l10n.es.aeat.sii.password,id:0
 msgid "ID"
 msgstr "ID"
 
 #. module: l10n_es_aeat_sii
 #: help:account.invoice,sii_send_failed:0
-msgid ""
-"Indicates that the last attempt to communicate this invoice to the SII has "
-"failed. See SII return for details"
-msgstr ""
-"Indica que el último intento de comunicar la factura al SII ha fallado. Ver "
-"el retorno SII para más detalles"
+msgid "Indicates that the last attempt to communicate this invoice to the SII has failed. See SII return for details"
+msgstr "Indica que el último intento de comunicar la factura al SII ha fallado. Ver el retorno SII para más detalles"
 
 #. module: l10n_es_aeat_sii
 #: help:account.invoice,sii_state:0
-msgid ""
-"Indicates the state of this invoice in relation with the presentation at the"
-" SII"
+msgid "Indicates the state of this invoice in relation with the presentation at the SII"
 msgstr "Indica el estado de esta factura en relación al registro en el SII"
 
 #. module: l10n_es_aeat_sii
@@ -347,7 +333,7 @@ msgstr "Línea de factura"
 #. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_account_invoice_refund
 msgid "Invoice Refund"
-msgstr "Factura rectificativa"
+msgstr "Abono factura"
 
 #. module: l10n_es_aeat_sii
 #: field:account.invoice.refund,sii_refund_type_required:0
@@ -357,7 +343,7 @@ msgstr "¿Es requerido el tipo de rectificativa SII?"
 #. module: l10n_es_aeat_sii
 #: field:account.invoice.refund,supplier_invoice_number_refund_required:0
 msgid "Is Supplier Invoice Number Required?"
-msgstr "¿Es requerido el número de factura del proveedor?"
+msgstr "¿Es requerido el nº de factura de proveedor?"
 
 #. module: l10n_es_aeat_sii
 #: field:res.company,sii_test:0
@@ -365,7 +351,8 @@ msgid "Is Test Environment?"
 msgstr "¿Es un entorno de pruebas?"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,__last_update:0 field:aeat.sii.map.lines,__last_update:0
+#: field:aeat.sii.map,__last_update:0
+#: field:aeat.sii.map.lines,__last_update:0
 #: field:aeat.sii.mapping.registration.keys,__last_update:0
 #: field:l10n.es.aeat.sii,__last_update:0
 #: field:l10n.es.aeat.sii.password,__last_update:0
@@ -373,7 +360,8 @@ msgid "Last Modified on"
 msgstr "Últ. modificación en"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,write_uid:0 field:aeat.sii.map.lines,write_uid:0
+#: field:aeat.sii.map,write_uid:0
+#: field:aeat.sii.map.lines,write_uid:0
 #: field:aeat.sii.mapping.registration.keys,write_uid:0
 #: field:l10n.es.aeat.sii,write_uid:0
 #: field:l10n.es.aeat.sii.password,write_uid:0
@@ -381,7 +369,8 @@ msgid "Last Updated by"
 msgstr "Últ. actualización por"
 
 #. module: l10n_es_aeat_sii
-#: field:aeat.sii.map,write_date:0 field:aeat.sii.map.lines,write_date:0
+#: field:aeat.sii.map,write_date:0
+#: field:aeat.sii.map.lines,write_date:0
 #: field:aeat.sii.mapping.registration.keys,write_date:0
 #: field:l10n.es.aeat.sii,write_date:0
 #: field:l10n.es.aeat.sii.password,write_date:0
@@ -417,15 +406,13 @@ msgstr "Método"
 #. module: l10n_es_aeat_sii
 #: help:account.invoice,sii_description_method:0
 #: help:res.company,sii_description_method:0
-msgid ""
-"Method for the SII invoices description, can be one of these:\n"
+msgid "Method for the SII invoices description, can be one of these:\n"
 "- Automatic: the description will be the join of the invoice   lines description\n"
 "- Fixed: the description write on the below field 'SII   Description'\n"
 "- Manual (by default): It will be necessary to manually enter   the description on each invoice\n"
 "\n"
 "For all the options you can append a header text using the below fields 'SII Sale header' and 'SII Purchase header'"
-msgstr ""
-"Método para la descripción de las facturas para el SII. Puede ser uno de estos:\n"
+msgstr "Método para la descripción de las facturas para el SII. Puede ser uno de estos:\n"
 "- Automático: la descripción será la unión de la descripción de las líneas de la factura\n"
 "- Fijo: la descripción escrita en el campo de abajo 'Descripción SII'\n"
 "- Manual (por defecto): será necesario introducir manualmente la descripción en cada factura\n"
@@ -498,6 +485,11 @@ msgid "Operaciones no sujetas en el TAI por reglas de localización"
 msgstr "Operaciones no sujetas en el TAI por reglas de localización"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.model,name:l10n_es_aeat_sii.model_res_partner
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: l10n_es_aeat_sii
 #: field:l10n.es.aeat.sii.password,password:0
 msgid "Password"
 msgstr "Contraseña"
@@ -521,6 +513,11 @@ msgstr "Clave pública"
 #: selection:aeat.sii.mapping.registration.keys,type:0
 msgid "Purchase"
 msgstr "Compras"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model,name:l10n_es_aeat_sii.model_queue_job
+msgid "Queue Job"
+msgstr "Trabajo de Cola"
 
 #. module: l10n_es_aeat_sii
 #: view:account.invoice:l10n_es_aeat_sii.invoice_sii_form
@@ -722,6 +719,11 @@ msgid "Sent time"
 msgstr "Hora de envío"
 
 #. module: l10n_es_aeat_sii
+#: field:res.partner,sii_simplified_invoice:0
+msgid "Simplified invoices in SII?"
+msgstr "¿Facturas simplificadas en el SII?"
+
+#. module: l10n_es_aeat_sii
 #: field:l10n.es.aeat.sii,date_start:0
 msgid "Start Date"
 msgstr "Fecha de inicio"
@@ -734,7 +736,7 @@ msgstr "Estado"
 #. module: l10n_es_aeat_sii
 #: field:account.invoice.refund,supplier_invoice_number_refund:0
 msgid "Supplier Invoice Number"
-msgstr "Número de factura del proveedor"
+msgstr "Nº factura proveedor"
 
 #. module: l10n_es_aeat_sii
 #: field:aeat.sii.map.lines,taxes:0
@@ -743,12 +745,8 @@ msgstr "Impuestos"
 
 #. module: l10n_es_aeat_sii
 #: help:res.company,sii_description:0
-msgid ""
-"The description for invoices. Only used when the field SII Description "
-"Method is 'Fixed'."
-msgstr ""
-"La descripción para las facturas. Usada solo cuando el campo 'Método de "
-"descripción de SII' es 'Fijo'."
+msgid "The description for invoices. Only used when the field SII Description Method is 'Fixed'."
+msgstr "La descripción para las facturas. Usada solo cuando el campo 'Método de descripción de SII' es 'Fijo'."
 
 #. module: l10n_es_aeat_sii
 #: view:account.invoice:l10n_es_aeat_sii.view_account_invoice_sii_filter
@@ -756,25 +754,25 @@ msgid "The last attemp to sent to SII has failed"
 msgstr "El último intento de envío al SII ha fallado"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:476
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:485
 #, python-format
 msgid "The partner has not a VAT configured."
 msgstr "La empresa no tiene un NIF establecido."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:493
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:502
 #, python-format
 msgid "The supplier number invoice is required"
 msgstr "El número de factura del proveedor es obligatorio"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:484
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:493
 #, python-format
 msgid "This company doesn't have SII enabled."
 msgstr "Esta compañía no tiene habilitado el SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:488
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:497
 #, python-format
 msgid "This invoice is not SII enabled."
 msgstr "Esta factura no está habilitada para el SII."
@@ -801,69 +799,52 @@ msgid "With modifications not sent to SII"
 msgstr "Modificaciones no enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:926
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:937
 #, python-format
 msgid "You can not cancel this invoice because there is a job running!"
 msgstr "No puede cancelar una factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:893
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:904
 #, python-format
-msgid ""
-"You can not communicate the cancellation of this invoice at this moment "
-"because there is a job running!"
-msgstr ""
-"En este momento no puede comunicar la cancelación de esta factura porque hay"
-" un trabajo ejecutándose!"
+msgid "You can not communicate the cancellation of this invoice at this moment because there is a job running!"
+msgstr "En este momento no puede comunicar la cancelación de esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:822
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:833
 #, python-format
-msgid ""
-"You can not communicate this invoice at this moment because there is a job "
-"running!"
-msgstr ""
-"En este momento no puede comunicar esta factura porque hay un trabajo "
-"ejecutándose!"
+msgid "You can not communicate this invoice at this moment because there is a job running!"
+msgstr "En este momento no puede comunicar esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:941
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:952
 #, python-format
 msgid "You can not set to draft this invoice because there is a job running!"
-msgstr ""
-"En este momento no puede poner en borrador esta factura porque hay un "
-"trabajo ejecutándose!"
+msgstr "En este momento no puede poner en borrador esta factura porque hay un trabajo ejecutándose!"
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:480
+#, python-format
+msgid "You can't make a supplier simplified invoice."
+msgstr "No puede realizar una facturas simplificada a un proveedor."
 
 #. module: l10n_es_aeat_sii
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:157
 #, python-format
-msgid ""
-"You cannot change the invoice date of an invoice already registered at the "
-"SII. You must cancel the invoice and create a new one with the correct date"
-msgstr ""
-"No puede cambiar la fecha de factura de una factura enviada al SII. Debe "
-"cancelar la factura y crear una nueva con la fecha correcta"
+msgid "You cannot change the invoice date of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct date"
+msgstr "No puede cambiar la fecha de factura de una factura enviada al SII. Debe cancelar la factura y crear una nueva con la fecha correcta"
 
 #. module: l10n_es_aeat_sii
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:174
 #, python-format
-msgid ""
-"You cannot change the supplier invoice number of an invoice already "
-"registered at the SII. You must cancel the invoice and create a new one with"
-" the correct number"
-msgstr ""
-"No puede cambiar el número de factura del proveedor de una factura enviada "
-"al SII. Debe cancelar la factura y crear una nueva con el número correcto"
+msgid "You cannot change the supplier invoice number of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct number"
+msgstr "No puede cambiar el número de factura del proveedor de una factura enviada al SII. Debe cancelar la factura y crear una nueva con el número correcto"
 
 #. module: l10n_es_aeat_sii
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:167
 #, python-format
-msgid ""
-"You cannot change the supplier of an invoice already registered at the SII. "
-"You must cancel the invoice and create a new one with the correct supplier"
-msgstr ""
-"No puede cambiar el proveedor de una factura enviada al SII. Debe cancelar "
-"la factura y crear una nueva con el proveedor correcto"
+msgid "You cannot change the supplier of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct supplier"
+msgstr "No puede cambiar el proveedor de una factura enviada al SII. Debe cancelar la factura y crear una nueva con el proveedor correcto"
 
 #. module: l10n_es_aeat_sii
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:191
@@ -872,7 +853,7 @@ msgid "You cannot delete an invoice already registered at the SII."
 msgstr "No puede eliminar una factura enviada al SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:479
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:488
 #, python-format
 msgid "You have to select what account chart template use this company."
 msgstr "Debe seleccionar qué plan contable utiliza esta compañía"
@@ -895,28 +876,18 @@ msgstr "[E2] Art. 21: Exenciones en las exportaciones de bienes"
 
 #. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
-msgid ""
-"[E3] Art. 22: Exenciones en las operaciones asimiladas a las exportaciones"
-msgstr ""
-"[E3] Art. 22: Exenciones en las operaciones asimiladas a las exportaciones"
+msgid "[E3] Art. 22: Exenciones en las operaciones asimiladas a las exportaciones"
+msgstr "[E3] Art. 22: Exenciones en las operaciones asimiladas a las exportaciones"
 
 #. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
-msgid ""
-"[E4] Art. 23 y 24: Exenciones relativas a regímenes aduaneros y fiscales. "
-"Exenciones zonas francas, depósitos francos y otros depósitos."
-msgstr ""
-"[E4] Art. 23 y 24: Exenciones relativas a regímenes aduaneros y fiscales. "
-"Exenciones zonas francas, depósitos francos y otros depósitos."
+msgid "[E4] Art. 23 y 24: Exenciones relativas a regímenes aduaneros y fiscales. Exenciones zonas francas, depósitos francos y otros depósitos."
+msgstr "[E4] Art. 23 y 24: Exenciones relativas a regímenes aduaneros y fiscales. Exenciones zonas francas, depósitos francos y otros depósitos."
 
 #. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
-msgid ""
-"[E5] Art. 25: Exenciones en las entregas de bienes destinados a otro estado "
-"miembro."
-msgstr ""
-"[E5] Art. 25: Exenciones en las entregas de bienes destinados a otro estado "
-"miembro."
+msgid "[E5] Art. 25: Exenciones en las entregas de bienes destinados a otro estado miembro."
+msgstr "[E5] Art. 25: Exenciones en las entregas de bienes destinados a otro estado miembro."
 
 #. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
@@ -931,4 +902,5 @@ msgstr "o"
 #. module: l10n_es_aeat_sii
 #: view:account.invoice:l10n_es_aeat_sii.invoice_supplier_sii_form
 msgid "{'required':[('state','not in',['open','paid','cancel'])]}"
-msgstr ""
+msgstr "{'required':[('state','not in',['open','paid','cancel'])]}"
+

--- a/l10n_es_aeat_sii/models/__init__.py
+++ b/l10n_es_aeat_sii/models/__init__.py
@@ -9,3 +9,4 @@ from . import aeat_sii_map
 from . import product_product
 from . import account_fiscal_position
 from . import account_invoice
+from . import res_partner

--- a/l10n_es_aeat_sii/models/res_partner.py
+++ b/l10n_es_aeat_sii/models/res_partner.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    sii_enabled = fields.Boolean(
+        related="company_id.sii_enabled", readonly=True,
+    )
+    sii_simplified_invoice = fields.Boolean(
+        string="Simplified invoices in SII?",
+        help="Checking this mark, invoices done to this partner will be "
+             "sent to SII as simplified invoices."
+    )

--- a/l10n_es_aeat_sii/views/res_partner_views.xml
+++ b/l10n_es_aeat_sii/views/res_partner_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<openerp>
+<data>
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base_vat.view_partner_form" />
+        <field name="arch" type="xml">
+            <div name="vat_info" position="after">
+                <field name="sii_enabled" invisible="1"/>
+                <field name="sii_simplified_invoice"
+                       attrs="{'invisible': [('sii_enabled', '=', False)]}"
+                />
+            </div>
+        </field>
+    </record>
+</data>
+</openerp>


### PR DESCRIPTION
Bueno, al final este requisito lo he necesitado para el típico cliente "Ventas al contado", y aunque lo necesito para la versión 9, lo he decidido hacer en la v8 para así maximizar la audiencia del mismo.

Gracias a @JuanjoA por la investigación original sobre cómo implementarlo, al que también añado en los créditos por ésta y otras aportaciones que ha hecho y que injustamente no estaba ahí.