### PR TITLE
[10.0][l10n_es_vat_book] corrige error en la lectura de asientos no asociados a facturas.

### DIFF
--- a/l10n_es_vat_book/__manifest__.py
+++ b/l10n_es_vat_book/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Libro de IVA",
-    "version": "10.0.1.0.2",
+    "version": "10.0.1.0.3",
     "author": "PRAXYA, "
               "Eficent, "
               "Odoo Community Association (OCA)",

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -171,9 +171,9 @@ class L10nEsVatBook(models.Model):
             Returns:
                 dictionary: Vals from the new record.
         """
-        invoice = min(move.line_ids.mapped('invoice_id'))
         ref = move.ref
         ext_ref = ''
+        invoice = move.line_ids.mapped('invoice_id')[:1]
         if invoice:
             ref = invoice.number
             ext_ref = invoice.reference


### PR DESCRIPTION
El error que daba, cuando tienes un asiento no directamente asociado a una factura (sino a un account.voucher, por ejemplo):

`  File "/opt/odoo/auto/addons/l10n_es_vat_book/models/l10n_es_vat_book.py", line 174, in _get_vals_invoice_line
    invoice = min(move.line_ids.mapped('invoice_id'))
ValueError: min() arg is an empty sequence`