### PR TITLE
[10.0][l10n_es_mis_report]. Nunca autoexpandir la sección VII. Resultado del ejercicio en el balance de situación

### DIFF
--- a/l10n_es_mis_report/__manifest__.py
+++ b/l10n_es_mis_report/__manifest__.py
@@ -11,7 +11,7 @@
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/l10n-spain',
     'category': 'Reporting',
-    'version': '10.0.2.0.1',
+    'version': '10.0.2.0.2',
     'license': 'AGPL-3',
     'depends': [
         'mis_builder',  # OCA/account-financial-reporting

--- a/l10n_es_mis_report/data/mis_report_balance_abreviated.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_abreviated.xml
@@ -385,8 +385,7 @@
          <field name="name">es21700</field>
          <field name="description">VII. Resultado del ejercicio</field>
          <field name="expression">-bale[129%,6%,7%]-balu[6%,7%]</field>
-         <field name="auto_expand_accounts">True</field>
-         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"/>
+         <field name="auto_expand_accounts">False</field>
          <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_abreviado_21800" model="mis.report.kpi">

--- a/l10n_es_mis_report/data/mis_report_balance_normal.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_normal.xml
@@ -1026,8 +1026,7 @@
          <field name="name">es21700</field>
          <field name="description">VII. Resultado del ejercicio</field>
          <field name="expression">-bale[129%,6%,7%]-balu[6%,7%]</field>
-         <field name="auto_expand_accounts">True</field>
-         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"/>
+         <field name="auto_expand_accounts">False</field>
          <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_normal_21800" model="mis.report.kpi">

--- a/l10n_es_mis_report/data/mis_report_balance_sme.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_sme.xml
@@ -367,8 +367,7 @@
          <field name="name">es21700</field>
          <field name="description">VII. Resultado del ejercicio</field>
          <field name="expression">-bale[129%,6%,7%]-balu[6%,7%]</field>
-         <field name="auto_expand_accounts">True</field>
-         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"/>
+         <field name="auto_expand_accounts">False</field>
          <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"/>
       </record>
       <record id="mis_report_kpi_es_balance_pymes_21800" model="mis.report.kpi">


### PR DESCRIPTION
Esto es necesario porque de lo contrario se mostrarían las cuentas de PyG.