### PR TITLE
[11.0][l10n_es_facturae] Corrige llamada a método _get_tax_vals

### DIFF
--- a/l10n_es_facturae/models/account_tax_template.py
+++ b/l10n_es_facturae/models/account_tax_template.py
@@ -40,7 +40,8 @@ class AccountTaxTemplate(models.Model):
         ], string='Facturae code'
     )
 
-    def _get_tax_vals(self, company):
-        val = super(AccountTaxTemplate, self)._get_tax_vals(company)
+    def _get_tax_vals(self, company, tax_template_to_tax):
+        val = super(AccountTaxTemplate, self)._get_tax_vals(
+            company, tax_template_to_tax)
         val['facturae_code'] = self.facturae_code
         return val


### PR DESCRIPTION
Este PR corrige un error que está provocando que la rama 11.0 de errores.

En v11 el método `_get_tax_vals` de `account.tax.template` tiene 2 argumentos. En el código de facturae sólamente se le estaba pasando uno.