### PR TITLE
[9.0][IMP] l10n_es_aeat_mod303: Automatic compensation and return improvement

### DIFF
--- a/l10n_es_aeat_mod303/__openerp__.py
+++ b/l10n_es_aeat_mod303/__openerp__.py
@@ -7,13 +7,13 @@
 
 {
     "name": "AEAT modelo 303",
-    "version": "9.0.1.4.1",
+    "version": "9.0.1.5.0",
     'category': "Accounting & Finance",
     'author': "Guadaltech,"
               "AvanzOSC,"
               "Tecnativa,"
               "Odoo Community Association (OCA)",
-    'website': "https://odoo-community.org/",
+    'website': "https://github.com/OCA/l10n-spain",
     "license": "AGPL-3",
     "depends": [
         "l10n_es",

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
@@ -61,7 +61,7 @@
         <field name="sequence">6</field>
         <field name="export_config_id" ref="aeat_mod303_2017_sub01_export_config"/>
         <field name="name">Tipo de declaración</field>
-        <field name="expression">${(object.result_type == 'D' and object.compensate and 'C') or object.result_type}</field>
+        <field name="expression">${object.result_type}</field>
         <field name="export_type">string</field>
         <field name="size">1</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_data.xml
@@ -53,7 +53,7 @@
     <field name="sequence">5</field>
     <field name="export_config_id" ref="aeat_mod303_sub01_export_config"/>
     <field name="name">Tipo de declaración</field>
-    <field name="expression">${(object.result_type == 'D' and object.compensate and 'C') or object.result_type}</field>
+    <field name="expression">${object.result_type}</field>
     <field name="export_type">string</field>
     <field name="size">1</field>
     <field name="alignment">left</field>

--- a/l10n_es_aeat_mod303/i18n/es.po
+++ b/l10n_es_aeat_mod303/i18n/es.po
@@ -397,6 +397,11 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod303
 #: selection:l10n.es.aeat.mod303.report,result_type:0
+msgid "To compensate"
+msgstr "Solicitud de compensación"
+
+#. module: l10n_es_aeat_mod303
+#: selection:l10n.es.aeat.mod303.report,result_type:0
 msgid "To enter"
 msgstr "A ingresar"
 

--- a/l10n_es_aeat_mod303/migrations/9.0.1.5.0/post-migration.py
+++ b/l10n_es_aeat_mod303/migrations/9.0.1.5.0/post-migration.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014-2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    # for not requiring openupgradelib if not migrating
+    from openupgradelib import openupgrade
+    openupgrade.logged_query(
+        cr, """
+        UPDATE l10n_es_aeat_mod303_report
+        SET result_type = 'C'
+        WHERE %s = True""" % openupgrade.get_legacy_name('compensate')
+    )

--- a/l10n_es_aeat_mod303/migrations/9.0.1.5.0/pre-migration.py
+++ b/l10n_es_aeat_mod303/migrations/9.0.1.5.0/pre-migration.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2014-2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    # for not requiring openupgradelib if not migrating
+    from openupgradelib import openupgrade
+    openupgrade.rename_columns(
+        cr, {
+            'l10n_es_aeat_mod303_report': ('compensate', None),
+        }
+    )

--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -90,11 +90,10 @@
                        options="{'currency_field': 'currency_id'}"
                         />
                 <field name="result_type"/>
-                <field name="compensate" attrs="{'invisible': [('result_type', '!=', 'D')]}"/>
                 <field name="company_partner_id" invisible="1"/>
                 <field name="bank_account_id"
                        domain="[('partner_id', '=', company_partner_id)]"
-                       attrs="{'invisible': ['|', ('result_type', 'not in', ('D', 'B', 'I')), ('compensate', '=', True)]}"
+                       attrs="{'invisible': [('result_type', 'not in', ('D', 'B', 'I'))], 'required': [('result_type', '=', 'D')]}"
                 />
             </group>
             <group string="Tax lines"


### PR DESCRIPTION
Si no estás inscrito en el REDEME (Registro de Devolución Mensual), y la declaración sale negativa, la única posibilidad es la de compensar, por lo que no tiene sentido que se tenga que marcar manualmente la casilla, ya que si olvida y se exporta, Hacienda no lo admite.

Por eso, este cambio detecta automáticamente esta situación y coloca el tipo de resultado, eliminando la casilla extra.

Se incluye script de migración para restituir correctamente los datos de anteriores declaraciones.

También se hace obligatoria la cuenta bancaria cuando la declaración sea a devolver, ya que es también un dato obligatorio al presentarlo a Hacienda.

@Tecnativa