### PR TITLE
8.0 l10n es aeat sii fix no sujetas recibidas + redondeos

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.13.0",
+    "version": "8.0.2.13.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -494,6 +494,7 @@ class AccountInvoice(models.Model):
         taxes_dict = {}
         taxes_f = {}
         taxes_isp = {}
+        taxes_ns = {}
         taxes_sfrs = self._get_sii_taxes_map(['SFRS'])
         taxes_sfrisp = self._get_sii_taxes_map(['SFRISP'])
         taxes_sfrns = self._get_sii_taxes_map(['SFRNS'])
@@ -507,20 +508,18 @@ class AccountInvoice(models.Model):
                 elif tax_line in taxes_sfrs:
                     inv_line._update_sii_tax_line(taxes_f, tax_line)
                 elif tax_line in taxes_sfrns:
-                    nsub_dict = taxes_dict.setdefault(
-                        'DesgloseIVA',
-                        {'DetalleIVA': {'BaseImponible': 0}},
-                    )
-                    nsub_dict['DetalleIVA']['BaseImponible'] += inv_line.\
+                    taxes_ns.setdefault('no_sujeto', {'BaseImponible': 0},)
+                    taxes_ns['no_sujeto']['BaseImponible'] += inv_line.\
                         _get_sii_line_price_subtotal() * sign
 
         if taxes_isp:
             taxes_dict.setdefault(
                 'InversionSujetoPasivo', {'DetalleIVA': taxes_isp.values()},
             )
-        if taxes_f:
+        if taxes_f or taxes_ns:
             taxes_dict.setdefault(
-                'DesgloseIVA', {'DetalleIVA': taxes_f.values()},
+                'DesgloseIVA', {'DetalleIVA': (taxes_f.values() +
+                                               taxes_ns.values())},
             )
         for val in taxes_isp.values() + taxes_f.values():
             val['CuotaSoportada'] = float_round(


### PR DESCRIPTION
Algunas correcciones:

- Si se recibía una factura con iva y con no sujetos, sólo se enviaban al SII los no sujetos, porque ya se definía para estos la estructura del diccionario y luego el "setdefault" que añadía los ivas ya no tenía efecto, el SII devolvía error ya que no coincidía la cuota deducible que se enviaba con el desglose de impuestos.

- Redondeo para la base imponible no sujeta en recibidas

- Redondeo para la base imponible de no sujetas en emitidas normales

- Redondeo para la base imponible de exentas y no sujetas en emitidas de prestación de servicios