### PR TITLE
[8.0][IMP]l10n_es_aeat_sii: Añadido mapeo de impuestos para servicios extracomunitarios

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.14.0",
+    "version": "8.0.2.15.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -118,7 +118,10 @@
             <field name="taxes" eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_p_iva21_isp'),
                 ref('l10n_es.account_tax_template_p_iva10_isp'),
-                ref('l10n_es.account_tax_template_p_iva4_isp')
+                ref('l10n_es.account_tax_template_p_iva4_isp'),
+                ref('l10n_es.account_tax_template_p_iva21_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva10_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva4_sp_ex')
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas ISP</field>


### PR DESCRIPTION
En respuesta al issue https://github.com/OCA/l10n-spain/issues/622 se añade mapeo de impuestos para adquisición de servicios extracomunitarios.