### PR TITLE
[8.0][IMP] l10n_es_aeat_sii: Traducir las calves de registro

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "8.0.2.15.0",
+    "version": "8.0.2.16.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/data/aeat_sii_mapping_registration_keys_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_mapping_registration_keys_data.xml
@@ -4,142 +4,142 @@
     
         <record id="aeat_sii_mapping_registration_keys_01" model="aeat.sii.mapping.registration.keys">
             <field name="code">01</field>
-            <field name="name">Operación de régimen general</field>
+            <field name="name">Operation general scheme</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_02" model="aeat.sii.mapping.registration.keys">
             <field name="code">02</field>
-            <field name="name">Exportación</field>
+            <field name="name">Export</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_03" model="aeat.sii.mapping.registration.keys">
             <field name="code">03</field>
-            <field name="name">Operaciones a las que se aplique el régimen especial de bienes usados, objetos de arte, antigüedades y objetos de colección</field>
+            <field name="name">Transactions to which the special regime used, objects of art, antiques and collectibles goods applies</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_04" model="aeat.sii.mapping.registration.keys">
             <field name="code">04</field>
-            <field name="name">Régimen especial oro de inversión</field>
+            <field name="name">Special scheme for investment gold</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_05" model="aeat.sii.mapping.registration.keys">
             <field name="code">05</field>
-            <field name="name">Régimen especial agencias de viajes</field>
+            <field name="name">Special scheme for travel agents</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_06" model="aeat.sii.mapping.registration.keys">
             <field name="code">06</field>
-            <field name="name">Régimen especial grupo de entidades en IVA (Nivel Avanzado)</field>
+            <field name="name">Special Regime Tax group entities (Advanced Level)</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_07" model="aeat.sii.mapping.registration.keys">
             <field name="code">07</field>
-            <field name="name">Régimen especial criterio de caja</field>
+            <field name="name">Special Regime cash basis</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_08" model="aeat.sii.mapping.registration.keys">
             <field name="code">08</field>
-            <field name="name">Operaciones sujetas al IPSI / IGIC (Impuesto sobre la Producción, los Servicios y la Importación / Impuesto General Indirecto Canario)</field>
+            <field name="name">Transactions subject to IPSI / IGIC (Tax on Production, Services and Import / IGIC)</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_09" model="aeat.sii.mapping.registration.keys">
             <field name="code">09</field>
-            <field name="name">Facturación de las prestaciones de servicios de agencias de viaje que actúan como mediadoras en nombre y por cuenta ajena (D.A.4ª RD1619/2012)</field>
+            <field name="name">Turnover services of travel agencies acting as mediators on behalfothers (DA4ª RD1619 / 2012)</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_10" model="aeat.sii.mapping.registration.keys">
             <field name="code">10</field>
-            <field name="name">Cobros por cuenta de terceros de honorarios profesionales o de derechos derivados de la propiedad industrial, de autor u otros por cuenta de sus socios, asociados o colegiados efectuados por sociedades, asociaciones, colegios profesionales u otras entidades que realicen estas funciones de cobro</field>
+            <field name="name">Proceeds from third parties of professional fees or rights arising from industrial property, copyright or other by behalf of its members, associates or collegiate made by companies, associations, professional associations or other entities that perform these functions collection</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_11" model="aeat.sii.mapping.registration.keys">
             <field name="code">11</field>
-            <field name="name">Operaciones de arrendamiento de local de negocio sujetas a retención</field>
+            <field name="name">Letting of business premises subject to withholding</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_12" model="aeat.sii.mapping.registration.keys">
             <field name="code">12</field>
-            <field name="name">Operaciones de arrendamiento de local de negocio no  sujetos a retención</field>
+            <field name="name">Operations lease of commercial premises not subject to withholding</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_13" model="aeat.sii.mapping.registration.keys">
             <field name="code">13</field>
-            <field name="name">Operaciones de arrendamiento de local de negocio sujetas y no sujetas a retención</field>
+            <field name="name">Letting of business premises subject and not subject to withholding</field>
             <field name="type">sale</field>
         </record> 
         <record id="aeat_sii_mapping_registration_keys_14" model="aeat.sii.mapping.registration.keys">
             <field name="code">14</field>
