### PR TITLE
[10.0][IMP] l10n_es_aeat_sii: No enviar al SII el mismo contenido

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -994,47 +994,55 @@ class AccountInvoice(models.Model):
             }
             try:
                 inv_dict = invoice._get_sii_invoice_dict()
-                inv_vals['sii_content_sent'] = json.dumps(inv_dict, indent=4)
-                if invoice.type in ['out_invoice', 'out_refund']:
-                    res = serv.SuministroLRFacturasEmitidas(
-                        header, inv_dict)
-                elif invoice.type in ['in_invoice', 'in_refund']:
-                    res = serv.SuministroLRFacturasRecibidas(
-                        header, inv_dict)
-                # TODO Facturas intracomunitarias 66 RIVA
-                # elif invoice.fiscal_position_id.id == self.env.ref(
-                #     'account.fp_intra').id:
-                #     res = serv.SuministroLRDetOperacionIntracomunitaria(
-                #         header, invoices)
-                res_line = res['RespuestaLinea'][0]
-                if res['EstadoEnvio'] == 'Correcto':
+                sii_content_sent = json.dumps(inv_dict, indent=4)
+                if sii_content_sent != invoice.sii_content_sent \
+                        or invoice.sii_send_failed:
+                    inv_vals['sii_content_sent'] = sii_content_sent
+                    if invoice.type in ['out_invoice', 'out_refund']:
+                        res = serv.SuministroLRFacturasEmitidas(
+                            header, inv_dict)
+                    elif invoice.type in ['in_invoice', 'in_refund']:
+                        res = serv.SuministroLRFacturasRecibidas(
+                            header, inv_dict)
+                    # TODO Facturas intracomunitarias 66 RIVA
+                    # elif invoice.fiscal_position_id.id == self.env.ref(
+                    #     'account.fp_intra').id:
+                    #     res = serv.SuministroLRDetOperacionIntracomunitaria(
+                    #         header, invoices)
+                    res_line = res['RespuestaLinea'][0]
+                    if res['EstadoEnvio'] == 'Correcto':
+                        inv_vals.update({
+                            'sii_state': 'sent',
+                            'sii_csv': res['CSV'],
+                            'sii_send_failed': False,
+                        })
+                    elif res['EstadoEnvio'] == 'ParcialmenteCorrecto' and \
+                            res_line['EstadoRegistro'] == 'AceptadoConErrores':
+                        inv_vals.update({
+                            'sii_state': 'sent_w_errors',
+                            'sii_csv': res['CSV'],
+                            'sii_send_failed': True,
+                        })
+                    else:
+                        inv_vals['sii_send_failed'] = True
+                    if ('sii_state' in inv_vals and
+                            not invoice.sii_account_registration_date and
+                            invoice.type[:2] == 'in'):
+                        inv_vals['sii_account_registration_date'] = (
+                            self._get_account_registration_date()
+                        )
+                    inv_vals['sii_return'] = res
+                    send_error = False
+                    if res_line['CodigoErrorRegistro']:
+                        send_error = u"{} | {}".format(
+                            unicode(res_line['CodigoErrorRegistro']),
+                            unicode(res_line['DescripcionErrorRegistro'])[:60])
+                    inv_vals['sii_send_error'] = send_error
+                else:
                     inv_vals.update({
                         'sii_state': 'sent',
-                        'sii_csv': res['CSV'],
                         'sii_send_failed': False,
                     })
-                elif res['EstadoEnvio'] == 'ParcialmenteCorrecto' and \
-                        res_line['EstadoRegistro'] == 'AceptadoConErrores':
-                    inv_vals.update({
-                        'sii_state': 'sent_w_errors',
-                        'sii_csv': res['CSV'],
-                        'sii_send_failed': True,
-                    })
-                else:
-                    inv_vals['sii_send_failed'] = True
-                if ('sii_state' in inv_vals and
-                        not invoice.sii_account_registration_date and
-                        invoice.type[:2] == 'in'):
-                    inv_vals['sii_account_registration_date'] = (
-                        self._get_account_registration_date()
-                    )
-                inv_vals['sii_return'] = res
-                send_error = False
-                if res_line['CodigoErrorRegistro']:
-                    send_error = u"{} | {}".format(
-                        unicode(res_line['CodigoErrorRegistro']),
-                        unicode(res_line['DescripcionErrorRegistro'])[:60])
-                inv_vals['sii_send_error'] = send_error
                 invoice.write(inv_vals)
             except Exception as fault:
                 new_cr = RegistryManager.get(self.env.cr.dbname).cursor()


### PR DESCRIPTION
En muchas ocasiones, una vez enviada la factura al SII, se han de cambiar campos como el modo/plazo de pago, la cuenta contable de las líneas o incluso algún impuesto (bienes, servicios, inversión) sin que esto afecte para nada al SII.

En todos estos casos, ahora mismo se vuelve a enviar la factura al SII con comunicación A1, si la factura está dentro de plazo no hay problema, pero también hay veces que se revisa después del día 16 y varios clientes nos solicitan que si el contenido que va a enviarse no ha cambiado desde el último envío, que no se envíe.

A nivel técnico no sabemos si es mejor poner esta comprobación antes de enviar al SII o incluso antes de generar el job, se aceptan sugerencias.