### PR TITLE
[FIX] Envío de facturas tipo out_invoice con importe negativo

### DIFF
--- a/l10n_es_aeat_sii/__manifest__.py
+++ b/l10n_es_aeat_sii/__manifest__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "10.0.1.0.3",
+    "version": "10.0.1.0.4",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1288,8 +1288,9 @@ class AccountInvoice(models.Model):
     @api.multi
     def _get_sii_sign(self):
         self.ensure_one()
-        return -1.0 if self.sii_refund_type == 'I' and 'refund' in self.type \
-            else 1.0
+        return -1.0 if (self.sii_refund_type == 'I' and 'refund' in self.type)\
+            or (self.type == 'out_invoice' and
+                self.amount_total_company_signed < 0) else 1.0
 
     @job
     @api.multi


### PR DESCRIPTION
Según lo comentado en el issue #712 se puede dar el caso en según que sectores que se realice facturas de venta con importe negativo.

Sin el fix, la factura se manda correctamente pero no mantiene el signo negativo.
Únicamente se ha modifcado el método  _get_sii_sign del modelo account_invoice para que contemple este caso.