-            <field name="name">Factura con IVA pendiente de devengo en certificaciones de obra cuyo destinatario sea una Administración Pública</field>
+            <field name="name">VAT invoice Unearned interest on certificates of work whose recipient is a public authority</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_15" model="aeat.sii.mapping.registration.keys">
             <field name="code">15</field>
-            <field name="name">Factura con IVA pendiente de devengo en operaciones de tracto sucesivo</field>
+            <field name="name">VAT invoice accrual pending operations successive tract</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_29" model="aeat.sii.mapping.registration.keys">
             <field name="code">16</field>
-            <field name="name">Primer semestre 2017</field>
+            <field name="name">First semester 2017</field>
             <field name="type">sale</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_16" model="aeat.sii.mapping.registration.keys">
             <field name="code">01</field>
-            <field name="name">Operación de régimen general</field>
+            <field name="name">Operation general scheme</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_17" model="aeat.sii.mapping.registration.keys">
             <field name="code">02</field>
-            <field name="name">Operaciones por las que los empresarios satisfacen compensaciones en las adquisiciones a personas acogidas al Régimen especial de la agricultura, ganaderia y pesca</field>
+            <field name="name">Getting why entrepreneurs meet compensation in acquisitions under the special regime of agriculture, livestock and fishing people</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_18" model="aeat.sii.mapping.registration.keys">
             <field name="code">03</field>
-            <field name="name">Operaciones a las que se aplique el régimen especial de bienes usados, objetos de arte, antigüedades y objetos de colección</field>
+            <field name="name">Transactions to which the special regime used, objects of art, antiques and collectibles goods applies</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_19" model="aeat.sii.mapping.registration.keys">
             <field name="code">04</field>
-            <field name="name">Régimen especial oro de inversión</field>
+            <field name="name">Special scheme for investment gold</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_20" model="aeat.sii.mapping.registration.keys">
             <field name="code">05</field>
-            <field name="name">Régimen especial agencias de viajes</field>
+            <field name="name">Special scheme for travel agents</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_21" model="aeat.sii.mapping.registration.keys">
             <field name="code">06</field>
-            <field name="name">Régimen especial grupo de entidades en IVA (Nivel Avanzado)</field>
+            <field name="name">Special Regime Tax group entities (Advanced Level)</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_22" model="aeat.sii.mapping.registration.keys">
             <field name="code">07</field>
-            <field name="name">Régimen especial criterio de caja</field>
+            <field name="name">Special Regime cash basis</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_23" model="aeat.sii.mapping.registration.keys">
             <field name="code">08</field>
-            <field name="name">Operaciones sujetas al IPSI / IGIC (Impuesto sobre la Producción, los Servicios y la Importación / Impuesto General Indirecto Canario)</field>
+            <field name="name">Transactions subject to IPSI / IGIC (Tax on Production, Services and Import / IGIC)</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_24" model="aeat.sii.mapping.registration.keys">
             <field name="code">09</field>
-            <field name="name">Adquisiciones intracomunitarias de bienes y prestaciones de servicios</field>
+            <field name="name">Community acquisition of goods and services</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_27" model="aeat.sii.mapping.registration.keys">
             <field name="code">12</field>
-            <field name="name">Operaciones de arrendamiento de local de negocio</field>
+            <field name="name">Operations leasing business premises</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_28" model="aeat.sii.mapping.registration.keys">
             <field name="code">13</field>
-            <field name="name">Factura correspondiente a una importación (informada sin asociar a un DUA)</field>
+            <field name="name">Corresponding to an import invoice (informed without attaching a DUA)</field>
             <field name="type">purchase</field>
         </record>
         <record id="aeat_sii_mapping_registration_keys_30" model="aeat.sii.mapping.registration.keys">
             <field name="code">14</field>
