### PR TITLE
[FIX] l10n_es_aeat_sii: Conversion de divisas a moneda de compañia

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.17.1",
+    "version": "8.0.2.17.2",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1403,7 +1403,8 @@ class AccountInvoiceLine(models.Model):
             from_currency = self.invoice_id.currency_id.\
                 with_context(date=self.invoice_id.date_invoice)
             price_unit = from_currency.\
-                compute(price_unit, self.invoice_id.company_id.currency_id)
+                compute(price_unit, self.invoice_id.company_id.currency_id,
+                        round=False)
         return price_unit
 
     @api.multi

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -533,14 +533,13 @@ class AccountInvoice(models.Model):
                             inv_line._get_sii_line_price_subtotal() * sign
                         )
         for val in taxes_f.values() + taxes_to.values():
-            val['CuotaRepercutida'] = float_round(
-                val['CuotaRepercutida'] * sign, 2,
-            )
-            val['BaseImponible'] = float_round(val['BaseImponible'] * sign, 2)
+            val['CuotaRepercutida'] = round(
+                float_round(val['CuotaRepercutida'] * sign, 2), 2)
+            val['BaseImponible'] = round(
+                float_round(val['BaseImponible'] * sign, 2), 2)
             if 'CuotaRecargoEquivalencia' in val:
-                val['CuotaRecargoEquivalencia'] = float_round(
-                    val['CuotaRecargoEquivalencia'] * sign, 2,
-                )
+                val['CuotaRecargoEquivalencia'] = round(
+                    float_round(val['CuotaRecargoEquivalencia'] * sign, 2), 2)
         if taxes_f:
             breakdown = tax_breakdown['Sujeta']['NoExenta']['DesgloseIVA']
             breakdown['DetalleIVA'] = taxes_f.values()
@@ -550,23 +549,28 @@ class AccountInvoice(models.Model):
         if 'Sujeta' in tax_breakdown and 'Exenta' in tax_breakdown['Sujeta']:
             exempt_dict = tax_breakdown['Sujeta']['Exenta']
             exempt_dict['BaseImponible'] = \
-                float_round(exempt_dict['BaseImponible'] * sign, 2)
+                round(
+                    float_round(exempt_dict['BaseImponible'] * sign, 2), 2)
         if 'NoSujeta' in tax_breakdown:
             nsub_dict = tax_breakdown['NoSujeta']
             nsub_dict[default_no_taxable_cause] = \
-                float_round(nsub_dict[default_no_taxable_cause] * sign, 2)
+                round(
+                    float_round(nsub_dict[default_no_taxable_cause] * sign, 2),
+                    2)
         if type_breakdown:
             services_dict = type_breakdown['PrestacionServicios']
             if 'Sujeta' in services_dict \
                     and 'Exenta' in services_dict['Sujeta']:
                 exempt_dict = services_dict['Sujeta']['Exenta']
                 exempt_dict['BaseImponible'] = \
-                    float_round(exempt_dict['BaseImponible'] * sign, 2)
+                    round(
+                        float_round(exempt_dict['BaseImponible'] * sign, 2), 2)
             if 'NoSujeta' in services_dict:
                 nsub_dict = services_dict['NoSujeta']
                 nsub_dict["ImporteTAIReglasLocalizacion"] = \
-                    float_round(nsub_dict["ImporteTAIReglasLocalizacion"] *
-                                sign, 2)
+                    round(
+                        float_round(nsub_dict["ImporteTAIReglasLocalizacion"] *
+                                    sign, 2), 2)
 
         # Ajustes finales breakdown
         # - DesgloseFactura y DesgloseTipoOperacion son excluyentes
@@ -631,26 +635,25 @@ class AccountInvoice(models.Model):
                                                taxes_nd.values())},
             )
         for val in taxes_isp.values() + taxes_f.values() + taxes_fa.values():
-            val['CuotaSoportada'] = float_round(
-                val['CuotaSoportada'] * sign, 2,
-            )
-            val['BaseImponible'] = float_round(val['BaseImponible'] * sign, 2)
+            val['CuotaSoportada'] = round(
+                float_round(val['CuotaSoportada'] * sign, 2), 2)
+            val['BaseImponible'] = round(
+                float_round(val['BaseImponible'] * sign, 2), 2)
             if 'CuotaRecargoEquivalencia' in val:
