### PR TITLE
[10.0][FIX] l10n_es_aeat_mod303: Nombre de la empresa sin números

### DIFF
--- a/l10n_es_aeat/README.rst
+++ b/l10n_es_aeat/README.rst
@@ -86,6 +86,7 @@ Contribudores
 * AvanzOSC (http://www.avanzosc.es)
 * Ainara Galdona
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
+* Abraham Anes <abraham@studio73.es>
 
 Maintainer
 ----------

--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -9,7 +9,7 @@
 {
     'name': "AEAT Base",
     'summary': "Modulo base para declaraciones de la AEAT",
-    'version': "10.0.2.0.0",
+    'version': "10.0.2.0.1",
     'author': "Pexego,"
               "Acysos,"
               "AvanzOSC,"

--- a/l10n_es_aeat/models/l10n_es_aeat_export_config_line.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_export_config_line.py
@@ -30,6 +30,7 @@ class AeatModelExportConfigLine(models.Model):
         oldname='sub_config')
     export_type = fields.Selection(
         selection=[('string', 'Alphanumeric'),
+                   ('alphabetic', 'Alphabetic'),
                    ('float', 'Number with decimals'),
                    ('integer', 'Number without decimals'),
                    ('boolean', 'Boolean'),

--- a/l10n_es_aeat/wizard/export_to_boe.py
+++ b/l10n_es_aeat/wizard/export_to_boe.py
@@ -63,6 +63,16 @@ class L10nEsAeatReportExportToBoe(models.TransientModel):
         # Return string
         return ascii_string
 
+    def _format_alphabetic_string(self, text, length, fill=' ', align='<'):
+        u"""Format the string into a fixed length ASCII (iso-8859-1) record
+            without numbers.
+        """
+        if not text:
+            return fill * length
+        # Replace numbers
+        name = re.sub(ur"[\d-]", '', text, re.UNICODE | re.X)
+        return self._format_string(name, length, fill=fill, align=align)
+
     def _format_number(self, number, int_length, dec_length=0,
                        include_sign=False, positive_sign=' ',
                        negative_sign='N'):
@@ -213,6 +223,10 @@ class L10nEsAeatReportExportToBoe(models.TransientModel):
             return self._format_string(val or '', line.size, align=align)
         elif line.export_type == 'boolean':
             return self._format_boolean(val, line.bool_yes, line.bool_no)
+        elif line.export_type == 'alphabetic':
+            align = '>' if line.alignment == 'right' else '<'
+            return self._format_alphabetic_string(
+                val or '', line.size, align=align)
         else:  # float or integer
             decimal_size = (0 if line.export_type == 'integer' else
                             line.decimal_size)

--- a/l10n_es_aeat_mod303/__manifest__.py
+++ b/l10n_es_aeat_mod303/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "AEAT modelo 303",
-    "version": "10.0.2.1.0",
+    "version": "10.0.2.2.0",
     'category': "Accounting & Finance",
     'author': "Guadaltech,"
               "AvanzOSC,"

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2017_data.xml
@@ -92,7 +92,7 @@
         <field name="export_config_id" ref="aeat_mod303_2017_sub01_export_config"/>
         <field name="name">Identificación: Nombre</field>
         <field name="expression">${object.company_id.name}</field>
-        <field name="export_type">string</field>
+        <field name="export_type">alphabetic</field>
         <field name="size">20</field>
         <field name="alignment">left</field>
     </record>

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2018_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2018_data.xml
@@ -92,7 +92,7 @@
         <field name="export_config_id" ref="aeat_mod303_2018_sub01_export_config"/>
         <field name="name">Identificación: Nombre</field>
         <field name="expression">${object.company_id.name}</field>
-        <field name="export_type">string</field>
+        <field name="export_type">alphabetic</field>
         <field name="size">20</field>
         <field name="alignment">left</field>
     </record>


### PR DESCRIPTION
Solución para #717 .

- Agregamos nuevo formato `_format_alphabetic_string` que elimina los números.
- Añadimos nuevo `export_type` `alphabetic`.
- Modificamos la configuración del exportador del modelo 303 para añadir el nuevo `export_type`.