### PR TITLE
Corrección traducción

### DIFF
--- a/l10n_es_aeat_mod340/i18n/es.po
+++ b/l10n_es_aeat_mod340/i18n/es.po
@@ -495,7 +495,7 @@ msgstr "Factura"
 msgid ""
 "Invoice %s, Amount untaxed Lines %.2f do not correspond to AmountUntaxed on "
 "Invoice %.2f"
-msgstr "Factura %s, la base imposible de las líneas %.2f no se corresponde con la base imponible en la factura %.2f"
+msgstr "Factura %s, la base imponible de las líneas %.2f no se corresponde con la base imponible en la factura %.2f"
 
 #. module: l10n_es_aeat_mod340
 #: field:l10n.es.aeat.mod340.tax_line_issued,invoice_record_id:0


### PR DESCRIPTION
Nada, pequeña corrección en la traducción.