-            <field name="name">Primer semestre 2017</field>
+            <field name="name">First semester 2017</field>
             <field name="type">purchase</field>
         </record>
     </data>

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -5,13 +5,14 @@
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 # Pedro Rodríguez <pedro@otherway.es>, 2017
+# Abraham Anes <abraham@studio73.es>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-29 01:00+0000\n"
-"PO-Revision-Date: 2017-08-29 01:00+0000\n"
-"Last-Translator: Pedro Rodríguez <pedro@otherway.es>, 2017\n"
+"POT-Creation-Date: 2017-09-28 10:41+0000\n"
+"PO-Revision-Date: 2017-09-28 12:56+0200\n"
+"Last-Translator: Abraham Anes <abraham@studio73.es>, 2017\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -192,6 +193,11 @@ msgid "Code"
 msgstr "Código"
 
 #. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_24
+msgid "Community acquisition of goods and services"
+msgstr "Adquisiciones intracomunitarias de bienes y prestaciones de servicios"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_res_company
 msgid "Companies"
 msgstr "Compañías"
@@ -217,6 +223,11 @@ msgstr "Trabajos del conector"
 #: view:res.company:l10n_es_aeat_sii.view_company_sii_form
 msgid "Connector config"
 msgstr "Configuración del conector"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_28
+msgid "Corresponding to an import invoice (informed without attaching a DUA)"
+msgstr "Factura correspondiente a una importación (informada sin asociar a un DUA)"
 
 #. module: l10n_es_aeat_sii
 #: field:aeat.sii.map,create_uid:0 field:aeat.sii.map.lines,create_uid:0
@@ -302,6 +313,7 @@ msgstr "¡Error! Las fechas del registro se superponen con otro registro"
 
 #. module: l10n_es_aeat_sii
 #: selection:account.fiscal.position,sii_partner_identification_type:0
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_02
 msgid "Export"
 msgstr "Exportación"
 
@@ -309,6 +321,12 @@ msgstr "Exportación"
 #: field:l10n.es.aeat.sii,file:0
 msgid "File"
 msgstr "Fichero"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_29
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_30
+msgid "First semester 2017"
+msgstr "Primer semestre 2017"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_account_fiscal_position
@@ -330,6 +348,11 @@ msgstr "Nombre Carpeta"
 #: view:account.invoice:l10n_es_aeat_sii.invoice_supplier_sii_form
 msgid "General"
 msgstr "General"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_17
+msgid "Getting why entrepreneurs meet compensation in acquisitions under the special regime of agriculture, livestock and fishing people"
+msgstr "Operaciones por las que los empresarios satisfacen compensaciones en las adquisiciones a personas acogidas al Régimen especial de la agricultura, ganaderia y pesca"
 
 #. module: l10n_es_aeat_sii
 #: view:aeat.sii.mapping.registration.keys:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_view_search
@@ -435,6 +458,16 @@ msgstr "Últ. actualización por"
 #: field:l10n.es.aeat.sii.password,write_date:0
 msgid "Last Updated on"
 msgstr "Últ. actualización en"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_13
+msgid "Letting of business premises subject and not subject to withholding"
+msgstr "Operaciones de arrendamiento de local de negocio sujetas y no sujetas a retención"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_11
+msgid "Letting of business premises subject to withholding"
+msgstr "Operaciones de arrendamiento de local de negocio sujetas a retención"
 
 #. module: l10n_es_aeat_sii
 #: field:aeat.sii.map,map_lines:0
@@ -546,6 +579,22 @@ msgid "Operaciones no sujetas en el TAI por reglas de localización"
 msgstr "Operaciones no sujetas en el TAI por reglas de localización"
 
 #. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_01
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_16
+msgid "Operation general scheme"
+msgstr "Operación de régimen general"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_12
+msgid "Operations lease of commercial premises not subject to withholding"
+msgstr "Operaciones de arrendamiento de local de negocio no  sujetos a retención"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_27
+msgid "Operations leasing business premises"
+msgstr "Operaciones de arrendamiento de local de negocio"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_res_partner
 msgid "Partner"
 msgstr "Empresa"
@@ -559,6 +608,11 @@ msgstr "Contraseña"
 #: field:l10n.es.aeat.sii,private_key:0
 msgid "Private Key"
 msgstr "Clave privada"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_10
