### PR TITLE
[10.0] l10n_es_aeat_sii: Enviar los importes de impuesto en la moneda de la compañía

### DIFF
--- a/l10n_es_aeat_sii/__manifest__.py
+++ b/l10n_es_aeat_sii/__manifest__.py
@@ -11,7 +11,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "10.0.2.0.1",
+    "version": "10.0.2.1.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * l10n_es_aeat_sii
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 # Ismael Calvo <ismaelcj@gmail.com>, 2017
@@ -95,6 +95,11 @@ msgid "Already sent to SII. It includes cancelled invoices"
 msgstr "Ya enviadas al SII. Incluye facturas canceladas"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_tax_amount_company
+msgid "Amount in company currency"
+msgstr "Cuota en la moneda de la compañía"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.model.fields,help:l10n_es_aeat_sii.field_res_company_sii_header_customer
 msgid ""
 "An optional header description for customer invoices. Applied on all the SII"
@@ -122,6 +127,11 @@ msgstr "A una hora fija"
 #: selection:res.company,sii_method:0
 msgid "Automatic"
 msgstr "Automático"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_tax_base_company
+msgid "Base in company currency"
+msgstr "Base en la moneda de la compañía"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model.fields,help:l10n_es_aeat_sii.field_res_company_sii_method

--- a/l10n_es_aeat_sii/models/__init__.py
+++ b/l10n_es_aeat_sii/models/__init__.py
@@ -9,5 +9,6 @@ from . import aeat_sii_map
 from . import product_product
 from . import queue_job
 from . import account_fiscal_position
+from . import account_invoice_tax
 from . import account_invoice
 from . import res_partner

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -512,8 +512,8 @@ class AccountInvoice(models.Model):
                     sub_dict.setdefault('Exenta', {'BaseImponible': 0})
                     if exempt_cause:
                         sub_dict['Exenta']['CausaExencion'] = exempt_cause
