### PR TITLE
[IMP] l10n_es_aeat_sii: Claves de registro adicionales

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.12.0",
+    "version": "8.0.2.12.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.12.1",
+    "version": "8.0.2.13.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * l10n_es_aeat_sii
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
@@ -37,6 +37,16 @@ msgstr "Activar"
 #: selection:l10n.es.aeat.sii,state:0
 msgid "Active"
 msgstr "Activo"
+
+#. module: l10n_es_aeat_sii
+#: field:account.invoice,sii_registration_key_additional2:0
+msgid "Additional 2 SII registration key"
+msgstr "Clave de registro adicional 2 SII"
+
+#. module: l10n_es_aeat_sii
+#: field:account.invoice,sii_registration_key_additional1:0
+msgid "Additional SII registration key"
+msgstr "Clave de registro adicional SII"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_aeat_sii_mapping_registration_keys

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -118,6 +118,14 @@ class AccountInvoice(models.Model):
         # required=True, This is not set as required here to avoid the
         # set not null constraint warning
     )
+    sii_registration_key_additional1 = fields.Many2one(
+        comodel_name='aeat.sii.mapping.registration.keys',
+        string="Additional SII registration key"
+    )
+    sii_registration_key_additional2 = fields.Many2one(
+        comodel_name='aeat.sii.mapping.registration.keys',
+        string="Additional 2 SII registration key"
+    )
     sii_registration_key_code = fields.Char(
         related="sii_registration_key.code", readonly=True,
     )
@@ -620,6 +628,14 @@ class AccountInvoice(models.Model):
                 "TipoDesglose": self._get_sii_out_taxes(),
                 "ImporteTotal": self.cc_amount_total * sign,
             }
+            if self.sii_registration_key_additional1:
+                inv_dict["FacturaExpedida"].\
+                    update({'ClaveRegimenEspecialOTrascendenciaAdicional1': (
+                        self.sii_registration_key_additional1.code)})
+            if self.sii_registration_key_additional2:
+                inv_dict["FacturaExpedida"].\
+                    update({'ClaveRegimenEspecialOTrascendenciaAdicional2': (
+                        self.sii_registration_key_additional2.code)})
             if self.sii_registration_key.code in ['12', '13']:
                 inv_dict["FacturaExpedida"]['DatosInmueble'] = {
                     'DetalleInmueble': {
@@ -712,6 +728,14 @@ class AccountInvoice(models.Model):
                 "ImporteTotal": self.cc_amount_total * sign,
                 "CuotaDeducible": float_round(tax_amount * sign, 2),
             }
+            if self.sii_registration_key_additional1:
+                inv_dict["FacturaRecibida"].\
+                    update({'ClaveRegimenEspecialOTrascendenciaAdicional1': (
+                        self.sii_registration_key_additional1.code)})
+            if self.sii_registration_key_additional2:
+                inv_dict["FacturaRecibida"].\
+                    update({'ClaveRegimenEspecialOTrascendenciaAdicional2': (
+                        self.sii_registration_key_additional2.code)})
             # Uso condicional de IDOtro/NIF
             inv_dict['FacturaRecibida']['Contraparte'].update(ident)
             if self.type == 'in_refund':

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -34,6 +34,8 @@
                             <field name="sii_refund_type"
                                    attrs="{'required': [('sii_enabled', '=', True),('type', 'in', ('out_refund','in_refund'))], 'invisible': [('type', 'not in', ('out_refund', 'in_refund'))]}"/>
                             <field name="sii_registration_key" domain="[('type', '=', 'purchase')]" attrs="{'required': [('sii_enabled', '=', True)]}" widget="selection"/>
+                            <field name="sii_registration_key_additional1" domain="[('type', '=', 'purchase')]" widget="selection"/>
+                            <field name="sii_registration_key_additional2" domain="[('type', '=', 'purchase')]" widget="selection"/>
                             <field name="sii_enabled" invisible="1"/>
                         </group>
                         <group string="SII Result" groups="l10n_es_aeat.group_account_aeat">
@@ -94,6 +96,8 @@
                             <field name="sii_refund_type"
                                    attrs="{'required': [('sii_enabled', '=', True),('type', 'in', ('out_refund','in_refund'))], 'invisible': [('type', 'not in', ('out_refund','in_refund'))]}"/>
                             <field name="sii_registration_key" domain="[('type', '=', 'sale')]" attrs="{'required': [('sii_enabled', '=', True)]}" widget="selection"/>
+                            <field name="sii_registration_key_additional1" domain="[('type', '=', 'sale')]" widget="selection"/>
+                            <field name="sii_registration_key_additional2" domain="[('type', '=', 'sale')]" widget="selection"/>
                             <field name="sii_registration_key_code" invisible="1"/>
                             <field name="sii_enabled" invisible="1"/>
                             <field name="sii_property_location"


### PR DESCRIPTION
El caso concreto sería una factura de alquiler con IGIC recibida, pero pueden
existir otras combinaciones como se puede ver en el FAQ del SII, buscando por "combinar".
 
Tras preguntar como se representaría este caso técnicamente al SII, esta es su respuesta:

Tienen que incluir en su XML los campos ClaveRegimenEspecialOTrascendenciaAdicional1 y ClaveRegimenEspecialOTrascendenciaAdicional2 a continuación de ClaveRegimenEspecialOTrascendencia.

