### PR TITLE
[8.0][IMP]l10n_es_aeat_sii: Añadido control de IVA no deducible

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.15.0",
+    "version": "8.0.2.16.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -160,5 +160,14 @@
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFact Recargo Equivalencia</field>
         </record>
+        
+        <record id="aeat_sii_map_line_SFRND" model="aeat.sii.map.lines">
+            <field name="code">SFRND</field>
+            <field name="taxes" eval="[(6, 0, [
+                ref('l10n_es.account_tax_template_p_iva0_nd')
+            ])]"/>
+            <field name="sii_map_id" ref="aeat_sii_map"/>
+            <field name="name">SuministroFactRecibidas No Deducible</field>
+        </record>
     </data>
 </openerp>

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -10,7 +10,7 @@
             <field name="taxes" eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_s_iva21b'),
                 ref('l10n_es.account_tax_template_s_iva4b'),
-                ref('l10n_es.account_tax_template_s_iva10b')
+                ref('l10n_es.account_tax_template_s_iva10b'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactEmitidas Sujetas Bienes</field>
@@ -19,7 +19,7 @@
         <record id="aeat_sii_map_line_SFESISP" model="aeat.sii.map.lines">
             <field name="code">SFESISP</field>
             <field name="taxes" eval="[(6, 0, [
-                ref('l10n_es.account_tax_template_s_iva0_isp')
+                ref('l10n_es.account_tax_template_s_iva0_isp'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactEmitidas Sujetas ISP</field>
@@ -28,7 +28,7 @@
         <record id="aeat_sii_map_line_SFENS" model="aeat.sii.map.lines">
             <field name="code">SFENS</field>
             <field name="taxes" eval="[(6, 0, [
-                ref('l10n_es.account_tax_template_s_iva_ns')
+                ref('l10n_es.account_tax_template_s_iva_ns'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactEmitidas No Sujeta</field>
@@ -98,7 +98,7 @@
                 ref('l10n_es.account_tax_template_p_iva21_ic_bi'),
                 ref('l10n_es.account_tax_template_p_iva4_ibc'),
                 ref('l10n_es.account_tax_template_p_iva10_ibc'),
-                ref('l10n_es.account_tax_template_p_iva21_ibc')
+                ref('l10n_es.account_tax_template_p_iva21_ibc'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas Sujetas</field>
@@ -121,7 +121,7 @@
                 ref('l10n_es.account_tax_template_p_iva4_isp'),
                 ref('l10n_es.account_tax_template_p_iva21_sp_ex'),
                 ref('l10n_es.account_tax_template_p_iva10_sp_ex'),
-                ref('l10n_es.account_tax_template_p_iva4_sp_ex')
+                ref('l10n_es.account_tax_template_p_iva4_sp_ex'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas ISP</field>
@@ -132,7 +132,7 @@
             <field name="taxes" eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_p_iva4_bi'),
                 ref('l10n_es.account_tax_template_p_iva10_bi'),
-                ref('l10n_es.account_tax_template_p_iva21_bi')
+                ref('l10n_es.account_tax_template_p_iva21_bi'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas Bienes de Inversión</field>
@@ -141,7 +141,7 @@
         <record id="aeat_sii_map_line_SFRNS" model="aeat.sii.map.lines">
             <field name="code">SFRNS</field>
             <field name="taxes" eval="[(6, 0, [
-                ref('l10n_es.account_tax_template_p_iva0_ns')
+                ref('l10n_es.account_tax_template_p_iva0_ns'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas No Sujeta</field>
@@ -155,7 +155,7 @@
                 ref('l10n_es.account_tax_template_p_req014'),
                 ref('l10n_es.account_tax_template_s_req014'),
                 ref('l10n_es.account_tax_template_p_req05'),
-                ref('l10n_es.account_tax_template_s_req05')
+                ref('l10n_es.account_tax_template_s_req05'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFact Recargo Equivalencia</field>
@@ -164,7 +164,7 @@
         <record id="aeat_sii_map_line_SFRND" model="aeat.sii.map.lines">
             <field name="code">SFRND</field>
             <field name="taxes" eval="[(6, 0, [
-                ref('l10n_es.account_tax_template_p_iva0_nd')
+                ref('l10n_es.account_tax_template_p_iva0_nd'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas No Deducible</field>


### PR DESCRIPTION
Tal y como se ha acordado aquí https://github.com/OCA/l10n-spain/issues/623 se introduce un nuevo mapeo para el IVA soportado no deducible 'SFRND' y se tiene en cuenta que los impuestos mapeados en esta posición no deben sumar su cuota al total de IVA deducible de la factura. No obstante, se comunica como una línea de impuesto más la base, tipo y cuota soportada correspondiente al IVA no deducible.