### PR TITLE
[FIX] l10n_es_aeat: onchange_chart_template_id is missing

### DIFF
--- a/l10n_es_aeat/__openerp__.py
+++ b/l10n_es_aeat/__openerp__.py
@@ -9,7 +9,7 @@
 {
     'name': "AEAT Base",
     'summary': "Modulo base para declaraciones de la AEAT",
-    'version': "9.0.1.0.5",
+    'version': "9.0.1.0.6",
     'author': "Pexego,"
               "Acysos,"
               "AvanzOSC,"

--- a/l10n_es_aeat/tests/test_l10n_es_aeat_mod_base.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_mod_base.py
@@ -46,6 +46,7 @@ class TestL10nEsAeatModBase(common.TransactionCase):
             'currency_id': self.ref('base.EUR'),
             'transfer_account_id': self.chart.transfer_account_id.id,
         })
+        wizard.onchange_chart_template_id()
         wizard.execute()
         return True
 


### PR DESCRIPTION
If not, company chart template is not updated correctly on tests.

