### PR TITLE
[ADD] l10n_es_facturae_face

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ addons:
       # needed because server-tools is loaded in the dependency chain
       - unixodbc-dev
       - python-mysqldb
+      - libxml2-dev
+      - openssl
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ addons:
       - unixodbc-dev
       - python-mysqldb
       - libxml2-dev
+      - libxmlsec1-dev
+      - libxmlsec1-openssl
       - openssl
 
 env:
@@ -38,7 +40,7 @@ install:
   - travis_install_nightly
 
 script:
-  - travis_wait travis_run_tests
+  - travis_run_tests
 
 after_success:
   - travis_after_tests_success

--- a/l10n_es_facturae_face/README.rst
+++ b/l10n_es_facturae_face/README.rst
@@ -1,0 +1,76 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===============================================================
+Envío de la facturación electrónica española (Factura-E) a FACe
+===============================================================
+
+Este módulo permite la gestión del envío de la facturación electrónica española
+a FACe.
+
+La gestión del envío se realiza mediante los certificados con los que se firma.
+
+Instalación
+===========
+
+Este módulo depende del módulo *l10n_es_facturae* y sus dependencias
+
+Es necesario tener instalado el módulo xmlsec y zeep en la versión que envía en
+formato c14n.
+
+Configuración
+=============
+
+* Es necesario añadir el correo electrónico al que notificar los cambios de
+  estado en la empresa
+* Se debe configurar el servidor de envío
+* Por defecto se añado el servicio web de test:
+  https://se-face-webservice.redsara.es/facturasspp2
+* Si queremos añadir el de producción, debemos cambiar el parámetro por
+  https://webservice.face.gob.es/facturasspp2 y modificar el certificado en
+  parámetros de sistema
+
+Uso
+===
+
+* Accedemos a un cliente y le configuramos la factura electrónica
+* Accedemos a una factura validada del cliente y pulsamos el botón
+  'Enviar a FACe'
+* Podremos añadir adjuntos que al envío de la factura original
+* Pulsamos 'Enviar' en el registro de envío a FACe
+* Si el envío es correcto, nos mostrará el resultado y el número de registro
+* Si el envío es correcto, podremos actualizar el estado de forma online
+* Si el envío es correcto, podremos solicitar la anulación de la factura
+  pulsando 'Cancelar Envío' e introduciendo el motivo
+* Un registro Enviado correctamente no puede ser Eliminado
+* Sólo puede existir un envío Enviado correctamente
+* Se genera una tarea programada que actualiza los registros enviados
+  correctamente no pagados y no anulados
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/189/10.0
+
+Credits
+=======
+
+Contributors
+------------
+
+* Enric Tobella <etobella@creublanca.es>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/l10n_es_facturae_face/__init__.py
+++ b/l10n_es_facturae_face/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models
+from . import wizard

--- a/l10n_es_facturae_face/__manifest__.py
+++ b/l10n_es_facturae_face/__manifest__.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# © 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Envío de Factura-e a FACe",
+    "version": "10.0.1.0.0",
+    "author": "Creu Blanca, "
+              "Odoo Community Association (OCA)",
+    "category": "Accounting & Finance",
+    "website": "https://github.com/OCA/l10n-spain",
+    "license": "AGPL-3",
+    "depends": [
+        "l10n_es_facturae",
+    ],
+    "data": [
+        "data/face_data.xml",
+        "views/res_company_view.xml",
+        "views/res_config_views.xml",
+        "wizard/account_invoice_integration_cancel_view.xml"
+    ],
+    "external_dependencies": {
+        "python": [
+            "OpenSSL",
+            "zeep",
+            "xmlsec"
+        ]
+    },
+    "installable": True,
+}

