### PR TITLE
[8.0][aeat_sii][IMP] Control de respuesta 'AceptadoConErrores'

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.8.0",
+    "version": "8.0.2.9.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-11 07:55+0000\n"
-"PO-Revision-Date: 2017-07-11 07:55+0000\n"
+"POT-Creation-Date: 2017-07-12 23:26+0000\n"
+"PO-Revision-Date: 2017-07-12 23:26+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,6 +19,11 @@ msgstr ""
 #: view:res.company:l10n_es_aeat_sii.view_company_sii_form
 msgid "AEAT SII Configuration"
 msgstr "Configuración AEAT SII"
+
+#. module: l10n_es_aeat_sii
+#: selection:account.invoice,sii_state:0
+msgid "Accepted with errors"
+msgstr "Aceptado con errores"
 
 #. module: l10n_es_aeat_sii
 #: view:l10n.es.aeat.sii:l10n_es_aeat_sii.l10n_es_sii_form_view
@@ -453,7 +458,7 @@ msgid "Never sent to SII"
 msgstr "Nunca enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:277
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:279
 #, python-format
 msgid "No VAT configured for the company '{}'"
 msgstr "La compañía '{}' no tiene ningún NIF establecido"
@@ -785,25 +790,25 @@ msgid "The last attemp to sent to SII has failed"
 msgstr "El último intento de envío al SII ha fallado"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:491
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:493
 #, python-format
 msgid "The partner has not a VAT configured."
 msgstr "La empresa no tiene un NIF establecido."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:508
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:510
 #, python-format
 msgid "The supplier number invoice is required"
 msgstr "El nº de factura del proveedor es obligatorio"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:499
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:501
 #, python-format
 msgid "This company doesn't have SII enabled."
 msgstr "Esta compañía no tiene habilitado el SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:503
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:505
 #, python-format
 msgid "This invoice is not SII enabled."
 msgstr "Esta factura no está habilitada para el SII."
@@ -830,67 +835,67 @@ msgid "With modifications not sent to SII"
 msgstr "Modificaciones no enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:946
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:951
 #, python-format
 msgid "You can not cancel this invoice because there is a job running!"
 msgstr "No puede cancelar una factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:916
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:921
 #, python-format
 msgid "You can not communicate the cancellation of this invoice at this moment because there is a job running!"
 msgstr "En este momento no puede comunicar la cancelación de esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:845
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:849
 #, python-format
 msgid "You can not communicate this invoice at this moment because there is a job running!"
 msgstr "En este momento no puede comunicar esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:961
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:966
 #, python-format
 msgid "You can not set to draft this invoice because there is a job running!"
 msgstr "En este momento no puede poner en borrador esta factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:486
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:488
 #, python-format
 msgid "You can't make a supplier simplified invoice."
 msgstr "No puede realizar una factura simplificada a un proveedor."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:163
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:165
 #, python-format
 msgid "You cannot change the invoice date of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct date"
 msgstr "No puede cambiar la fecha de factura de una factura enviada al SII. Debe cancelar la factura y crear una nueva con la fecha correcta"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:180
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:182
 #, python-format
 msgid "You cannot change the supplier invoice number of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct number"
 msgstr "No puede cambiar el número de factura del proveedor de una factura enviada al SII. Debe cancelar la factura y crear una nueva con el número correcto"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:173
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:175
 #, python-format
 msgid "You cannot change the supplier of an invoice already registered at the SII. You must cancel the invoice and create a new one with the correct supplier"
 msgstr "No puede cambiar el proveedor de una factura enviada al SII. Debe cancelar la factura y crear una nueva con el proveedor correcto"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:197
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:199
 #, python-format
 msgid "You cannot delete an invoice already registered at the SII."
 msgstr "No puede eliminar una factura enviada al SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:494
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:496
 #, python-format
 msgid "You have to select what account chart template use this company."
 msgstr "Debe seleccionar qué plan contable utiliza esta compañía"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:129
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:131
 #, python-format
 msgid "You must have at least one refunded invoice"
 msgstr "Debe tener al menos una factura rectificada"

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -13,13 +13,13 @@
                             groups="l10n_es_aeat.group_account_aeat"
                             attrs="{'invisible': ['|','|',('state', 'not in', ['open','paid']),
                                 ('sii_enabled', '=', False),
-                                ('sii_state', 'not in', ['not_sent','sent_modified','cancelled_modified'])]}" />
+                                ('sii_state', 'in', ['sent','cancelled'])]}" />
                     <button type="object" string="Send cancellation to SII"
                             name="cancel_sii"
                             groups="l10n_es_aeat.group_account_aeat"
                             attrs="{'invisible': ['|','|',('sii_enabled', '=', False),
                                 ('state', 'not in', ['cancel']),
-                                ('sii_state', 'not in', ['sent','sent_modified'])]}" />
+                                ('sii_state', 'not in', ['sent','sent_w_errors','sent_modified'])]}" />
                 </button>
 
                 <field name="supplier_invoice_number" position="attributes">
@@ -78,12 +78,12 @@
                     <button type="object" string="Send to SII"
                             name="send_sii"
                             groups="l10n_es_aeat.group_account_aeat"
-                            attrs="{'invisible': ['|','|',('sii_enabled', '=', False), ('state', 'not in', ['open','paid']), ('sii_state','not in',['not_sent','sent_modified','cancelled_modified'])]}"
+                            attrs="{'invisible': ['|','|',('sii_enabled', '=', False), ('state', 'not in', ['open','paid']), ('sii_state','in',['sent','cancelled'])]}"
                     />
                     <button type="object" string="Send cancellation to SII"
                             name="cancel_sii"
                             groups="l10n_es_aeat.group_account_aeat"
-                            attrs="{'invisible': ['|','|',('sii_enabled', '=', False), ('state', 'not in', ['cancel']), ('sii_state', 'not in', ['sent','sent_modified'])]}"
+                            attrs="{'invisible': ['|','|',('sii_enabled', '=', False), ('state', 'not in', ['cancel']), ('sii_state', 'not in', ['sent','sent_w_errors','sent_modified'])]}"
                     />
                 </button>
                 <notebook position="inside">
@@ -140,7 +140,7 @@
                             domain="[('sii_state', '=', 'not_sent'), ('date_invoice', '>=', '2017-01-01')]"
                             help="Never sent to SII" />
                         <filter name="sii_sent" string="SII sent"
-                            domain="[('sii_state', 'in', ['sent','cancelled','sent_modified','cancelled_modified'])]"
+                            domain="[('sii_state', 'not in', ['not_sent'])]"
                             help="Already sent to SII. It includes cancelled invoices"/>
                         <separator />
                         <filter name="sii_cancelled" string="SII cancelled"


### PR DESCRIPTION
Se añade control de la respuesta 'AceptadoConErrores' que da el SII cuando una factura se ha registrado pero contiene errores que deben subsanarse. En este estado las comunicaciones siguientes ya deben ser de modificación (A1) ya que si va como 'A0' el SII dará error de registro duplicado. Para controlar esta situación se ha añadido un nuevo estado SII 'sent_w_errors'. Al recibir la respuesta 'AceptadoConErrores' se pone la factura en este nuevo estado y se marca con error de envío para mejor seguimiento por parte del usuario.

Se pone también como readonly el campo 'sii_state' ya que con el control añadido se cubren todas las posibles respuestas del SII y ya no debería ser necesario establecer el estado de envío al SII manualmente.