### PR TITLE
[FIX] account_balance_reporting: move ignored if closing_type account…

### DIFF
--- a/account_balance_reporting/models/account_balance_reporting_report.py
+++ b/account_balance_reporting/models/account_balance_reporting_report.py
@@ -371,12 +371,14 @@ class AccountBalanceReportingLine(models.Model):
                                 ('date', '<=', report.previous_date_to)]
             # Exclude closing moves (if account_fiscal_year_closing installed)
             if 'closing_type' in self.env['account.move']._fields:
-                domain_current.append(
+                domain_current += [
+                    '|', ('move_id.closing_type', '=', False),
                     ('move_id.closing_type', '!=', 'closing')
-                )
-                domain_previous.append(
+                ]
+                domain_previous += [
+                    '|', ('move_id.closing_type', '=', False),
                     ('move_id.closing_type', '!=', 'closing')
-                )
+                ]
             for line in self.filtered(lambda l: l.report_id == report):
                 if (line.calc_date and
                         line.calc_date == line.report_id.calc_date):


### PR DESCRIPTION
…_move field is null

'closing_type' field is not mandatory in 'account_move' model, therefore it is necessary to filter by 'null' as well to be sure that all movements are considered.