--- a/l10n_es_facturae_face/data/face_data.xml
+++ b/l10n_es_facturae_face/data/face_data.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<odoo noupdate="1">
+    <record id="account_invoice_face_server" model="ir.config_parameter">
+        <field name="key">account.invoice.face.server</field>
+        <field name="value">https://se-face-webservice.redsara.es/facturasspp2?wsdl</field>
+        <field name="group_ids" eval="[(4, ref('base.group_system'))]"/>
+    </record>
+    <record id="face_certificate" model="ir.attachment">
+        <field name="name">account.invoice.face.certificate</field>
+        <field name="datas_fname">face_certificate.crt</field>
+        <field name="datas">LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUYvVENDQk9XZ0F3SUJBZ0lRVWo1b2Z5N1RZ
+WGhXc0tCWlZ6Nmx4REFOQmdrcWhraUc5dzBCQVFzRkFEQkgKTVFzd0NRWURWUVFHRXdKRlV6RVJN
+QThHQTFVRUNnd0lSazVOVkMxU1EwMHhKVEFqQmdOVkJBc01IRUZESUVOdgpiWEJ2Ym1WdWRHVnpJ
+RWx1Wm05eWJjT2hkR2xqYjNNd0hoY05NVFl3TWpBeU1USXlOakF4V2hjTk1Ua3dNakF5Ck1USXlO
+VFU1V2pDQjJERUxNQWtHQTFVRUJoTUNSVk14RHpBTkJnTlZCQWNNQmsxQlJGSkpSREU4TURvR0Ex
+VUUKQ2d3elRVbE9TVk5VUlZKSlR5QkVSU0JJUVVOSlJVNUVRU0JaSUVGRVRVbE9TVk5VVWtGRFNV
+OU9SVk1nVU1PYQpRa3hKUTBGVE1Vc3dTUVlEVlFRTERFSkVTVkpGUTBOSnc1Tk9JRVJGSUZSRlEw
+NVBURTlIdzQxQlV5QkVSU0JNClFTQkpUa1pQVWsxQlEwbkRrMDRnV1NCTVFWTWdRMDlOVlU1SlEw
+RkRTVTlPUlZNeEVqQVFCZ05WQkFVVENWTXkKT0RNek1EQXlSVEVaTUJjR0ExVUVBd3dRUkZSSlF5
+QkJSMFVnVUZKVlJVSkJVekNDQVNJd0RRWUpLb1pJaHZjTgpBUUVCQlFBRGdnRVBBRENDQVFvQ2dn
+RUJBTEJjb3V5NXdrMVAxTHdxMzhiK21WYlpmb3Fza1BCZXBhd2llSGFyClExTnJrSkpWK2hJWU9u
+Z0dYLzREZHBvVUtyL2V6QXFyTml1MG1IMVd4UEkrZVJMc2UxbG9VYmp3UVRneG5KSTkKUVAwdjc5
+TDZnMFVxTHlGY3d5eTcvZEl4VmtKVUlxN3FQSFhianZsZ3U1ZkN3NnVCOGgwRVEySmxycEtmcXRk
+awpoK2lwRG1VZmluYWdlTTExc01YRWViUytZeE8waWlxSzBXZ0hQRzI3ZFN6ZDBUZm8yU0tRL1hI
+c2d1VHRySW9WCjRra3RHaGtiN0lFcE84K0c4UXpIZDM0N0hpUUF5L01ydXplTEFKamFCaGNZemtD
+bU1GdzV4V2M3azZQQjBTODIKaGVGQjZSTis0UkdZUDE0OVZJTkdTUXJTMFdxSVhyWEpDSExRYjVj
+N0hCZU5wbTBDQXdFQUFhT0NBbEV3Z2dKTgpNQWtHQTFVZEV3UUNNQUF3Z1lFR0NDc0dBUVVGQndF
+QkJIVXdjekE3QmdnckJnRUZCUWN3QVlZdmFIUjBjRG92CkwyOWpjM0JqYjIxd0xtTmxjblF1Wm01
+dGRDNWxjeTl2WTNOd0wwOWpjM0JTWlhOd2IyNWtaWEl3TkFZSUt3WUIKQlFVSE1BS0dLR2gwZEhB
+Nkx5OTNkM2N1WTJWeWRDNW1ibTEwTG1WekwyTmxjblJ6TDBGRFEwOU5VQzVqY25RdwpSQVlEVlIw
+Z0JEMHdPekE1QmdvckJnRUVBYXhtQXdrQ01Dc3dLUVlJS3dZQkJRVUhBZ0VXSFdoMGRIQTZMeTkz
+CmQzY3VZMlZ5ZEM1bWJtMTBMbVZ6TDJSd1kzTXZNQzRHQTFVZEVRUW5NQ1drSXpBaE1SOHdIUVlK
+S3dZQkJBR3MKWmdFSURCQkVWRWxESUVGSFJTQlFVbFZGUWtGVE1CTUdBMVVkSlFRTU1Bb0dDQ3NH
+QVFVRkJ3TUNNQTRHQTFVZApEd0VCL3dRRUF3SUVzREFkQmdOVkhRNEVGZ1FVbVVQYUNLUzFHWFVM
+UnY3VFlHRk1HNkJ4bWNRd0h3WURWUjBqCkJCZ3dGb0FVR2ZoWUx4VFdwc3liQkpnSURVelhxd0Nu
+ZzJVd2dlQUdBMVVkSHdTQjJEQ0IxVENCMHFDQno2Q0IKeklhQm5teGtZWEE2THk5c1pHRndZMjl0
+Y0M1alpYSjBMbVp1YlhRdVpYTXZRMDQ5UTFKTU1TeFBWVDFCUXlVeQpNRU52YlhCdmJtVnVkR1Z6
+SlRJd1NXNW1iM0p0WVhScFkyOXpMRTg5Ums1TlZDMVNRMDBzUXoxRlV6OWpaWEowCmFXWnBZMkYw
+WlZKbGRtOWpZWFJwYjI1TWFYTjBPMkpwYm1GeWVUOWlZWE5sUDI5aWFtVmpkR05zWVhOelBXTlMK
+VEVScGMzUnlhV0oxZEdsdmJsQnZhVzUwaGlsb2RIUndPaTh2ZDNkM0xtTmxjblF1Wm01dGRDNWxj
+eTlqY214egpZMjl0Y0M5RFVrd3hMbU55YkRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVRsWjNE
+UEZ6MWdRMzJZT1lJSUx6CmY5OWt1azJ3RllVTGcrWGFEcWlzL3kvUzZicGhLRjN4YnR5eHNJWCts
+eDB6STE3ZHlEVEtBKzZzV05IaWl1SDQKWWpYa3FieGJJOEVZSGZlUnpiUkszUzRHajF5YXRHVnRo
+c0NLNndEcmxyOFJyajhRZ250RkFNKy9rZnlzR0psSApFaUZzZ1ROMmlYZk9zam1YTk5LMUx3U2JR
+M0dDd1BhTFlLWm9uTnNFajhQL1M1cjkxSUNlamZHbFZacDFBRVh5ClAzakp6aWJyMFNLeHdFdDMy
+ci8rWmpUbVFnckx1QW1HcmdjVnNqQUFtMkNwN3VzSllhUy9TeVBGajFRRFVsWm8KVk91bzRkZmdG
+VVpMQ1ZCZk1VQlk3M1dOYXpWQW9qcVpoRzlkOHRBZ2cyYzY0bnVzdU1EWSsyNU1MVUtGenNiegpG
+Zz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0KCg==</field>
+        <field name="group_ids" eval="[(4, ref('base.group_system'))]"/>
+    </record>
+    <record id="seq_account_invoice_face" model="ir.sequence">
+        <field name="name">Integration FACe</field>
+        <field name="code">account.invoice.integration.face</field>
+        <field name="prefix">FACe</field>
+        <field name="padding">8</field>
+    </record>
+    <record id="integration_face" model="account.invoice.integration.method">
+        <field name="name">FACe</field>
+        <field name="code">FACe</field>
+        <field name="sequence_id" ref="l10n_es_facturae_face.seq_account_invoice_face"/>
+    </record>
+</odoo>

