### PR TITLE
[FIX][l10n_es_account_asset] Modificación del onchange para el campo category_id

### DIFF
--- a/l10n_es_account_asset/models/account_asset.py
+++ b/l10n_es_account_asset/models/account_asset.py
@@ -77,9 +77,8 @@ class AccountAssetAsset(models.Model):
          'Wrong percentage!'),
     ]
 
-    @api.multi
-    def onchange_category_id(self, category_id):
-        res = super(AccountAssetAsset, self).onchange_category_id(category_id)
+    def onchange_category_id_values(self, category_id):
+        res = super(AccountAssetAsset, self).onchange_category_id_values(category_id)
         if category_id:
             category_obj = self.env['account.asset.category']
             category = category_obj.browse(category_id)

--- a/l10n_es_account_asset/models/account_asset.py
+++ b/l10n_es_account_asset/models/account_asset.py
@@ -78,7 +78,8 @@ class AccountAssetAsset(models.Model):
     ]
 
     def onchange_category_id_values(self, category_id):
-        res = super(AccountAssetAsset, self).onchange_category_id_values(category_id)
+        res = super(AccountAssetAsset, self).\
+            onchange_category_id_values(category_id)
         if category_id:
             category_obj = self.env['account.asset.category']
             category = category_obj.browse(category_id)


### PR DESCRIPTION
Buenas, esta es mi primera contribución a OCA.

Pasos para reproducir el error:
1. Crear un tipo de activo
2. Al crear un nuevo activo, los datos de la periodicidad configurados en el tipo de activo no se importan al nuevo activo.

Corrección:
El método a sobreescribir debe ser el "onchange_category_id_values" y no el "onchange_category_id" tal y como es actualmente.

Un saludo

Fixes #658 