### PR TITLE
[FIX] changed test on invoice_sequence

### DIFF
--- a/l10n_es_account_invoice_sequence/tests/test_create_chart.py
+++ b/l10n_es_account_invoice_sequence/tests/test_create_chart.py
@@ -7,8 +7,6 @@ from odoo import exceptions
 from ..hooks import post_init_hook
 
 
-@common.at_install(False)
-@common.post_install(True)
 class TestCreateChart(common.SavepointCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
El test de `l10n_es_account_invoice_sequence` provocaba un error de timeout en el test de #703.

Se passa de SavepointCase a TransactionCase y se elimina el at_install y post_install.

Lo separo en dos PRs para que quede más claro y sencillo.