### PR TITLE
[8.0][IMP] l10n_es_aeat_mod347: modificaciones para registros de inmuebles

### DIFF
--- a/l10n_es_aeat_mod347/__openerp__.py
+++ b/l10n_es_aeat_mod347/__openerp__.py
@@ -10,7 +10,7 @@
 
 {
     'name': "Modelo 347 AEAT",
-    'version': "8.0.1.5.0",
+    'version': "8.0.1.6.0",
     'author': "Pexego,"
               "ASR-OSS,"
               "NaN·tic,"

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -296,16 +296,14 @@
                                    context="{'report_id': active_id}"
                                    readonly="True"/>
                         </page>
-                        <!-- Disable Real State records, because you can not
-                             add manually a partner record related with it -->
-                        <!--page string="Real Estate records">
+                        <page string="Real Estate records">
                             <button name="button_list_real_estate_records"
                                     string="Edit records"
                                     type="object" colspan="1"/>
                             <field name="real_estate_record_ids" nolabel="1"
                                    context="{'report_id': active_id}"
                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"/>
-                        </page-->
+                        </page>
                     </notebook>
                 </group>
             </field>

--- a/l10n_es_aeat_mod347/wizard/export_mod347_to_boe.py
+++ b/l10n_es_aeat_mod347/wizard/export_mod347_to_boe.py
@@ -257,7 +257,8 @@ class L10nEsAeatMod347ExportToBoe(models.TransientModel):
         # NIF del representante legal
         text += self._formatString(partner_record.representative_vat, 9)
         # Apellidos y nombre, razón social o denominación del declarado
-        text += self._formatFiscalName(partner_record.partner_id.name, 40)
+        text += self._formatFiscalName(
+            partner_record.partner_id.commercial_partner_id.name, 40)
         # Tipo de hoja: Constante ‘I’.
         text += 'I'
         # Blancos


### PR DESCRIPTION
- Poner visible los registros de inmueble
- Exportar nombre de la compañia matriz en el caso de los registros de inmueble