### PR TITLE
[10.0] l10n_es_aeat_sii: Añadidos P_IVA10_ND y P_IVA4_ND al mapeo del SII

### DIFF
--- a/l10n_es_aeat_sii/README.rst
+++ b/l10n_es_aeat_sii/README.rst
@@ -143,6 +143,7 @@ Contributors
 * Javi Melendez <javimelex@gmail.com>
 * Santi Argüeso - Comunitea S.L. <santi@comunitea.com>
 * Angel Moya - PESOL <angel.moya@pesol.es>
+* Nacho Muñoz <nacmuro@gmail.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_aeat_sii/__manifest__.py
+++ b/l10n_es_aeat_sii/__manifest__.py
@@ -13,7 +13,7 @@
 
 {
     "name": u"Suministro Inmediato de Información en el IVA",
-    "version": "10.0.3.3.1",
+    "version": "10.0.3.4.0",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -165,6 +165,8 @@
             <field name="code">SFRND</field>
             <field name="taxes" eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_p_iva0_nd'),
+                ref('l10n_es.account_tax_template_p_iva10_nd'),
+                ref('l10n_es.account_tax_template_p_iva4_nd'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas No Deducible</field>

--- a/l10n_es_aeat_sii/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_sii/readme/CONTRIBUTORS.rst
@@ -10,3 +10,4 @@
 * Javi Melendez <javimelex@gmail.com>
 * Santi Argüeso - Comunitea S.L. <santi@comunitea.com>
 * Angel Moya - PESOL <angel.moya@pesol.es>
+* Nacho Muñoz <nacmuro@gmail.com>


### PR DESCRIPTION
Este PR añade los impuestos P_IVA10_ND y P_IVA4_ND al mapeo del SII.

Pasará los tests cuando esté mergeado el https://github.com/OCA/l10n-spain/pull/752
