### PR TITLE
[10.0][FIX] l10n_account_invoice_sequence: allocate number before move creation and not after

### DIFF
--- a/l10n_es_account_invoice_sequence/__manifest__.py
+++ b/l10n_es_account_invoice_sequence/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Secuencia para facturas separada de la secuencia de asientos",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": "Spanish Localization Team, "
               "NaN·Tic, "
               "Trey, "

--- a/l10n_es_account_invoice_sequence/models/account_invoice.py
+++ b/l10n_es_account_invoice_sequence/models/account_invoice.py
@@ -15,6 +15,7 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def action_move_create(self):
+        res = super(AccountInvoice, self).action_move_create()
         for inv in self:
             if not inv.invoice_number:
                 sequence = inv.journal_id.invoice_sequence_id
@@ -33,7 +34,6 @@ class AccountInvoice(models.Model):
                 })
             else:  # pragma: no cover
                 inv.number = inv.invoice_number
-        res = super(AccountInvoice, self).action_move_create()
         for inv in self:
             # Include the invoice reference on the created journal item
             # This is done for displaying the number on the conciliation


### PR DESCRIPTION
Call to super after allocation number otherwise  `number = inv.move_id.name` will always be False because move doesn't exist yet.