### PR TITLE
[8.0][aeat_sii][FIX] Poner copy=False en invoice_jobs_ids

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -118,7 +118,7 @@ class AccountInvoice(models.Model):
     )
     invoice_jobs_ids = fields.Many2many(
         comodel_name='queue.job', column1='invoice_id', column2='job_id',
-        string="Connector Jobs",
+        string="Connector Jobs", copy=False
     )
 
     @api.onchange('sii_refund_type')

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -118,7 +118,7 @@ class AccountInvoice(models.Model):
     )
     invoice_jobs_ids = fields.Many2many(
         comodel_name='queue.job', column1='invoice_id', column2='job_id',
-        string="Connector Jobs", copy=False
+        string="Connector Jobs", copy=False,
     )
 
     @api.onchange('sii_refund_type')


### PR DESCRIPTION
Los invoice_jobs_ids se duplican al duplicar una factura. Se establece copy=False para evitarlo.