### PR TITLE
[FIX] l10n_es: See correctly tax name in invoice report

### DIFF
--- a/l10n_es/__manifest__.py
+++ b/l10n_es/__manifest__.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
-# © 2008-2010 Jordi Esteve - Zikzakmedia S.L.
-# © 2011-2018 Ignacio - Ibeas - Acysos
-# © 2012-2013 Grupo Opentia
-# © 2014 Pablo Cayuela - Aserti Global Solutions
-# © 2014 Ángel Moya - Domatix
-# © 2015 Carlos Liébana - Factor Libre
-# © 2015 Albert Cabedo - GAFIC consultores
-# © 2013-2018 Tecnativa - Pedro M. Baeza
+# Copyright 2008-2010 Jordi Esteve - Zikzakmedia S.L.
+# Copyright 2011 Ignacio - Ibeas - Acysos
+# Copyright 2012-2013 Grupo Opentia
+# Copyright 2014 Pablo Cayuela - Aserti Global Solutions
+# Copyright 2014 Ángel Moya - Domatix
+# Copyright 2015 Carlos Liébana - Factor Libre
+# Copyright 2015 Albert Cabedo - GAFIC consultores
+# Copyright 2013-2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": "Planes de cuentas españoles (según PGCE 2008)",
-    "version": "10.0.2.0.0",
+    "version": "10.0.2.1.0",
     "author": "Spanish Localization Team, "
               "Odoo Community Association (OCA)",
     "website": 'https://github.com/OCA/l10n-spain',
@@ -33,6 +33,7 @@
         "data/taxes_common.xml",
         "data/fiscal_positions_common.xml",
         "data/account_chart_template_post.xml",
+        "views/report_invoice.xml",
     ],
     'installable': True,
     'images': [

--- a/l10n_es/views/report_invoice.xml
+++ b/l10n_es/views/report_invoice.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document" priority="9999">
+        <xpath expr="//span[contains(@t-esc, 'x.description or x.name')]" position="attributes">
+            <attribute name="t-esc">', '.join(map(lambda x: x.name, l.invoice_line_tax_ids))</attribute>
+        </xpath>
+        <xpath expr="//span[contains(@t-esc, 'o.tax_line_ids.tax_id.description or o.tax_line_ids.tax_id.name')]" position="attributes">
+            <attribute name="t-esc">amount_by_group[0] if len(o.tax_line_ids) > 1 else o.tax_line_ids.tax_id.name</attribute>
+        </xpath>
+        <xpath expr="//span[@t-field='t.tax_id.description']" position="attributes">
+            <attribute name="t-field">t.tax_id.name</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Background
==========

For Spanish localization, we use the field `description` in account.tax model for having a programatic code like "S_IVA21B" that serves us for obtaining other localization functionalities like specific taxes reports. These are other reasons for that code:

* On v8, we had taxes codes that serves for the tax report purpose, but on >= v9, there's only taxes.
* We need a permanent field in taxes for their update with the module account_chart_update, keeping `name` field for user/DB specific strings preferences.
* We could base the tax engine in taxes groups, but that means in practical terms that we would need one tax group for each tax, losing the concept of groups. And even more, we would need to duplicate data maintenance.

Issue
=====

The problem is that in Odoo, for most of the times, the value taken for reports is `description` field, not `name` one.

Workarounds
===========

* For v8, we solved the visualization/printing through `name_get` in account.tax in the module `l10n_es`.

* For v9, everything was working as is, as Odoo was aligned with our interpretation.

* For v11, things are mixed, as we have a correct text on invoice footers, but not on line taxes column (but better not to open up this discussion, hehe, or I figure out that they will change everything as in v10).

* In v10, all the references in the reports are to the `description` field, so the only solution I see is that `l10n_es` modifies the invoice report (as it depends already on account) for having the proper field. This has 2 problems:

  * If a DB is multi-localization, this will affect to all the printed invoices, no matter if the invoice is for an Spanish invoice or not. Including a check for selecting the same field as it was would be very performance drainer IMO. Any way, checking the rest of the localizations, they tend to have very similar texts of both fields, so this problem is not very severe.
  * Sale and purchase reports will still contain the tax description instead of name. These documments are not critical in the taxes part, but for solving this, we will need extra modules depending on them and overwriting the same way the reports.

Future
======

A definitive solution for this is to propose an unique field `code` at account.tax model in v12 for avoiding all of these problems.

@Tecnativa