--- a/l10n_es_facturae_face/models/__init__.py
+++ b/l10n_es_facturae_face/models/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import res_partner
+from . import res_company
+from . import config
+from . import account_invoice_integration_method
+from . import account_invoice_integration
+from . import account_invoice_integration_log

--- a/l10n_es_facturae_face/models/account_invoice_integration.py
+++ b/l10n_es_facturae_face/models/account_invoice_integration.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# © 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import models, fields
+
+
+class AccountInvoiceIntegration(models.Model):
+    _inherit = "account.invoice.integration"
+
+    integration_status = fields.Selection(selection_add=[
+        ('face-1200', 'Registered on REC'),
+        ('face-1300', 'Registered on RCF'),
+        ('face-2400', 'Accepted'),
+        ('face-2500', 'Payed'),
+        ('face-2600', 'Rejected'),
+        ('face-3100', 'Cancellation approved'),
+    ])
+    cancellation_status = fields.Selection(selection_add=[
+        ('face-4100', 'Not requested'),
+        ('face-4200', 'Cancellation requested'),
+        ('face-4300', 'Cancellation accepted'),
+        ('face-4400', 'Cancellation rejected'),
+    ])

--- a/l10n_es_facturae_face/models/account_invoice_integration_log.py
+++ b/l10n_es_facturae_face/models/account_invoice_integration_log.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+# © 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import models
+import base64
+import logging
+from .wsse_signature import MemorySignature
+try:
+    from OpenSSL import crypto
+    from zeep import Client
+except (ImportError, IOError) as err:
+    logging.info(err)
+
+ns = "https://ssweb.seap.minhap.es/web-service-test-face/sspp"
+
+
+class AccountInvoiceIntegration(models.Model):
+    _inherit = "account.invoice.integration.log"
+
+    def update_method(self):
+        if self.integration_id.method_id == self.env.ref(
+                'l10n_es_facturae_face.integration_face'):
+            invoice = self.integration_id.invoice_id
+            cert = crypto.load_pkcs12(
+                base64.b64decode(invoice.company_id.facturae_cert),
+                invoice.company_id.facturae_cert_password
+            )
+            cert.set_ca_certificates(None)
+            client = Client(
+                wsdl=self.env["ir.config_parameter"].get_param(
+                    "account.invoice.face.server", default=None),
+                wsse=MemorySignature(
+                    cert.export(),
+                    base64.b64decode(
+                        self.env.ref(
+                            'l10n_es_facturae_face.face_certificate').datas
+                    ),
+                )
+            )
+            response = client.service.consultarFactura(
+                self.integration_id.register_number
+            )
+            self.result_code = response.resultado.codigo
+            self.log = response.resultado.descripcion
+            if self.result_code == '0':
+                self.state = 'sent'
+                factura = response.factura
+                integ = self.integration_id
+                integ.integration_status = 'face-' + factura.tramitacion.codigo
+                integ.integration_description = factura.tramitacion.motivo
+                integ.cancellation_status = 'face-' + factura.anulacion.codigo
+                integ.cancellation_description = factura.anulacion.motivo
+                if integ.cancellation_status != 'face-4100':
+                    integ.can_cancel = False
+            else:
+                self.state = 'failed'
+            return
+        return super(AccountInvoiceIntegration, self).update_method()
+
+    def cancel_method(self):
+        if self.integration_id.method_id == self.env.ref(
+                'l10n_es_facturae_face.integration_face'):
+            invoice = self.integration_id.invoice_id
+            cert = crypto.load_pkcs12(
+                base64.b64decode(invoice.company_id.facturae_cert),
+                invoice.company_id.facturae_cert_password
+            )
+            cert.set_ca_certificates(None)
+            client = Client(
+                wsdl=self.env["ir.config_parameter"].get_param(
+                    "account.invoice.face.server", default=None),
+                wsse=MemorySignature(
+                    cert.export(),
+                    base64.b64decode(
+                        self.env.ref(
+                            'l10n_es_facturae_face.face_certificate').datas
+                    )
+                )
+            )
+            response = client.service.anularFactura(
+                self.integration_id.register_number,
+                self.cancellation_motive
+            )
+            self.result_code = response.resultado.codigo
+            self.log = response.resultado.descripcion
+            if self.result_code == '0':
+                self.state = 'sent'
+                self.integration_id.state = 'cancelled'
+                self.integration_id.can_cancel = False
+            else:
+                self.state = 'failed'
+            return
+        return super(AccountInvoiceIntegration, self).cancel_method()
+
+    def send_method(self):
+        if self.integration_id.method_id == self.env.ref(
+                'l10n_es_facturae_face.integration_face'):
+            invoice = self.integration_id.invoice_id
+            cert = crypto.load_pkcs12(
+                base64.b64decode(invoice.company_id.facturae_cert),
+                invoice.company_id.facturae_cert_password
+            )
+            cert.set_ca_certificates(None)
+            client = Client(
+                wsdl=self.env["ir.config_parameter"].get_param(
+                    "account.invoice.face.server", default=None),
+                wsse=MemorySignature(
+                    cert.export(),
+                    base64.b64decode(
+                        self.env.ref(
+                            'l10n_es_facturae_face.face_certificate').datas
+                    )
+                )
+            )
+            invoice_file = client.get_type('ns0:FacturaFile')(
+                self.integration_id.attachment_id.datas,
+                self.integration_id.attachment_id.datas_fname,
+                self.integration_id.attachment_id.mimetype
+            )
+            anexos_list = []
+            if self.integration_id.attachment_ids:
+                for attachment in self.attachment_ids:
+                    anexo = client.get_type('ns0:AnexoFile')(
+                        attachment.datas,
+                        attachment.datas_fname,
+                        attachment.mimetype
+                    )
+                    anexos_list.append(anexo)
+            anexos = client.get_type('ns0:ArrayOfAnexoFile')(
+                anexos_list
+            )
+            invoice_call = client.get_type('ns0:EnviarFacturaRequest')(
+                invoice.company_id.face_email,
+                invoice_file,
+                anexos
+            )
+            response = client.service.enviarFactura(
+                invoice_call
+            )
+            self.result_code = response.resultado.codigo
+            self.log = response.resultado.descripcion
+            if self.result_code == '0':
+                self.state = 'sent'
+                integ = self.integration_id
+                integ.register_number = response.factura.numeroRegistro
+                integ.state = 'sent'
+                integ.can_cancel = True
+                integ.can_update = True
+                integ.can_send = False
+            else:
+                self.integration_id.state = 'failed'
+                self.state = 'failed'
+            return
+        return super(AccountInvoiceIntegration, self).send_method()

