### PR TITLE
[IMP] 8.0 - account_refund_original: backport features from 'account_invoice_refund_link' (OCA/account-invoicing, branch 9.0)

### DIFF
--- a/account_refund_original/__openerp__.py
+++ b/account_refund_original/__openerp__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Relationship refund - origin invoice",
-    "version": "8.0.2.0.0",
+    "version": "8.0.2.1.0",
     "author": "Spanish Localization Team,"
               "Tecnativa,"
               "Odoo Community Association (OCA)",

--- a/account_refund_original/tests/__init__.py
+++ b/account_refund_original/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_invoice_refund_link

--- a/account_refund_original/tests/test_invoice_refund_link.py
+++ b/account_refund_original/tests/test_invoice_refund_link.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# Copyright 2014-2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp.tests import common
+
+
+class TestInvoiceRefundLink(common.SavepointCase):
+    filter_refund = 'refund'
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestInvoiceRefundLink, cls).setUpClass()
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'Test partner',
+        })
+        default_line_account = cls.env['account.account'].search([
+            ('type', '=', 'other'),
+            ('company_id', '=', cls.env.user.company_id.id),
+        ], limit=1)
+        account_receive = cls.env.ref('account.a_recv')
+        cls.invoice_lines = [(0, False, {
+            'name': 'Test description #1',
+            'account_id': default_line_account.id,
+            'quantity': 1.0,
+            'price_unit': 100.0,
+        }), (0, False, {
+            'name': 'Test description #2',
+            'account_id': default_line_account.id,
+            'quantity': 2.0,
+            'price_unit': 25.0,
+        })]
+        cls.invoice = cls.env['account.invoice'].create({
+            'partner_id': cls.partner.id,
+            'type': 'out_invoice',
+            'invoice_line': cls.invoice_lines,
+            'account_id': account_receive.id,
+        })
+        cls.invoice.signal_workflow('invoice_open')
+        cls.refund_invoices_description = 'The refund reason'
+        cls.env['account.invoice.refund'].with_context(
+            active_ids=cls.invoice.ids).create({
+                'filter_refund': cls.filter_refund,
+                'description': cls.refund_invoices_description,
+            }).invoice_refund()
+
+    def test_refund_link(self):
+        self.assertTrue(self.invoice.refund_invoice_ids)
+        refund = self.invoice.refund_invoice_ids[0]
+        self.assertEqual(refund.refund_invoices_description,
+                         self.refund_invoices_description)
+        self.assertEqual(refund.origin_invoices_ids[0], self.invoice)
+        self.assertEqual(len(self.invoice.invoice_line),
+                         len(self.invoice_lines))
+        self.assertEqual(len(refund.invoice_line),
+                         len(self.invoice_lines))
+        self.assertTrue(refund.invoice_line[0].origin_line_ids)
+        self.assertEqual(self.invoice.invoice_line[0],
+                         refund.invoice_line[0].origin_line_ids[0])
+        self.assertTrue(refund.invoice_line[1].origin_line_ids)
+        self.assertEqual(self.invoice.invoice_line[1],
+                         refund.invoice_line[1].origin_line_ids[0])
+
+
+class TestInvoiceRefundCancelLink(TestInvoiceRefundLink):
+    filter_refund = 'cancel'
+
+
+class TestInvoiceRefundModifyLink(TestInvoiceRefundLink):
+    filter_refund = 'modify'

--- a/account_refund_original/views/account_invoice_view.xml
+++ b/account_refund_original/views/account_invoice_view.xml
@@ -8,11 +8,17 @@
             <field name="inherit_id" ref="account.invoice_form"/>
             <field name="arch" type="xml">
                 <page string="Payments" position="after">
-                    <page string="Refunds" attrs="{'invisible':[('type', 'not in', ['in_refund', 'out_refund'])]}">
-                        <separator string="Description" colspan="4"/>
-                        <field name="refund_invoices_description" colspan="4" nolabel="1"/>
-                        <separator string="Refunded invoices" colspan="4"/>
-                        <field name="origin_invoices_ids" colspan="4" nolabel="1"/>
+                    <page name="refunds" string="Refunds">
+                        <group attrs="{'invisible':[('type', 'not in', ['in_refund', 'out_refund'])]}">
+                            <separator string="Description" colspan="4"/>
+                            <field name="refund_invoices_description" colspan="4" nolabel="1"/>
+                            <separator string="Refunded invoices" colspan="4"/>
+                            <field name="origin_invoices_ids" colspan="4" nolabel="1"/>
+                        </group>
+                        <group attrs="{'invisible':[('type', 'not in', ['in_invoice', 'out_invoice'])]}">
+                            <separator string="Refund invoices" colspan="4"/>
+                            <field name="refund_invoice_ids" colspan="4" nolabel="1"/>
+                        </group>
                     </page>
                 </page>
             </field>
@@ -24,11 +30,17 @@
             <field name="inherit_id" ref="account.invoice_supplier_form"/>
             <field name="arch" type="xml">
                 <page string="Payments" position="after">
-                    <page string="Refunds" attrs="{'invisible':[('type', 'not in', ['in_refund', 'out_refund'])]}">
-                        <separator string="Description" colspan="4"/>
-                        <field name="refund_invoices_description" colspan="4" nolabel="1"/>
-                        <separator string="Refunded invoices" colspan="4"/>
-                        <field name="origin_invoices_ids" colspan="4" nolabel="1"/>
+                    <page string="Refunds">
+                        <group attrs="{'invisible':[('type', 'not in', ['in_refund', 'out_refund'])]}">
+                            <separator string="Description" colspan="4"/>
+                            <field name="refund_invoices_description" colspan="4" nolabel="1"/>
+                            <separator string="Refunded invoices" colspan="4"/>
+                            <field name="origin_invoices_ids" colspan="4" nolabel="1"/>
+                        </group>
+                        <group attrs="{'invisible':[('type', 'not in', ['in_invoice', 'out_invoice'])]}">
+                            <separator string="Refund invoices" colspan="4"/>
+                            <field name="refund_invoice_ids" colspan="4" nolabel="1"/>
+                        </group>
                     </page>
                 </page>
             </field>


### PR DESCRIPTION
- display refunds on the invoice form,
- handle the links between invoice lines and refund lines
- add unit tests

All of these has been backported from the new module `account_invoice_refund_link` in OCA/account-invoicing repo (9.0).