### PR TITLE
[FIX] l10n_es_aeat_sii: añadido código adecuado para 'no censado'

### DIFF
--- a/l10n_es_aeat_sii/README.rst
+++ b/l10n_es_aeat_sii/README.rst
@@ -111,6 +111,7 @@ Contributors
 * Omar Castiñeira - Comunitea S.L. <omar@comunitea.com>
 * Juanjo Algaz <jalgaz@gmail.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* Iván Antón <ozono@ozonomultimedia.com>
 
 Maintainer
 ----------

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -5,6 +5,7 @@
 # Copyright 2017 Otherway - Pedro Rodríguez Gil
 # Copyright 2017 Tecnativa - Pedro M. Baeza
 # Copyright 2017 Comunitea - Omar Castiñeira <omar@comunitea.com>
+# Copyright 2017 Ozono Multimedia - Iván Antón <ozono@ozonomultimedia.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
@@ -994,7 +995,8 @@ class AccountInvoice(models.Model):
             (self.partner_id.vat or '')[:2]
         ).upper()
         if gen_type == 1:
-            if '1117' in (self.sii_send_error or ''):
+            if ('1117' in (self.sii_send_error or '') or
+                    '2011' in (self.sii_send_error or '')):
                 return {
                     "IDOtro": {
                         "CodigoPais": country_code,


### PR DESCRIPTION
Nos ha devuelto 'No censado' que, como figura en el [documento de validaciones](http://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/Version_Produc/Validaciones_ErroresSII_es_es.pdf) es '2011' El NIF de la contraparte no está censado.

Por lo que lo hemos añadido a la condición. 

No hemos eliminado el anterior valor '1117' - El NIF no está identificado. NIF:XXXXX. NOMBRE_RAZON:YYYYY por seguridad