### PR TITLE
[10.0][FIX] account_balance_reporting: name_search()

### DIFF
--- a/account_balance_reporting/README.rst
+++ b/account_balance_reporting/README.rst
@@ -73,6 +73,7 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
 * Vicent Cubells <vicent@vcubells.net>
+* Javi Melendez <javimelex@gmail.com>
 
 Financiadores
 -------------

--- a/account_balance_reporting/__manifest__.py
+++ b/account_balance_reporting/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Account balance reporting engine",
-    "version": "10.0.1.3.2",
+    "version": "10.0.1.3.3",
     "author": "Pexego, "
               "AvanzOSC, "
               "Tecnativa, "
@@ -21,6 +21,7 @@
         "Pedro M. Baeza <pedro.baeza@tecnativa.com>",
         "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
         "Vicent Cubells <vicent.cubells@tecnativa.com>",
+        "Javi Melendez <javimelex@gmail.com>",
     ],
     "license": 'AGPL-3',
     "depends": [

--- a/account_balance_reporting/models/account_balance_reporting_report.py
+++ b/account_balance_reporting/models/account_balance_reporting_report.py
@@ -218,7 +218,8 @@ class AccountBalanceReportingLine(models.Model):
         """Allow to search by code."""
         if args is None:
             args = []
-        args += ['|', ('code', operator, name)]
+        if name:
+            args += ['|', ('code', operator, name)]
         return super(AccountBalanceReportingLine, self).name_search(
             name=name, args=args, operator=operator, limit=limit,
         )

--- a/account_balance_reporting/models/account_balance_reporting_template.py
+++ b/account_balance_reporting/models/account_balance_reporting_template.py
@@ -162,7 +162,8 @@ class AccountBalanceReportingTemplateLine(models.Model):
         """Allow to search by code."""
         if args is None:
             args = []
-        args += ['|', ('code', operator, name)]
+        if name:
+            args += ['|', ('code', operator, name)]
         return super(AccountBalanceReportingTemplateLine, self).name_search(
             name=name, args=args, operator=operator, limit=limit,
         )

--- a/account_balance_reporting/tests/test_account_balance.py
+++ b/account_balance_reporting/tests/test_account_balance.py
@@ -256,12 +256,28 @@ class TestAccountBalance(TestAccountBalanceBase):
         line_obj = self.env['account.balance.reporting.template.line']
         self.assertTrue(line_obj.name_search('account'))
         self.assertTrue(line_obj.name_search('1600'))
+        self.assertTrue(line_obj.name_search(
+            args=[('template_id', '=', self.template.id)]))
+        self.assertListEqual(
+            line_obj.name_search(self.line5.code),
+            line_obj.name_search(args=[('code', 'ilike', self.line5.code)]))
+        self.assertListEqual(
+            line_obj.name_search(self.line5.name),
+            line_obj.name_search(args=[('name', 'ilike', self.line5.name)]))
 
     def test_report_line_name_search(self):
         self.report.action_calculate()
         line_obj = self.env['account.balance.reporting.line']
         self.assertTrue(line_obj.name_search('account'))
         self.assertTrue(line_obj.name_search('1600'))
+        self.assertTrue(line_obj.name_search(
+            args=[('template_line_id', '=', self.line5.id)]))
+        self.assertListEqual(
+            line_obj.name_search(self.line5.code),
+            line_obj.name_search(args=[('code', 'ilike', self.line5.code)]))
+        self.assertListEqual(
+            line_obj.name_search(self.line5.name),
+            line_obj.name_search(args=[('name', 'ilike', self.line5.name)]))
 
     def test_account_balance_mode_0(self):
         """ Check results for debit-credit report. """


### PR DESCRIPTION
El name_search() de las líneas de plantilla está fallando cuando el parámetro name va vacío
![image](https://user-images.githubusercontent.com/14833643/34153721-5a60759e-e4b3-11e7-9e02-87e9659caf2d.png)

Al principio no entendía en que situación podía funcionar un dominio con un '|' (or) delante de un único elemento. Después de mirar los test ya lo he pillado. El ORM concatena al final la condición de búsqueda del name, sólo si hay name. Como en los test no estaban contemplado el caso del name vacío, los test daban correcto. Pero en cuanto haces una búsqueda sin name, zasca.

Voy a corregir el código y completar los test con búsquedas sin name

Para reproducir el error ir a _Contabilidad / Configuración / Informes financieros / Informes financieros_ y modificar el campo _Padre_ de una línea de informe