### PR TITLE
[FIX] l10n_es: Al crear una factura seleccionando varios pedidos se 

### DIFF
--- a/l10n_es/data/taxes_common.xml
+++ b/l10n_es/data/taxes_common.xml
@@ -802,15 +802,33 @@
         <field name="tax_group_id" ref="tax_group_iva_10"/>
         <field name="tag_ids" eval="[(6, False, [ref('mod_303_04_06'), ref('mod_303_14_15_sale')])]"/>
     </record>
+    <!-- TODO: Change iva0_nd to iva21_nd in next migration -->
     <record id="account_tax_template_p_iva0_nd" model="account.tax.template">
         <field name="description">P_IVA0_ND</field>
         <field name="type_tax_use">purchase</field>
-        <field name="name">IVA Soportado no deducible</field>
-        <field name="refund_account_id" ref="pgc_472_child"/>
+        <field name="name">IVA Soportado no deducible 21%</field>
         <field name="chart_template_id" ref="account_chart_template_common"/>
         <field name="amount" eval="21"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_iva_21"/>
+    </record>
+    <record id="account_tax_template_p_iva10_nd" model="account.tax.template">
+        <field name="description">P_IVA10_ND</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA Soportado no deducible 10%</field>
+        <field name="chart_template_id" ref="account_chart_template_common"/>
+        <field name="amount" eval="10"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_10"/>
+    </record>
+    <record id="account_tax_template_p_iva4_nd" model="account.tax.template">
+        <field name="description">P_IVA4_ND</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA Soportado no deducible 4%</field>
+        <field name="chart_template_id" ref="account_chart_template_common"/>
+        <field name="amount" eval="4"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_4"/>
     </record>
     <record id="account_tax_template_s_iva4s" model="account.tax.template">
         <field name="description">S_IVA4S</field>

--- a/l10n_es/data/taxes_common.xml
+++ b/l10n_es/data/taxes_common.xml
@@ -590,7 +590,9 @@
     <record id="account_tax_template_s_iva0_sp_i" model="account.tax.template">
         <field name="description">S_IVA0_SP_I</field>
         <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="pgc_477_child"/>
         <field name="name">IVA 0% Prestación de servicios intracomunitario</field>
+        <field name="refund_account_id" ref="pgc_477_child"/>
         <field name="chart_template_id" ref="account_chart_template_common"/>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
@@ -600,7 +602,9 @@
     <record id="account_tax_template_s_iva_ns" model="account.tax.template">
         <field name="description">S_IVA_NS</field>
         <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="pgc_477_child"/>
         <field name="name">No sujeto Repercutido</field>
+        <field name="refund_account_id" ref="pgc_477_child"/>
         <field name="chart_template_id" ref="account_chart_template_common"/>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
@@ -610,7 +614,9 @@
     <record id="account_tax_template_s_iva_e" model="account.tax.template">
         <field name="description">S_IVA_SP_E</field>
         <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="pgc_477_child"/>
         <field name="name">IVA 0% Prestación de servicios extracomunitaria</field>
+        <field name="refund_account_id" ref="pgc_477_child"/>
         <field name="chart_template_id" ref="account_chart_template_common"/>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
@@ -752,7 +758,9 @@
     <record id="account_tax_template_s_iva0" model="account.tax.template">
         <field name="description">S_IVA0</field>
         <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="pgc_477_child"/>
         <field name="name">IVA Exento Repercutido</field>
+        <field name="refund_account_id" ref="pgc_477_child"/>
         <field name="chart_template_id" ref="account_chart_template_common"/>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
@@ -798,6 +806,7 @@
         <field name="description">P_IVA0_ND</field>
         <field name="type_tax_use">purchase</field>
         <field name="name">IVA Soportado no deducible</field>
+        <field name="refund_account_id" ref="pgc_472_child"/>
         <field name="chart_template_id" ref="account_chart_template_common"/>
         <field name="amount" eval="21"/>
         <field name="amount_type">percent</field>
@@ -854,7 +863,9 @@
     <record id="account_tax_template_p_iva0_bc" model="account.tax.template">
         <field name="description">P_IVA0_BC</field>
         <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="pgc_472_child"/>
         <field name="name">IVA Soportado exento (operaciones corrientes)</field>
+        <field name="refund_account_id" ref="pgc_472_child"/>
         <field name="chart_template_id" ref="account_chart_template_common"/>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
@@ -863,7 +874,9 @@
     <record id="account_tax_template_p_iva0_ns" model="account.tax.template">
         <field name="description">P_IVA0_NS</field>
         <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="pgc_472_child"/>
         <field name="name">IVA Soportado no sujeto</field>
+        <field name="refund_account_id" ref="pgc_472_child"/>
         <field name="chart_template_id" ref="account_chart_template_common"/>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
@@ -1059,7 +1072,9 @@
     <record id="account_tax_template_s_iva0_e" model="account.tax.template">
         <field name="description">S_IVA0_E</field>
         <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="pgc_477_child"/>
         <field name="name">IVA 0% Exportaciones</field>
+        <field name="refund_account_id" ref="pgc_477_child"/>
         <field name="chart_template_id" ref="account_chart_template_common"/>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
@@ -1069,7 +1084,9 @@
     <record id="account_tax_template_s_iva0_ic" model="account.tax.template">
         <field name="description">S_IVA0_IC</field>
         <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="pgc_477_child"/>
         <field name="name">IVA 0% Entregas Intracomunitarias exentas</field>
+        <field name="refund_account_id" ref="pgc_477_child"/>
         <field name="chart_template_id" ref="account_chart_template_common"/>
         <field name="amount" eval="0"/>
         <field name="amount_type">percent</field>
@@ -1349,7 +1366,9 @@
     </record>
     <record id="account_tax_template_s_iva0_isp" model="account.tax.template">
         <field name="description">S_IVA0_ISP</field>
+        <field name="account_id" ref="pgc_477_child"/>
         <field name="name">IVA 0% Venta con Inversión del Sujeto Pasivo</field>
+        <field name="refund_account_id" ref="pgc_477_child"/>
         <field name="type_tax_use">sale</field>
         <field name="amount_type">percent</field>
         <field name="amount" eval="0"/>


### PR DESCRIPTION
crean varias lineas en account.invoice.tax con el mismo impuesto si el impuesto no tiene cuenta asociada.

Este PR añade cuentas contables a impuestos que teóricamente no necesitan por ser 0 el porcentaje.

@Tecnativa