-                val['CuotaRecargoEquivalencia'] = float_round(
-                    val['CuotaRecargoEquivalencia'] * sign, 2,
-                )
+                val['CuotaRecargoEquivalencia'] = round(
+                    float_round(val['CuotaRecargoEquivalencia'] * sign, 2), 2)
             tax_amount += val['CuotaSoportada']
         for val in taxes_nd.values():
-            val['CuotaSoportada'] = float_round(
-                val['CuotaSoportada'] * sign, 2,
-            )
-            val['BaseImponible'] = float_round(val['BaseImponible'] * sign, 2)
+            val['CuotaSoportada'] = round(
+                float_round(val['CuotaSoportada'] * sign, 2), 2)
+            val['BaseImponible'] = round(
+                float_round(val['BaseImponible'] * sign, 2), 2)
             if 'CuotaRecargoEquivalencia' in val:
-                val['CuotaRecargoEquivalencia'] = float_round(
-                    val['CuotaRecargoEquivalencia'] * sign, 2,
-                )
+                val['CuotaRecargoEquivalencia'] = round(
+                    float_round(val['CuotaRecargoEquivalencia'] * sign, 2), 2)
         for reg in taxes_ns.values():
-            reg['BaseImponible'] = float_round(reg['BaseImponible'] * sign, 2)
+            reg['BaseImponible'] = round(
+                float_round(reg['BaseImponible'] * sign, 2), 2)
         if taxes_fa:
             # Régimen especial agricultura - Cambiar claves
             for tax_fa in taxes_fa.values():
@@ -860,7 +863,8 @@ class AccountInvoice(models.Model):
                 "FechaRegContable": reg_date,
                 "ImporteTotal": self.cc_amount_total * sign,
                 "CuotaDeducible": self.period_id.date_start >=
-                SII_START_DATE and float_round(tax_amount * sign, 2) or 0.0,
+                SII_START_DATE and round(
+                    float_round(tax_amount * sign, 2), 2) or 0.0,
             }
             if self.sii_registration_key_additional1:
                 inv_dict["FacturaRecibida"].\


### PR DESCRIPTION
Este PR es para solventar un problema que nos hemos encontrado con la conversión de importes a moneda de compañía.

Al realizar el calculo de precio unitario por linea ya en moneda de compañía y con el redondeo de la conversión aplicado si hay bastantes unidades de un producto estamos perdiendo decimales.

Por ejemplo para una factura con una línea de 9,95$ por ud y 45 ud, teniendo una tasa de cambio de 1,1418:

- Al realizar la conversión de la manera actual obtenemos un precio unitario en moneda de compañía de 8,71€ que multiplicado por las 45 ud nos sale 391,95€.
- Si nos vamos a la información de factura vemos que en el campo "Subtotal moneda compañía" tenemos 392,14€, lo cual nos está descuadrando 19 centimos respecto a la información que tenemos nosotros en la factura y lo que estamos enviando al SII
- Lo mismo nos pasa con el importe de los impuestos, obteniendo un valor de CuotaRepercutida de 82,13€ mientras que en nuestra factura el valor de "Impuesto moneda compañía" es de 82,35, en este caso 22 centimos de diferencia

Con este cambio del PR, al no realizar la solicitud de precio unitario ya redondeado obtenemos:

- Un precio unitario de 8,714310737432124 que multiplicado por las 45 ud. nos da un valor de 392,1439831844456€ que después de redondear son 392,14€ (El mismo valor que en la factura)
- En el valor enviado a SII para la CuotaRepercutida es de 82,35000000000001€, No se por qué no redondea el valor enviado en este caso (Aunque se le aplique el float_round lo mantiene tal cual). 

¿Estaría bien modificarlo y sacar el valor final para enviar utilizando la funcion float_repr del float_utils del ERP? Si me decis que sí lo cambio y lo incluyo en este PR