--- a/l10n_es_facturae_face/models/account_invoice_integration_method.py
+++ b/l10n_es_facturae_face/models/account_invoice_integration_method.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# © 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import models, exceptions, _
+import base64
+
+
+class AccountInvoiceIntegrationMethod(models.Model):
+    _inherit = "account.invoice.integration.method"
+
+    # Default values for integration. It could be extended
+    def integration_values(self, invoice):
+        res = super(AccountInvoiceIntegrationMethod, self).integration_values(
+            invoice
+        )
+        if self.code == 'FACe':
+            if not invoice.company_id.facturae_cert:
+                raise exceptions.UserError(
+                    _('Certificate must be added for company'))
+            if not invoice.company_id.facturae_cert_password:
+                raise exceptions.UserError(
+                    _('Certificate password must be added for company'))
+            invoice_file, file_name = invoice.get_facturae(True)
+            attachment = self.env['ir.attachment'].create({
+                'name': file_name,
+                'datas': base64.b64encode(invoice_file),
+                'datas_fname': file_name,
+                'res_model': 'account.invoice',
+                'res_id': invoice.id,
+                'mimetype': 'application/xml'
+            })
+            res['attachment_id'] = attachment.id
+        return res

--- a/l10n_es_facturae_face/models/config.py
+++ b/l10n_es_facturae_face/models/config.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# © 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields, api
+
+
+class AccountConfigSettings(models.TransientModel):
+    _inherit = 'account.config.settings'
+
+    face_server = fields.Char(string="FACe server location")
+
+    @api.model
+    def get_default_face_server(self, fields):
+        face_server = self.env["ir.config_parameter"].get_param(
+            "account.invoice.face.server", default=None)
+        return {'face_server': face_server or False}
+
+    @api.multi
+    def set_face_server(self):
+        for record in self:
+            self.env['ir.config_parameter'].set_param(
+                "account.invoice.face.server", record.face_server or '')

--- a/l10n_es_facturae_face/models/res_company.py
+++ b/l10n_es_facturae_face/models/res_company.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# © 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
+import re
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    face_email = fields.Char()
+
+    @api.constrains('face_email')
+    def check_face_email(self):
+        for record in self:
+            if not re.match(
+                    '(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$)',
+                    record.face_email):
+                raise ValidationError(_('Invalid facturae email'))

--- a/l10n_es_facturae_face/models/res_partner.py
+++ b/l10n_es_facturae_face/models/res_partner.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# © 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+from odoo import models, api, exceptions, _
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.constrains('facturae', 'vat', 'country_id', 'state_id',
+                    'invoice_integration_method_ids')
+    def constrain_face(self):
+        face = self.env.ref('l10n_es_facturae_face.integration_face')
+        for record in self.filtered(
+                lambda x: face in x.invoice_integration_method_ids):
+            if not record.facturae:
+                raise exceptions.ValidationError(
+                    _('Facturae must be selected in order to send to FACe')
+                )
+            if not record.vat:
+                raise exceptions.ValidationError(
+                    _('Vat must be defined in order to send to FACe'))
+            if not record.country_id:
+                raise exceptions.ValidationError(
+                    _('Country must be defined in order to send to FACe'))
+            if record.country_id.code_alpha3 == 'ESP':
+                if not record.state_id:
+                    raise exceptions.ValidationError(
+                        _('State must be defined in Spain in order to '
+                          'send to FACe'))