+msgid "Proceeds from third parties of professional fees or rights arising from industrial property, copyright or other by behalf of its members, associates or collegiate made by companies, associations, professional associations or other entities that perform these functions collection"
+msgstr "Cobros por cuenta de terceros de honorarios profesionales o de derechos derivados de la propiedad industrial, de autor u otros por cuenta de sus socios, asociados o colegiados efectuados por sociedades, asociaciones, colegios profesionales u otras entidades que realicen estas funciones de cobro"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_product_template
@@ -814,6 +868,30 @@ msgid "Simplified invoices in SII?"
 msgstr "¿Facturas simplificadas en el SII?"
 
 #. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_06
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_21
+msgid "Special Regime Tax group entities (Advanced Level)"
+msgstr "Régimen especial grupo de entidades en IVA (Nivel Avanzado)"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_07
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_22
+msgid "Special Regime cash basis"
+msgstr "Régimen especial criterio de caja"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_04
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_19
+msgid "Special scheme for investment gold"
+msgstr "Régimen especial oro de inversión"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_05
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_20
+msgid "Special scheme for travel agents"
+msgstr "Régimen especial agencias de viajes"
+
+#. module: l10n_es_aeat_sii
 #: field:l10n.es.aeat.sii,date_start:0
 msgid "Start Date"
 msgstr "Fecha de inicio"
@@ -878,6 +956,23 @@ msgid "This invoice is not SII enabled."
 msgstr "Esta factura no está habilitada para el SII."
 
 #. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_08
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_23
+msgid "Transactions subject to IPSI / IGIC (Tax on Production, Services and Import / IGIC)"
+msgstr "Operaciones sujetas al IPSI / IGIC (Impuesto sobre la Producción, los Servicios y la Importación / Impuesto General Indirecto Canario)"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_03
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_18
+msgid "Transactions to which the special regime used, objects of art, antiques and collectibles goods applies"
+msgstr "Operaciones a las que se aplique el régimen especial de bienes usados, objetos de arte, antigüedades y objetos de colección"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_09
+msgid "Turnover services of travel agencies acting as mediators on behalfothers (DA4ª RD1619 / 2012)"
+msgstr "Facturación de las prestaciones de servicios de agencias de viaje que actúan como mediadoras en nombre y por cuenta ajena (D.A.4ª RD1619/2012)"
+
+#. module: l10n_es_aeat_sii
 #: view:aeat.sii.mapping.registration.keys:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_view_search
 #: field:aeat.sii.mapping.registration.keys,type:0
 msgid "Type"
@@ -887,6 +982,16 @@ msgstr "Tipo"
 #: field:res.company,use_connector:0
 msgid "Use connector"
 msgstr "Usar conector"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_14
+msgid "VAT invoice Unearned interest on certificates of work whose recipient is a public authority"
+msgstr "Factura con IVA pendiente de devengo en certificaciones de obra cuyo destinatario sea una Administración Pública"
+
+#. module: l10n_es_aeat_sii
+#: model:aeat.sii.mapping.registration.keys,name:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_15
+msgid "VAT invoice accrual pending operations successive tract"
+msgstr "Factura con IVA pendiente de devengo en operaciones de tracto sucesivo"
 
 #. module: l10n_es_aeat_sii
 #: selection:res.company,send_mode:0

--- a/l10n_es_aeat_sii/models/aeat_sii_mapping_registration_keys.py
+++ b/l10n_es_aeat_sii/models/aeat_sii_mapping_registration_keys.py
@@ -10,7 +10,7 @@ class AeatSiiMappingRegistrationKeys(models.Model):
     _description = 'Aeat SII Invoice Registration Keys'
 
     code = fields.Char(string='Code', required=True, size=2)
-    name = fields.Char(string='Name', required=True)
+    name = fields.Char(string='Name', required=True, translate=True)
     type = fields.Selection(
         selection=[('sale', 'Sale'), ('purchase', 'Purchase')], string='Type',
         required=True)


### PR DESCRIPTION
Por defecto las claves de registro están en español, se han creado en ingles y implementado las traducciones.