### PR TITLE
[FIX] account_balance_reporting: Integration tests

### DIFF
--- a/account_balance_reporting/tests/test_account_balance.py
+++ b/account_balance_reporting/tests/test_account_balance.py
@@ -3,11 +3,13 @@
 # Copyright 2016-2017 Tecnativa - Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.0).
 
-from odoo.tests import common
+from odoo.tests import at_install, post_install, SavepointCase
 from odoo import fields
 
 
-class TestAccountBalanceBase(common.SavepointCase):
+@at_install(False)
+@post_install(True)
+class TestAccountBalanceBase(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super(TestAccountBalanceBase, cls).setUpClass()


### PR DESCRIPTION
Fix conflicts with module `account_analytic_required`, which produces
this while running the test:

    ERROR: setUpClass (odoo.addons.account_balance_reporting.tests.test_account_balance.TestAccountBalance)
    Traceback (most recent call last):
    `   File "/opt/odoo/auto/addons/account_balance_reporting/tests/test_account_balance.py", line 28, in setUpClass
    `     name='other',
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3847, in create
    `     record = self.browse(self._create(old_vals))
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3942, in _create
    `     cr.execute(query, tuple(u[2] for u in updates if len(u) > 2))
    `   File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 154, in wrapper
    `     return f(self, *args, **kwargs)
    `   File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 231, in execute
    `     res = self._obj.execute(query, params)
    ` IntegrityError: null value in column "analytic_policy" violates not-null constraint
    ` DETAIL:  Failing row contains (25, 1, other, 1, null, 2018-05-15 08:03:05.208936, 2018-05-15 08:03:05.208936, f, other, null).

@Tecnativa