### PR TITLE
[FIX] Issue with UnicodeEncodeError exception during the validation of Supplier invoice

### DIFF
--- a/l10n_es_account_invoice_sequence/__manifest__.py
+++ b/l10n_es_account_invoice_sequence/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Secuencia para facturas separada de la secuencia de asientos",
-    "version": "10.0.1.0.2",
+    "version": "10.0.1.0.3",
     "author": "Spanish Localization Team, "
               "NaN·Tic, "
               "Trey, "

--- a/l10n_es_account_invoice_sequence/models/account_invoice.py
+++ b/l10n_es_account_invoice_sequence/models/account_invoice.py
@@ -38,7 +38,7 @@ class AccountInvoice(models.Model):
             # Include the invoice reference on the created journal item
             # This is done for displaying the number on the conciliation
             inv.move_id.ref = (
-                "{0} - {1}" if inv.move_id.ref else "{1}"
+                u"{0} - {1}" if inv.move_id.ref else u"{1}"
             ).format(inv.move_id.ref, inv.invoice_number)
         return res
 


### PR DESCRIPTION
**To reproduce the issue:**
- Create a supplier invoice
- Fill the supplier reference with special char (é, è,...)
- Click on the validate button
- Traceback

**Fix:**
- This fix force the text to be encoded with unicode