--- a/l10n_es_facturae_face/models/wsse_signature.py
+++ b/l10n_es_facturae_face/models/wsse_signature.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+# © 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+"""Functions for WS-Security (WSSE) signature creation and verification.
+
+Heavily based on test examples in https://github.com/mehcode/python-xmlsec as
+well as the xmlsec documentation at https://www.aleksey.com/xmlsec/.
+
+Reading the xmldsig, xmlenc, and ws-security standards documents, though
+admittedly painful, will likely assist in understanding the code in this
+module.
+
+"""
+from lxml import etree
+from lxml.etree import QName
+import logging
+try:
+    from zeep import ns
+    from zeep.exceptions import SignatureVerificationFailed
+    from zeep.utils import detect_soap_env
+    from zeep.wsse.utils import ensure_id, get_security_header
+    from OpenSSL import crypto
+except (ImportError, IOError) as err:
+    logging.info(err)
+import base64
+from datetime import datetime, timedelta
+
+try:
+    import xmlsec
+except ImportError:
+    xmlsec = None
+
+# SOAP envelope
+SOAP_NS = 'http://schemas.xmlsoap.org/soap/envelope/'
+
+
+def _read_file(f_name):
+    with open(f_name, "rb") as f:
+        return f.read()
+
+
+def _make_sign_key(key_data, cert_data, password):
+    key = xmlsec.Key.from_memory(key_data,
+                                 xmlsec.KeyFormat.PKCS12_PEM, password)
+    return key
+
+
+def _make_verify_key(cert_data):
+    key = xmlsec.Key.from_memory(cert_data,
+                                 xmlsec.KeyFormat.CERT_PEM, None)
+    return key
+
+
+class MemorySignature(object):
+    """Sign given SOAP envelope with WSSE sig using given key and cert."""
+
+    def __init__(self, key_data, cert_data, password=None):
+        check_xmlsec_import()
+
+        self.key_data = key_data
+        self.cert_data = cert_data
+        self.password = password
+
+    def apply(self, envelope, headers):
+        signed = sign_envelope(envelope, self.key_data, self.cert_data,
+                               self.password)
+        return signed, headers
+
+    def verify(self, envelope):
+        key = _make_verify_key(self.cert_data)
+        _verify_envelope_with_key(envelope, key)
+        return envelope
+
+
+class Signature(MemorySignature):
+    """Sign given SOAP envelope with WSSE sig using given key file and
+    cert file."""
+
+    def __init__(self, key_file, certfile, password=None):
+        super(Signature, self).__init__(_read_file(key_file),
+                                        _read_file(certfile),
+                                        password)
+
+
+def check_xmlsec_import():
+    if xmlsec is None:
+        raise ImportError(
+            "The xmlsec module is required for wsse.Signature()\n" +
+            "You can install xmlsec with: pip install xmlsec\n" +
+            "or install zeep via: pip install zeep[xmlsec]\n"
+        )
+
+
+def sign_envelope(envelope, keyfile, certfile, password=None):
+    key = _make_sign_key(keyfile, certfile, password)
+    reference_id = 'Reference'
+    security = get_security_header(envelope)
+    security.set(QName(ns.SOAP_ENV_11, 'mustUnderstand'), '1')
+    x509type = 'http://docs.oasis-open.org/wss/2004/01/' \
+               'oasis-200401-wss-x509-token-profile-1.0#X509v3'
+    encoding_type = "http://docs.oasis-open.org/wss/2004/01/" \
+                    "oasis-200401-wss-soap-message-security-1.0#Base64Binary"
+    binary_token = etree.SubElement(
+        security,
+        QName(ns.WSSE, 'BinarySecurityToken'),
+        attrib={
+            QName(ns.WSU, 'Id'): reference_id,
+            'ValueType': x509type,
+            'EncodingType': encoding_type
+        }
+    )
+    binary_token.text = base64.b64encode(
+        crypto.dump_certificate(
+            crypto.FILETYPE_ASN1,
+            crypto.load_pkcs12(keyfile, password).get_certificate()
+        )
+    )
+    signature = xmlsec.template.create(
+        envelope,
+        xmlsec.Transform.EXCL_C14N,
+        xmlsec.Transform.RSA_SHA1,
+        ns='ds'
+    )
+
+    # Add a KeyInfo node with X509Data child to the Signature. XMLSec will fill
+    # in this template with the actual certificate details when it signs.
+    key_info = xmlsec.template.ensure_key_info(signature)
+    sec_token_ref = etree.SubElement(
+        key_info, QName(ns.WSSE, 'SecurityTokenReference'))
+    etree.SubElement(
+        sec_token_ref,
+        QName(ns.WSSE, 'Reference'),
+        attrib={
+            'URI': '#' + reference_id,
+            'ValueType': x509type
+        }
+    )
+    # Insert the Signature node in the wsse:Security header.
+
+    security.append(signature)
+
+    # Perform the actual signing.
+    ctx = xmlsec.SignatureContext()
+    ctx.key = key
+
+    timestamp = etree.SubElement(security, QName(ns.WSU, 'Timestamp'))
+    now = datetime.now()
+    etree.SubElement(timestamp, QName(ns.WSU, 'Created')).text = now.strftime(
+        '%Y-%m-%dT%H:%M:%SZ'
+    )
+    exp = now + timedelta(hours=1)
+    etree.SubElement(timestamp, QName(ns.WSU, 'Expires')).text = exp.strftime(
+        '%Y-%m-%dT%H:%M:%SZ'
+    )
+
+    soap_env = detect_soap_env(envelope)
+    _sign_node(ctx, signature, envelope.find(QName(soap_env, 'Body')))
+    _sign_node(ctx, signature, security.find(QName(ns.WSU, 'Timestamp')))
+
+    ctx.sign(signature)
+    return etree.fromstring(etree.tostring(envelope, method='c14n'))
+
+
+def verify_envelope(envelope, certfile):
+    """Verify WS-Security signature on given SOAP envelope with given cert.
+
+    Expects a document like that found in the sample XML in the ``sign()``
+    docstring.
+
+    Raise SignatureVerificationFailed on failure, silent on success.
+
+    """
+    key = _make_verify_key(_read_file(certfile))
+    return _verify_envelope_with_key(envelope, key)
+
+
+def _verify_envelope_with_key(envelope, key):
+    soap_env = detect_soap_env(envelope)
+
+    header = envelope.find(QName(soap_env, 'Header'))
+    if not header:
+        raise SignatureVerificationFailed()
+
+    security = header.find(QName(ns.WSSE, 'Security'))
+    signature = security.find(QName(ns.DS, 'Signature'))
+
+    ctx = xmlsec.SignatureContext()
+
+    # Find each signed element and register its ID with the signing context.
+    refs = signature.xpath(
+        'ds:SignedInfo/ds:Reference', namespaces={'ds': ns.DS})
+    for ref in refs:
+        # Get the reference URI and cut off the initial '#'
+        referenced_id = ref.get('URI')[1:]
+        referenced = envelope.xpath(
+            "//*[@wsu:Id='%s']" % referenced_id,
+            namespaces={'wsu': ns.WSU},
+        )[0]
+        ctx.register_id(referenced, 'Id', ns.WSU)
+
+    ctx.key = key
+
+    try:
+        ctx.verify(signature)
+    except xmlsec.Error:
+        # Sadly xmlsec gives us no details about the reason for the failure, so
+        # we have nothing to pass on except that verification failed.
+        raise SignatureVerificationFailed()
+
+
+def _sign_node(ctx, signature, target):
+    """Add sig for ``target`` in ``signature`` node, using ``ctx`` context.
+
+    Doesn't actually perform the signing; ``ctx.sign(signature)`` should be
+    called later to do that.
+
+    Adds a Reference node to the signature with URI attribute pointing to the
+    target node, and registers the target node's ID so XMLSec will be able to
+    find the target node by ID when it signs.
+
+    """
+
+    # Ensure the target node has a wsu:Id attribute and get its value.
+    node_id = ensure_id(target)
+
+    # Unlike HTML, XML doesn't have a single standardized Id. WSSE suggests the
+    # use of the wsu:Id attribute for this purpose, but XMLSec doesn't
+    # understand that natively. So for XMLSec to be able to find the referenced
+    # node by id, we have to tell xmlsec about it using the register_id method.
+    ctx.register_id(target, 'Id', ns.WSU)
+
+    # Add reference to signature with URI attribute pointing to that ID.
+    ref = xmlsec.template.add_reference(
+        signature, xmlsec.Transform.SHA1, uri='#' + node_id)
+    # This is an XML normalization transform which will be performed on the
+    # target node contents before signing. This ensures that changes to
+    # irrelevant whitespace, attribute ordering, etc won't invalidate the
+    # signature.
+    xmlsec.template.add_transform(ref, xmlsec.Transform.EXCL_C14N)

--- a/l10n_es_facturae_face/tests/__init__.py
+++ b/l10n_es_facturae_face/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_facturae_face

--- a/l10n_es_facturae_face/tests/test_facturae_face.py
+++ b/l10n_es_facturae_face/tests/test_facturae_face.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+# © 2017 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import base64
+
+from odoo import exceptions
+from odoo.tests import common
+import logging
+import mock
+try:
+    from zeep import Client
+    from OpenSSL import crypto
+except (ImportError, IOError) as err:
+    logging.info(err)
+
+
+class TestL10nEsFacturaeFACe(common.TransactionCase):
+    def setUp(self):
+        super(TestL10nEsFacturaeFACe, self).setUp()
+        pkcs12 = crypto.PKCS12()
+        pkey = crypto.PKey()
+        pkey.generate_key(crypto.TYPE_RSA, 512)
+        x509 = crypto.X509()
+        x509.set_pubkey(pkey)
+        x509.set_serial_number(0)
+        x509.get_subject().CN = "me"
+        x509.set_issuer(x509.get_subject())
+        x509.gmtime_adj_notBefore(0)
+        x509.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
+        x509.sign(pkey, 'md5')
+        pkcs12.set_privatekey(pkey)
+        pkcs12.set_certificate(x509)
+        main_company = self.env.ref('base.main_company')
+        main_company.facturae_cert = base64.b64encode(
+            pkcs12.export(passphrase='password'))
+        main_company.facturae_cert_password = 'password'
+        self.tax = self.env['account.tax'].create({
+            'name': 'Test tax',
+            'amount_type': 'percent',
+            'amount': 21,
+            'type_tax_use': 'sale',
+            'facturae_code': '01',
+        })
+        self.state = self.env['res.country.state'].create({
+            'name': 'Ciudad Real',
+            'code': '13',
+            'country_id': self.ref('base.es'),
+        })
+        self.partner = self.env['res.partner'].create({
+            'name': 'Cliente de prueba',
+            'street': 'C/ Ejemplo, 13',
+            'zip': '13700',
+            'city': 'Tomelloso',
+            'state_id': self.state.id,
+            'country_id': self.ref('base.es'),
+            'vat': 'ES05680675C',
+            'facturae': True,
+            'organo_gestor': 'U00000038',
+            'unidad_tramitadora': 'U00000038',
+            'oficina_contable': 'U00000038',
+            'invoice_integration_method_ids': [(6, 0, [
+                self.env.ref('l10n_es_facturae_face.integration_face').id
+            ])]
+        })
+        main_company.vat = "ESA12345674"
+        main_company.partner_id.country_id = self.ref('base.uk')
+        main_company.currency_id = self.ref('base.EUR')
+        bank_obj = self.env['res.partner.bank']
+        self.bank = bank_obj.search([
+            ('acc_number', '=', 'BE96 9988 7766 5544')], limit=1)
+        if not self.bank:
+            self.bank = bank_obj.create({
+                'state': 'iban',
+                'acc_number': 'BE96 9988 7766 5544',
+                'partner_id': self.partner.id,
+                'bank_id': self.env['res.bank'].search(
+                    [('bic', '=', 'PSSTFRPPXXX')], limit=1).id
+            })
+        self.mandate = self.env['account.banking.mandate'].create({
+            'company_id': main_company.id,
+            'format': 'basic',
+            'partner_id': self.partner.id,
+            'state': 'valid',
+            'partner_bank_id': self.bank.id,
+            'signature_date': '2016-03-12',
+        })
+        self.payment_method = self.env['account.payment.method'].create({
+            'name': 'inbound_mandate',
+            'code': 'inbound_mandate',
+            'payment_type': 'inbound',
+            'bank_account_required': False,
+            'mandate_required': True,
+            'active': True
+        })
+        payment_methods = self.env['account.payment.method'].search([
+            ('payment_type', '=', 'inbound')
+        ])
+        self.journal = self.env['account.journal'].create({
+            'name': 'Test journal',
+            'code': 'TEST',
+            'type': 'bank',
+            'company_id': main_company.id,
+            'inbound_payment_method_ids': [(6, 0, payment_methods.ids)]
+        })
+        self.payment_mode = self.env['account.payment.mode'].create({
+            'name': 'Test payment mode',
+            'bank_account_link': 'fixed',
+            'fixed_journal_id': self.journal.id,
+            'payment_method_id': self.env.ref(
+                'payment.account_payment_method_electronic_in').id,
+            'facturae_code': '01',
+        })
+        self.payment_mode_02 = self.env['account.payment.mode'].create({
+            'name': 'Test payment mode 02',
+            'bank_account_link': 'fixed',
+            'fixed_journal_id': self.journal.id,
+            'payment_method_id': self.payment_method.id,
+            'facturae_code': '02',
+        })
+        account = self.env['account.account'].create({
+            'company_id': main_company.id,
+            'name': 'Facturae Product account',
+            'code': 'facturae_product',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_revenue').id
+        })
+        self.invoice = self.env['account.invoice'].create({
+            'partner_id': self.partner.id,
+            'account_id': self.partner.property_account_receivable_id.id,
+            'journal_id': self.journal.id,
+            'date_invoice': '2016-03-12',
+            'partner_bank_id': self.bank.id,
+            'payment_mode_id': self.payment_mode.id
+        })
+        self.invoice_line = self.env['account.invoice.line'].create({
+            'product_id': self.env.ref('product.product_delivery_02').id,
+            'account_id': account.id,
+            'invoice_id': self.invoice.id,
+            'name': 'Producto de prueba',
+            'quantity': 1.0,
+            'price_unit': 100.0,
+            'invoice_line_tax_ids': [(6, 0, self.tax.ids)],
+        })
+        self.invoice._onchange_invoice_line_ids()
+        self.invoice.action_invoice_open()
+        self.invoice.number = '2999/99998'
+
+    def test_facturae_face(self):
+        class DemoService(object):
+            def __init__(self, value):
+                self.value = value
+
+            def enviarFactura(self, *args):
+                return self.value
+
+            def anularFactura(self, *args):
+                return self.value
+
+            def consultarFactura(self, *args):
+                return self.value
+
+        main_company = self.env.ref('base.main_company')
+        with self.assertRaises(exceptions.ValidationError):
+            main_company.face_email = 'test'
+        main_company.face_email = 'test@test.com'
+        self.invoice.action_integrations()
+        integration = self.env['account.invoice.integration'].search([
+            ('invoice_id', '=', self.invoice.id)
+        ])
+        self.assertEqual(integration.method_id.code, "FACe")
+        self.assertEqual(integration.can_send, True)
+        client = Client(
+            wsdl=self.env["ir.config_parameter"].get_param(
+                "account.invoice.face.server", default=None)
+        )
+        integration.send_action()
+        self.assertEqual(integration.state, 'failed')
+        integration_code = '1234567890'
+        response_ok = client.get_type('ns0:EnviarFacturaResponse')(
+            client.get_type('ns0:Resultado')(
+                codigo='0',
+                descripcion='OK'
+            ),
+            client.get_type('ns0:EnviarFactura')(
+                numeroRegistro=integration_code
+            )
+        )
+        with mock.patch('zeep.client.ServiceProxy') as mock_client:
+            mock_client.return_value = DemoService(response_ok)
+            integration.send_action()
+        self.assertEqual(integration.register_number, integration_code)
+        self.assertEqual(integration.state, 'sent')
+        response_update = client.get_type('ns0:ConsultarFacturaResponse')(
+            client.get_type('ns0:Resultado')(
+                codigo='0',
+                descripcion='OK'
+            ),
+            client.get_type('ns0:ConsultarFactura')(
+                '1234567890',
+                client.get_type('ns0:EstadoFactura')(
+                    '1200',
+                    'DESC',
+                    'MOTIVO'
+                ),
+                client.get_type('ns0:EstadoFactura')(
+                    '4100',
+                    'DESC',
+                    'MOTIVO'
+                )
+            )
+        )
+        with mock.patch('zeep.client.ServiceProxy') as mock_client:
+            mock_client.return_value = DemoService(response_update)
+            integration.update_action()
+        self.assertEqual(integration.integration_status, 'face-1200')
+        response_cancel = client.get_type('ns0:ConsultarFacturaResponse')(
+            client.get_type('ns0:Resultado')(
+                '0',
+                'OK'
+            ),
+            client.get_type('ns0:AnularFactura')(
+                '1234567890',
+                'ANULADO'
+            )
+        )
+        with mock.patch('zeep.client.ServiceProxy') as mock_client:
+            mock_client.return_value = DemoService(response_cancel)
+            cancel = self.env['account.invoice.integration.cancel'].create({
+                'integration_id': integration.id,
+                'motive': 'Anulacion'
+            })
+            cancel.cancel_integration()
+        self.assertEqual(integration.state, 'cancelled')

--- a/l10n_es_facturae_face/views/res_company_view.xml
+++ b/l10n_es_facturae_face/views/res_company_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="view_company_form">
+        <field name="name">res.company.form</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="l10n_es_facturae.view_company_form"/>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <field name="facturae_cert_password" position="after">
+                <field name="face_email"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/l10n_es_facturae_face/views/res_config_views.xml
+++ b/l10n_es_facturae_face/views/res_config_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_config_settings" model="ir.ui.view">
+        <field name="name">Account Settings</field>
+        <field name="model">account.config.settings</field>
+        <field name="inherit_id" ref="account.view_account_config_settings"/>
+        <field name="arch" type="xml">
+            <group name="multi_currency" position='after'>
+                <group name="face_configuration"
+                       string="FACe configuration">
+                    <field name="face_server"/>
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/l10n_es_facturae_face/wizard/__init__.py
+++ b/l10n_es_facturae_face/wizard/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import account_invoice_integration_cancel

--- a/l10n_es_facturae_face/wizard/account_invoice_integration_cancel.py
+++ b/l10n_es_facturae_face/wizard/account_invoice_integration_cancel.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields
+
+
+class AccountInvoiceIntegrationCancel(models.TransientModel):
+    _inherit = 'account.invoice.integration.cancel'
+    _description = 'Cancels a created integration'
+
+    motive = fields.Char()
+    method_code = fields.Char(related='integration_id.method_id.code')
+
+    def cancel_values(self):
+        res = super(AccountInvoiceIntegrationCancel, self).cancel_values()
+        if self.method_code == 'FACe':
+            res['cancellation_motive'] = self.motive
+        return res

--- a/l10n_es_facturae_face/wizard/account_invoice_integration_cancel_view.xml
+++ b/l10n_es_facturae_face/wizard/account_invoice_integration_cancel_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_account_invoice_integration_cancel"
+                model="ir.ui.view">
+            <field name="name">account.invoice.integration.cancel.form</field>
+            <field name="model">account.invoice.integration.cancel</field>
+            <field name="inherit_id"
+                   ref="l10n_es_facturae.view_account_invoice_integration_cancel"/>
+            <field name="arch" type="xml">
+                <field name="integration_id" position="after">
+                    <field name="method_code" invisible="1"/>
+                    <field name="motive"
+                           attrs="{'invisible': [('method_code', '!=', 'FACe')],
+                           'required': [('method_code', '=', 'FACe')]}"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -6,6 +6,8 @@ account-invoicing
 account-payment
 bank-payment
 bank-statement-import
+community-data-files
+l10n-spain-facturae https://github.com/etobella/l10n-spain 10.0-mig-facturae
 partner-contact
 queue
 reporting-engine

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ unidecode
 unicodecsv
 requests
 xlrd
+xmlsec
+xmlsig
 zeep


### PR DESCRIPTION
Este módulo depende del PR #576.
Nos permite gestionar el envío de facturas a FACe (seleccionando producción o desarrollo en la configuración) y su gestión (anulación, actualización de estados, etc.)
Cómo que la firma de SOAPs no acaba de funcionar correctamente, se ha realizado la firma en un código Java de mi [repositorio](https://github.com/etobella/wsse_caller) que se ejecuta por llamada.
Para que funcione, debe utilizarse un certificado aceptado por FACe para firmar las facturas y los envíos. Además, debemos registrarnos en FACe como proveedores con la parte pública del certificado:
* https://se-face.redsara.es/es/proveedores : Testeo
* https://face.gob.es/es/proveedores : Producción