### PR TITLE
[FIX] l10n_es_aeat_sii: Adapt to changes in account_invoice_refund_link

### DIFF
--- a/l10n_es_aeat_mod349/__manifest__.py
+++ b/l10n_es_aeat_mod349/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Modelo 349 AEAT",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.0.2",
     "author": "Pexego, "
               "Top Consultant, "
               "Tecnativa, "

--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -100,8 +100,8 @@ class Mod349(models.Model):
             if move_line.invoice_id.type in ('in_refund', 'out_refund'):
                 # Check for refunds if the origin invoice period is different
                 # from the declaration
-                origin_invoice = move_line.invoice_id.origin_invoice_ids[:1]
-                if move_line.invoice_id.origin_invoice_ids:
+                origin_invoice = move_line.invoice_id.refund_invoice_id
+                if origin_invoice:
                     if (origin_invoice.date < self.date_start or
                             origin_invoice.date > self.date_end):
                         self._create_349_refund_detail(move_line)
@@ -173,9 +173,7 @@ class Mod349(models.Model):
             move_line = refund_detail.refund_line_id
             partner = move_line.partner_id
             op_key = move_line.l10n_es_aeat_349_operation_key
-            origin_invoice = move_line.invoice_id.mapped(
-                'origin_invoice_ids'
-            )[:1]
+            origin_invoice = move_line.invoice_id.refund_invoice_id
             if not origin_invoice:
                 # TODO: Instead continuing, generate an empty record and a msg
                 continue

--- a/l10n_es_aeat_sii/__manifest__.py
+++ b/l10n_es_aeat_sii/__manifest__.py
@@ -10,7 +10,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "11.0.1.0.3",
+    "version": "11.0.1.0.4",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -88,7 +88,7 @@ class TestL10nEsAeatSii(common.SavepointCase):
         })
         cls.invoice.action_invoice_open()
         cls.invoice.number = 'INV001'
-        cls.invoice.origin_invoice_ids = cls.invoice.copy()
+        cls.invoice.refund_invoice_id = cls.invoice.copy()
         cls.user = cls.env['res.users'].create({
             'name': 'Test user',
             'login': 'test_user',
@@ -201,7 +201,7 @@ class TestL10nEsAeatSii(common.SavepointCase):
         self.invoice.sii_refund_type = 'S'
         self.invoice.reference = 'sup0001'
         self.invoice.compute_taxes()
-        self.invoice.origin_invoice_ids.type = 'in_invoice'
+        self.invoice.refund_invoice_id.type = 'in_invoice'
         invoices = self.invoice._get_sii_invoice_dict()
         test_in_refund = self._get_invoices_test('R4', '01')
         for key in list(invoices.keys()):


### PR DESCRIPTION
As the module account_invoice_refund_link was overwriting several fields and now Odoo includes an standard field for referring to the original invoice, we use that one for the module.

The changes are in https://github.com/OCA/account-invoicing/pull/367

@Tecnativa