-                    sub_dict['Exenta']['BaseImponible'] += \
-                        tax_line.base_company * sign
+                    sub_dict['Exenta']['BaseImponible'] += (
+                        tax_line.base_company * sign)
                 else:
                     sub_dict.setdefault('NoExenta', {
                         'TipoNoExenta': (
@@ -538,8 +538,8 @@ class AccountInvoice(models.Model):
                 nsub_dict = tax_breakdown.setdefault(
                     'NoSujeta', {default_no_taxable_cause: 0},
                 )
-                nsub_dict[default_no_taxable_cause] += \
-                    tax_line.base_company * sign
+                nsub_dict[default_no_taxable_cause] += (
+                    tax_line.base_company * sign)
             if tax in (taxes_sfess + taxes_sfesse + taxes_sfesns):
                 type_breakdown = taxes_dict.setdefault(
                     'DesgloseTipoOperacion', {
@@ -557,8 +557,8 @@ class AccountInvoice(models.Model):
                     )
                     if exempt_cause:
                         exempt_dict['CausaExencion'] = exempt_cause
-                    exempt_dict['BaseImponible'] += \
-                        tax_line.base_company * sign
+                    exempt_dict['BaseImponible'] += (
+                        tax_line.base_company * sign)
                 if tax in taxes_sfess:
                     # TODO l10n_es_ no tiene impuesto ISP de servicios
                     # if tax in taxes_sfesisps:

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -360,13 +360,13 @@ class AccountInvoice(models.Model):
             tax_type = abs(tax.amount)
         tax_dict = {
             'TipoImpositivo': str(tax_type),
-            'BaseImponible': sign * abs(round(tax_line.base, 2)),
+            'BaseImponible': sign * abs(round(tax_line.base_company, 2)),
         }
         if self.type in ['out_invoice', 'out_refund']:
             key = 'CuotaRepercutida'
         else:
             key = 'CuotaSoportada'
-        tax_dict[key] = sign * abs(round(tax_line.amount, 2))
+        tax_dict[key] = sign * abs(round(tax_line.amount_company, 2))
         # Recargo de equivalencia
         re_tax_line = self._get_sii_tax_line_req(tax)
         if re_tax_line:
@@ -374,7 +374,7 @@ class AccountInvoice(models.Model):
                 abs(re_tax_line.tax_id.amount)
             )
             tax_dict['CuotaRecargoEquivalencia'] = (
-                sign * abs(round(re_tax_line.amount, 2))
+                sign * abs(round(re_tax_line.amount_company, 2))
             )
         return tax_dict
 
@@ -512,7 +512,8 @@ class AccountInvoice(models.Model):
                     sub_dict.setdefault('Exenta', {'BaseImponible': 0})
                     if exempt_cause:
                         sub_dict['Exenta']['CausaExencion'] = exempt_cause
-                    sub_dict['Exenta']['BaseImponible'] += tax_line.base * sign
+                    sub_dict['Exenta']['BaseImponible'] += \
+                        tax_line.base_company * sign
                 else:
                     sub_dict.setdefault('NoExenta', {
                         'TipoNoExenta': (
@@ -537,7 +538,8 @@ class AccountInvoice(models.Model):
                 nsub_dict = tax_breakdown.setdefault(
                     'NoSujeta', {default_no_taxable_cause: 0},
                 )
-                nsub_dict[default_no_taxable_cause] += tax_line.base * sign
+                nsub_dict[default_no_taxable_cause] += \
+                    tax_line.base_company * sign
             if tax in (taxes_sfess + taxes_sfesse + taxes_sfesns):
                 type_breakdown = taxes_dict.setdefault(
                     'DesgloseTipoOperacion', {
@@ -555,7 +557,8 @@ class AccountInvoice(models.Model):
                     )
                     if exempt_cause:
                         exempt_dict['CausaExencion'] = exempt_cause
-                    exempt_dict['BaseImponible'] += tax_line.base * sign
+                    exempt_dict['BaseImponible'] += \
+                        tax_line.base_company * sign
                 if tax in taxes_sfess:
                     # TODO l10n_es_ no tiene impuesto ISP de servicios
                     # if tax in taxes_sfesisps:
@@ -621,7 +624,7 @@ class AccountInvoice(models.Model):
                 isp_dict['DetalleIVA'].append(
                     self._get_sii_tax_dict(tax_line, sign),
                 )
-                tax_amount += abs(round(tax_line.amount, 2))
+                tax_amount += abs(round(tax_line.amount_company, 2))
             elif tax in taxes_sfrs:
                 sfrs_dict = taxes_dict.setdefault(
                     'DesgloseIVA', {'DetalleIVA': []},
@@ -629,13 +632,13 @@ class AccountInvoice(models.Model):
                 sfrs_dict['DetalleIVA'].append(
                     self._get_sii_tax_dict(tax_line, sign),
                 )
-                tax_amount += abs(round(tax_line.amount, 2))
+                tax_amount += abs(round(tax_line.amount_company, 2))
             elif tax in taxes_sfrns:
                 sfrns_dict = taxes_dict.setdefault(
                     'DesgloseIVA', {'DetalleIVA': []},
                 )
                 sfrns_dict['DetalleIVA'].append({
-                    'BaseImponible': sign * tax_line.base,
+                    'BaseImponible': sign * tax_line.base_company,
                 })
             elif tax in taxes_sfrsa:
                 sfrsa_dict = taxes_dict.setdefault(

--- a/l10n_es_aeat_sii/models/account_invoice_tax.py
+++ b/l10n_es_aeat_sii/models/account_invoice_tax.py
@@ -23,12 +23,12 @@ class AccountInvoiceTax(models.Model):
         for tax in self:
             if (tax.invoice_id.currency_id !=
                     tax.invoice_id.company_id.currency_id):
-                currency = tax.invoice_id.currency_id.\
-                    with_context(date=tax.invoice_id.date_invoice)
-                tax.base_company = currency.\
-                    compute(tax.base, tax.invoice_id.company_id.currency_id)
-                tax.amount_company = currency.\
-                    compute(tax.amount, tax.invoice_id.company_id.currency_id)
+                currency = tax.invoice_id.currency_id.with_context(
+                    date=tax.invoice_id.date_invoice)
+                tax.base_company = currency.compute(
+                    tax.base, tax.invoice_id.company_id.currency_id)
+                tax.amount_company = currency.compute(
+                    tax.amount, tax.invoice_id.company_id.currency_id)
             else:
                 tax.base_company = tax.base
                 tax.amount_company = tax.amount

--- a/l10n_es_aeat_sii/models/account_invoice_tax.py
+++ b/l10n_es_aeat_sii/models/account_invoice_tax.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Comunitea - Omar Castiñeira <omar@comunitea.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, api, fields
+
+
+class AccountInvoiceTax(models.Model):
+
+    _inherit = "account.invoice.tax"
+
+    @api.multi
+    def _get_company_curr_amounts(self):
+        for tax in self:
+            if tax.invoice_id.currency_id != \
+                    tax.invoice_id.company_id.currency_id:
+                currency = tax.invoice_id.currency_id.\
+                    with_context(date=tax.invoice_id.date_invoice)
+                tax.base_company = currency.\
+                    compute(tax.base, tax.invoice_id.company_id.currency_id)
+                tax.amount_company = currency.\
+                    compute(tax.amount, tax.invoice_id.company_id.currency_id)
+            else:
+                tax.base_company = tax.base
+                tax.amount_company = tax.amount
+
+    base_company = fields.Monetary(string='Base in company currency',
+                                   compute="_get_company_curr_amounts")
+    amount_company = fields.Monetary(string='Amount in company currency',
+                                     compute="_get_company_curr_amounts")

--- a/l10n_es_aeat_sii/models/account_invoice_tax.py
+++ b/l10n_es_aeat_sii/models/account_invoice_tax.py
@@ -24,7 +24,8 @@ class AccountInvoiceTax(models.Model):
             if (tax.invoice_id.currency_id !=
                     tax.invoice_id.company_id.currency_id):
                 currency = tax.invoice_id.currency_id.with_context(
-                    date=tax.invoice_id.date_invoice)
+                    date=tax.invoice_id.date_invoice,
+                    company_id=tax.invoice_id.company_id.id)
                 tax.base_company = currency.compute(
                     tax.base, tax.invoice_id.company_id.currency_id)
                 tax.amount_company = currency.compute(

--- a/l10n_es_aeat_sii/models/account_invoice_tax.py
+++ b/l10n_es_aeat_sii/models/account_invoice_tax.py
@@ -2,18 +2,27 @@
 # Copyright 2018 Comunitea - Omar Castiñeira <omar@comunitea.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, api, fields
+from odoo import api, fields, models
 
 
 class AccountInvoiceTax(models.Model):
 
     _inherit = "account.invoice.tax"
 
+    base_company = fields.Monetary(
+        string='Base in company currency',
+        compute="_compute_base_amount_company",
+    )
+    amount_company = fields.Monetary(
+        string='Amount in company currency',
+        compute="_compute_base_amount_company",
+    )
+
     @api.multi
-    def _get_company_curr_amounts(self):
+    def _compute_base_amount_company(self):
         for tax in self:
-            if tax.invoice_id.currency_id != \
-                    tax.invoice_id.company_id.currency_id:
+            if (tax.invoice_id.currency_id !=
+                    tax.invoice_id.company_id.currency_id):
                 currency = tax.invoice_id.currency_id.\
                     with_context(date=tax.invoice_id.date_invoice)
                 tax.base_company = currency.\
@@ -23,8 +32,3 @@ class AccountInvoiceTax(models.Model):
             else:
                 tax.base_company = tax.base
                 tax.amount_company = tax.amount
-
-    base_company = fields.Monetary(string='Base in company currency',
-                                   compute="_get_company_curr_amounts")
-    amount_company = fields.Monetary(string='Amount in company currency',
-                                     compute="_get_company_curr_amounts")


### PR DESCRIPTION
 Se envían los importes de cuota y base al SII en la moneda de la compañía. Comentado en el issue https://github.com/OCA/l10n-spain/issues/778