### PR TITLE
[8.0][aeat_sii][FIX] Corrección para cálculo correcto de signo de impuestos

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.9.1",
+    "version": "8.0.2.9.2",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"


### PR DESCRIPTION
Se corrige el cálculo del signo de los impuestos que se hacía incorrectamente cuando algunos impuestos hijos no están en el orden 'esperado' (primero los positivos). Se corrige tomando el abs del tipo impositivo obtenido (nunca será negativo) y sumando sólo las cuotas de los impuestos que sean del mismo signo (+ ó -) que el de la base sobre la que se aplican.