### PR TITLE
[10.0][l10n_es_aeat] soporte para generar mensaje de advertencia

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -9,7 +9,7 @@
 {
     'name': "AEAT Base",
     'summary': "Modulo base para declaraciones de la AEAT",
-    'version': "10.0.1.0.3",
+    'version': "10.0.1.1.0",
     'author': "Pexego,"
               "Acysos,"
               "AvanzOSC,"

--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -169,6 +169,13 @@ class L10nEsAeatReport(models.AbstractModel):
         help='Company bank account used for the presentation',
         domain="[('acc_type', '=', 'iban'), "
                " ('partner_id', '=', partner_id)]")
+    exception_msg = fields.Char('Exception message',
+                                compute='_compute_exception_msg')
+
+    @api.multi
+    def _compute_exception_msg(self):
+        """To override"""
+
     _sql_constraints = [
         ('name_uniq', 'unique(name, company_id)',
          'AEAT report identifier must be unique'),

--- a/l10n_es_aeat/tests/test_l10n_es_aeat_report.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_report.py
@@ -8,6 +8,7 @@ from odoo import exceptions
 
 class TestL10nEsAeatReport(common.TransactionCase):
     def setUp(self):
+
         super(TestL10nEsAeatReport, self).setUp()
         self.AeatReport = self.env["l10n.es.aeat.report"]
         self.period_types = {
@@ -29,6 +30,28 @@ class TestL10nEsAeatReport(common.TransactionCase):
             '11': ('2016-11-01', '2016-11-30'),
             '12': ('2016-12-01', '2016-12-31'),
         }
+
+    def test_onchange_company_id(self):
+        test_company1 = self.env['res.company'].create(
+            {'name': 'Test company 1',
+             'vat': 'ES12345678Z',
+             })
+        test_company2 = self.env['res.company'].create(
+            {'name': 'Test company 2',
+             'vat': 'ESN7326987J',
+             })
+
+        self.env.user.partner_id.phone = '93 555 67 01'
+
+        report = self.AeatReport.new({
+            'year': 2016,
+            'company_id': test_company1.id,
+        })
+        report.company_id = test_company2
+        report.onchange_company_id()
+        self.assertEqual(report.company_vat, 'N7326987J')
+        self.assertEqual(report.contact_name, 'Administrator')
+        self.assertEqual(report.contact_phone, '935556701')
 
     def test_onchange_period_type(self):
         with self.env.do_in_onchange():

--- a/l10n_es_aeat/views/aeat_report_view.xml
+++ b/l10n_es_aeat/views/aeat_report_view.xml
@@ -48,6 +48,11 @@
                        statusbar_colors="{'cancelled': 'red', 'done': 'blue', 'posted': 'blue'}"
                        />
             </header>
+            <div class="alert alert-warning"
+                     role="alert" style="margin-bottom:0px;"
+                     attrs="{'invisible':[('exception_msg','=', False)]}">
+                <bold><field name="exception_msg"/></bold>
+            </div>
             <sheet>
                 <field name="allow_posting" invisible="1"/>
                 <field name="number" invisible="1"/>


### PR DESCRIPTION
Se amplian los tests del modulo y se añade soporte para generar mensajes de advertencia.

Ejemplo incluido en el modelo 303 (ver PR https://github.com/OCA/l10n-spain/pull/719):
![image](https://user-images.githubusercontent.com/7683926/34075164-934992e2-e2be-11e7-8c8f-cfe17d4873f2.png)

