### PR TITLE
[10.0][MIG] l10n_es_account_banking_sepa_fsdd

### DIFF
--- a/l10n_es_account_banking_sepa_fsdd/README.rst
+++ b/l10n_es_account_banking_sepa_fsdd/README.rst
@@ -1,5 +1,5 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :target: http://www.gnu.org/licenses/agpl
    :alt: License: AGPL-3
 
 ==================================================
@@ -26,7 +26,7 @@ al identificador del fichero.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/189/8.0
+   :target: https://runbot.odoo-community.org/runbot/189/10.0
 
 Bug Tracker
 ===========
@@ -34,11 +34,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues
 <https://github.com/OCA/l10n-spain/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
-help us smashing it by providing a detailed and welcomed `feedback
-<https://github.com/OCA/
-l10n-spain/issues/new?body=module:%20
-l10n_es_account_banking_sepa_fsdd%0Aversion:%20
-8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+help us smash it by providing detailed and welcomed feedback.
 
 Credits
 =======
@@ -52,6 +48,7 @@ Contributors
 ------------
 
 * Omar Castiñeira Saavedra <omar@comunitea.com>
+* Luis M. Ontalba <luis.martinez@tecnativa.com>
 
 Maintainer
 ----------

--- a/l10n_es_account_banking_sepa_fsdd/__init__.py
+++ b/l10n_es_account_banking_sepa_fsdd/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# © 2016 Comunitea Servicios Tecnológicos <omar@comunitea.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
-from . import wizard

--- a/l10n_es_account_banking_sepa_fsdd/__manifest__.py
+++ b/l10n_es_account_banking_sepa_fsdd/__manifest__.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
-# © 2016 Comunitea Servicios Tecnológicos <omar@comunitea.com>
+# Copyright 2016 Comunitea Servicios Tecnológicos <omar@comunitea.com>
+# Copyright 2017 Tecnativa - Luis M. Ontalba <luis.martinez@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Account Banking Sepa - FSDD (Anticipos de crédito)",
-    "version": "8.0.1.0.0",
-    "author": "Comunitea,Odoo Community Association (OCA)",
+    "version": "10.0.1.0.0",
+    "author": "Tecnativa, "
+              "Odoo Community Association (OCA)",
+    'license': 'AGPL-3',
     "website": "http://www.comunitea.com",
     "category": "Banking addons",
     "depends": [
-        "account_banking_sepa_direct_debit"
+        "account_banking_sepa_direct_debit",
     ],
-    "demo": [],
     "data": [
         "views/payment_mode_view.xml",
     ],
-    'installable': False,
+    'installable': True,
 }

--- a/l10n_es_account_banking_sepa_fsdd/i18n/ca.po
+++ b/l10n_es_account_banking_sepa_fsdd/i18n/ca.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * l10n_es_account_banking_sepa_fsdd
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: l10n-spain (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-29 02:56+0000\n"
+"PO-Revision-Date: 2016-03-02 10:02+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Catalan (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/ca/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ca\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: help:payment.mode,charge_financed:0
+msgid "Adds FSDD prefix to sepa file id"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_banking_export_sdd_wizard
+msgid "Export SEPA Direct Debit File"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: field:payment.mode,charge_financed:0
+msgid "Financed Charge"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_payment_mode
+msgid "Payment Mode"
+msgstr "Forma de pagament "

--- a/l10n_es_account_banking_sepa_fsdd/i18n/es.po
+++ b/l10n_es_account_banking_sepa_fsdd/i18n/es.po
@@ -1,38 +1,37 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_account_banking_sepa_fsdd
-# 
-# Translators:
+#	* l10n_es_account_banking_sepa_fsdd
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-spain (8.0)\n"
+"Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-05 10:32+0000\n"
-"PO-Revision-Date: 2016-03-02 10:02+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/es/)\n"
+"POT-Creation-Date: 2017-07-24 09:27+0000\n"
+"PO-Revision-Date: 2017-07-24 09:27+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_account_banking_sepa_fsdd
-#: help:payment.mode,charge_financed:0
+#: model:ir.model.fields,help:l10n_es_account_banking_sepa_fsdd.field_account_payment_mode_charge_financed
 msgid "Adds FSDD prefix to sepa file id"
 msgstr "Añade el prefijo FSDD al identificador del fichero sepa"
 
 #. module: l10n_es_account_banking_sepa_fsdd
-#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_banking_export_sdd_wizard
-msgid "Export SEPA Direct Debit File"
-msgstr "Exportar archivo de adeudo directo SEPA"
-
-#. module: l10n_es_account_banking_sepa_fsdd
-#: field:payment.mode,charge_financed:0
+#: model:ir.model.fields,field_description:l10n_es_account_banking_sepa_fsdd.field_account_payment_mode_charge_financed
 msgid "Financed Charge"
 msgstr "Cobro financiado"
 
 #. module: l10n_es_account_banking_sepa_fsdd
-#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_payment_mode
-msgid "Payment Mode"
-msgstr "Modo de pago"
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_account_payment_mode
+msgid "Payment Modes"
+msgstr "Modos de pago"
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_account_payment_order
+msgid "Payment Order"
+msgstr "Orden de pago"
+

--- a/l10n_es_account_banking_sepa_fsdd/i18n/fr.po
+++ b/l10n_es_account_banking_sepa_fsdd/i18n/fr.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * l10n_es_account_banking_sepa_fsdd
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: l10n-spain (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-18 02:07+0000\n"
+"PO-Revision-Date: 2016-03-02 10:02+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: French (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: help:payment.mode,charge_financed:0
+msgid "Adds FSDD prefix to sepa file id"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_banking_export_sdd_wizard
+msgid "Export SEPA Direct Debit File"
+msgstr "Export du fichier de prélèvement SEPA"
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: field:payment.mode,charge_financed:0
+msgid "Financed Charge"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_payment_mode
+msgid "Payment Mode"
+msgstr "Mode de paiement"

--- a/l10n_es_account_banking_sepa_fsdd/i18n/nl.po
+++ b/l10n_es_account_banking_sepa_fsdd/i18n/nl.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * l10n_es_account_banking_sepa_fsdd
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: l10n-spain (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-05-20 01:14+0000\n"
+"PO-Revision-Date: 2016-03-02 10:02+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Dutch (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/nl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nl\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: help:payment.mode,charge_financed:0
+msgid "Adds FSDD prefix to sepa file id"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_banking_export_sdd_wizard
+msgid "Export SEPA Direct Debit File"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: field:payment.mode,charge_financed:0
+msgid "Financed Charge"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_payment_mode
+msgid "Payment Mode"
+msgstr "Betaalwijze"

--- a/l10n_es_account_banking_sepa_fsdd/i18n/pt_BR.po
+++ b/l10n_es_account_banking_sepa_fsdd/i18n/pt_BR.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * l10n_es_account_banking_sepa_fsdd
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: l10n-spain (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-29 02:56+0000\n"
+"PO-Revision-Date: 2016-03-02 10:02+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: help:payment.mode,charge_financed:0
+msgid "Adds FSDD prefix to sepa file id"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_banking_export_sdd_wizard
+msgid "Export SEPA Direct Debit File"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: field:payment.mode,charge_financed:0
+msgid "Financed Charge"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_payment_mode
+msgid "Payment Mode"
+msgstr "Modo de pagamento"

--- a/l10n_es_account_banking_sepa_fsdd/i18n/sl.po
+++ b/l10n_es_account_banking_sepa_fsdd/i18n/sl.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * l10n_es_account_banking_sepa_fsdd
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: l10n-spain (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-04-29 02:56+0000\n"
+"PO-Revision-Date: 2016-03-02 10:02+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Slovenian (http://www.transifex.com/oca/OCA-l10n-spain-8-0/language/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: help:payment.mode,charge_financed:0
+msgid "Adds FSDD prefix to sepa file id"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_banking_export_sdd_wizard
+msgid "Export SEPA Direct Debit File"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: field:payment.mode,charge_financed:0
+msgid "Financed Charge"
+msgstr ""
+
+#. module: l10n_es_account_banking_sepa_fsdd
+#: model:ir.model,name:l10n_es_account_banking_sepa_fsdd.model_payment_mode
+msgid "Payment Mode"
+msgstr "Način plačila"

--- a/l10n_es_account_banking_sepa_fsdd/models/__init__.py
+++ b/l10n_es_account_banking_sepa_fsdd/models/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Comunitea Servicios Tecnológicos <omar@comunitea.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import payment_mode
+from . import account_payment_mode
+from . import account_payment_order

--- a/l10n_es_account_banking_sepa_fsdd/models/account_payment_mode.py
+++ b/l10n_es_account_banking_sepa_fsdd/models/account_payment_mode.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
-# © 2016 Comunitea Servicios Tecnológicos <omar@comunitea.com>
+# Copyright 2016 Comunitea Servicios Tecnológicos <omar@comunitea.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, fields
+from odoo import fields, models
 
 
 class PaymentMode(models.Model):
 
-    _inherit = "payment.mode"
+    _inherit = "account.payment.mode"
 
     charge_financed = fields.Boolean(
         'Financed Charge', help="Adds FSDD prefix to sepa file id")

--- a/l10n_es_account_banking_sepa_fsdd/models/account_payment_order.py
+++ b/l10n_es_account_banking_sepa_fsdd/models/account_payment_order.py
@@ -1,20 +1,19 @@
 # -*- coding: utf-8 -*-
-# © 2016 Comunitea Servicios Tecnológicos <omar@comunitea.com>
+# Copyright 2016 Comunitea Servicios Tecnológicos <omar@comunitea.com>
+# Copyright 2017 Tecnativa - Luis M. Ontalba <luis.martinez@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, api
+from odoo import api, models
 
 
-class BankingExportSddWizard(models.TransientModel):
-    _inherit = 'banking.export.sdd.wizard'
+class AccountPaymentOrder(models.Model):
+    _inherit = 'account.payment.order'
 
     @api.model
     def generate_group_header_block(self, parent_node, gen_args):
-        res = super(BankingExportSddWizard, self).\
+        res = super(AccountPaymentOrder, self).\
             generate_group_header_block(parent_node, gen_args)
-
-        if self.payment_order_ids[0].mode.charge_financed:
+        if self.payment_mode_id.charge_financed:
             reference = parent_node.xpath('//GrpHdr/MsgId')
             reference[0].text = u"FSDD " + reference[0].text
-
         return res

--- a/l10n_es_account_banking_sepa_fsdd/tests/__init__.py
+++ b/l10n_es_account_banking_sepa_fsdd/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import test_l10n_es_account_banking_sepa_fsdd

--- a/l10n_es_account_banking_sepa_fsdd/tests/test_l10n_es_account_banking_sepa_fsdd.py
+++ b/l10n_es_account_banking_sepa_fsdd/tests/test_l10n_es_account_banking_sepa_fsdd.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa S.L. - Luis M. Ontalba
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.addons.account_banking_sepa_direct_debit.tests.test_sdd import \
+    TestSDD
+from lxml import etree
+
+
+class TestSDD(TestSDD):
+
+    def test_financed_sdd(self):
+        self.payment_mode.charge_financed = True
+        super(TestSDD, self).test_sdd()
+        action = self.payment_order.open2generated()
+        attachment = self.attachment_model.browse(action['res_id'])
+        xml_file = attachment.datas.decode('base64')
+        xml_root = etree.fromstring(xml_file)
+        namespaces = xml_root.nsmap
+        namespaces['p'] = xml_root.nsmap[None]
+        namespaces.pop(None)
+        financed_sepa_xpath = xml_root.xpath('//p:GrpHdr/p:MsgId',
+                                             namespaces=namespaces)
+        self.assertEquals(financed_sepa_xpath[0].text[0:4], u"FSDD")

--- a/l10n_es_account_banking_sepa_fsdd/views/payment_mode_view.xml
+++ b/l10n_es_account_banking_sepa_fsdd/views/payment_mode_view.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<odoo>
 
-        <record id="view_payment_mode_form_add_charge_financed" model="ir.ui.view">
-            <field name="name">add.suffix.in.payment.mode.form</field>
-            <field name="model">payment.mode</field>
-            <field name="inherit_id" ref="account_banking_payment_export.view_payment_mode_form_inherit"/>
-            <field name="arch" type="xml">
-                <field name="type" position="after">
-                    <field name="charge_financed" attrs="{'invisible': [('sale_ok', '!=', True)]}"/>
-                </field>
+    <record id="view_payment_mode_form_add_charge_financed" model="ir.ui.view">
+        <field name="name">add.suffix.in.payment.mode.form</field>
+        <field name="model">account.payment.mode</field>
+        <field name="inherit_id"
+               ref="account_banking_pain_base.account_payment_mode_form"/>
+        <field name="arch" type="xml">
+            <field name="payment_type" position="after">
+                <field name="charge_financed"
+                       attrs="{'invisible': [('payment_type', '!=', 'inbound')]}"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/l10n_es_account_banking_sepa_fsdd/wizard/__init__.py
+++ b/l10n_es_account_banking_sepa_fsdd/wizard/__init__.py
@@ -1,5 +1,0 @@
-# -*- coding: utf-8 -*-
-# © 2016 Comunitea Servicios Tecnológicos <omar@comunitea.com>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
-from . import banking_export_sdd_wzd


### PR DESCRIPTION
Account Banking Sepa - FSDD (Anticipos de crédito)
=========================================

Este módulo permite establecer el prefijo FSDD en el identificador de un fichero sepa para el producto nicho de anticipos de crédito, antiguamente exportado en el cuaderno 58.

Installation
-------------
Para instalar este módulo es necesario tener disponible el módulo *account_banking_sepa_direct_debit* del repositorio https://github.com/OCA/bank-payment.

cc @Tecnativa