### PR TITLE
[11.0][l10n_es_aeat] Corrige exportación a BOE

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -9,7 +9,7 @@
 {
     'name': "AEAT Base",
     'summary': "Modulo base para declaraciones de la AEAT",
-    'version': "11.0.1.0.0",
+    'version': "11.0.1.0.1",
     'author': "Pexego,"
               "Acysos,"
               "AvanzOSC,"

--- a/l10n_es_aeat/tests/test_l10n_es_aeat_export_config.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_export_config.py
@@ -35,6 +35,19 @@ class TestL10nEsAeatExportConfig(common.TransactionCase):
                              'Apply sign must be False for a subtype line')
 
     def test_export_config_file(self):
+        export_subconfig = self.env['aeat.model.export.config'].create({
+            'name': 'Test Export Sub Config',
+            'model_number': '000',
+            'config_line_ids': [
+                (0, 0, {
+                    'sequence': 1,
+                    'name': '<T',
+                    'fixed_value': '<T',
+                    'export_type': 'string',
+                    'size': 3,
+                    'alignment': 'left'
+                })]
+        })
         export_config = self.env['aeat.model.export.config'].create({
             'name': 'Test Export Config',
             'model_number': '000',
@@ -94,6 +107,16 @@ class TestL10nEsAeatExportConfig(common.TransactionCase):
                     'fixed_value': '>',
                     'size': 1,
                     'alignment': 'left'
+                })
+                ,
+                (0, 0, {
+                    'sequence': 8,
+                    'name': 'False expression',
+                    'export_type': 'subconfig',
+                    'alignment': 'left',
+                    'subconfig_id': export_subconfig.id,
+                    'conditional_expression': 'False',
+
                 })
             ]
         })

--- a/l10n_es_aeat/tests/test_l10n_es_aeat_export_config.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_export_config.py
@@ -107,8 +107,7 @@ class TestL10nEsAeatExportConfig(common.TransactionCase):
                     'fixed_value': '>',
                     'size': 1,
                     'alignment': 'left'
-                })
-                ,
+                }),
                 (0, 0, {
                     'sequence': 8,
                     'name': 'False expression',

--- a/l10n_es_aeat/wizard/export_to_boe.py
+++ b/l10n_es_aeat/wizard/export_to_boe.py
@@ -191,7 +191,7 @@ class L10nEsAeatReportExportToBoe(models.TransientModel):
         val = b''
         if line.conditional_expression:
             if not merge_eval(line.conditional_expression):
-                return ''
+                return val
         if line.repeat_expression:
             obj_list = merge_eval(line.repeat_expression)
         else:


### PR DESCRIPTION
Con este PR se pretende corregir un error detectado durante la migración del 303 https://github.com/OCA/l10n-spain/pull/687, por el cual fallaba la exportación a BOE de este modelo.

cc @oihane 