### PR TITLE
[9.0][FIX] l10n_es_account_asset: Casos de prorrateo en _compute_board_undone_dotation_nb

### DIFF
--- a/l10n_es_account_asset/__openerp__.py
+++ b/l10n_es_account_asset/__openerp__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Gestión de activos fijos para España",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "depends": [
         "account_asset",
     ],

--- a/l10n_es_account_asset/models/account_asset.py
+++ b/l10n_es_account_asset/models/account_asset.py
@@ -108,8 +108,9 @@ class AccountAssetAsset(models.Model):
             percentage = 100.0
             while percentage > 0:
                 if number == 0 and self.prorata:
-                    days = (total_days -
-                            float(depreciation_date.strftime('%j'))) + 1
+                    total_days = calendar.monthrange(
+                        depreciation_date.year, depreciation_date.month)[1]
+                    days = total_days - float(depreciation_date.day) + 1
                     percentage -= self.method_percentage * days / total_days
                 else:
                     percentage -= self.method_percentage

--- a/l10n_es_account_asset/tests/test_l10n_es_account_asset.py
+++ b/l10n_es_account_asset/tests/test_l10n_es_account_asset.py
@@ -107,3 +107,17 @@ class TestL10nEsAccountAsset(common.SavepointCase):
                 line_date.day,
                 calendar.monthrange(line_date.year, line_date.month)[1],
                 "Depreciation date is not the end of period.")
+
+    def test_prorated_percentage_asset_different_years(self):
+        start_depreciation_date = fields.Date.from_string('2017-11-15')
+        self.asset_percentage.write(
+            {'prorata': True,
+             'method_percentage': 70,
+             'start_depreciation_date': start_depreciation_date})
+        self.asset_linear.write(
+            {'date': '2017-11-15',
+             'method_time': 'percentage'})
+        self.asset_percentage.compute_depreciation_board()
+        self.assertGreater(
+            self.asset_percentage.depreciation_line_ids[-1:].amount, 0,
+            "Last depreciation amount is not correct.")


### PR DESCRIPTION
El porcentaje inicial que se resta en las amortizaciones con prorrateo no se calcula correctamente.

Se ha corregido la función para que la cantidad a restar se calcule correctamente.