### PR TITLE
[8.0][l10n_es_aeat_sii] Prestaciones de servicios extracomunitarias  e intracomunitarias

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.11.2",
+    "version": "8.0.2.12.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -34,12 +34,22 @@
             <field name="name">SuministroFactEmitidas No Sujeta</field>
         </record>
 
+        <record id="aeat_sii_map_line_SFESNS" model="aeat.sii.map.lines">
+            <field name="code">SFESNS</field>
+            <field name="taxes" eval="[(6, 0, [
+                ref('l10n_es.account_tax_template_s_iva_e'),
+                ref('l10n_es.account_tax_template_s_iva0_sp_i'),
+            ])]"/>
+            <field name="sii_map_id" ref="aeat_sii_map"/>
+            <field name="name">SuministroFactEmitidas Servicios No Sujeta</field>
+        </record>
+
         <record id="aeat_sii_map_line_SFESS" model="aeat.sii.map.lines">
             <field name="code">SFESS</field>
             <field name="taxes" eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_s_iva21s'),
                 ref('l10n_es.account_tax_template_s_iva10s'),
-                ref('l10n_es.account_tax_template_s_iva4s')
+                ref('l10n_es.account_tax_template_s_iva4s'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactEmitidas Sujetas Servicios</field>
@@ -59,7 +69,6 @@
             <field name="code">SFESSE</field>
             <field name="taxes" eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_s_iva0'),
-                ref('l10n_es.account_tax_template_s_iva0_sp_i')
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactEmitidas Servicios Exento</field>


### PR DESCRIPTION
Inclusión de una nueva linea en el mapeo para los impuestos **IVA 0%  prestaciones de servicios intracomunitarios y extracomunitarios** y su envío a hacienda.

Respuestas de la aeat (asistente virtual) 

**Intracomunitarios**
AEAT: Cuando se trate de la prestación de un servicio a un cliente establecido en otro Estado miembro de la Unión Europea distinto de España que no esté sujeta al IVA, el prestador consignará la factura en el libro registro de facturas emitidas desglosando el tipo de operación e indicando que se trata de una prestación de servicios no sujeta por reglas de localización. Puede ver más detalle en la plantilla que se muestra en la parte izquierda.

**Extracomunitarios**

AEAT: Cuando se trate de la prestación de un servicio a un cliente establecido fuera de la Unión Europea que no esté sujeta al IVA, el prestador consignará la factura en el libro registro de facturas emitidas desglosando el tipo de operación e indicando que se trata de una prestación de servicios no sujeta por reglas de localización. Puede ver más detalle en la plantilla que se muestra en la parte izquierda


