### PR TITLE
[10.0] [FIX]l10n_es_mis_report. Cuantas a activo o pasivo según signo del saldo 

### DIFF
--- a/l10n_es_mis_report/data/mis_report_balance_abreviated.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_abreviated.xml
@@ -182,7 +182,7 @@
          <field name="sequence">180</field>
          <field name="name">es12400</field>
          <field name="description">IV. Inversiones en empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,593%,5943%,5944%,5953%,5954%]+bale[5523%,5524%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,593%,5943%,5944%,5953%,5954%]+bale[5523%] if bale[5523%]>0 else 0 + bale[5524%] if bale[5524%] >0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_12500_summary" model="mis.report.kpi">
@@ -192,7 +192,7 @@
          <field name="sequence">190</field>
          <field name="name">es12500</field>
          <field name="description">V. Inversiones financieras a corto plazo</field>
-         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,5593%,565%,566%,5945%,5955%,597%,598%]+bale[551%,5525%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,5593%,565%,566%,5945%,5955%,597%,598%]+bale[551%] if bale[551%]>0 else 0+bale[5525%] if bale[5525%] >0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_12600_summary" model="mis.report.kpi">
@@ -552,7 +552,7 @@
          <field name="sequence">550</field>
          <field name="name">es32390</field>
          <field name="description">3. Otras deudas a corto plazo</field>
-         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,501%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,5595%,5598%,560%,561%,569%]-bale[551%,5525%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,501%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,5595%,5598%,560%,561%,569%]-bale[551%] if bale[551%]<0 else 0-bale[5525%] if bale[5525%]<0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_32400_summary" model="mis.report.kpi">
@@ -562,7 +562,7 @@
          <field name="sequence">560</field>
          <field name="name">es32400</field>
          <field name="description">IV. Deudas con empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%,5524%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%] if bale[5523%]<0 else 0 - bale[5524%] if bale[5524%]<0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_32500_summary" model="mis.report.kpi">

--- a/l10n_es_mis_report/data/mis_report_balance_abreviated.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_abreviated.xml
@@ -182,7 +182,7 @@
          <field name="sequence">180</field>
          <field name="name">es12400</field>
          <field name="description">IV. Inversiones en empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,593%,5943%,5944%,5953%,5954%]+bale[5523%] if bale[5523%]&gt; else 0 + bale[5524%] if bale[5524%] &gt; else 0</field>
+         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,593%,5943%,5944%,5953%,5954%]+bale[5523%] if bale[5523%]&gt;0 else 0 + bale[5524%] if bale[5524%] &gt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_12500_summary" model="mis.report.kpi">
@@ -192,7 +192,7 @@
          <field name="sequence">190</field>
          <field name="name">es12500</field>
          <field name="description">V. Inversiones financieras a corto plazo</field>
-         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,5593%,565%,566%,5945%,5955%,597%,598%]+bale[551%] if bale[551%]&gt; else 0+bale[5525%] if bale[5525%] &gt; else 0</field>
+         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,5593%,565%,566%,5945%,5955%,597%,598%]+bale[551%] if bale[551%]&gt;0 else 0+bale[5525%] if bale[5525%] &gt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_12600_summary" model="mis.report.kpi">

--- a/l10n_es_mis_report/data/mis_report_balance_abreviated.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_abreviated.xml
@@ -182,7 +182,7 @@
          <field name="sequence">180</field>
          <field name="name">es12400</field>
          <field name="description">IV. Inversiones en empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,593%,5943%,5944%,5953%,5954%]+bale[5523%,5524%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,593%,5943%,5944%,5953%,5954%]+bale[5523%] if bale[5523%]%gt; else 0 + bale[5524%] if bale[5524%] %gt; else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_12500_summary" model="mis.report.kpi">
@@ -192,7 +192,7 @@
          <field name="sequence">190</field>
          <field name="name">es12500</field>
          <field name="description">V. Inversiones financieras a corto plazo</field>
