### PR TITLE
[10.0] [FIX] SII NIE

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1232,10 +1232,11 @@ class AccountInvoice(models.Model):
         country_code = self._get_sii_country_code()
         if gen_type == 1:
             if '1117' in (self.sii_send_error or ''):
+                nie = vat[:2] == 'ES' and vat[2] in ['X', 'Y', 'Z']
                 return {
                     "IDOtro": {
                         "CodigoPais": country_code,
-                        "IDType": '07',
+                        "IDType": nie and '06' or '07',
                         "ID": vat[2:],
                     }
                 }


### PR DESCRIPTION
Para el caso de una factura de un proveedor autónomo con NIE.

Parece ser que no todos los NIE pasan a la primera como un CIF.

Con esta modificación al reenviar al SII después de un error por error en el identificador, detecto si es un NIE y lo paso como tipo de documento "06 otro documento probatorio".

En la factura que he tenido el error ha podido pasar sin problema, pero no se si sería mejor detectar si es un NIE antes de que nos devuelva el error.