### PR TITLE
[11.0][l10n_es_vat_book] corrige problema por el cual en el libro de iva se reflejan facturas "normales" como rectificativas.

### DIFF
--- a/l10n_es_vat_book/__manifest__.py
+++ b/l10n_es_vat_book/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Libro de IVA",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": "PRAXYA, "
               "Eficent, "
               "Odoo Community Association (OCA)",

--- a/l10n_es_vat_book/data/map_taxes_vat_book.xml
+++ b/l10n_es_vat_book/data/map_taxes_vat_book.xml
@@ -90,9 +90,9 @@
             ref('l10n_es.account_tax_template_p_iva4_bi'),
             ref('l10n_es.account_tax_template_p_iva10_bi'),
             ref('l10n_es.account_tax_template_p_iva21_bi'),
-            ref('l10n_es.account_tax_template_p_iva4_sp_in_1'),
-            ref('l10n_es.account_tax_template_p_iva10_sp_in_1'),
-            ref('l10n_es.account_tax_template_p_iva21_sp_in_1'),
+            ref('l10n_es.account_tax_template_p_iva4_sp_in_2'),
+            ref('l10n_es.account_tax_template_p_iva10_sp_in_2'),
+            ref('l10n_es.account_tax_template_p_iva21_sp_in_2'),
             ref('l10n_es.account_tax_template_p_iva4_ic_bc_1'),
             ref('l10n_es.account_tax_template_p_iva10_ic_bc_1'),
             ref('l10n_es.account_tax_template_p_iva21_ic_bc_1'),
@@ -122,9 +122,9 @@
             ref('l10n_es.account_tax_template_p_iva21_isp_1'),
             ref('l10n_es.account_tax_template_p_iva10_isp_1'),
             ref('l10n_es.account_tax_template_p_iva4_isp_1'),
-            ref('l10n_es.account_tax_template_p_iva21_sp_ex_1'),
-            ref('l10n_es.account_tax_template_p_iva10_sp_ex_1'),
-            ref('l10n_es.account_tax_template_p_iva4_sp_ex_1'),
+            ref('l10n_es.account_tax_template_p_iva21_sp_ex_2'),
+            ref('l10n_es.account_tax_template_p_iva10_sp_ex_2'),
+            ref('l10n_es.account_tax_template_p_iva4_sp_ex_2'),
         ])]"/>
         <field name="name">SuministroFactRecibidas ISP</field>
     </record>


### PR DESCRIPTION
Corrige https://github.com/OCA/l10n-spain/issues/807