### PR TITLE
[10.0][l10n_es_mis_report] Migración a 10.0.2.0.0

### DIFF
--- a/l10n_es_mis_report/__manifest__.py
+++ b/l10n_es_mis_report/__manifest__.py
@@ -13,7 +13,7 @@
               'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/l10n-spain',
     'category': 'Reporting',
-    'version': '10.0.2.1.0',
+    'version': '10.0.2.1.1',
     'license': 'AGPL-3',
     'depends': [
         'mis_builder',  # OCA/account-financial-reporting

--- a/l10n_es_mis_report/migrations/10.0.2.0.0/pre-migration.py
+++ b/l10n_es_mis_report/migrations/10.0.2.0.0/pre-migration.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    list = {
+        'mis_report_es_balance_abreviado_summary':
+            'mis_report_es_balance_abreviado',
+        'mis_report_es_balance_normal_summary':
+            'mis_report_es_balance_normal',
+        'mis_report_es_balance_pymes_summary':
+            'mis_report_es_balance_pymes',
+        'mis_report_es_pyg_abreviado_summary':
+            'mis_report_es_pyg_abreviado',
+        'mis_report_es_pyg_normal_summary':
+            'mis_report_es_pyg_normal',
+        'mis_report_es_pyg_pymes_summary':
+            'mis_report_es_pyg_pymes',
+        'mis_report_es_eiyg_normal_summary':
+            'mis_report_es_eiyg_normal',
+    }
+    for key in list.keys():
+        cr.execute("""
+            UPDATE ir_model_data
+            SET name = '%s'
+            WHERE name = '%s'
+            AND module = 'l10n_es_mis_report'
+            """ % (list[key], key))

--- a/l10n_es_mis_report/migrations/10.0.2.0.0/pre-migration.py
+++ b/l10n_es_mis_report/migrations/10.0.2.0.0/pre-migration.py
@@ -6,8 +6,7 @@
 def migrate(cr, version):
     if not version:
         return
-
-    list = {
+    mapping = {
         'mis_report_es_balance_abreviado_summary':
             'mis_report_es_balance_abreviado',
         'mis_report_es_balance_normal_summary':
@@ -23,10 +22,10 @@ def migrate(cr, version):
         'mis_report_es_eiyg_normal_summary':
             'mis_report_es_eiyg_normal',
     }
-    for key in list.keys():
+    for key in mapping.keys():
         cr.execute("""
             UPDATE ir_model_data
-            SET name = '%s'
-            WHERE name = '%s'
+            SET name = %s
+            WHERE name = %s
             AND module = 'l10n_es_mis_report'
-            """ % (list[key], key))
+            """, (mapping[key], key))


### PR DESCRIPTION
A partir de la versión 10.0.2.0.0 los xmlid de los informes mis cambió (se quitó el sufijo 'summary'). Este PR incluye el script de migración necesario para los que migren de versiones menores anteriores.

cc @Cedric-Pigeon @pedrobaeza 