### PR TITLE
[8.0][l10n_es_aeat_sii][FIX] Registro correcto de rectificativas por sustitución (opción 2)

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.5.2",
+    "version": "8.0.2.6.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -546,8 +546,9 @@ class AccountInvoice(models.Model):
             inv_dict["FacturaExpedida"] = {
                 # TODO: Incluir los 5 tipos de facturas rectificativas
                 "TipoFactura": (
-                    'R4' if self.sii_refund_type == 'I' or \
-                        self.sii_substitution_refund else 'F1'
+                    'R4' if ((self.type == 'out_refund' and
+                            self.sii_refund_type == 'I') or
+                            self.sii_substitution_refund) else 'F1'
                 ),
                 "ClaveRegimenEspecialOTrascendencia": (
                     self.sii_registration_key.code
@@ -620,8 +621,9 @@ class AccountInvoice(models.Model):
             inv_dict["FacturaRecibida"] = {
                 # TODO: Incluir los 5 tipos de facturas rectificativas
                 "TipoFactura": (
-                    'R4' if self.sii_refund_type == 'I' or \
-                        self.sii_substitution_refund else 'F1'
+                    'R4' if ((self.type == 'in_refund' and
+                            self.sii_refund_type == 'I') or
+                            self.sii_substitution_refund) else 'F1'
                 ),
                 "ClaveRegimenEspecialOTrascendencia": (
                     self.sii_registration_key.code

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -547,8 +547,8 @@ class AccountInvoice(models.Model):
                 # TODO: Incluir los 5 tipos de facturas rectificativas
                 "TipoFactura": (
                     'R4' if ((self.type == 'out_refund' and
-                            self.sii_refund_type == 'I') or
-                            self.sii_substitution_refund) else 'F1'
+                              self.sii_refund_type == 'I') or
+                             self.sii_substitution_refund) else 'F1'
                 ),
                 "ClaveRegimenEspecialOTrascendencia": (
                     self.sii_registration_key.code
@@ -622,8 +622,8 @@ class AccountInvoice(models.Model):
                 # TODO: Incluir los 5 tipos de facturas rectificativas
                 "TipoFactura": (
                     'R4' if ((self.type == 'in_refund' and
-                            self.sii_refund_type == 'I') or
-                            self.sii_substitution_refund) else 'F1'
+                              self.sii_refund_type == 'I') or
+                             self.sii_substitution_refund) else 'F1'
                 ),
                 "ClaveRegimenEspecialOTrascendencia": (
                     self.sii_registration_key.code

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -98,6 +98,11 @@ class AccountInvoice(models.Model):
         string="SII Refund Type", default=_default_sii_refund_type,
         oldname='refund_type',
     )
+    sii_substitution_refund = fields.Boolean(
+        string="Is a refund by substitution?", copy=False,
+        help="Check when this invoice has been registered as the final "
+             "correct invoice of a refund process by substitution"
+    )
     sii_registration_key = fields.Many2one(
         comodel_name='aeat.sii.mapping.registration.keys',
         string="SII registration key", default=_default_sii_registration_key,
@@ -541,7 +546,8 @@ class AccountInvoice(models.Model):
             inv_dict["FacturaExpedida"] = {
                 # TODO: Incluir los 5 tipos de facturas rectificativas
                 "TipoFactura": (
-                    'R4' if self.type == 'out_refund' else 'F1'
+                    'R4' if self.sii_refund_type == 'I' or \
+                        self.sii_substitution_refund else 'F1'
                 ),
                 "ClaveRegimenEspecialOTrascendencia": (
                     self.sii_registration_key.code
@@ -558,18 +564,14 @@ class AccountInvoice(models.Model):
             exp_dict = inv_dict['FacturaExpedida']
             # Uso condicional de IDOtro/NIF
             exp_dict['Contraparte'].update(self._get_sii_identifier())
-            if self.type == 'out_refund':
+            if self.type == 'out_refund' and self.sii_refund_type == 'I':
                 exp_dict['TipoRectificativa'] = self.sii_refund_type
-                if self.sii_refund_type == 'S':
-                    exp_dict['ImporteRectificacion'] = {
-                        'BaseRectificada': sum(
-                            self.
-                            mapped('origin_invoices_ids.cc_amount_untaxed')
-                        ),
-                        'CuotaRectificada': sum(
-                            self.mapped('origin_invoices_ids.cc_amount_tax')
-                        ),
-                    }
+            elif self.sii_substitution_refund:
+                exp_dict['TipoRectificativa'] = 'S'
+                exp_dict['ImporteRectificacion'] = {
+                    'BaseRectificada': 0,
+                    'CuotaRectificada': 0,
+                }
         return inv_dict
 
     @api.multi
@@ -618,7 +620,8 @@ class AccountInvoice(models.Model):
             inv_dict["FacturaRecibida"] = {
                 # TODO: Incluir los 5 tipos de facturas rectificativas
                 "TipoFactura": (
-                    'R4' if self.type == 'in_refund' else 'F1'
+                    'R4' if self.sii_refund_type == 'I' or \
+                        self.sii_substitution_refund else 'F1'
                 ),
                 "ClaveRegimenEspecialOTrascendencia": (
                     self.sii_registration_key.code
@@ -635,22 +638,16 @@ class AccountInvoice(models.Model):
                 "CuotaDeducible": float_round(tax_amount * sign, 2),
             }
             # Uso condicional de IDOtro/NIF
-            inv_dict['FacturaRecibida']['Contraparte'].update(ident)
-            if self.type == 'in_refund':
-                rec_dict = inv_dict['FacturaRecibida']
+            rec_dict = inv_dict['FacturaRecibida']
+            rec_dict['Contraparte'].update(ident)
+            if self.type == 'in_refund' and self.sii_refund_type == 'I':
                 rec_dict['TipoRectificativa'] = self.sii_refund_type
-                refund_tax_amount = sum([
-                    x._get_sii_in_taxes()[1]
-                    for x in self.origin_invoices_ids
-                ])
-                if self.sii_refund_type == 'S':
-                    rec_dict['ImporteRectificacion'] = {
-                        'BaseRectificada': sum(
-                            self.
-                            mapped('origin_invoices_ids.cc_amount_untaxed')
-                        ),
-                        'CuotaRectificada': refund_tax_amount,
-                    }
+            elif self.sii_substitution_refund:
+                rec_dict['TipoRectificativa'] = 'S'
+                rec_dict['ImporteRectificacion'] = {
+                    'BaseRectificada': 0,
+                    'CuotaRectificada': 0,
+                }
         return inv_dict
 
     @api.multi
@@ -1105,7 +1102,7 @@ class AccountInvoice(models.Model):
     @api.multi
     def _get_sii_sign(self):
         self.ensure_one()
-        return -1.0 if self.sii_refund_type == 'I' else 1.0
+        return -1.0 if self.type in ['in_refund', 'out_refund'] else 1.0
 
 
 class AccountInvoiceLine(models.Model):

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -33,6 +33,7 @@
                             <field name="sii_refund_type"
                                    attrs="{'required': [('sii_enabled', '=', True),('type', 'in', ('out_refund','in_refund'))], 'invisible': [('type', 'not in', ('out_refund', 'in_refund'))]}"/>
                             <field name="sii_registration_key" domain="[('type', '=', 'purchase')]" attrs="{'required': [('sii_enabled', '=', True)]}"/>
+                            <field name="sii_substitution_refund" attrs="{'invisible': [('type', 'in', ('in_refund', 'out_refund'))]}"/>
                             <field name="sii_enabled" invisible="1"/>
                         </group>
                         <group string="SII Result">
@@ -87,6 +88,7 @@
                             <field name="sii_refund_type"
                                    attrs="{'required': [('sii_enabled', '=', True),('type', 'in', ('out_refund','in_refund'))], 'invisible': [('type', 'not in', ('out_refund','in_refund'))]}"/>
                             <field name="sii_registration_key" domain="[('type', '=', 'sale')]" attrs="{'required': [('sii_enabled', '=', True)]}" widget="selection"/>
+                            <field name="sii_substitution_refund" attrs="{'invisible': [('type', 'in', ('in_refund', 'out_refund'))]}"/>
                             <field name="sii_enabled" invisible="1"/>
                         </group>
                         <group string="SII Result">

--- a/l10n_es_aeat_sii/wizards/account_invoice_refund_views.xml
+++ b/l10n_es_aeat_sii/wizards/account_invoice_refund_views.xml
@@ -12,7 +12,8 @@
                 <field name="sii_refund_type_required" invisible="1"/>
                 <field name="supplier_invoice_number_refund_required" invisible="1" />
                 <field name="sii_refund_type"
-                       attrs="{'required': [('sii_refund_type_required', '=', True)], 'invisible': [('sii_refund_type_required', '=', False)]}"
+                       invisible="1"
+                       attrs="{'required': [('sii_refund_type_required', '=', True)]}"
                 />
                 <field name="supplier_invoice_number_refund"
                        attrs="{'required': [('supplier_invoice_number_refund_required', '=', True)], 'invisible': [('supplier_invoice_number_refund_required', '=', False)]}"


### PR DESCRIPTION
Propuesta a la polémica de las rectificativas por sustitución, a corde con la opción 2 de la AEAT. Esta opción, según se entiende de las instrucciones de la AEAT, implica:

1. Presentar un nuevo registro (A0 , F1) con la **base y cuota negativas** por los mismos importes que la original rectificada. No se debe indicar que es rectificativa (va implícito en que los importes sean negativos), ni se cominican bases ni cuotas rectificadas ni facturas a las que se rectifica. Es como un alta normal solo que con importes negativos. Vamos a tener en cuenta que la AEAT lo va a entender como una rectificación de bases y cuotas, que es lo que es realmente al ir en negativo.
2. Presentar un nuevo registro (A0, Rx, S) como una rectificativa por el importe final válido tras la sustitución (base y cuota positivas), indicando expresamente que la **base y la cuota rectificada son 0**. Este registro se comunica como rectificativa de sustitución, ya que realmente supone el registro que SUSTITUYE al que estamos rectificando. La AEAT lo va a entender como la factura 'normal' que hemos hemitido para sustituir a otra/s (cuyas bases y cuotas ya hemos rectificado mediante el otro registro que se presenta en negativo). No es necesario comunicar las facturas a las que sustituye.

Creo que la polémica con este tipo de rectificativas viene de que interpretamos que donde la AEAT dice en su ejemplo 

> La modificación por sustitución supondría emitir dos facturas: una factura con base imponible de -1000 € y una factura rectificativa en la que se indicará que
> la base imponible es de 800 €

entendemos que la 'factura rectificativa' debe ser una factura rectificativa de Odoo, cuando realmente se refiere a la factura que rectifica a la original, o sea, la normal de Odoo que se emite en sustitución de la primera (no olvidemos el tipo de rectificación en que estamos). La rectificativa de Odoo es la que rectifica bases y cuotas (por eso se comunica en negativo), pero la que realmente sustituye a la original es la 'normal', por eso es ésa la que debe comunicarse como rectificativa de sustitución en este caso.

Como solución en este PR propongo lo siguiente:

- En el wizard de generación de rectificativas establecer automáticamente el tipo de rectificativa SII en función del método de abono seleccionado. Los métodos 'Crear una factura rectificativa en borador' y 'Cancelar: crea la factura rectificativa y concilia' se corresponden con la rectificación por diferencias ya que sólo modifican bases y coutas (parcial o totalmente) sin generar una nueva factura que sustituya a la primera. Por su parte el método 'Modificar: crea reembolso, concilia y crea una nueva factura en borrador' claramente es la rectificación por sustitución. Para simplificar el UI he ocultado el campo 'Tipo rectificativa SII', ya que no es necesario mostrar los dos porque el método de abono ya implica el tipo SII y así evitamos confusiones y errores.
- He añadido un nuevo campo a factura 'sii_substitution_refund' de tipo Boolenao que nos permite marcar aquellas facturas que se emitan/reciban en sustitución de otras, es decir, la factura en borrador generada por el método de abono 'Modificar'. Lo he añadido a la vista de formulario de factura porque así permitimos que se pueda hacer una rectificación por sustitución manualmente, generando una rectificativa por el total y luego una nueva factura a la que se marca este campo.
- He añadido la lógica para la generación de los diccionarios según lo anteriormente expuesto, las comunicaciones he comprobado que se realizan correctamente y todas las facturas quedan registradas en estado correcto.
- He eliminado lo hecho anteriormente sobre las rectificaciones de tipo 'S' ya que era completamente incorrecto.