-         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,5593%,565%,566%,5945%,5955%,597%,598%]+bale[551%,5525%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,5593%,565%,566%,5945%,5955%,597%,598%]+bale[551%] if bale[551%]%gt; else 0+bale[5525%] if bale[5525%] %gt; else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_12600_summary" model="mis.report.kpi">
@@ -552,7 +552,7 @@
          <field name="sequence">550</field>
          <field name="name">es32390</field>
          <field name="description">3. Otras deudas a corto plazo</field>
-         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,501%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,5595%,5598%,560%,561%,569%]-bale[551%,5525%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,501%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,5595%,5598%,560%,561%,569%]-bale[551%] if bale[551%]&lt;0 else 0-bale[5525%] if bale[5525%]&lt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_32400_summary" model="mis.report.kpi">
@@ -562,7 +562,7 @@
          <field name="sequence">560</field>
          <field name="name">es32400</field>
          <field name="description">IV. Deudas con empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%,5524%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%] if bale[5523%]&lt;0 else 0 - bale[5524%] if bale[5524%]&lt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_32500_summary" model="mis.report.kpi">

--- a/l10n_es_mis_report/data/mis_report_balance_normal.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_normal.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+a<?xml version="1.0" encoding="utf-8"?>
 <odoo>
    <data>
       <record id="mis_report_es_balance_normal_summary" model="mis.report">
@@ -609,7 +609,7 @@
          <field name="sequence">610</field>
          <field name="name">es12450</field>
          <field name="description">5. Otros activos financieros</field>
-         <field name="expression">+bale[5353%,5354%]+bale[5523%,5524%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5353%,5354%]+bale[5523%] if bale[5523%]>0 else 0 + bale[5524%] if bale[5524%] >0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_12460_summary" model="mis.report.kpi">
@@ -679,7 +679,7 @@
          <field name="sequence">680</field>
          <field name="name">es12550</field>
          <field name="description">5. Otros activos financieros</field>
-         <field name="expression">+bale[5355%,545%,548%,565%,566%]+bale[550%,551%,554%,5525%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5355%,545%,548%,565%,566%]+bale[550%] if bale[550%]>0 else 0+bale[551%] if bale[551%]>0 else 0+bale[554%] if bale[554%]>0 else 0+bale[5525%] if bale[5525%]>0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_12560_summary" model="mis.report.kpi">
@@ -1239,7 +1239,7 @@
          <field name="sequence">1240</field>
          <field name="name">es32350</field>
          <field name="description">5. Otros pasivos financieros</field>
-         <field name="expression">-bale[1034%,1044%,190%,192%,194%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,560%,561%,569%]-bale[550%,551%,554%,5525%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,560%,561%,569%]-bale[550%%] if bale[550%%]<0 else 0 - bale[551%] if bale[551%]<0 else 0 - bale[554%] if bale[554%]<0 else 0 - bale[5525%] if bale[5525%]<0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_32400_summary" model="mis.report.kpi">
@@ -1249,7 +1249,7 @@
          <field name="sequence">1250</field>
          <field name="name">es32400</field>
          <field name="description">IV. Deudas con empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%,5524%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%] if bale[5523%]<0 else 0 - bale[5524%] if bale[5524%]<0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_32500_summary" model="mis.report.kpi">

--- a/l10n_es_mis_report/data/mis_report_balance_normal.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_normal.xml
@@ -609,7 +609,7 @@ a<?xml version="1.0" encoding="utf-8"?>
          <field name="sequence">610</field>
          <field name="name">es12450</field>
          <field name="description">5. Otros activos financieros</field>
-         <field name="expression">+bale[5353%,5354%]+bale[5523%] if bale[5523%]%gt; else 0 + bale[5524%] if bale[5524%] %gt; else 0</field>
+         <field name="expression">+bale[5353%,5354%]+bale[5523%] if bale[5523%]&gt;0 else 0 + bale[5524%] if bale[5524%] &gt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_12460_summary" model="mis.report.kpi">
@@ -679,7 +679,7 @@ a<?xml version="1.0" encoding="utf-8"?>
          <field name="sequence">680</field>
          <field name="name">es12550</field>
          <field name="description">5. Otros activos financieros</field>
