### PR TITLE
[8.0][FIX] l10n_es_aeat_sii: Signo en CuotaDeducible

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -864,7 +864,7 @@ class AccountInvoice(models.Model):
                 "ImporteTotal": self.cc_amount_total * sign,
                 "CuotaDeducible": self.period_id.date_start >=
                 SII_START_DATE and round(
-                    float_round(tax_amount * sign, 2), 2) or 0.0,
+                    float_round(tax_amount, 2), 2) or 0.0,
             }
             if self.sii_registration_key_additional1:
                 inv_dict["FacturaRecibida"].\


### PR DESCRIPTION
El PR viene del issue #808 
El campo CuotaDeducible en las facturas por diferencias se estaba subiendo al SII con el signo en positivo.