### PR TITLE
[8.0][FIX] Asegurarse que tipo impositivo es siempre positivo + Asegurarse que las cuotas siempre suman

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1188,9 +1188,9 @@ class AccountInvoiceLine(models.Model):
         """
         self.ensure_one()
         if tax_line.child_depend:
-            tax_type = tax_line.child_ids.filtered('amount')[:1].amount
+            tax_type = abs(tax_line.child_ids.filtered('amount')[:1].amount)
         else:
-            tax_type = tax_line.amount
+            tax_type = abs(tax_line.amount)
         if tax_type not in tax_dict:
             tax_dict[tax_type] = {
                 'TipoImpositivo': str(tax_type * 100),
@@ -1216,7 +1216,7 @@ class AccountInvoiceLine(models.Model):
             key = 'CuotaRepercutida'
         else:
             key = 'CuotaSoportada'
-        tax_dict[tax_type][key] += taxes['taxes'][0]['amount']
+        tax_dict[tax_type][key] += abs(taxes['taxes'][0]['amount'])
 
 
 @job(default_channel='root.invoice_validate_sii')


### PR DESCRIPTION
Creo que esto se ha perdido en el último stash, además he añadido un abs a la cuota porque hay casos (Factura intracomunitaria con líneas de bienes y líneas de servicios) en los que el diccionario coge una cuota en positivo y la otra en negativo y las resta en lugar de sumarlas.