-         <field name="expression">+bale[5355%,545%,548%,565%,566%]+bale[550%] if bale[550%]%gt; else 0+bale[551%] if bale[551%]%gt; else 0+bale[554%] if bale[554%]%gt; else 0+bale[5525%] if bale[5525%]%gt; else 0</field>
+         <field name="expression">+bale[5355%,545%,548%,565%,566%]+bale[550%] if bale[550%]&gt;0 else 0+bale[551%] if bale[551%]&gt;0 else 0+bale[554%] if bale[554%]&gt;0 else 0+bale[5525%] if bale[5525%]&gt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_12560_summary" model="mis.report.kpi">
@@ -1239,7 +1239,7 @@ a<?xml version="1.0" encoding="utf-8"?>
          <field name="sequence">1240</field>
          <field name="name">es32350</field>
          <field name="description">5. Otros pasivos financieros</field>
-         <field name="expression">-bale[1034%,1044%,190%,192%,194%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,560%,561%,569%]-bale[550%%] if bale[550%%]%lt; else 0 - bale[551%] if bale[551%]%lt; else 0 - bale[554%] if bale[554%]%lt; else 0 - bale[5525%] if bale[5525%]%lt; else 0</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,560%,561%,569%]-bale[550%%] if bale[550%%]&lt;0 else 0 - bale[551%] if bale[551%]&lt;0 else 0 - bale[554%] if bale[554%]&lt;0 else 0 - bale[5525%] if bale[5525%]&lt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_32400_summary" model="mis.report.kpi">
@@ -1249,7 +1249,7 @@ a<?xml version="1.0" encoding="utf-8"?>
          <field name="sequence">1250</field>
          <field name="name">es32400</field>
          <field name="description">IV. Deudas con empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%] if bale[5523%]%lt; else 0 - bale[5524%] if bale[5524%]%lt; else 0</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%] if bale[5523%]&lt;0 else 0 - bale[5524%] if bale[5524%]&lt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_32500_summary" model="mis.report.kpi">

--- a/l10n_es_mis_report/data/mis_report_balance_normal.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_normal.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+a<?xml version="1.0" encoding="utf-8"?>
 <odoo>
    <data>
       <record id="mis_report_es_balance_normal_summary" model="mis.report">
@@ -609,7 +609,7 @@
          <field name="sequence">610</field>
          <field name="name">es12450</field>
          <field name="description">5. Otros activos financieros</field>
-         <field name="expression">+bale[5353%,5354%]+bale[5523%,5524%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5353%,5354%]+bale[5523%] if bale[5523%]%gt; else 0 + bale[5524%] if bale[5524%] %gt; else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_12460_summary" model="mis.report.kpi">
@@ -679,7 +679,7 @@
          <field name="sequence">680</field>
          <field name="name">es12550</field>
          <field name="description">5. Otros activos financieros</field>
-         <field name="expression">+bale[5355%,545%,548%,565%,566%]+bale[550%,551%,554%,5525%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5355%,545%,548%,565%,566%]+bale[550%] if bale[550%]%gt; else 0+bale[551%] if bale[551%]%gt; else 0+bale[554%] if bale[554%]%gt; else 0+bale[5525%] if bale[5525%]%gt; else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_12560_summary" model="mis.report.kpi">
@@ -1239,7 +1239,7 @@
          <field name="sequence">1240</field>
          <field name="name">es32350</field>
          <field name="description">5. Otros pasivos financieros</field>
-         <field name="expression">-bale[1034%,1044%,190%,192%,194%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,560%,561%,569%]-bale[550%,551%,554%,5525%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,560%,561%,569%]-bale[550%%] if bale[550%%]%lt; else 0 - bale[551%] if bale[551%]%lt; else 0 - bale[554%] if bale[554%]%lt; else 0 - bale[5525%] if bale[5525%]%lt; else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_32400_summary" model="mis.report.kpi">
@@ -1249,7 +1249,7 @@
          <field name="sequence">1250</field>
          <field name="name">es32400</field>
          <field name="description">IV. Deudas con empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%,5524%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%] if bale[5523%]%lt; else 0 - bale[5524%] if bale[5524%]%lt; else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_32500_summary" model="mis.report.kpi">

