### PR TITLE
[FIX][10.0] l10n_es_vat_book: permisos incorrectos usuario tests

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -9,7 +9,7 @@
 {
     'name': "AEAT Base",
     'summary': "Modulo base para declaraciones de la AEAT",
-    'version': "10.0.1.1.1",
+    'version': "10.0.1.1.2",
     'author': "Pexego,"
               "Acysos,"
               "AvanzOSC,"

--- a/l10n_es_aeat/tests/test_l10n_es_aeat_mod_base.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_mod_base.py
@@ -230,7 +230,8 @@ class TestL10nEsAeatModBase(common.TransactionCase):
             'login': 'billing_user',
             'email': 'billing.user@example.com',
             'notify_email': 'none',
-            'groups_id': [(6, 0, [invocing_grp.id])]})
+            'groups_id': [(6, 0, [invocing_grp.id]),
+                          (6, 0, [account_user_grp.id])]})
         self.account_user = Users.create({
             'name': 'Account user',
             'login': 'account_user',


### PR DESCRIPTION
Con esto se corrige error en los tests cuando se tiene instalado el módulo sale_order_type.

cc @Tecnativa