### PR TITLE
[IMP+FIX] l10n_es_aeat_mod303_cash_basis: Fix cash basis taxes in same period + 12% farming

### DIFF
--- a/l10n_es_aeat_mod303_cash_basis/__manifest__.py
+++ b/l10n_es_aeat_mod303_cash_basis/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "AEAT modelo 303 - Extensión para criterio de caja",
-    "version": "10.0.1.0.0",
+    "version": "10.0.2.0.0",
     'category': "Accounting & Finance",
     'author': "Tecnativa,"
               "Odoo Community Association (OCA)",

--- a/l10n_es_aeat_mod303_cash_basis/data/tax_code_map_mod303_data.xml
+++ b/l10n_es_aeat_mod303_cash_basis/data/tax_code_map_mod303_data.xml
@@ -34,7 +34,7 @@
         <field name="sum_type">both</field>
         <field name="exigible_type">no</field>
         <field name="inverse" eval="True"/>
-        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva4_sc'), ref('l10n_es.account_tax_template_p_iva4_bc'), ref('l10n_es.account_tax_template_p_iva10_sc'), ref('l10n_es.account_tax_template_p_iva10_bc'), ref('l10n_es.account_tax_template_p_iva21_sc'), ref('l10n_es.account_tax_template_p_iva21_bc')])]"/>
+        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva4_sc'), ref('l10n_es.account_tax_template_p_iva4_bc'), ref('l10n_es.account_tax_template_p_iva10_sc'), ref('l10n_es.account_tax_template_p_iva10_bc'), ref('l10n_es.account_tax_template_p_iva21_sc'), ref('l10n_es.account_tax_template_p_iva21_bc'), ref('l10n_es.account_tax_template_p_iva12_agr')])]"/>
     </record>
     <record id="aeat_mod303_map_line_75" model="l10n.es.aeat.map.tax.line">
         <field name="map_parent_id" ref="l10n_es_aeat_mod303.aeat_mod303_map"/>
@@ -46,6 +46,6 @@
         <field name="sum_type">both</field>
         <field name="exigible_type">no</field>
         <field name="inverse" eval="True"/>
-        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva4_sc'), ref('l10n_es.account_tax_template_p_iva4_bc'), ref('l10n_es.account_tax_template_p_iva10_sc'), ref('l10n_es.account_tax_template_p_iva10_bc'), ref('l10n_es.account_tax_template_p_iva21_sc'), ref('l10n_es.account_tax_template_p_iva21_bc')])]"/>
+        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva4_sc'), ref('l10n_es.account_tax_template_p_iva4_bc'), ref('l10n_es.account_tax_template_p_iva10_sc'), ref('l10n_es.account_tax_template_p_iva10_bc'), ref('l10n_es.account_tax_template_p_iva21_sc'), ref('l10n_es.account_tax_template_p_iva21_bc'), ref('l10n_es.account_tax_template_p_iva12_agr')])]"/>
     </record>
 </odoo>

--- a/l10n_es_aeat_mod303_cash_basis/models/__init__.py
+++ b/l10n_es_aeat_mod303_cash_basis/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- encoding: utf-8 -*-
 
+from . import account_partial_reconcile
 from . import mod303

--- a/l10n_es_aeat_mod303_cash_basis/models/account_partial_reconcile.py
+++ b/l10n_es_aeat_mod303_cash_basis/models/account_partial_reconcile.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class AccountPartialReconcileCashBasis(models.Model):
+    _inherit = 'account.partial.reconcile'
+
+    def create_tax_cash_basis_entry(self, value_before_reconciliation):
+        """Modify tax_exigible and tax values before reconciliation for
+        the special case of 12% VAT for farming, as its value is included in
+        IRPF 2%.
+
+        This way, we trick standard cash basis system for generating proper
+        payment accounting moves.
+        """
+        moves = self.debit_move_id.move_id + self.credit_move_id.move_id
+        tax_lines = self.env['account.move.line']
+        base_lines = {}
+        for line in moves.mapped('line_ids'):
+            if 'P_IRPF2' in line.tax_ids.mapped('description'):
+                base_lines[line.tax_ids] = line
+                if (line.tax_line_id.description == 'P_IVA12_AGR' and
+                        line.tax_exigible):
+                    tax_lines += line
+        if tax_lines:
+            tax_lines.write({'tax_exigible': False})
+        for line in base_lines.values():
+            line.tax_ids = [
+                (3, x.id) for x in
+                line.tax_ids.filtered(lambda l: l.description == 'P_IRPF2')
+            ]
+        res = super(
+            AccountPartialReconcileCashBasis, self,
+        ).create_tax_cash_basis_entry(value_before_reconciliation)
+        if tax_lines:
+            tax_lines.write({'tax_exigible': True})
+        for taxes, line in base_lines.items():
+            line.tax_ids = [(6, 0, taxes.ids)]
+        return res

