### PR TITLE
Bump the addon version in the manifest to trigger wheel generation.

### DIFF
--- a/l10n_es_aeat_sii/__manifest__.py
+++ b/l10n_es_aeat_sii/__manifest__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"


### PR DESCRIPTION
Actually, the whl file was not regenerated because the only change was in setup.py which is outside of the addon directory. I suggest you bump the addon version in the manifest of l10n_es_aeat_sii and you should get the correct wheel tomorrow morning.