### PR TITLE
[FIX] l10n_es_aeat_sii: Don't write several times on the invoice

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.10.1",
+    "version": "8.0.2.10.2",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"


### PR DESCRIPTION
Writing on one cursor some invoice values and on error in another, makes the process to hang due to a lock. Deferring the write to the end and accumulating values prevents this lock.

Closes #594