--- a/l10n_es_mis_report/data/mis_report_balance_normal.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_normal.xml
@@ -1,4 +1,3 @@
-a<?xml version="1.0" encoding="utf-8"?>
 <odoo>
    <data>
       <record id="mis_report_es_balance_normal_summary" model="mis.report">

--- a/l10n_es_mis_report/data/mis_report_balance_sme.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_sme.xml
@@ -170,7 +170,7 @@
          <field name="sequence">170</field>
          <field name="name">es12400</field>
          <field name="description">III. Inversiones en empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,5933%,5934%,5943%,5944%,5953%,5954%]+bale[5523%,5524%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,5933%,5934%,5943%,5944%,5953%,5954%]+bale[5523%] if bale[5523%]>0 else 0 + bale[5524%] if bale[5524%] >0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_12500_summary" model="mis.report.kpi">
@@ -180,7 +180,7 @@
          <field name="sequence">180</field>
          <field name="name">es12500</field>
          <field name="description">IV. Inversiones financieras a corto plazo</field>
-         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,565%,566%,5935%,5945%,5955%,596%,597%,598%]+bale[550%,551%,554%,5525%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,565%,566%,5935%,5945%,5955%,596%,597%,598%]+bale[550%] if bale[550%]>0 else 0+bale[551%] if bale[551%]>0 else 0+bale[554%] if bale[554%]>0 else 0+bale[5525%] if bale[5525%]>0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_12600_summary" model="mis.report.kpi">
@@ -520,7 +520,7 @@
          <field name="sequence">520</field>
          <field name="name">es32390</field>
          <field name="description">3. Otras deudas a corto plazo</field>
-         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,555%,5565%,5566%,5595%,560%,561%]-bale[550%,551%,554%,5525%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,555%,5565%,5566%,5595%,560%,561%]-bale[550%%] if bale[550%%]<0 else 0 - bale[551%] if bale[551%]<0 else 0 - bale[554%] if bale[554%]<0 else 0 - bale[5525%] if bale[5525%]<0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_32400_summary" model="mis.report.kpi">
@@ -530,7 +530,7 @@
          <field name="sequence">530</field>
          <field name="name">es32400</field>
          <field name="description">III. Deudas con empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%,5524%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%] if bale[5523%]<0 else 0 - bale[5524%] if bale[5524%]<0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_32500_summary" model="mis.report.kpi">

--- a/l10n_es_mis_report/data/mis_report_balance_sme.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_sme.xml
@@ -170,7 +170,7 @@
          <field name="sequence">170</field>
          <field name="name">es12400</field>
          <field name="description">III. Inversiones en empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,5933%,5934%,5943%,5944%,5953%,5954%]+bale[5523%,5524%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,5933%,5934%,5943%,5944%,5953%,5954%]+bale[5523%] if bale[5523%]%gt; else 0 + bale[5524%] if bale[5524%] %gt; else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_12500_summary" model="mis.report.kpi">
@@ -180,7 +180,7 @@
          <field name="sequence">180</field>
          <field name="name">es12500</field>
          <field name="description">IV. Inversiones financieras a corto plazo</field>
-         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,565%,566%,5935%,5945%,5955%,596%,597%,598%]+bale[550%,551%,554%,5525%][('debit', '&gt;', 0.0)]</field>
+         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,565%,566%,5935%,5945%,5955%,596%,597%,598%]+bale[550%] if bale[550%]%gt; else 0+bale[551%] if bale[551%]%gt; else 0+bale[554%] if bale[554%]%gt; else 0+bale[5525%] if bale[5525%]%gt; else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_12600_summary" model="mis.report.kpi">
@@ -520,7 +520,7 @@
          <field name="sequence">520</field>
          <field name="name">es32390</field>
          <field name="description">3. Otras deudas a corto plazo</field>
