### PR TITLE
Updated requirements.txt on branch 8.0; reason #706

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ six>=1.9.0
 unidecode
 unicodecsv
 zeep
-
+pyOpenSSL


### PR DESCRIPTION
Como comento en:

#706 

Es necesario el módulo pyOpenSSL para el correcto funcionamiento de l10n_es_aeat_sii