--- a/l10n_es_aeat_mod303_cash_basis/models/mod303.py
+++ b/l10n_es_aeat_mod303_cash_basis/models/mod303.py
@@ -2,7 +2,8 @@
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
+from odoo.osv.expression import normalize_domain, AND, OR
 
 
 class L10nEsAeatMod303Report(models.Model):
@@ -31,10 +32,38 @@ class L10nEsAeatMod303Report(models.Model):
         default=_default_cash_basis_payable,
     )
 
+    @api.model
+    def _get_tax_lines(self, codes, date_start, date_end, map_line):
+        """Hide cash basis lines that are payment entries for the same period
+        of their counterpart, for not declaring twice the amount.
+        """
+        AccountMove = self.env['account.move']
+        move_lines = super(L10nEsAeatMod303Report, self)._get_tax_lines(
+            codes, date_start, date_end, map_line,
+        )
+        if map_line.field_number in [62, 63, 74, 75]:
+            new_lines = self.env['account.move.line']
+            for line in move_lines:
+                recs = (
+                    line.move_id.mapped('line_ids.matched_debit_ids') +
+                    line.move_id.mapped('line_ids.matched_credit_ids')
+                )
+                other_move = AccountMove.search([
+                    ('tax_cash_basis_rec_id', 'in', recs.ids),
+                ], limit=1)
+                if (not other_move or other_move.date < date_start or
+                        other_move.date > date_end):
+                    new_lines += line
+            move_lines = new_lines
+        return move_lines
+
     def _get_move_line_domain(self, codes, date_start, date_end, map_line):
         """Add the possibility of getting move lines from moves generated
         from cash basis reconciliations so that the amounts appear on the
-        payment date.
+        payment date. This is needed as the cash basis move is not of the
+        expected move type.
+
+        Also adjust domains for the special case of 12% VAT for farming.
         """
         domain = super(L10nEsAeatMod303Report, self)._get_move_line_domain(
             codes, date_start, date_end, map_line,
@@ -46,4 +75,28 @@ class L10nEsAeatMod303Report(models.Model):
                     ('move_id.tax_cash_basis_rec_id', '!=', False),
                 ]
                 break
+        if map_line.field_number == 42:
+            # Exclude here the VAT that is used as base for IRPF 2%, as it
+            # has the tax_exigible field marked.
+            domain += [
+                ('tax_ids', '=', False),
+            ]
+        elif map_line.field_number == 75:
+            # And add it here
+            domain_mandatory = []
+            domain_optional = []
+            domain_extra = []
+            for i, element in enumerate(domain):
+                if element[0] == 'date' and element[1] == '<=':
+                    domain_mandatory = normalize_domain(domain[:i+1])
+                    domain_optional = normalize_domain(domain[i+1:])
+                    domain_extra = [
+                        '&',
+                        ('tax_ids', '!=', False),
+                        ('tax_line_id.description', '=', 'P_IVA12_AGR'),
+                    ]
+                    break
+            domain = AND(
+                [domain_mandatory] + [OR([domain_extra, domain_optional])]
+            )
         return domain


### PR DESCRIPTION
* Tener en cuenta el IVA 12% de agricultura, con el dolor de cabeza de que el IRPF es sobre BI + IVA.
* Arreglar el 303 cuando el pago se realiza dentro del mismo periodo que la declaración, para que no aparezca 2 veces.