### PR TITLE
[10.0][l10n_es_aeat_303] Varias mejoras

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -9,7 +9,7 @@
 {
     'name': "AEAT Base",
     'summary': "Modulo base para declaraciones de la AEAT",
-    'version': "10.0.1.1.0",
+    'version': "10.0.1.1.1",
     'author': "Pexego,"
               "Acysos,"
               "AvanzOSC,"

--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -312,7 +312,7 @@ class L10nEsAeatReport(models.AbstractModel):
     def _prepare_move_vals(self):
         self.ensure_one()
         return {
-            'date': fields.Date.today(),
+            'date': self.date_end,
             'journal_id': self.journal_id.id,
             'ref': self.name,
             'company_id': self.company_id.id,

--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -295,7 +295,7 @@ class L10nEsAeatReport(models.AbstractModel):
         return self.search([
             ('year', '=', self.year),
             ('date_start', '<', date),
-        ]) or None
+        ])
 
     @api.multi
     def calculate(self):

--- a/l10n_es_aeat_mod303/README.rst
+++ b/l10n_es_aeat_mod303/README.rst
@@ -56,6 +56,7 @@ Contribuidores
 * Comunitea (http://www.comunitea.com)
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
 * Luis M. Ontalba <luis.martinez@tecnativa.com>
+* Jordi Ballester <jordi.ballester@eficent.com>
 
 Maintainer
 ----------

--- a/l10n_es_aeat_mod303/__manifest__.py
+++ b/l10n_es_aeat_mod303/__manifest__.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
 # Copyright 2013 Alberto Martín Cortada (Guadaltech)
 # Copyright 2015 AvanzOSC - Ainara Galdona
-# Copyright 2016 Tecnativa - Antonio Espinosa <antonio.espinosa@tecnativa.com>
-# Copyright 2014-2017 Tecnativa - Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2016 Tecnativa - Antonio Espinosa
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2014-2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0
 
 {
     "name": "AEAT modelo 303",
-    "version": "10.0.1.5.0",
+    "version": "10.0.2.0.0",
     'category': "Accounting & Finance",
     'author': "Guadaltech,"
               "AvanzOSC,"
               "Tecnativa,"
+              "Eficent,"
               "Odoo Community Association (OCA)",
     'website': "https://github.com/OCA/l10n-spain",
     "license": "AGPL-3",

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
@@ -2190,7 +2190,7 @@
         <field name="sequence">26</field>
         <field name="export_config_id" ref="aeat_mod303_2017_sub03_export_config"/>
         <field name="name">Devolución. SWIFT-BIC</field>
-        <field name="expression">${object.bank_account_id.bank_bic}</field>
+        <field name="expression">${object.partner_bank_id.bank_bic}</field>
         <field name="fixed_value"/>
         <field name="export_type">string</field>
         <field name="size">11</field>
@@ -2201,7 +2201,7 @@
         <field name="sequence">27</field>
         <field name="export_config_id" ref="aeat_mod303_2017_sub03_export_config"/>
         <field name="name">Domiciliación/Devolución - IBAN</field>
-        <field name="expression">${object.bank_account_id and object.bank_account_id.acc_number.replace(' ', '') or ''}</field>
+        <field name="expression">${object.partner_bank_id and object.partner_bank_id.acc_number.replace(' ', '') or ''}</field>
         <field name="fixed_value"/>
         <field name="export_type">string</field>
         <field name="size">34</field>

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2018_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2018_data.xml
@@ -2212,7 +2212,7 @@
         <field name="sequence">26</field>
         <field name="export_config_id" ref="aeat_mod303_2018_sub03_export_config"/>
         <field name="name">Devolución. SWIFT-BIC</field>
-        <field name="expression">${object.bank_account_id.bank_bic}</field>
+        <field name="expression">${object.partner_bank_id.bank_bic}</field>
         <field name="fixed_value"/>
         <field name="export_type">string</field>
         <field name="size">11</field>
@@ -2223,7 +2223,7 @@
         <field name="sequence">27</field>
         <field name="export_config_id" ref="aeat_mod303_2018_sub03_export_config"/>
         <field name="name">Domiciliación/Devolución - IBAN</field>
-        <field name="expression">${object.bank_account_id and object.bank_account_id.acc_number.replace(' ', '') or ''}</field>
+        <field name="expression">${object.partner_bank_id and object.partner_bank_id.acc_number.replace(' ', '') or ''}</field>
         <field name="fixed_value"/>
         <field name="export_type">string</field>
         <field name="size">34</field>

--- a/l10n_es_aeat_mod303/i18n/es.po
+++ b/l10n_es_aeat_mod303/i18n/es.po
@@ -1,22 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat_mod303
-# 
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
+#	* l10n_es_aeat_mod303
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-14 20:10+0000\n"
-"PO-Revision-Date: 2017-12-14 20:10+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"POT-Creation-Date: 2018-04-13 18:57+0000\n"
+"PO-Revision-Date: 2018-04-13 18:57+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: es\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_casilla_46
@@ -49,23 +46,9 @@ msgid "Allow posting"
 msgstr "Permitir generar asiento"
 
 #. module: l10n_es_aeat_mod303
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_bank_account_id
-msgid "Bank account"
-msgstr "Cuenta bancaria"
-
-#. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_casilla_77
-msgid ""
-"Contributions of import tax included in the documents evidencing the payment"
-" made by the Administration and received in the settlement period. You can "
-"only complete this box when the requirements of Article 74.1 of the Tax "
-"Regulations Value Added are met."
-msgstr ""
-"Se hará constar el importe de las cuotas del Impuesto a la importación "
-"incluidas en los documentos en los que conste la liquidación practicada por "
-"la Administración recibidos en el periodo de liquidación. Solamente podrá "
-"cumplimentarse esta casilla cuando se cumplan los requisitos establecidos en"
-" el artículo 74.1 del Reglamento del Impuesto sobre el Valor Añadido."
+msgid "Contributions of import tax included in the documents evidencing the payment made by the Administration and received in the settlement period. You can only complete this box when the requirements of Article 74.1 of the Tax Regulations Value Added are met."
+msgstr "Se hará constar el importe de las cuotas del Impuesto a la importación incluidas en los documentos en los que conste la liquidación practicada por la Administración recibidos en el periodo de liquidación. Solamente podrá cumplimentarse esta casilla cuando se cumplan los requisitos establecidos en el artículo 74.1 del Reglamento del Impuesto sobre el Valor Añadido."
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_counterpart_account_id
@@ -85,21 +68,17 @@ msgstr "Creado por"
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_create_date
 msgid "Created on"
-msgstr "Creado en"
+msgstr "Creado el"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_display_name
 msgid "Display Name"
-msgstr "Nombre mostrado"
+msgstr "Nombre a mostrar"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_cuota_compensar
-msgid ""
-"Fee to compensate for prior periods, in which his statement was to return "
-"and compensation back option was chosen"
-msgstr ""
-"Cuota a compensar de periodos anteriores, en los que su declaración fue a "
-"devolver y se escogió la opción de compensación posterior"
+msgid "Fee to compensate for prior periods, in which his statement was to return and compensation back option was chosen"
+msgstr "Cuota a compensar de periodos anteriores, en los que su declaración fue a devolver y se escogió la opción de compensación posterior"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_id
@@ -107,24 +86,20 @@ msgid "ID"
 msgstr "ID"
 
 #. module: l10n_es_aeat_mod303
+#: code:addons/l10n_es_aeat_mod303/models/mod303.py:118
+#, python-format
+msgid "In previous declarations this year you reported a Result Type 'To Compensate'. You might need to fill field '[67] Fees to compensate' in this declaration."
+msgstr "In previous declarations this year you reported a Result Type 'To Compensate'. You might need to fill field '[67] Fees to compensate' in this declaration."
+
+#. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_regularizacion_anual
-msgid ""
-"In the last auto settlement of the year, shall be recorded (the fourth "
-"period or 12th month), with the appropriate sign, the result of the annual "
-"adjustment as have the laws by the Economic Agreement approved between the "
-"State and the Autonomous Community the Basque Country and the Economic "
-"Agreement between the State and Navarre."
-msgstr ""
-"En la última autoliquidación del año (la del período 4T o mes 12) se hará "
-"constar, con el signo que corresponda, el resultado de la regularización "
-"anual conforme disponen las Leyes por las que se aprueban el Concierto "
-"Económico entre el Estado y la Comunidad Autónoma del País Vasco y el "
-"Convenio Económico entre el Estado y la Comunidad Foral de Navarra."
+msgid "In the last auto settlement of the year, shall be recorded (the fourth period or 12th month), with the appropriate sign, the result of the annual adjustment as have the laws by the Economic Agreement approved between the State and the Autonomous Community the Basque Country and the Economic Agreement between the State and Navarre."
+msgstr "En la última autoliquidación del año (la del período 4T o mes 12) se hará constar, con el signo que corresponda, el resultado de la regularización anual conforme disponen las Leyes por las que se aprueban el Concierto Económico entre el Estado y la Comunidad Autónoma del País Vasco y el Convenio Económico entre el Estado y la Comunidad Foral de Navarra."
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report___last_update
 msgid "Last Modified on"
-msgstr "Last Modified on"
+msgstr "Última modificación en"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_write_uid
@@ -134,7 +109,7 @@ msgstr "Última actualización por"
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_write_date
 msgid "Last Updated on"
-msgstr "Última actualización en"
+msgstr "Última actualización el"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_devolucion_mensual
@@ -147,23 +122,14 @@ msgid "No activity/Zero result"
 msgstr "Sin actividad/Resultado cero"
 
 #. module: l10n_es_aeat_mod303
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_company_partner_id
-msgid "Partner"
-msgstr "Empresa"
-
-#. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_devolucion_mensual
 msgid "Registered in the Register of Monthly Return"
 msgstr "Inscrito en el Registro de Devolución Mensual"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_previous_result
-msgid ""
-"Result of the previous or prior statements of the same concept, exercise and"
-" period"
-msgstr ""
-"Resultado de la anterior o anteriores declaraciones del mismo concepto, "
-"ejercicio y periodo"
+msgid "Result of the previous or prior statements of the same concept, exercise and period"
+msgstr "Resultado de la anterior o anteriores declaraciones del mismo concepto, ejercicio y periodo"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_result_type
@@ -176,13 +142,7 @@ msgid "Resultado"
 msgstr "Resultado"
 
 #. module: l10n_es_aeat_mod303
-#: code:addons/l10n_es_aeat_mod303/models/mod303.py:185
-#, python-format
-msgid "Select an account for making the charge"
-msgstr "Seleccione una cuenta bancaria para realizar el cargo"
-
-#. module: l10n_es_aeat_mod303
-#: code:addons/l10n_es_aeat_mod303/models/mod303.py:187
+#: code:addons/l10n_es_aeat_mod303/models/mod303.py:237
 #, python-format
 msgid "Select an account for receiving the money"
 msgstr "Seleccione una cuenta bancaria para recibir el dinero"
@@ -194,26 +154,19 @@ msgstr "Líneas de impuestos"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_porcentaje_atribuible_estado
-msgid ""
-"Taxpayers who pay jointly to the Central Government and the Provincial "
-"Councils of the Basque Country or the Autonomous Community of Navarra, will "
-"enter in this box the percentage of volume operations in the common "
-"territory. Other taxpayers will enter in this box 100%"
-msgstr ""
-"Los sujetos pasivos que tributen conjuntamente a la Administración del "
-"Estado y a las Diputaciones Forales del País Vasco o a la Comunidad Foral de"
-" Navarra, consignarán en esta casilla el porcentaje del volumen de "
-"operaciones en territorio común. Los demás sujetos pasivos consignarán en "
-"esta casilla el 100%"
+msgid "Taxpayers who pay jointly to the Central Government and the Provincial Councils of the Basque Country or the Autonomous Community of Navarra, will enter in this box the percentage of volume operations in the common territory. Other taxpayers will enter in this box 100%"
+msgstr "Los sujetos pasivos que tributen conjuntamente a la Administración del Estado y a las Diputaciones Forales del País Vasco o a la Comunidad Foral de Navarra, consignarán en esta casilla el porcentaje del volumen de operaciones en territorio común. Los demás sujetos pasivos consignarán en esta casilla el 100%"
+
+#. module: l10n_es_aeat_mod303
+#: code:addons/l10n_es_aeat_mod303/models/mod303.py:246
+#, python-format
+msgid "The fee to compensate must be indicated as a positive number."
+msgstr "La cuota a compensar debe ser indicada como una cantidad positiva."
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_counterpart_account_id
-msgid ""
-"This account will be the counterpart for all the journal items that are "
-"regularized when posting the report."
-msgstr ""
-"Esta cuenta será la contrapartida para todos los elementos del diario que "
-"están regularizados al contabilizar el informe."
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
+msgstr "Esta cuenta será la contrapartida para todos los elementos del diario que están regularizados al contabilizar el informe."
 
 #. module: l10n_es_aeat_mod303
 #: selection:l10n.es.aeat.mod303.report,result_type:0
@@ -257,12 +210,8 @@ msgstr "[66] Atribuible a la Administración"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_casilla_69
-msgid ""
-"[66] Attributable to the Administration - [67] Fees to compensate + [68] "
-"Annual regularization"
-msgstr ""
-"Atribuible a la Administración [66] - Cuotas a compensar [67] + "
-"Regularización anual [68]"
+msgid "[66] Attributable to the Administration - [67] Fees to compensate + [68] Annual regularization"
+msgstr "Atribuible a la Administración [66] - Cuotas a compensar [67] + Regularización anual [68]"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_cuota_compensar
@@ -293,3 +242,4 @@ msgstr "[71] Result. liquidación"
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report_casilla_77
 msgid "[77] VAT deferred (Settle by customs)"
 msgstr "[77] Iva Diferido (Liquidado por aduana)"
+

--- a/l10n_es_aeat_mod303/migrations/10.0.1.4.0/pre-migration.py
+++ b/l10n_es_aeat_mod303/migrations/10.0.1.4.0/pre-migration.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute("""
+        UPDATE l10n_es_aeat_mod303_report
+        SET cuota_compensar = abs(cuota_compensar)""")
+
+    cr.execute("""
+        UPDATE l10n_es_aeat_mod303_report
+        SET partner_bank_id = bank_account_id
+        WHERE partner_bank_id IS Null
+        AND bank_account_id IS NOT Null""")

--- a/l10n_es_aeat_mod303/migrations/10.0.2.0.0/pre-migration.py
+++ b/l10n_es_aeat_mod303/migrations/10.0.2.0.0/pre-migration.py
@@ -9,7 +9,6 @@ def migrate(cr, version):
     cr.execute("""
         UPDATE l10n_es_aeat_mod303_report
         SET cuota_compensar = abs(cuota_compensar)""")
-
     cr.execute("""
         UPDATE l10n_es_aeat_mod303_report
         SET partner_bank_id = bank_account_id

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -5,7 +5,14 @@
 # Copyright 2014-2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api, _
+from odoo import api, exceptions, fields, models, _
+
+_ACCOUNT_PATTERN_MAP = {
+    'C': '4700',
+    'D': '4700',
+    'N': '4700',
+    'I': '4750',
+}
 
 
 class L10nEsAeatMod303Report(models.Model):
@@ -17,11 +24,9 @@ class L10nEsAeatMod303Report(models.Model):
     def _default_counterpart_303(self):
         return self.env['account.account'].search([
             ('code', 'like', '4750%'),
+            ('company_id', '=', self._default_company_id().id)
         ])[:1]
 
-    company_partner_id = fields.Many2one(
-        comodel_name='res.partner', string="Partner",
-        relation='company_id.partner_id', store=True)
     devolucion_mensual = fields.Boolean(
         string="Montly Return", states={'done': [('readonly', True)]},
         help="Registered in the Register of Monthly Return")
@@ -86,13 +91,32 @@ class L10nEsAeatMod303Report(models.Model):
             ('C', 'To compensate'),
             ('N', 'No activity/Zero result'),
         ], string="Result type", compute='_compute_result_type')
-    bank_account_id = fields.Many2one(
-        comodel_name="res.partner.bank", string="Bank account",
-        states={'done': [('readonly', True)]}, oldname='bank_account')
     counterpart_account_id = fields.Many2one(
         comodel_name='account.account', string="Counterpart account",
-        default=_default_counterpart_303, oldname='counterpart_account')
+        default=_default_counterpart_303,
+        domain="[('company_id', '=', company_id)]",
+        oldname='counterpart_account')
     allow_posting = fields.Boolean(string="Allow posting", default=True)
+
+    @api.multi
+    @api.depends('date_start', 'cuota_compensar')
+    def _compute_exception_msg(self):
+        super(L10nEsAeatMod303Report, self)._compute_exception_msg()
+        for mod303 in self:
+            # Get result from previous declarations, in order to identify if
+            # there is an amount to compensate.
+            prev_reports = mod303._get_previous_fiscalyear_reports(
+                mod303.date_start)
+            prev_reports.filtered(lambda x: x.state not in ['draft',
+                                                            'cancelled'])
+            for prev_report in prev_reports:
+                if prev_report.result_type == 'C' and not \
+                        mod303.cuota_compensar:
+                    mod303.exception_msg = \
+                        _("In previous declarations this year you "
+                          "reported a Result Type 'To Compensate'. "
+                          "You might need to fill field '[67] "
+                          "Fees to compensate' in this declaration.")
 
     @api.multi
     @api.depends('tax_line_ids', 'tax_line_ids.amount')
@@ -131,7 +155,7 @@ class L10nEsAeatMod303Report(models.Model):
     def _compute_casilla_69(self):
         for report in self:
             report.casilla_69 = (
-                report.atribuible_estado + report.casilla_77 +
+                report.atribuible_estado + report.casilla_77 -
                 report.cuota_compensar + report.regularizacion_anual)
 
     @api.multi
@@ -177,16 +201,49 @@ class L10nEsAeatMod303Report(models.Model):
             self.previous_result = 0
 
     @api.multi
+    def calculate(self):
+        res = super(L10nEsAeatMod303Report, self).calculate()
+        account_pattern_mapping = _ACCOUNT_PATTERN_MAP
+        for mod303 in self:
+            mod303.counterpart_account_id = \
+                self.env['account.account'].search([
+                    ('code', 'like', '%s%%' % account_pattern_mapping.get(
+                        mod303.result_type)),
+                    ('company_id', '=', mod303.company_id.id),
+                ])[:1]
+            prev_reports = mod303._get_previous_fiscalyear_reports(
+                mod303.date_start)
+            if prev_reports:
+                prev_reports = prev_reports.filtered(
+                    lambda x: x.state != 'cancelled')
+                prev_report = min(prev_reports, key=lambda x: abs(
+                    fields.Date.from_string(x.date_end) -
+                    fields.Date.from_string(mod303.date_start)))
+                if prev_report.resultado_liquidacion < 0.0:
+                    mod303.cuota_compensar = abs(
+                        prev_report.resultado_liquidacion)
+        return res
+
+    @api.multi
     def button_confirm(self):
         """Check records"""
         msg = ""
         for mod303 in self:
-            if mod303.result_type == 'I' and not mod303.bank_account_id:
+            if mod303.result_type == 'I' and not mod303.partner_bank_id:
                 msg = _('Select an account for making the charge')
-            if mod303.result_type == 'D' and not mod303.bank_account_id:
+            if mod303.result_type == 'D' and not mod303.partner_bank_id:
                 msg = _('Select an account for receiving the money')
         if msg:
             # Don't raise error, because data is not used
             # raise exceptions.Warning(msg)
             pass
         return super(L10nEsAeatMod303Report, self).button_confirm()
+
+    @api.multi
+    @api.constrains('cuota_compensar')
+    def check_qty(self):
+        for record in self:
+            if record.cuota_compensar < 0.0:
+                raise exceptions.ValidationError(
+                    _('The fee to compensate must be indicated '
+                      'as a positive number. '))

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -106,17 +106,20 @@ class L10nEsAeatMod303Report(models.Model):
             # Get result from previous declarations, in order to identify if
             # there is an amount to compensate.
             prev_reports = mod303._get_previous_fiscalyear_reports(
-                mod303.date_start)
-            prev_reports.filtered(lambda x: x.state not in ['draft',
-                                                            'cancelled'])
+                mod303.date_start
+            ).filtered(lambda x: x.state not in ['draft', 'cancelled'])
             for prev_report in prev_reports:
-                if prev_report.result_type == 'C' and not \
-                        mod303.cuota_compensar:
-                    mod303.exception_msg = \
-                        _("In previous declarations this year you "
-                          "reported a Result Type 'To Compensate'. "
-                          "You might need to fill field '[67] "
-                          "Fees to compensate' in this declaration.")
+                if (prev_report.result_type == 'C' and not
+                        mod303.cuota_compensar):
+                    if mod303.exception_msg:
+                        mod303.exception_msg += "\n"
+                    else:
+                        mod303.exception_msg = ""
+                    mod303.exception_msg += _(
+                        "In previous declarations this year you reported a "
+                        "Result Type 'To Compensate'. You might need to fill "
+                        "field '[67] Fees to compensate' in this declaration."
+                    )
 
     @api.multi
     @api.depends('tax_line_ids', 'tax_line_ids.amount')
@@ -203,25 +206,26 @@ class L10nEsAeatMod303Report(models.Model):
     @api.multi
     def calculate(self):
         res = super(L10nEsAeatMod303Report, self).calculate()
-        account_pattern_mapping = _ACCOUNT_PATTERN_MAP
         for mod303 in self:
             mod303.counterpart_account_id = \
                 self.env['account.account'].search([
-                    ('code', 'like', '%s%%' % account_pattern_mapping.get(
-                        mod303.result_type)),
+                    ('code', 'like', '%s%%' % _ACCOUNT_PATTERN_MAP.get(
+                        mod303.result_type, '4750')),
                     ('company_id', '=', mod303.company_id.id),
-                ])[:1]
+                ], limit=1)
             prev_reports = mod303._get_previous_fiscalyear_reports(
-                mod303.date_start)
-            if prev_reports:
-                prev_reports = prev_reports.filtered(
-                    lambda x: x.state != 'cancelled')
-                prev_report = min(prev_reports, key=lambda x: abs(
+                mod303.date_start
+            ).filtered(lambda x: x.state not in ['draft', 'cancelled'])
+            if not prev_reports:
+                continue
+            prev_report = min(
+                prev_reports, key=lambda x: abs(
                     fields.Date.from_string(x.date_end) -
-                    fields.Date.from_string(mod303.date_start)))
-                if prev_report.resultado_liquidacion < 0.0:
-                    mod303.cuota_compensar = abs(
-                        prev_report.resultado_liquidacion)
+                    fields.Date.from_string(mod303.date_start)
+                ),
+            )
+            if prev_report.resultado_liquidacion < 0.0:
+                mod303.cuota_compensar = abs(prev_report.resultado_liquidacion)
         return res
 
     @api.multi
@@ -229,21 +233,16 @@ class L10nEsAeatMod303Report(models.Model):
         """Check records"""
         msg = ""
         for mod303 in self:
-            if mod303.result_type == 'I' and not mod303.partner_bank_id:
-                msg = _('Select an account for making the charge')
             if mod303.result_type == 'D' and not mod303.partner_bank_id:
                 msg = _('Select an account for receiving the money')
         if msg:
-            # Don't raise error, because data is not used
-            # raise exceptions.Warning(msg)
-            pass
+            raise exceptions.Warning(msg)
         return super(L10nEsAeatMod303Report, self).button_confirm()
 
     @api.multi
     @api.constrains('cuota_compensar')
     def check_qty(self):
-        for record in self:
-            if record.cuota_compensar < 0.0:
-                raise exceptions.ValidationError(
-                    _('The fee to compensate must be indicated '
-                      'as a positive number. '))
+        if self.filtered(lambda x: x.cuota_compensar < 0.0):
+            raise exceptions.ValidationError(_(
+                'The fee to compensate must be indicated as a positive number.'
+            ))

--- a/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
+++ b/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
@@ -5,6 +5,7 @@
 import logging
 from odoo.addons.l10n_es_aeat.tests.test_l10n_es_aeat_mod_base import \
     TestL10nEsAeatModBase
+from odoo import exceptions
 
 _logger = logging.getLogger('aeat.303')
 
@@ -265,10 +266,12 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
         self._invoice_sale_create('2017-01-12')
         sale = self._invoice_sale_create('2017-01-13')
         self._invoice_refund(sale, '2017-01-14')
+
+    def test_model_303(self):
         # Create model
         export_config = self.env.ref(
             'l10n_es_aeat_mod303.aeat_mod303_main_export_config')
-        self.model303 = self.env['l10n.es.aeat.mod303.report'].create({
+        model303 = self.env['l10n.es.aeat.mod303.report'].new({
             'name': '9990000000303',
             'company_id': self.company.id,
             'company_vat': '1234567890',
@@ -282,16 +285,23 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
             'date_end': '2017-03-31',
             'export_config_id': export_config.id,
             'journal_id': self.journal_misc.id,
-            'counterpart_account_id': self.accounts['475000'].id
         })
-
-
-class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
-    def test_model_303(self):
+        model303.counterpart_account_id \
+            = model303._default_counterpart_303()
+        self.assertEqual(model303.counterpart_account_id.id,
+                         self.accounts['475000'].id)
+        model303 = self.env[
+            'l10n.es.aeat.mod303.report'].create(
+            model303._convert_to_write(model303._cache))
         _logger.debug('Calculate AEAT 303 1T 2017')
-        self.model303.button_calculate()
+        model303.button_calculate()
+        self.assertEqual(model303.state, 'calculated')
+        model303.button_recover()
+        self.assertEqual(model303.state, 'draft')
+        self.assertEqual(model303.calculation_date, False)
+        model303.button_calculate()
         # Fill manual fields
-        self.model303.write({
+        model303.write({
             # % atribuible al Estado
             'porcentaje_atribuible_estado': 95,
             # Cuotas a compensar
@@ -299,8 +309,10 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
             # Iva Diferido (Liquidado por aduana)
             'casilla_77': 455,
         })
+        model303.button_recalculate()
+        self.assertEqual(model303.state, 'calculated')
         if self.debug:
-            self._print_tax_lines(self.model303.tax_line_ids)
+            self._print_tax_lines(model303.tax_line_ids)
         # Check tax lines
         for field, result in self.taxes_result.iteritems():
             _logger.debug('Checking tax line: %s' % field)
@@ -318,14 +330,14 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
             '29', '31', '33', '35', '37', '39', '41', '42', '43', '44')])
         subtotal = round(devengado - deducir, 3)
         estado = round(subtotal * 0.95, 3)
-        result = round(estado + 455 + 250, 3)
-        self.assertAlmostEqual(self.model303.total_devengado, devengado, 2)
-        self.assertAlmostEqual(self.model303.total_deducir, deducir, 2)
-        self.assertAlmostEqual(self.model303.casilla_46, subtotal, 2)
-        self.assertAlmostEqual(self.model303.atribuible_estado, estado, 2)
-        self.assertAlmostEqual(self.model303.casilla_69, result, 2)
-        self.assertAlmostEqual(self.model303.resultado_liquidacion, result, 2)
-        self.assertEqual(self.model303.result_type, 'I')
+        result = round(estado + 455 - 250, 3)
+        self.assertAlmostEqual(model303.total_devengado, devengado, 2)
+        self.assertAlmostEqual(model303.total_deducir, deducir, 2)
+        self.assertAlmostEqual(model303.casilla_46, subtotal, 2)
+        self.assertAlmostEqual(model303.atribuible_estado, estado, 2)
+        self.assertAlmostEqual(model303.casilla_69, result, 2)
+        self.assertAlmostEqual(model303.resultado_liquidacion, result, 2)
+        self.assertEqual(model303.result_type, 'I')
         # Export to BOE
         export_to_boe = self.env['l10n.es.aeat.report.export_to_boe'].create({
             'name': 'test_export_to_boe.txt',
@@ -338,5 +350,19 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
         for xml_id in export_config_xml_ids:
             export_config = self.env.ref(xml_id)
             self.assertTrue(
-                export_to_boe._export_config(self.model303, export_config)
+                export_to_boe._export_config(model303, export_config)
             )
+
+        with self.assertRaises(exceptions.ValidationError):
+            model303.cuota_compensar = -250
+        model303.button_post()
+        self.assertFalse(not model303.move_id)
+        self.assertEqual(model303.move_id.ref, model303.name)
+        self.assertEqual(model303.move_id.state, 'draft')
+        self.assertEqual(model303.move_id.journal_id, model303.journal_id)
+        self.assertEqual(model303.move_id.partner_id,
+                         self.env.ref('l10n_es_aeat.res_partner_aeat'))
+        codes = model303.move_id.line_ids.mapped('account_id').mapped('code')
+        self.assertTrue('475000' in codes)
+        self.assertTrue('477000' in codes)
+        self.assertTrue('472000' in codes)

--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -25,6 +25,9 @@
     <field name="model">l10n.es.aeat.mod303.report</field>
     <field name="inherit_id" ref="l10n_es_aeat.view_l10n_es_aeat_report_form"/>
     <field name="arch" type="xml">
+        <field name="partner_bank_id" position="attributes">
+            <attribute name="attrs">{'invisible': [('result_type', 'not in', ('D', 'B', 'I'))], 'required': [('result_type', '=', 'D')]}</attribute>
+        </field>
         <field name="previous_number" position="after">
             <field name="devolucion_mensual"/>
         </field>
@@ -90,11 +93,6 @@
                        options="{'currency_field': 'currency_id'}"
                         />
                 <field name="result_type"/>
-                <field name="company_partner_id" invisible="1"/>
-                <field name="bank_account_id"
-                       domain="[('partner_id', '=', company_partner_id)]"
-                       attrs="{'invisible': [('result_type', 'not in', ('D', 'B', 'I'))], 'required': [('result_type', '=', 'D')]}"
-                />
             </group>
             <group string="Tax lines"
                    name="group_tax_lines"

--- a/l10n_es_aeat_vat_prorrate/tests/test_l10n_es_vat_prorrate.py
+++ b/l10n_es_aeat_vat_prorrate/tests/test_l10n_es_vat_prorrate.py
@@ -24,78 +24,57 @@ class TestL10nEsAeatVatProrrate(TestL10nEsAeatMod303Base):
             'code': 'COUNTERPART',
             'user_type_id': self.account_type.id,
         })
-
-    def test_vat_prorrate(self):
-        export_config = self.env.ref(
-            'l10n_es_aeat_mod303.aeat_mod303_main_export_config')
-        model303 = self.env['l10n.es.aeat.mod303.report'].create({
-            'name': '9990000000303',
-            'company_id': self.company.id,
-            'company_vat': '1234567890',
-            'contact_name': 'Test owner',
-            'type': 'N',
-            'support_type': 'T',
-            'contact_phone': '911234455',
-            'year': 2017,
-            'period_type': '1T',
-            'date_start': '2017-01-01',
-            'date_end': '2017-03-31',
-            'export_config_id': export_config.id,
-            'journal_id': self.journal_misc.id,
-            'counterpart_account_id': self.accounts['475000'].id
-        })
-
-        prorrate_regul_account = self.env['account.account'].search([
+        self.prorrate_regul_account = self.env['account.account'].search([
             ('code', 'like', '6391%'),
-            ('company_id', '=', model303.company_id.id),
+            ('company_id', '=', self.model303.company_id.id),
         ], limit=1)
-        if not prorrate_regul_account:
-            prorrate_regul_account = self.env['account.account'].create({
+        if not self.prorrate_regul_account:
+            self.prorrate_regul_account = self.env['account.account'].create({
                 'name': 'Test prorrate regularization account',
                 'code': '6391000',
                 'user_type_id': self.account_type.id,
             })
-
-        model303.write({
+        self.model303.write({
             'vat_prorrate_type': 'general',
             'vat_prorrate_percent': 80,
             'journal_id': self.journal.id,
-            'counterpart_account_id': self.counterpart_account.id,
         })
-        model303_4t = model303.copy({
+        self.model303_4t = self.model303.copy({
             'name': '9994000000303',
             'period_type': '4T',
             'date_start': '2017-09-01',
             'date_end': '2017-12-31',
         })
 
+    def test_vat_prorrate(self):
         # First semester
-        model303.button_calculate()
-        self.assertAlmostEqual(model303.total_deducir, 2043.82, 2)
-        model303.create_regularization_move()
-        self.assertAlmostEqual(len(model303.move_id.line_ids), 82, 2)
-        lines = model303.move_id.line_ids
+        self.model303.button_calculate()
+        self.model303.counterpart_account_id = self.counterpart_account.id
+        self.assertAlmostEqual(self.model303.total_deducir, 2043.82, 2)
+        self.model303.create_regularization_move()
+        self.assertAlmostEqual(len(self.model303.move_id.line_ids), 82, 2)
+        lines = self.model303.move_id.line_ids
         line_counterpart = lines.filtered(
             lambda x: x.account_id == self.counterpart_account
         )
         self.assertAlmostEqual(line_counterpart.credit, 2036.18, 2)
         # Last semester
         wizard = self.env['l10n.es.aeat.compute.vat.prorrate'].with_context(
-            active_id=model303_4t.id,
+            active_id=self.model303_4t.id,
         ).create({
             'year': 2017,
         })
         wizard.button_compute()
-        self.assertAlmostEqual(model303_4t.vat_prorrate_percent, 82, 2)
-        model303_4t.button_calculate()
-        self.assertAlmostEqual(model303_4t.casilla_44, 51.10, 2)
+        self.assertAlmostEqual(self.model303_4t.vat_prorrate_percent, 82, 2)
+        self.model303_4t.button_calculate()
+        self.assertAlmostEqual(self.model303_4t.casilla_44, 51.10, 2)
         self.assertEqual(
-            model303_4t.prorrate_regularization_account_id,
-            prorrate_regul_account,
+            self.model303_4t.prorrate_regularization_account_id,
+            self.prorrate_regul_account,
         )
-        model303_4t.create_regularization_move()
-        lines = model303_4t.move_id.line_ids
+        self.model303_4t.create_regularization_move()
+        lines = self.model303_4t.move_id.line_ids
         line_prorrate_regularization = lines.filtered(
-            lambda x: x.account_id == prorrate_regul_account
+            lambda x: x.account_id == self.prorrate_regul_account
         )
         self.assertAlmostEqual(line_prorrate_regularization.credit, 51.10, 2)

--- a/l10n_es_aeat_vat_prorrate/tests/test_l10n_es_vat_prorrate.py
+++ b/l10n_es_aeat_vat_prorrate/tests/test_l10n_es_vat_prorrate.py
@@ -24,57 +24,78 @@ class TestL10nEsAeatVatProrrate(TestL10nEsAeatMod303Base):
             'code': 'COUNTERPART',
             'user_type_id': self.account_type.id,
         })
-        self.prorrate_regul_account = self.env['account.account'].search([
+
+    def test_vat_prorrate(self):
+        export_config = self.env.ref(
+            'l10n_es_aeat_mod303.aeat_mod303_main_export_config')
+        model303 = self.env['l10n.es.aeat.mod303.report'].create({
+            'name': '9990000000303',
+            'company_id': self.company.id,
+            'company_vat': '1234567890',
+            'contact_name': 'Test owner',
+            'type': 'N',
+            'support_type': 'T',
+            'contact_phone': '911234455',
+            'year': 2017,
+            'period_type': '1T',
+            'date_start': '2017-01-01',
+            'date_end': '2017-03-31',
+            'export_config_id': export_config.id,
+            'journal_id': self.journal_misc.id,
+            'counterpart_account_id': self.accounts['475000'].id
+        })
+
+        prorrate_regul_account = self.env['account.account'].search([
             ('code', 'like', '6391%'),
-            ('company_id', '=', self.model303.company_id.id),
+            ('company_id', '=', model303.company_id.id),
         ], limit=1)
-        if not self.prorrate_regul_account:
-            self.prorrate_regul_account = self.env['account.account'].create({
+        if not prorrate_regul_account:
+            prorrate_regul_account = self.env['account.account'].create({
                 'name': 'Test prorrate regularization account',
                 'code': '6391000',
                 'user_type_id': self.account_type.id,
             })
-        self.model303.write({
+
+        model303.write({
             'vat_prorrate_type': 'general',
             'vat_prorrate_percent': 80,
             'journal_id': self.journal.id,
             'counterpart_account_id': self.counterpart_account.id,
         })
-        self.model303_4t = self.model303.copy({
+        model303_4t = model303.copy({
             'name': '9994000000303',
             'period_type': '4T',
             'date_start': '2017-09-01',
             'date_end': '2017-12-31',
         })
 
-    def test_vat_prorrate(self):
         # First semester
-        self.model303.button_calculate()
-        self.assertAlmostEqual(self.model303.total_deducir, 2043.82, 2)
-        self.model303.create_regularization_move()
-        self.assertAlmostEqual(len(self.model303.move_id.line_ids), 82, 2)
-        lines = self.model303.move_id.line_ids
+        model303.button_calculate()
+        self.assertAlmostEqual(model303.total_deducir, 2043.82, 2)
+        model303.create_regularization_move()
+        self.assertAlmostEqual(len(model303.move_id.line_ids), 82, 2)
+        lines = model303.move_id.line_ids
         line_counterpart = lines.filtered(
             lambda x: x.account_id == self.counterpart_account
         )
         self.assertAlmostEqual(line_counterpart.credit, 2036.18, 2)
         # Last semester
         wizard = self.env['l10n.es.aeat.compute.vat.prorrate'].with_context(
-            active_id=self.model303_4t.id,
+            active_id=model303_4t.id,
         ).create({
             'year': 2017,
         })
         wizard.button_compute()
-        self.assertAlmostEqual(self.model303_4t.vat_prorrate_percent, 82, 2)
-        self.model303_4t.button_calculate()
-        self.assertAlmostEqual(self.model303_4t.casilla_44, 51.10, 2)
+        self.assertAlmostEqual(model303_4t.vat_prorrate_percent, 82, 2)
+        model303_4t.button_calculate()
+        self.assertAlmostEqual(model303_4t.casilla_44, 51.10, 2)
         self.assertEqual(
-            self.model303_4t.prorrate_regularization_account_id,
-            self.prorrate_regul_account,
+            model303_4t.prorrate_regularization_account_id,
+            prorrate_regul_account,
         )
-        self.model303_4t.create_regularization_move()
-        lines = self.model303_4t.move_id.line_ids
+        model303_4t.create_regularization_move()
+        lines = model303_4t.move_id.line_ids
         line_prorrate_regularization = lines.filtered(
-            lambda x: x.account_id == self.prorrate_regul_account
+            lambda x: x.account_id == prorrate_regul_account
         )
         self.assertAlmostEqual(line_prorrate_regularization.credit, 51.10, 2)


### PR DESCRIPTION
Depende de https://github.com/OCA/l10n-spain/pull/721.

Mejoras incluidas en este PR:

1) Calcula la cuenta de contrapartida correcta en función del resultado de la declaración.

* Si la declaración del 303 es a devolver o a compensar, la cuenta de contrapartida debe ser "4700 Hacienda Pública, deudora por IVA".
* Si es a ingresar, la cuenta debe ser "4750 Hacienda Pública, acreedora por IVA".
2) Fuerza que en a casilla de importes a compensar debe constar, EN POSITIVO, las cuotas a compensar procedentes de periodos anteriores. Hasta ahora debias indicar el importe en negativo, pero esto era incorrecto segun Hacienda. Ver http://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Declaraciones/Modelos_300_al_399/303/Instrucciones/instr_mod303_es_es.pdf
3) Amplia base de tests
4) Se añade mensaje de advertencia cuando en presentaciones anteriores durante el año existieron cuotas a compensar, a fin de que el usuario recuerde cumplimentar la casilla [67] Cuotas a compensar.
![image](https://user-images.githubusercontent.com/7683926/34075195-44b23f02-e2bf-11e7-8909-13080e9f2983.png)
5) Se precalcula la cuota a compensar (casilla [67] Cuotas a compensar) en base a la anterior declaración encontrada del mismo año.