-         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,555%,5565%,5566%,5595%,560%,561%]-bale[550%,551%,554%,5525%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,555%,5565%,5566%,5595%,560%,561%]-bale[550%%] if bale[550%%]%lt; else 0 - bale[551%] if bale[551%]%lt; else 0 - bale[554%] if bale[554%]%lt; else 0 - bale[5525%] if bale[5525%]%lt; else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_32400_summary" model="mis.report.kpi">
@@ -530,7 +530,7 @@
          <field name="sequence">530</field>
          <field name="name">es32400</field>
          <field name="description">III. Deudas con empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%,5524%][('credit', '&gt;', 0.0)]</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%] if bale[5523%]%lt; else 0 - bale[5524%] if bale[5524%]%lt; else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_32500_summary" model="mis.report.kpi">

--- a/l10n_es_mis_report/data/mis_report_balance_sme.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_sme.xml
@@ -170,7 +170,7 @@
          <field name="sequence">170</field>
          <field name="name">es12400</field>
          <field name="description">III. Inversiones en empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,5933%,5934%,5943%,5944%,5953%,5954%]+bale[5523%] if bale[5523%]%gt; else 0 + bale[5524%] if bale[5524%] %gt; else 0</field>
+         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,5933%,5934%,5943%,5944%,5953%,5954%]+bale[5523%] if bale[5523%]&gt;0 else 0 + bale[5524%] if bale[5524%] &gt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_12500_summary" model="mis.report.kpi">
@@ -180,7 +180,7 @@
          <field name="sequence">180</field>
          <field name="name">es12500</field>
          <field name="description">IV. Inversiones financieras a corto plazo</field>
-         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,565%,566%,5935%,5945%,5955%,596%,597%,598%]+bale[550%] if bale[550%]%gt; else 0+bale[551%] if bale[551%]%gt; else 0+bale[554%] if bale[554%]%gt; else 0+bale[5525%] if bale[5525%]%gt; else 0</field>
+         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,565%,566%,5935%,5945%,5955%,596%,597%,598%]+bale[550%] if bale[550%]&gt;0 else 0+bale[551%] if bale[551%]&gt;0 else 0+bale[554%] if bale[554%]&gt;0 else 0+bale[5525%] if bale[5525%]&gt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_12600_summary" model="mis.report.kpi">
@@ -520,7 +520,7 @@
          <field name="sequence">520</field>
          <field name="name">es32390</field>
          <field name="description">3. Otras deudas a corto plazo</field>
-         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,555%,5565%,5566%,5595%,560%,561%]-bale[550%%] if bale[550%%]%lt; else 0 - bale[551%] if bale[551%]%lt; else 0 - bale[554%] if bale[554%]%lt; else 0 - bale[5525%] if bale[5525%]%lt; else 0</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,555%,5565%,5566%,5595%,560%,561%]-bale[550%%] if bale[550%%]&lt;0 else 0 - bale[551%] if bale[551%]&lt;0 else 0 - bale[554%] if bale[554%]&lt;0 else 0 - bale[5525%] if bale[5525%]&lt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l4"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_32400_summary" model="mis.report.kpi">
@@ -530,7 +530,7 @@
          <field name="sequence">530</field>
          <field name="name">es32400</field>
          <field name="description">III. Deudas con empresas del grupo y asociadas a corto plazo</field>
-         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%] if bale[5523%]%lt; else 0 - bale[5524%] if bale[5524%]%lt; else 0</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%]-bale[5523%] if bale[5523%]&lt;0 else 0 - bale[5524%] if bale[5524%]&lt;0 else 0</field>
          <field name="style_id" ref="mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_32500_summary" model="mis.report.kpi">


### PR DESCRIPTION
Corrige algunos conceptos del balance llevando ciertas cuentas al pasivo o activo según  el signo del saldo en lugar de llevar todo el debe y todo el haber