### PR TITLE
[8.0][aeat_sii][FIX] Envío correcto para el caso de facturas de bienes o ISP emitidas a clientes extranjeros con sucursal permanente en España

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.11.1",
+    "version": "8.0.2.11.2",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -312,6 +312,33 @@ class AccountInvoice(models.Model):
         return header
 
     @api.multi
+    def _is_sii_type_breakdown_required(self, taxes_dict):
+        """Calculates if the block 'DesgloseTipoOperacion' is required for
+        the invoice communication."""
+        self.ensure_one()
+        if 'DesgloseFactura' not in taxes_dict:
+            return False
+        country_code = self._get_sii_country_code()
+        sii_gen_type = self._get_sii_gen_type()
+        if 'DesgloseTipoOperacion' in taxes_dict:
+            # DesgloseTipoOperacion and DesgloseFactura are Exclusive
+            return True
+        elif sii_gen_type in (2, 3):
+            # DesgloseTipoOperacion required for Intracommunity and
+            # Export operations
+            return True
+        elif sii_gen_type == 1 and country_code != 'ES':
+            # DesgloseTipoOperacion required for national operations
+            # with 'IDOtro' in the SII identifier block
+            return True
+        elif (sii_gen_type == 1 and
+                (self.partner_id.vat or '').startswith('ESN')):
+            # DesgloseTipoOperacion required if customer's country is Spain and
+            # has a NIF which starts with 'N'
+            return True
+        return False
+
+    @api.multi
     def _get_sii_out_taxes(self):
         """Get the taxes for sales invoices.
 
@@ -430,13 +457,7 @@ class AccountInvoice(models.Model):
         # Ajustes finales breakdown
         # - DesgloseFactura y DesgloseTipoOperacion son excluyentes
         # - Ciertos condicionantes obligan DesgloseTipoOperacion
-        country_code = self._get_sii_country_code()
-        if (('DesgloseTipoOperacion' in taxes_dict and
-                'DesgloseFactura' in taxes_dict) or
-                ('DesgloseFactura' in taxes_dict and
-                 self._get_sii_gen_type() in (2, 3)) or
-                ('DesgloseFactura' in taxes_dict and
-                 self._get_sii_gen_type() == 1 and country_code != 'ES')):
+        if self._is_sii_type_breakdown_required(taxes_dict):
             taxes_dict.setdefault('DesgloseTipoOperacion', {})
             taxes_dict['DesgloseTipoOperacion']['Entrega'] = \
                 taxes_dict['DesgloseFactura']


### PR DESCRIPTION
En el caso de clientes extranjeros con sucursal permanente en España la AEAT les asigna un CIF que empieza por la letra 'N'. A todos los efectos son CIF españoles y el país de la empresa es España.

En estos casos debe incluirse obligatoriamente el bloque 'DesgloseTipoOperacion', según se establece en el punto 3.11 de las FAQs, y actualmente para el caso de venta de bienes o con ISP se incluye el bloque 'DesgloseFactura' y la AEAT devuelve este error:
> 2006 | La factura contiene un desglose a nivel de factura cuando le corresponde un desglose a nivel de operación, por no ser factura simplificada ni asiento resumen y la contraparte contiene un IdOtro o tiene un NIF que empiece por N

Para solucionarlo en este PR se tiene en cuenta que el CIF comience por 'N' en las comprobaciones del código que comprueban si debe cambiarse el bloque 'DesgloseFactura' por el bloque 'DesgloseTipoOperacion'.

