### PR TITLE
[8.0] [FIX] l10n_es_aeat_mod303: Corregir fechas de inicio y fin de los formatos de exportación

### DIFF
--- a/l10n_es_aeat_mod303/__openerp__.py
+++ b/l10n_es_aeat_mod303/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "AEAT modelo 303",
-    "version": "8.0.1.12.0",
+    "version": "8.0.1.13.0",
     'category': "Accounting & Finance",
     'author': "Guadaltech,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
@@ -2608,6 +2608,7 @@
         <record id="aeat_mod303_2017_main_export_config" model="aeat.model.export.config">
             <field name="name">Exportación modelo 303 2017</field>
             <field name="date_start">2017-10-01</field>
+            <field name="date_end">2017-12-31</field>
             <field name="model_number">303</field>
             <field name="model" ref="l10n_es_aeat_mod303.model_l10n_es_aeat_mod303_report"/>
         </record>

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2018_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2018_data.xml
@@ -2629,7 +2629,7 @@
         <!--  MAIN-303  -->
         <record id="aeat_mod303_2018_main_export_config" model="aeat.model.export.config">
             <field name="name">Exportación modelo 303 2018-actualiad</field>
-            <field name="date_start">2017-10-01</field>
+            <field name="date_start">2018-01-01</field>
             <field name="model_number">303</field>
             <field name="model" ref="l10n_es_aeat_mod303.model_l10n_es_aeat_mod303_report"/>
         </record>


### PR DESCRIPTION
Por error en el último merge las fechas de inicio y fin de los formatos de exportacón de 2017 y 2018 no eran correctas. Corregido aquí.