### PR TITLE
[FIX] SII: Fecha Registro SII

### DIFF
--- a/l10n_es_aeat_sii/__manifest__.py
+++ b/l10n_es_aeat_sii/__manifest__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "10.0.2.0.0",
+    "version": "10.0.2.0.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -802,7 +802,8 @@ class AccountInvoice(models.Model):
         """
         self.ensure_one()
         invoice_date = self._change_date_format(self.date_invoice)
-        reg_date = self._change_date_format(self.date)
+        reg_date = self._change_date_format(
+            self._get_account_registration_date())
         ejercicio = fields.Date.from_string(self.date).year
         periodo = '%02d' % fields.Date.from_string(self.date).month
         desglose_factura, tax_amount = self._get_sii_in_taxes()

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -122,8 +122,8 @@ class TestL10nEsAeatSii(common.SavepointCase):
                 'ImporteTotal': 110,
             },
             'PeriodoImpositivo': {
-                'Periodo': '07',
-                'Ejercicio': 2017,
+                'Periodo': '%02d' % fields.Date.today().month,
+                'Ejercicio': fields.Date.today().year,
             }
         }
         if self.invoice.type in ['out_invoice', 'out_refund']:
@@ -142,7 +142,7 @@ class TestL10nEsAeatSii(common.SavepointCase):
             })
             res[expedida_recibida].update({
                 "FechaRegContable": self.invoice._change_date_format(
-                    self.invoice.date_invoice),
+                    fields.Date.today()),
                 "DesgloseFactura": {
                     'DesgloseIVA': {
                         'DetalleIVA': [

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from openerp.tests import common
-from openerp import exceptions
+from openerp import exceptions, fields
 
 
 def _deep_sort(obj):
@@ -64,7 +64,7 @@ class TestL10nEsAeatSii(common.SavepointCase):
         cls.env.user.company_id.sii_description_method = 'manual'
         cls.invoice = cls.env['account.invoice'].create({
             'partner_id': cls.partner.id,
-            'date_invoice': '2017-07-19',
+            'date_invoice': fields.Date.today(),
             'type': 'out_invoice',
             'account_id': cls.partner.property_account_payable_id.id,
             'invoice_line_ids': [
@@ -103,12 +103,13 @@ class TestL10nEsAeatSii(common.SavepointCase):
         self.assertTrue(self.invoice.invoice_jobs_ids)
 
     def _get_invoices_test(self, invoice_type, special_regime):
+        str_today = self.invoice._change_date_format(fields.Date.today())
         expedida_recibida = 'FacturaExpedida'
         if self.invoice.type in ['in_invoice', 'in_refund']:
             expedida_recibida = 'FacturaRecibida'
         res = {
             'IDFactura': {
-                'FechaExpedicionFacturaEmisor': '19-07-2017',
+                'FechaExpedicionFacturaEmisor': str_today,
             },
             expedida_recibida: {
                 'TipoFactura': invoice_type,
@@ -140,7 +141,8 @@ class TestL10nEsAeatSii(common.SavepointCase):
                 'IDEmisorFactura': {'NIF': u'F35999705'},
             })
             res[expedida_recibida].update({
-                "FechaRegContable": '19-07-2017',
+                "FechaRegContable": self.invoice._change_date_format(
+                    self.invoice.date_invoice),
                 "DesgloseFactura": {
                     'DesgloseIVA': {
                         'DetalleIVA': [

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -122,8 +122,9 @@ class TestL10nEsAeatSii(common.SavepointCase):
                 'ImporteTotal': 110,
             },
             'PeriodoImpositivo': {
-                'Periodo': '%02d' % fields.Date.today().month,
-                'Ejercicio': fields.Date.today().year,
+                'Periodo': '%02d' % fields.Date.from_string(
+                    fields.Date.today()).month,
+                'Ejercicio': fields.Date.from_string(fields.Date.today()).year,
             }
         }
         if self.invoice.type in ['out_invoice', 'out_refund']:


### PR DESCRIPTION
Según lo comentado en la lista de localización (https://groups.google.com/forum/#!topic/openerp-spain/k1rrZ-Kih6U) referente a la fecha de registro contable, efectivamente en la versión 8.0 utiliza la fecha de envío pero no ocurre así con la V10.





