### PR TITLE
[8.0][aeat_sii][FIX] Corrige captura de respuesta para estado 'Aceptado con errores'

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.10.0",
+    "version": "8.0.2.10.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -820,11 +820,13 @@ class AccountInvoice(models.Model):
                 #     'account.fp_intra').id:
                 #     res = serv.SuministroLRDetOperacionIntracomunitaria(
                 #         header, invoices)
+                res_line = res['RespuestaLinea'][0]
                 if res['EstadoEnvio'] == 'Correcto':
                     invoice.sii_state = 'sent'
                     invoice.sii_csv = res['CSV']
                     invoice.sii_send_failed = False
-                elif res['EstadoEnvio'] == 'AceptadoConErrores':
+                elif res['EstadoEnvio'] == 'ParcialmenteCorrecto' and \
+                        res_line['EstadoRegistro'] == 'AceptadoConErrores':
                     invoice.sii_state = 'sent_w_errors'
                     invoice.sii_csv = res['CSV']
                     invoice.sii_send_failed = True
@@ -832,7 +834,6 @@ class AccountInvoice(models.Model):
                     invoice.sii_send_failed = True
                 invoice.sii_return = res
                 send_error = False
-                res_line = res['RespuestaLinea'][0]
                 if res_line['CodigoErrorRegistro']:
                     send_error = u"{} | {}".format(
                         unicode(res_line['CodigoErrorRegistro']),


### PR DESCRIPTION
La captura del estado 'Aceptado con errores' no era la correcta, ya que en 'EstadoEnvio' lo que se devuelve es 'ParcialmenteCorrecto' y en RespuestaLinea[0]['EstadoRegistro'] es donde viene la clave 'AceptadoConErrores'. Comprobado por un caso en que ha dado esta respuesta y probada la solución simulando el mismo caso, ahora la respuesta se captura correctamente.