### PR TITLE
[FIX] l10n_es_aeat_sii: Se corrige la compañía de los trabajos

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.10.2",
+    "version": "8.0.2.10.3",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -591,8 +591,8 @@ class AccountInvoice(models.Model):
                 inv_dict["FacturaExpedida"]['DatosInmueble'] = {
                     'DetalleInmueble': {
                         'SituacionInmueble': self.sii_property_location,
-                        'ReferenciaCatastral':
-                            self.sii_property_cadastrial_code or ''
+                        'ReferenciaCatastral': (
+                            self.sii_property_cadastrial_code or '')
                     }
                 }
             exp_dict = inv_dict['FacturaExpedida']
@@ -769,8 +769,10 @@ class AccountInvoice(models.Model):
                 invoice._send_invoice_to_sii()
             else:
                 eta = company._get_sii_eta()
+                ctx = self.env.context.copy()
+                ctx.update(company_id=company.id)
                 session = ConnectorSession(
-                    self.env.cr, SUPERUSER_ID, context=self.env.context,
+                    self.env.cr, SUPERUSER_ID, context=ctx,
                 )
                 new_delay = confirm_one_invoice.delay(
                     session, 'account.invoice', invoice.id,

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -967,7 +967,11 @@ class AccountInvoice(models.Model):
                 invoice._cancel_invoice_to_sii()
             else:
                 eta = company._get_sii_eta()
-                session = ConnectorSession.from_env(self.env)
+                ctx = self.env.context.copy()
+                ctx.update(company_id=company.id)
+                session = ConnectorSession(
+                    self.env.cr, SUPERUSER_ID, context=ctx,
+                )
                 new_delay = cancel_one_invoice.delay(
                     session, 'account.invoice', invoice.id, eta=eta)
                 queue_ids = queue_obj.search([


### PR DESCRIPTION
Se están creando los trabajos del conector con la compañía de admin, esto provoca que si la compañía de admin no es la del SII no vean los trabajos desde la interfaz, lo mismo para un entorno multicompañia con varios SII, se crean sólo contra una de ellas.