### PR TITLE
[ADD][11.0][l10n_es_aeat_sii_invoice_summary]

### DIFF
--- a/l10n_es_aeat_sii_invoice_summary/README.rst
+++ b/l10n_es_aeat_sii_invoice_summary/README.rst
@@ -1,0 +1,67 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============================================
+Envio de factura simplificada resumen TPV a SII
+===============================================
+
+Permite diferenciar en las facturas del TPV de un farctura simple o un resumen
+de facturas al enviarlas al SII.
+
+
+Usage
+=====
+
+Para usar este modulo:
+
+1. Debes seleccionar el campo Resumen facturas simplificadas SII
+
+2. Rellenar el campo Resumen facturas simplificadas SII: Primera factura
+   con la primera factura del resumen.
+
+3. Rellenar el campo Resumen facturas simplificadas SII: Última factura
+   con la ultima factura del resumen.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/189/11.0
+   
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/l10n-spain/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
+
+Contributors
+------------
+
+* Hugo Santos <hugo.santos@factorlibre.com> (https://factorlibre.com/)
+* Victor Rodrigo <victor.rodrigo@factorlibre.com> (https://factorlibre.com/)
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/l10n_es_aeat_sii_invoice_summary/__init__.py
+++ b/l10n_es_aeat_sii_invoice_summary/__init__.py
@@ -1,0 +1,3 @@
+# © 2017 FactorLibre - Hugo Santos <hugo.santos@factorlibre.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import models

--- a/l10n_es_aeat_sii_invoice_summary/__manifest__.py
+++ b/l10n_es_aeat_sii_invoice_summary/__manifest__.py
@@ -1,0 +1,19 @@
+# © 2017 FactorLibre - Hugo Santos <hugo.santos@factorlibre.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': 'Envio de factura simplificada resumen TPV a SII',
+    'version': '8.0.1.0.0',
+    'depends': [
+        'point_of_sale',
+        'l10n_es_aeat_sii'
+    ],
+    'category': "Accounting & Finance",
+    'author': 'FactorLibre',
+    'license': 'AGPL-3',
+    'website': 'http://www.factorlibre.com',
+    'data': [
+        'views/account_invoice_view.xml'
+    ],
+    'installable': True,
+    'application': False
+}

--- a/l10n_es_aeat_sii_invoice_summary/i18n/es.po
+++ b/l10n_es_aeat_sii_invoice_summary/i18n/es.po
@@ -1,0 +1,56 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_es_aeat_sii_invoice_summary
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-03-20 12:10+0000\n"
+"PO-Revision-Date: 2018-03-20 13:13+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"Language: es\n"
+"X-Generator: Poedit 1.8.7.1\n"
+
+#. module: l10n_es_aeat_sii_invoice_summary
+#: model:ir.model,name:l10n_es_aeat_sii_invoice_summary.model_account_invoice
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: l10n_es_aeat_sii_invoice_summary
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_invoice_summary.field_account_invoice_is_invoice_summary
+msgid "Is SII simplified invoice Summary?"
+msgstr "Resumen facturas simplificadas SII"
+
+#. module: l10n_es_aeat_sii_invoice_summary
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_invoice_summary.field_account_invoice_sii_invoice_summary_start
+msgid "SII Invoice Summary: First Invoice"
+msgstr "Resumen facturas simplificadas SII: Primera factura"
+
+#. module: l10n_es_aeat_sii_invoice_summary
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_invoice_summary.field_account_invoice_sii_invoice_summary_end
+msgid "SII Invoice Summary: Last Invoice"
+msgstr "Resumen facturas simplificadas SII: Última factura"
+
+#. module: l10n_es_aeat_sii_invoice_summary
+#: code:addons/l10n_es_aeat_sii_invoice_summary/models/account_invoice.py:54
+#, python-format
+msgid "The partner has not a VAT configured."
+msgstr "El cliente no tiene un CIF/NIF configurado"
+
+#. module: l10n_es_aeat_sii_invoice_summary
+#: code:addons/l10n_es_aeat_sii_invoice_summary/models/account_invoice.py:62
+#, python-format
+msgid "This company doesn't have SII enabled."
+msgstr "Esta compañía no tiene el SII habilitado"
+
+#. module: l10n_es_aeat_sii_invoice_summary
+#: code:addons/l10n_es_aeat_sii_invoice_summary/models/account_invoice.py:57
+#, python-format
+msgid "You have to select what account chart template use this company."
+msgstr "Debe seleccionar el plan de cuentas que está utilizando esta compañía."

--- a/l10n_es_aeat_sii_invoice_summary/models/__init__.py
+++ b/l10n_es_aeat_sii_invoice_summary/models/__init__.py
@@ -1,0 +1,3 @@
+# © 2017 FactorLibre - Hugo Santos <hugo.santos@factorlibre.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import account_invoice

--- a/l10n_es_aeat_sii_invoice_summary/models/account_invoice.py
+++ b/l10n_es_aeat_sii_invoice_summary/models/account_invoice.py
@@ -1,0 +1,66 @@
+# © 2017 FactorLibre - Hugo Santos <hugo.santos@factorlibre.com>
+# © 2018 FactorLibre - Victor Rodrigo <victor.rodrigo@factorlibre.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import api, fields, exceptions, models, _
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    is_invoice_summary = fields.Boolean('Is SII simplified invoice Summary?')
+    sii_invoice_summary_start = fields.Char(
+        'SII Invoice Summary: First Invoice')
+    sii_invoice_summary_end = fields.Char('SII Invoice Summary: Last Invoice')
+
+    @api.multi
+    def _get_sii_invoice_dict_out(self, cancel=False):
+        inv_dict = super(AccountInvoice, self)._get_sii_invoice_dict_out(
+            cancel=cancel)
+        if self.is_invoice_summary and \
+                self.type == 'out_invoice':
+            tipo_factura = 'F4'
+            if self.sii_invoice_summary_start:
+                if self.sii_invoice_summary_start == \
+                        self.sii_invoice_summary_end:
+                    tipo_factura = 'F2'
+                else:
+                    inv_dict['IDFactura']['NumSerieFacturaEmisor'] =\
+                        self.sii_invoice_summary_start
+                    inv_dict['IDFactura'][
+                        'NumSerieFacturaEmisorsummarynFin'] =\
+                        self.sii_invoice_summary_end
+            if 'FacturaExpedida' in inv_dict:
+                if 'TipoFactura' in inv_dict['FacturaExpedida']:
+                    inv_dict['FacturaExpedida']['TipoFactura'] = tipo_factura
+                if tipo_factura == 'F4':
+                    if 'Contraparte' in inv_dict['FacturaExpedida']:
+                        del inv_dict['FacturaExpedida']['Contraparte']
+        return inv_dict
+
+    def _vat_required(self):
+        res = super(AccountInvoice, self)._vat_required()
+        if self.is_invoice_summary:
+            res = False
+        return res
+
+    @api.multi
+    def _sii_check_exceptions(self):
+        """Inheritable method for exceptions control when sending SII invoices.
+        """
+        self.ensure_one()
+        if (not self.fiscal_position_id and not self.partner_id.vat and
+                not self.is_invoice_summary) or \
+                (self.fiscal_position_id and
+                 self.fiscal_position_id.vat_required and not
+                 self.partner_id.vat):
+            raise exceptions.Warning(
+                _("The partner has not a VAT configured.")
+            )
+        if not self.company_id.chart_template_id:
+            raise exceptions.Warning(_(
+                'You have to select what account chart template use this'
+                ' company.'))
+        if not self.company_id.sii_enabled:
+            raise exceptions.Warning(
+                _("This company doesn't have SII enabled.")
+            )

--- a/l10n_es_aeat_sii_invoice_summary/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii_invoice_summary/views/account_invoice_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- © 2018 Victor Rodrigo <victor.rodrigo@factorlibre.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<openerp>
+  <data>
+    <record id="account_invoice_form_view" model="ir.ui.view">
+        <field name="name">account.invoice.form</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_form"/>
+        <field name="arch" type="xml">
+            <field name="sii_description" position="before">
+                <field name="is_invoice_summary"/>
+                <field name="sii_invoice_summary_start"/>
+                <field name="sii_invoice_summary_end"/>
+            </field>
+        </field>
+    </record>
+  </data>
+</openerp>


### PR DESCRIPTION
Envio de factura simplificada resumen a SII
==============

Permite diferenciar en las facturas del TPV de un farctura simple o un resumen
de facturas al enviarlas al SII.

Uso
=====

Para usar este modulo:

1. Debes seleccionar el campo Resumen facturas simplificadas SII

2. Rellenar el campo Resumen facturas simplificadas SII: Primera factura
   con la primera factura del resumen.

3. Rellenar el campo Resumen facturas simplificadas SII: Última factura
   con la ultima factura del resumen.