### PR TITLE
[11.0] [l10n_es_mis_report_kpi] Plantillas MIS Builder para análisis contable español

### DIFF
--- a/l10n_es_mis_report/data/mis_report_styles.xml
+++ b/l10n_es_mis_report/data/mis_report_styles.xml
@@ -118,5 +118,10 @@
       <field name="hide_empty" eval="0"/>
     </record>
 
+    <record id="mis_report_style_l10n_es_hide" model="mis.report.style">
+      <field name="name">l10n_es hide</field>
+      <field name="hide_always" eval="True"/>
+    </record>
+
   </data>
 </odoo>

--- a/l10n_es_mis_report_kpi/README.rst
+++ b/l10n_es_mis_report_kpi/README.rst
@@ -1,0 +1,95 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=====================================================
+Plantillas MIS Builder para análisis contable español
+=====================================================
+
+Incluye las siguientes plantillas para el motor de informes provisto
+por el módulo *mis_builder*:
+
+    * Ratios de Balance PYMEs (PGCE 2008)
+    * Ratios Cuenta de pérdidas y ganancias PYMEs (PGCE 2008)
+    * Ratios de Balance abreviado (PGCE 2008)
+    * Ratios de Cuenta de pérdidas y ganancias abreviado (PGCE 2008)
+    * Ratios Balance normal (PGCE 2008)
+    * Ratios de Cuenta de pérdidas y ganancias completo (PGCE 2008)
+
+Instalación
+===========
+Este módulo depende del módulo 'mis_builder' que puede obtenerse
+en https://apps.odoo.com, o bien en https://github.com/OCA/mis-builder.
+
+Uso
+===
+
+#. Acceda a *Contabilidad > Informes > MIS > Informes MIS*
+#. Cree un nuevo informe,
+#. Seleccione una de las plantillas que se corresponde con los informes
+   financieros españoles.
+#. Desmarque la opción de evitar auto-expansión de cuentas si desea que
+   se oculten las cuentas contables y se muestren solamente los niveles
+   predefinidos por el formato oficial.
+#. Para seleccionar los periodos puede:
+
+   * Seleccionar directamente el intervalo de fechas deseado o el nombre del
+     rango para obtener el informe únicamente para ese periodo.
+   * Pulsar sobre "Modo de comparación", e introducir en la pestaña "Columnas"
+     tantas líneas como distintas periodos se quieran poner. Dichos periodos
+     se pueden definir también con fechas fijas, o poner periodos relativos
+     (por ejemplo "Tipo de periodo" = "Año", "Desplazamiento" = "0" y
+     "Duración" = "1" para el año N, y lo mismo pero con "Desplazamiento" =
+     "-1" para el año N - 1. No hay que olvidar que la fecha base del informe
+     esté en el año a analizar).
+
+#. Pulse sobre "Previsualizar", "Imprimir" o "Exportar" para calcular el
+   informe y realizar la acción pulsada.
+#. Si está en modo previsualización, podrá pulsar sobre la cifra de las
+   filas detalle para ver los apuntes relacionados con dicha cifra.
+
+*AVISO*: El informe solamente considera las cuentas numeradas de acuerdo con el
+formato establecido por el PGCE. Cualquier cuenta personalizada que no sea
+subcuenta (tenga la misma , deberá ser
+añadida
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/119/11.0
+
+
+Incidencias
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/l10n-spain/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and
+welcomed feedback `here <https://github.com/OCA/l10n-spain/issues/new>`_.
+
+Créditos
+========
+
+Contribuidores
+--------------
+
+* Jordi Ballester (EFICENT) <jordi.ballester@eficent.com>
+* Aarón Henríquez (EFICENT) <ahenriquez@eficent.com>
+* Albert Cabedo (GAFIC) <albert@gafic.com>
+* Antonio Cánovas Pedreño (INGENIERÍA CLOUD) <antonio.canovas@ingenieriacloud.com>
+* Antonio Cánovas Pedreño (INGENIERÍA CLOUD) <antonio.canovas@ingenieriacloud.com>
+
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/l10n_es_mis_report_kpi/__manifest__.py
+++ b/l10n_es_mis_report_kpi/__manifest__.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+#                <contact@eficent.com>
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl
+
+{
+    'name': 'Plantillas MIS Builder para análisis contable español',
+    'summary': """
+        Plantillas MIS Builder para análisis contable español""",
+    'author': 'Eficent,'
+              'Gafic,'
+              'Ingeniería Cloud,'
+              'Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/l10n-spain',
+    'category': 'Reporting',
+    'version': '11.0.1.0.0',
+    'license': 'AGPL-3',
+    'depends': [
+        # OCA/mis-builder
+        'mis_builder',
+        'mis_builder_budget',
+        'l10n_es_mis_report',
+    ],
+    'data': [
+        'data/mis_report_styles.xml',
+        'data/mis_report_balance_abreviated.xml',
+        'data/mis_report_balance_normal.xml',
+        'data/mis_report_balance_sme.xml',
+        'data/mis_report_balance_abreviated_ratios.xml',
+        'data/mis_report_balance_normal_ratios.xml',
+        'data/mis_report_balance_sme_ratios.xml',
+        'data/mis_report_pyg_abreviated.xml',
+        'data/mis_report_pyg_normal.xml',
+        'data/mis_report_pyg_sme.xml',
+        'data/mis_report_pyg_abreviated_ratios.xml',
+        'data/mis_report_pyg_normal_ratios.xml',
+        'data/mis_report_pyg_sme_ratios.xml',
+    ],
+    'installable': True,
+}

--- a/l10n_es_mis_report_kpi/data/mis_report_balance_abreviated.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_balance_abreviated.xml
@@ -1,0 +1,754 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+   <data>
+      <record id="mis_report_es_balance_abreviado" model="mis.report">
+         <field name="name">Balance abreviado (PGCE 2008)</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_base"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_11000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">10</field>
+         <field name="name">es11000</field>
+         <field name="description">A) ACTIVO NO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es11100 +es11200 +es11300 +es11400 +es11500 +es11600 +es11700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_11100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">20</field>
+         <field name="name">es11100</field>
+         <field name="description">I. Inmovilizado intangible</field>
+         <field name="expression">+bale[20%,280%,290%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_11200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">30</field>
+         <field name="name">es11200</field>
+         <field name="description">II. Inmovilizado material </field>
+         <field name="expression">+bale[21%,281%,291%,23%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_11300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">40</field>
+         <field name="name">es11300</field>
+         <field name="description">III. Inversiones inmobiliarias</field>
+         <field name="expression">+bale[22%,282%,292%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_11400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">50</field>
+         <field name="name">es11400</field>
+         <field name="description">IV. Inversiones en empresas del grupo y asociadas a largo plazo</field>
+         <field name="expression">+bale[2403%,2404%,2413%,2414%,2423%,2424%,2493%,2494%,293%,2943%,2944%,2953%,2954%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_11500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">60</field>
+         <field name="name">es11500</field>
+         <field name="description">V. Inversiones financieras a largo plazo</field>
+         <field name="expression">+bale[2405%,2415%,2425%,2495%,250%,251%,252%,253%,254%,255%,257%,258%,259%,26%,2945%,2955%,297%,298%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_11600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">70</field>
+         <field name="name">es11600</field>
+         <field name="description">VI. Activos por impuesto diferido</field>
+         <field name="expression">+bale[474%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_11700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">80</field>
+         <field name="name">es11700</field>
+         <field name="description">VII. Deudores comerciales no corrientes</field>
+         <field name="expression">+bale[11700%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">90</field>
+         <field name="name">es12000</field>
+         <field name="description">B) ACTIVO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es12100 +es12200 +es12300 +es12400 +es12500 +es12600 +es12700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">100</field>
+         <field name="name">es12100</field>
+         <field name="description">I. Activos no corrientes mantenidos para la venta</field>
+         <field name="expression">+bale[580%,581%,582%,583%,584%,599%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">110</field>
+         <field name="name">es12200</field>
+         <field name="description">II. Existencias</field>
+         <field name="expression">+bale[30%,31%,32%,33%,34%,35%,36%,39%,407%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">120</field>
+         <field name="name">es12300</field>
+         <field name="description">III. Deudores comerciales y otras cuentas a cobrar</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es12380 +es12370 +es12390</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12380" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">130</field>
+         <field name="name">es12380</field>
+         <field name="description">1. Clientes por ventas y prestaciones de servicios</field>
+         <field name="expression">+bale[430%,431%,432%,433%,434%,435%,436%,437%,490%,493%] +es12381 +es12382</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12381" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">140</field>
+         <field name="name">es12381</field>
+         <field name="description">a) Clientes por ventas y prestaciones de servicios a largo plazo</field>
+         <field name="expression">+bale[12381%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12382" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">150</field>
+         <field name="name">es12382</field>
+         <field name="description">b) Clientes por ventas y prestaciones de servicios a corto plazo</field>
+         <field name="expression">+bale[12382%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12370" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">160</field>
+         <field name="name">es12370</field>
+         <field name="description">2. Accionistas (socios) por desembolsos exigidos</field>
+         <field name="expression">+bale[5580%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12390" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">170</field>
+         <field name="name">es12390</field>
+         <field name="description">3. Otros deudores</field>
+         <field name="expression">+bale[44%,460%,470%,471%,472%,5531%,5533%,544%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">180</field>
+         <field name="name">es12400</field>
+         <field name="description">IV. Inversiones en empresas del grupo y asociadas a corto plazo</field>
+         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,593%,5943%,5944%,5953%,5954%] + pbale[5523%] + pbale[5524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">190</field>
+         <field name="name">es12500</field>
+         <field name="description">V. Inversiones financieras a corto plazo</field>
+         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,5593%,565%,566%,5945%,5955%,597%,598%] + pbale[551%] + pbale[5525%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">200</field>
+         <field name="name">es12600</field>
+         <field name="description">VI. Periodificaciones a corto plazo</field>
+         <field name="expression">+bale[480%,567%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_12700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">210</field>
+         <field name="name">es12700</field>
+         <field name="description">VII. Efectivo y otros activos líquidos equivalentes</field>
+         <field name="expression">+bale[57%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_10000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">220</field>
+         <field name="name">es10000</field>
+         <field name="description">TOTAL ACTIVO (A + B)</field>
+         <field name="expression">+es11000+es12000</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_20000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">230</field>
+         <field name="name">es20000</field>
+         <field name="description">A) PATRIMONIO NETO</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21000 +es22000 +es23000</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">240</field>
+         <field name="name">es21000</field>
+         <field name="description">A-1) Fondos propios</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21100 +es21200 +es21300 +es21400 +es21500 +es21600 +es21700 +es21800 +es21900</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">250</field>
+         <field name="name">es21100</field>
+         <field name="description">I. Capital</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21110 +es21120</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21110" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">260</field>
+         <field name="name">es21110</field>
+         <field name="description">1. Capital escriturado</field>
+         <field name="expression">-bale[100%,101%,102%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21120" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">270</field>
+         <field name="name">es21120</field>
+         <field name="description">2. (Capital no exigido) </field>
+         <field name="expression">-bale[1030%,1040%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">280</field>
+         <field name="name">es21200</field>
+         <field name="description">II. Prima de emisión</field>
+         <field name="expression">-bale[110%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">290</field>
+         <field name="name">es21300</field>
+         <field name="description">III. Reservas</field>
+         <field name="expression">-bale[112%,113%,114%,115%,119%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">300</field>
+         <field name="name">es21400</field>
+         <field name="description">IV. (Acciones y participaciones en patrimonio propias)</field>
+         <field name="expression">-bale[108%,109%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">310</field>
+         <field name="name">es21500</field>
+         <field name="description">V. Resultados de ejercicios anteriores </field>
+         <field name="expression">-bale[120%,121%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">320</field>
+         <field name="name">es21600</field>
+         <field name="description">VI. Otras aportaciones de socios</field>
+         <field name="expression">-bale[118%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">330</field>
+         <field name="name">es21700</field>
+         <field name="description">VII. Resultado del ejercicio</field>
+         <field name="expression">-bale[129%,6%,7%]-balu[6%,7%]</field>
+         <field name="auto_expand_accounts">False</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21800" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">340</field>
+         <field name="name">es21800</field>
+         <field name="description">VIII. (Dividendo a cuenta)</field>
+         <field name="expression">-bale[557%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_21900" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">350</field>
+         <field name="name">es21900</field>
+         <field name="description">IX. Otros instrumentos de patrimonio neto</field>
+         <field name="expression">-bale[111%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_22000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">360</field>
+         <field name="name">es22000</field>
+         <field name="description">A-2) Ajustes por cambios de valor</field>
+         <field name="expression">-bale[133%,1340%,137%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_23000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">370</field>
+         <field name="name">es23000</field>
+         <field name="description">A-3) Subvenciones, donaciones y legados recibidos</field>
+         <field name="expression">-bale[130%,131%,132%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">380</field>
+         <field name="name">es31000</field>
+         <field name="description">B) PASIVO NO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es31100 +es31200 +es31300 +es31400 +es31500 +es31600 +es31700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">390</field>
+         <field name="name">es31100</field>
+         <field name="description">I. Provisiones a largo plazo</field>
+         <field name="expression">-bale[14%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">400</field>
+         <field name="name">es31200</field>
+         <field name="description">II. Deudas a largo plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es31220 +es31230 +es31290</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31220" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">410</field>
+         <field name="name">es31220</field>
+         <field name="description">1. Deudas con entidades de crédito</field>
+         <field name="expression">-bale[1605%,170%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31230" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">420</field>
+         <field name="name">es31230</field>
+         <field name="description">2. Acreedores por arrendamiento financiero</field>
+         <field name="expression">-bale[1625%,174%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31290" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">430</field>
+         <field name="name">es31290</field>
+         <field name="description">3. Otras deudas a largo plazo</field>
+         <field name="expression">-bale[1615%,1635%,171%,172%,173%,175%,176%,177%,178%,179%,180%,185%,189%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">440</field>
+         <field name="name">es31300</field>
+         <field name="description">III. Deudas con empresas del grupo y asociadas a largo plazo</field>
+         <field name="expression">-bale[1603%,1604%,1613%,1614%,1623%,1624%,1633%,1634%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">450</field>
+         <field name="name">es31400</field>
+         <field name="description">IV. Pasivos por impuesto diferido</field>
+         <field name="expression">-bale[479%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">460</field>
+         <field name="name">es31500</field>
+         <field name="description">V. Periodificaciones a largo plazo</field>
+         <field name="expression">-bale[181%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">470</field>
+         <field name="name">es31600</field>
+         <field name="description">VI. Acreedores comerciales no corrientes</field>
+         <field name="expression">-bale[31600%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_31700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">480</field>
+         <field name="name">es31700</field>
+         <field name="description">VII. Deuda con características especiales a largo plazo</field>
+         <field name="expression">-bale[15%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">490</field>
+         <field name="name">es32000</field>
+         <field name="description">C) PASIVO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es32100 +es32200 +es32300 +es32400 +es32500 +es32600 +es32700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">500</field>
+         <field name="name">es32100</field>
+         <field name="description">I. Pasivos vinculados con activos no corrientes mantenidos para la venta</field>
+         <field name="expression">-bale[585%,586%,587%,588%,589%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">510</field>
+         <field name="name">es32200</field>
+         <field name="description">II. Provisiones a corto plazo</field>
+         <field name="expression">-bale[499%,529%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">520</field>
+         <field name="name">es32300</field>
+         <field name="description">III. Deudas a corto plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es32320 +es32330 +es32390</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32320" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">530</field>
+         <field name="name">es32320</field>
+         <field name="description">1. Deudas con entidades de crédito</field>
+         <field name="expression">-bale[5105%,520%,527%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32330" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">540</field>
+         <field name="name">es32330</field>
+         <field name="description">2. Acreedores por arrendamiento financiero</field>
+         <field name="expression">-bale[5125%,524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32390" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">550</field>
+         <field name="name">es32390</field>
+         <field name="description">3. Otras deudas a corto plazo</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,501%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,5595%,5598%,560%,561%,569%] - nbale[551%] - nbale[5525%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">560</field>
+         <field name="name">es32400</field>
+         <field name="description">IV. Deudas con empresas del grupo y asociadas a corto plazo</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%] - nbale[5523%] - nbale[5524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">570</field>
+         <field name="name">es32500</field>
+         <field name="description">V. Acreedores comerciales y otras cuentas a pagar</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es32580 +es32590</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32580" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">580</field>
+         <field name="name">es32580</field>
+         <field name="description">1. Proveedores</field>
+         <field name="expression">-bale[400%,401%,403%,404%,405%,406%] +es32581 +es32582</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32581" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">590</field>
+         <field name="name">es32581</field>
+         <field name="description">a) Proveedores a largo plazo</field>
+         <field name="expression">-bale[32581%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32582" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">600</field>
+         <field name="name">es32582</field>
+         <field name="description">b) Proveedores a corto plazo</field>
+         <field name="expression">-bale[32582%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32590" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">610</field>
+         <field name="name">es32590</field>
+         <field name="description">2. Otros acreedores</field>
+         <field name="expression">-bale[41%,438%,465%,466%,475%,476%,477%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">620</field>
+         <field name="name">es32600</field>
+         <field name="description">VI. Periodificaciones a corto plazo</field>
+         <field name="expression">-bale[485%,568%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_32700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">630</field>
+         <field name="name">es32700</field>
+         <field name="description">VII. Deuda con características especiales a corto plazo</field>
+         <field name="expression">-bale[502%,507%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_abreviado_30000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">640</field>
+         <field name="name">es30000</field>
+         <field name="description">TOTAL PATRIMONIO NETO Y PASIVO (A + B + C)</field>
+         <field name="expression">+es20000+es31000+es32000</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+   </data>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_balance_abreviated_ratios.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_balance_abreviated_ratios.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+      <record id="l10n_es_mis_report_kpi.mis_report_es_balance_abreviado" model="mis.report">
+         <field name="name">Ratios de balance abreviado (PGCE 2008)</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_liquidez" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">5010</field>
+         <field name="name">ratios_liquidez</field>
+         <field name="description">1) RATIOS DE LIQUIDEZ</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_liquidez" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5020</field>
+         <field name="name">ratio_liquidez</field>
+         <field name="description">Ratio de liquidez</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> es12000 / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_disponibilidad" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5030</field>
+         <field name="name">ratio_disponibilidad</field>
+         <field name="description">Ratio de disponibilidad</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> es12700 / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_tesoreria" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5040</field>
+         <field name="name">ratio_tesoreria</field>
+         <field name="description">Ratio de tesorería</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12300+ es12700) / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5050</field>
+         <field name="name">ratio_endeudamiento</field>
+         <field name="description">Ratio de endeudamiento</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000+es31000) / (es20000 + es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_autonomia" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5060</field>
+         <field name="name">ratio_autonomia</field>
+         <field name="description">Ratio de autonomía</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es21000 / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_activo)" model="mis.report.kpi">
+          <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+          <field name="type">num</field>
+          <field name="compare_method">pct</field>
+          <field name="sequence">5070</field>
+          <field name="name">ratio_fondo_maniobra_activo</field>
+          <field name="description">Ratio de fondo de maniobra sobre activo</field>
+          <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+          <field name="expression">(es12000-es32000) / es10000</field>
+          <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_corto)" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5080</field>
+         <field name="name">ratio_fondo_maniobra_deuda_corto</field>
+         <field name="description">Ratio de fondo de maniobra sobre deudas a corto plazo</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000) / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5090</field>
+         <field name="name">ratio_fondo_maniobra</field>
+         <field name="description">Fondo de maniobra</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es12000-es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5100</field>
+         <field name="name">ratio_fondo_maniobra_ventas</field>
+         <field name="description">Fondo de maniobra sobre ventas</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000)/balp[70%]</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_activo_corriente_circulante" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5110</field>
+         <field name="name">ratio_fondo_maniobra_activo_corriente_circulante</field>
+         <field name="description">Fondo de maniobra sobre activo corriente o circulante</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000) / es12000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">6000</field>
+         <field name="name">ratios_endeudamiento</field>
+         <field name="description">2) RATIOS DE ENDEUDAMIENTO</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6010</field>
+         <field name="name">ratio_endeudamiento</field>
+         <field name="description">Ratio de endeudamiento</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000+es31000) / (es20000 + es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_autonomia" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6020</field>
+         <field name="name">ratio_autonomia</field>
+         <field name="description">Ratio de autonomía</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es21000 / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_calidad_deuda" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6030</field>
+         <field name="name">ratio_calidad_deuda</field>
+         <field name="description">Ratio de calidad de la deuda</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000 / es30000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_peso_recursos_permanentes" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6040</field>
+         <field name="name">peso_recursos_permanentes</field>
+         <field name="description">Peso de los recursos permanentes</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es20000+es31000) / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_rotacion_activos" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">7000</field>
+         <field name="name">ratios_rotacion_activos</field>
+         <field name="description">3) RATIOS DE ROTACIÓN DE ACTIVOS</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_rotacion_activo_no_corriente" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">7010</field>
+         <field name="name">ratio_rotacion_activo_no_corriente</field>
+         <field name="description">Rotación del activo no corriente</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">balp[70%] / es11000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_es_balance_abreviado_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">4000</field>
+         <field name="name">ventas</field>
+         <field name="description">Ventas</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> balp[700%,701%,702%,703%,704%,706%,708%,709%]</field>
+      </record>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_balance_normal.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_balance_normal.xml
@@ -1,0 +1,1607 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+   <data>
+      <record id="mis_report_es_balance_normal" model="mis.report">
+         <field name="name">Ratios para el Balance completo (PGCE 2008)</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_base"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">10</field>
+         <field name="name">es11000</field>
+         <field name="description">A) ACTIVO NO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es11100 +es11200 +es11300 +es11400 +es11500 +es11600 +es11700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">20</field>
+         <field name="name">es11100</field>
+         <field name="description">I. Inmovilizado intangible</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es11110 +es11120 +es11130 +es11140 +es11150 +es11160 +es11170</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11110" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">30</field>
+         <field name="name">es11110</field>
+         <field name="description">1. Desarrollo</field>
+         <field name="expression">+bale[201%,2801%,2901%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11120" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">40</field>
+         <field name="name">es11120</field>
+         <field name="description">2. Concesiones</field>
+         <field name="expression">+bale[202%,2802%,2902%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11130" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">50</field>
+         <field name="name">es11130</field>
+         <field name="description">3. Patentes, licencias, marcas y similares</field>
+         <field name="expression">+bale[203%,2803%,2903%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11140" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">60</field>
+         <field name="name">es11140</field>
+         <field name="description">4. Fondo de comercio</field>
+         <field name="expression">+bale[204%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11150" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">70</field>
+         <field name="name">es11150</field>
+         <field name="description">5. Aplicaciones informáticas</field>
+         <field name="expression">+bale[206%,2806%,2906%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11160" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">80</field>
+         <field name="name">es11160</field>
+         <field name="description">6. Investigación</field>
+         <field name="expression">+bale[200%,2800%,2900%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11170" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">90</field>
+         <field name="name">es11170</field>
+         <field name="description">7. Otro inmovilizado intangible</field>
+         <field name="expression">+bale[205%,209%,2805%,2905%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">100</field>
+         <field name="name">es11200</field>
+         <field name="description">II. Inmovilizado material</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es11210 +es11220 +es11230</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11210" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">110</field>
+         <field name="name">es11210</field>
+         <field name="description">1. Terrenos y construcciones</field>
+         <field name="expression">+bale[210%,211%,2811%,2910%,2911%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11220" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">120</field>
+         <field name="name">es11220</field>
+         <field name="description">2. Instalaciones técnicas y otro inmovilizado material</field>
+         <field name="expression">+bale[212%,213%,214%,215%,216%,217%,218%,219%,2812%,2813%,2814%,2815%,2816%,2817%,2818%,2819%,2912%,2913%,2914%,2915%,2916%,2917%,2918%,2919%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11230" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">130</field>
+         <field name="name">es11230</field>
+         <field name="description">3. Inmovilizado en curso y anticipos</field>
+         <field name="expression">+bale[23%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">140</field>
+         <field name="name">es11300</field>
+         <field name="description">III. Inversiones inmobiliarias</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es11310 +es11320</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11310" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">150</field>
+         <field name="name">es11310</field>
+         <field name="description">1. Terrenos</field>
+         <field name="expression">+bale[220%,2920%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11320" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">160</field>
+         <field name="name">es11320</field>
+         <field name="description">2. Construcciones</field>
+         <field name="expression">+bale[221%,282%,2921%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">170</field>
+         <field name="name">es11400</field>
+         <field name="description">IV. Inversiones en empresas del grupo y asociadas a largo plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es11410 +es11420 +es11430 +es11440 +es11450 +es11460</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11410" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">180</field>
+         <field name="name">es11410</field>
+         <field name="description">1. Instrumentos de patrimonio</field>
+         <field name="expression">+bale[2403%,2404%,2493%,2494%,293%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11420" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">190</field>
+         <field name="name">es11420</field>
+         <field name="description">2. Créditos a empresas</field>
+         <field name="expression">+bale[2423%,2424%,2953%,2954%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11430" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">200</field>
+         <field name="name">es11430</field>
+         <field name="description">3. Valores representativos de deuda</field>
+         <field name="expression">+bale[2413%,2414%,2943%,2944%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11440" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">210</field>
+         <field name="name">es11440</field>
+         <field name="description">4. Derivados</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11450" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">220</field>
+         <field name="name">es11450</field>
+         <field name="description">5. Otros activos financieros</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11460" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">230</field>
+         <field name="name">es11460</field>
+         <field name="description">6. Otras inversiones</field>
+         <field name="expression">+bale[11460%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">240</field>
+         <field name="name">es11500</field>
+         <field name="description">V. Inversiones financieras a largo plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es11510 +es11520 +es11530 +es11540 +es11550 +es11560</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11510" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">250</field>
+         <field name="name">es11510</field>
+         <field name="description">1. Instrumentos de patrimonio</field>
+         <field name="expression">+bale[2405%,2495%,250%,259%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11520" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">260</field>
+         <field name="name">es11520</field>
+         <field name="description">2. Créditos a terceros</field>
+         <field name="expression">+bale[2425%,252%,253%,254%,2955%,298%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11530" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">270</field>
+         <field name="name">es11530</field>
+         <field name="description">3. Valores representativos de deuda</field>
+         <field name="expression">+bale[2415%,251%,2945%,297%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11540" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">280</field>
+         <field name="name">es11540</field>
+         <field name="description">4. Derivados</field>
+         <field name="expression">+bale[255%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11550" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">290</field>
+         <field name="name">es11550</field>
+         <field name="description">5. Otros activos financieros</field>
+         <field name="expression">+bale[258%,26%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11560" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">300</field>
+         <field name="name">es11560</field>
+         <field name="description">6. Otras inversiones</field>
+         <field name="expression">+bale[257%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">310</field>
+         <field name="name">es11600</field>
+         <field name="description">VI. Activos por impuesto diferido</field>
+         <field name="expression">+bale[474%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_11700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">320</field>
+         <field name="name">es11700</field>
+         <field name="description">VII. Deudas comerciales no corrientes</field>
+         <field name="expression">+bale[11700%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">330</field>
+         <field name="name">es12000</field>
+         <field name="description">B) ACTIVO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es12100 +es12200 +es12300 +es12400 +es12500 +es12600 +es12700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">340</field>
+         <field name="name">es12100</field>
+         <field name="description">I. Activos no corrientes mantenidos para la venta*</field>
+         <field name="expression">+bale[580%,581%,582%,583%,584%,599%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">350</field>
+         <field name="name">es12200</field>
+         <field name="description">II. Existencias</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es12210 +es12220 +es12230 +es12240 +es12250 +es12260</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12210" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">360</field>
+         <field name="name">es12210</field>
+         <field name="description">1. Comerciales</field>
+         <field name="expression">+bale[30%,390%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12220" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">370</field>
+         <field name="name">es12220</field>
+         <field name="description">2. Materias primas y otros aprovisionamientos</field>
+         <field name="expression">+bale[31%,32%,391%,392%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12230" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">380</field>
+         <field name="name">es12230</field>
+         <field name="description">3. Productos en curso</field>
+         <field name="expression">+bale[33%,34%,393%,394%] +es12231 +es12232</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12231" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">390</field>
+         <field name="name">es12231</field>
+         <field name="description">a) De ciclo largo de produccción</field>
+         <field name="expression">+bale[12231%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12232" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">400</field>
+         <field name="name">es12232</field>
+         <field name="description">b) De ciclo corto de producción</field>
+         <field name="expression">+bale[12232%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12240" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">410</field>
+         <field name="name">es12240</field>
+         <field name="description">4. Productos terminados</field>
+         <field name="expression">+bale[35%,395%] +es12241 +es12242</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12241" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">420</field>
+         <field name="name">es12241</field>
+         <field name="description">a) De ciclo largo de produccción</field>
+         <field name="expression">+bale[12241%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12242" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">430</field>
+         <field name="name">es12242</field>
+         <field name="description">b) De ciclo corto de producción</field>
+         <field name="expression">+bale[12242%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12250" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">440</field>
+         <field name="name">es12250</field>
+         <field name="description">5. Subproductos, residuos y materiales recuperados</field>
+         <field name="expression">+bale[36%,396%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12260" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">450</field>
+         <field name="name">es12260</field>
+         <field name="description">6. Anticipos a proveedores</field>
+         <field name="expression">+bale[407%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">460</field>
+         <field name="name">es12300</field>
+         <field name="description">III. Deudores comerciales y otras cuentas a cobrar</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es12310 +es12320 +es12330 +es12340 +es12350 +es12360 +es12370</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12310" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">470</field>
+         <field name="name">es12310</field>
+         <field name="description">1. Clientes por ventas y prestaciones de servicios</field>
+         <field name="expression">+bale[430%,431%,432%,435%,436%,437%,490%,4935%] +es12311 +es12312</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12311" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">480</field>
+         <field name="name">es12311</field>
+         <field name="description">a) Clientes por ventas y prestaciones de servicios a largo plazo</field>
+         <field name="expression">+bale[12311%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12312" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">490</field>
+         <field name="name">es12312</field>
+         <field name="description">b) Clientes por ventas y prestaciones de servicios a corto plazo</field>
+         <field name="expression">+bale[12312%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12320" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">500</field>
+         <field name="name">es12320</field>
+         <field name="description">2. Clientes empresas del grupo y asociadas</field>
+         <field name="expression">+bale[433%,434%,4933%,4934%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12330" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">510</field>
+         <field name="name">es12330</field>
+         <field name="description">3. Deudores varios</field>
+         <field name="expression">+bale[44%,5531%,5533%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12340" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">520</field>
+         <field name="name">es12340</field>
+         <field name="description">4. Personal</field>
+         <field name="expression">+bale[460%,544%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12350" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">530</field>
+         <field name="name">es12350</field>
+         <field name="description">5. Activos por impuesto corriente</field>
+         <field name="expression">+bale[4709%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12360" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">540</field>
+         <field name="name">es12360</field>
+         <field name="description">6. Otros créditos con las Administraciones Públicas</field>
+         <field name="expression">+bale[4700%,4708%,471%,472%,473%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12370" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">550</field>
+         <field name="name">es12370</field>
+         <field name="description">7. Accionistas (socios) por desembolsos exigidos</field>
+         <field name="expression">+bale[5580%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">560</field>
+         <field name="name">es12400</field>
+         <field name="description">IV. Inversiones en empresas del grupo y asociadas a corto plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es12410 +es12420 +es12430 +es12440 +es12450 +es12460</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12410" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">570</field>
+         <field name="name">es12410</field>
+         <field name="description">1. Instrumentos de patrimonio</field>
+         <field name="expression">+bale[5303%,5304%,5393%,5394%,593%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12420" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">580</field>
+         <field name="name">es12420</field>
+         <field name="description">2. Créditos a empresas</field>
+         <field name="expression">+bale[5323%,5324%,5343%,5344%,5953%,5954%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12430" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">590</field>
+         <field name="name">es12430</field>
+         <field name="description">3. Valores representativos de deuda</field>
+         <field name="expression">+bale[5313%,5314%,5333%,5334%,5943%,5944%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12440" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">600</field>
+         <field name="name">es12440</field>
+         <field name="description">4. Derivados</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12450" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">610</field>
+         <field name="name">es12450</field>
+         <field name="description">5. Otros activos financieros</field>
+         <field name="expression">+bale[5353%,5354%] + pbale[5523%] + pbale[5524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12460" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">620</field>
+         <field name="name">es12460</field>
+         <field name="description">6. Otras inversiones</field>
+         <field name="expression">+bale[12460%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">630</field>
+         <field name="name">es12500</field>
+         <field name="description">V. Inversiones financieras a corto plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es12510 +es12520 +es12530 +es12540 +es12550 +es12560</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12510" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">640</field>
+         <field name="name">es12510</field>
+         <field name="description">1. Instrumentos de patrimonio</field>
+         <field name="expression">+bale[5305%,540%,5395%,549%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12520" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">650</field>
+         <field name="name">es12520</field>
+         <field name="description">2. Créditos a empresas</field>
+         <field name="expression">+bale[5325%,5345%,542%,543%,547%,5955%,598%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12530" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">660</field>
+         <field name="name">es12530</field>
+         <field name="description">3. Valores representativos de deuda</field>
+         <field name="expression">+bale[5315%,5335%,541%,546%,5945%,597%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12540" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">670</field>
+         <field name="name">es12540</field>
+         <field name="description">4. Derivados</field>
+         <field name="expression">+bale[5590%,5593%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12550" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">680</field>
+         <field name="name">es12550</field>
+         <field name="description">5. Otros activos financieros</field>
+         <field name="expression">+bale[5355%,545%,548%,565%,566%] + pbale[550%] + pbale[551%] + pbale[554%] + pbale[5525%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12560" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">690</field>
+         <field name="name">es12560</field>
+         <field name="description">6. Otras inversiones</field>
+         <field name="expression">+bale[12560%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">700</field>
+         <field name="name">es12600</field>
+         <field name="description">VI. Periodificaciones a corto plazo</field>
+         <field name="expression">+bale[480%,567%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">710</field>
+         <field name="name">es12700</field>
+         <field name="description">VII. Efectivo y otros activos líquidos equivalentes</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es12710 +es12720</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12710" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">720</field>
+         <field name="name">es12710</field>
+         <field name="description">1. Tesorería</field>
+         <field name="expression">+bale[570%,571%,572%,573%,574%,575%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_12720" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">730</field>
+         <field name="name">es12720</field>
+         <field name="description">2. Otros activos líquidos equivalentes</field>
+         <field name="expression">+bale[576%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_10000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">740</field>
+         <field name="name">es10000</field>
+         <field name="description">TOTAL ACTIVO (A + B)</field>
+         <field name="expression">+es11000+es12000</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_20000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">750</field>
+         <field name="name">es20000</field>
+         <field name="description">A) PATRIMONIO NETO</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21000 +es22000 +es23000</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">760</field>
+         <field name="name">es21000</field>
+         <field name="description">A-1) Fondos propios</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21100 +es21200 +es21300 +es21400 +es21500 +es21600 +es21700 +es21800 +es21900</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">770</field>
+         <field name="name">es21100</field>
+         <field name="description">I. Capital</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21110 +es21120</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21110" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">780</field>
+         <field name="name">es21110</field>
+         <field name="description">1. Capital escriturado</field>
+         <field name="expression">-bale[100%,101%,102%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21120" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">790</field>
+         <field name="name">es21120</field>
+         <field name="description">2. (Capital no exigido) </field>
+         <field name="expression">-bale[1030%,1040%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">800</field>
+         <field name="name">es21200</field>
+         <field name="description">II. Prima de emisión</field>
+         <field name="expression">-bale[110%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">810</field>
+         <field name="name">es21300</field>
+         <field name="description">III. Reservas</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21310 +es21320</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21310" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">820</field>
+         <field name="name">es21310</field>
+         <field name="description">1. Legal y estatutarias</field>
+         <field name="expression">-bale[112%,1141%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21320" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">830</field>
+         <field name="name">es21320</field>
+         <field name="description">2. Otras reservas</field>
+         <field name="expression">-bale[113%,1140%,1142%,1143%,1144%,115%,119%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">840</field>
+         <field name="name">es21400</field>
+         <field name="description">IV. (Acciones y participaciones en patrimonio propias)</field>
+         <field name="expression">-bale[108%,109%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">850</field>
+         <field name="name">es21500</field>
+         <field name="description">V. Resultados de ejercicios anteriores</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21510 +es21520</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21510" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">860</field>
+         <field name="name">es21510</field>
+         <field name="description">1. Remanente</field>
+         <field name="expression">-bale[120%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21520" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">870</field>
+         <field name="name">es21520</field>
+         <field name="description">2. (Resultados negativos de ejercicios anteriores)</field>
+         <field name="expression">-bale[121%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">880</field>
+         <field name="name">es21600</field>
+         <field name="description">VI. Otras aportaciones de socios</field>
+         <field name="expression">-bale[118%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">890</field>
+         <field name="name">es21700</field>
+         <field name="description">VII. Resultado del ejercicio</field>
+         <field name="expression">-bale[129%,6%,7%]-balu[6%,7%]</field>
+         <field name="auto_expand_accounts">False</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21800" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">900</field>
+         <field name="name">es21800</field>
+         <field name="description">VIII. (Dividendo a cuenta)</field>
+         <field name="expression">-bale[557%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_21900" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">910</field>
+         <field name="name">es21900</field>
+         <field name="description">IX. Otros instrumentos de patrimonio neto</field>
+         <field name="expression">-bale[111%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_22000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">920</field>
+         <field name="name">es22000</field>
+         <field name="description">A-2) Ajustes por cambios de valor </field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es22100 +es22200 +es22300 +es22400 +es22500</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_22100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">930</field>
+         <field name="name">es22100</field>
+         <field name="description">I. Activos financieros disponibles para la venta</field>
+         <field name="expression">-bale[133%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_22200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">940</field>
+         <field name="name">es22200</field>
+         <field name="description">II. Operaciones de cobertura</field>
+         <field name="expression">-bale[1340%,1341%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_22300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">950</field>
+         <field name="name">es22300</field>
+         <field name="description">III. Activos no corrientes y pasivos vinculados, mantenidos para la venta</field>
+         <field name="expression">-bale[136%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_22400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">960</field>
+         <field name="name">es22400</field>
+         <field name="description">IV. Diferencia de conversión</field>
+         <field name="expression">-bale[135%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_22500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">970</field>
+         <field name="name">es22500</field>
+         <field name="description">V. Otros</field>
+         <field name="expression">-bale[137%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_23000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">980</field>
+         <field name="name">es23000</field>
+         <field name="description">A-3) Subvenciones, donaciones y legados recibidos</field>
+         <field name="expression">-bale[130%,131%,132%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">990</field>
+         <field name="name">es31000</field>
+         <field name="description">B) PASIVO NO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es31100 +es31200 +es31300 +es31400 +es31500 +es31600 +es31700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1000</field>
+         <field name="name">es31100</field>
+         <field name="description">I. Provisiones a largo plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es31110 +es31120 +es31130 +es31140</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31110" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1010</field>
+         <field name="name">es31110</field>
+         <field name="description">1. Obligaciones por prestaciones a largo plazo al personal </field>
+         <field name="expression">-bale[140%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31120" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1020</field>
+         <field name="name">es31120</field>
+         <field name="description">2. Actuaciones medioambientales</field>
+         <field name="expression">-bale[145%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31130" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1030</field>
+         <field name="name">es31130</field>
+         <field name="description">3. Provisiones por reestructuración</field>
+         <field name="expression">-bale[146%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31140" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1040</field>
+         <field name="name">es31140</field>
+         <field name="description">4. Otras provisiones</field>
+         <field name="expression">-bale[141%,142%,143%,147%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1050</field>
+         <field name="name">es31200</field>
+         <field name="description">II. Deudas a largo plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es31210 +es31220 +es31230 +es31240 +es31250</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31210" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1060</field>
+         <field name="name">es31210</field>
+         <field name="description">1. Obligaciones y otros valores negociables</field>
+         <field name="expression">-bale[177%,178%,179%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31220" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1070</field>
+         <field name="name">es31220</field>
+         <field name="description">2. Deudas con entidades de crédito</field>
+         <field name="expression">-bale[1605%,170%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31230" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1080</field>
+         <field name="name">es31230</field>
+         <field name="description">3. Acreedores por arrendamiento financiero</field>
+         <field name="expression">-bale[1625%,174%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31240" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1090</field>
+         <field name="name">es31240</field>
+         <field name="description">4. Derivados</field>
+         <field name="expression">-bale[176%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31250" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1100</field>
+         <field name="name">es31250</field>
+         <field name="description">5. Otros pasivos financieros</field>
+         <field name="expression">-bale[1615%,1635%,171%,172%,173%,175%,180%,185%,189%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1110</field>
+         <field name="name">es31300</field>
+         <field name="description">III. Deudas con empresas del grupo y asociadas a largo plazo</field>
+         <field name="expression">-bale[1603%,1604%,1613%,1614%,1623%,1624%,1633%,1634%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1120</field>
+         <field name="name">es31400</field>
+         <field name="description">IV. Pasivos por impuesto diferido</field>
+         <field name="expression">-bale[479%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1130</field>
+         <field name="name">es31500</field>
+         <field name="description">V. Periodificaciones a largo plazo</field>
+         <field name="expression">-bale[181%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1140</field>
+         <field name="name">es31600</field>
+         <field name="description">VI. Acreedores comerciales no corrientes</field>
+         <field name="expression">-bale[31600%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_31700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1150</field>
+         <field name="name">es31700</field>
+         <field name="description">VII. Deuda con características especiales a largo plazo</field>
+         <field name="expression">-bale[15%,5585%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1160</field>
+         <field name="name">es32000</field>
+         <field name="description">C) PASIVO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es32100 +es32200 +es32300 +es32400 +es32500 +es32600 +es32700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1170</field>
+         <field name="name">es32100</field>
+         <field name="description">I. Pasivos vinculados con activos no corrientes mantenidos para la venta</field>
+         <field name="expression">-bale[585%,586%,587%,588%,589%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1180</field>
+         <field name="name">es32200</field>
+         <field name="description">II. Provisiones a corto plazo</field>
+         <field name="expression">-bale[499%,529%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1190</field>
+         <field name="name">es32300</field>
+         <field name="description">III. Deudas a corto plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es32310 +es32320 +es32330 +es32340 +es32350</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32310" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1200</field>
+         <field name="name">es32310</field>
+         <field name="description">1. Obligaciones y otros valores negociables</field>
+         <field name="expression">-bale[500%,501%,505%,506%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32320" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1210</field>
+         <field name="name">es32320</field>
+         <field name="description">2. Deudas con entidades de crédito</field>
+         <field name="expression">-bale[5105%,520%,527%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32330" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1220</field>
+         <field name="name">es32330</field>
+         <field name="description">3. Acreedores por arrendamiento financiero</field>
+         <field name="expression">-bale[5125%,524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32340" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1230</field>
+         <field name="name">es32340</field>
+         <field name="description">4. Derivados</field>
+         <field name="expression">-bale[5595%,5598%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32350" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1240</field>
+         <field name="name">es32350</field>
+         <field name="description">5. Otros pasivos financieros</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,5530%,5532%,555%,5565%,5566%,560%,561%,569%] - nbale[550%%] - nbale[551%] - nbale[554%] - nbale[5525%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1250</field>
+         <field name="name">es32400</field>
+         <field name="description">IV. Deudas con empresas del grupo y asociadas a corto plazo</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%] - nbale[5523%] - nbale[5524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1260</field>
+         <field name="name">es32500</field>
+         <field name="description">V. Acreedores comerciales y otras cuentas a pagar</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es32510 +es32520 +es32530 +es32540 +es32550 +es32560 +es32570</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32510" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1270</field>
+         <field name="name">es32510</field>
+         <field name="description">1. Proveedores</field>
+         <field name="expression">-bale[400%,401%,405%,406%] +es32511 +es32512</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32511" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1280</field>
+         <field name="name">es32511</field>
+         <field name="description">a) Proveedores a largo plazo</field>
+         <field name="expression">-bale[32511%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32512" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1290</field>
+         <field name="name">es32512</field>
+         <field name="description">b) Proveedores a corto plazo</field>
+         <field name="expression">-bale[32512%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32520" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1300</field>
+         <field name="name">es32520</field>
+         <field name="description">2. Proveedores, empresas del grupo y asociadas</field>
+         <field name="expression">-bale[403%,404%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32530" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1310</field>
+         <field name="name">es32530</field>
+         <field name="description">3. Acreedores varios </field>
+         <field name="expression">-bale[41%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32540" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1320</field>
+         <field name="name">es32540</field>
+         <field name="description">4. Personal (remuneraciones pendientes de pago)</field>
+         <field name="expression">-bale[465%,466%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32550" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1330</field>
+         <field name="name">es32550</field>
+         <field name="description">5. Pasivos por impuesto corriente</field>
+         <field name="expression">-bale[4752%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32560" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1340</field>
+         <field name="name">es32560</field>
+         <field name="description">6. Otras deudas con las Administraciones Públicas</field>
+         <field name="expression">-bale[4750%,4751%,4758%,4759%,476%,477%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32570" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1350</field>
+         <field name="name">es32570</field>
+         <field name="description">7. Anticipos de clientes</field>
+         <field name="expression">-bale[438%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1360</field>
+         <field name="name">es32600</field>
+         <field name="description">VI. Periodificaciones a corto plazo</field>
+         <field name="expression">-bale[485%,568%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_32700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1370</field>
+         <field name="name">es32700</field>
+         <field name="description">VII. Deuda con características especiales a corto plazo</field>
+         <field name="expression">-bale[195%,197%,199%,502%,507%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_normal_30000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">1380</field>
+         <field name="name">es30000</field>
+         <field name="description">TOTAL PATRIMONIO NETO Y PASIVO (A + B + C)</field>
+         <field name="expression">+es20000+es31000+es32000</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+   </data>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_balance_normal_ratios.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_balance_normal_ratios.xml
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+      <record id="l10n_es_mis_report_kpi.mis_report_es_balance_normal" model="mis.report">
+         <field name="name">Ratios de Balance completo (PGCE 2008)</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_base"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_liquidez" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">5010</field>
+         <field name="name">ratios_liquidez</field>
+         <field name="description">1) RATIOS DE LIQUIDEZ</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_liquidez" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5020</field>
+         <field name="name">ratio_liquidez</field>
+         <field name="description">Ratio de liquidez</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> es12000 / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_disponibilidad" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5030</field>
+         <field name="name">ratio_disponibilidad</field>
+         <field name="description">Ratio de disponibilidad</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> es12700 / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_tesoreria" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5040</field>
+         <field name="name">ratio_tesoreria</field>
+         <field name="description">Ratio de tesorería</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12300+ es12700) / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5050</field>
+         <field name="name">ratio_endeudamiento</field>
+         <field name="description">Ratio de endeudamiento</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000+es31000) / (es20000 + es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_autonomia" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5060</field>
+         <field name="name">ratio_autonomia</field>
+         <field name="description">Ratio de autonomía</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es21000 / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_activo)" model="mis.report.kpi">
+          <field name="report_id" ref="mis_report_es_balance_normal"/>
+          <field name="type">num</field>
+          <field name="compare_method">pct</field>
+          <field name="sequence">5070</field>
+          <field name="name">ratio_fondo_maniobra_activo</field>
+          <field name="description">Ratio de fondo de maniobra sobre activo</field>
+          <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+          <field name="expression">(es12000-es32000) / es10000</field>
+          <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_corto)" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5080</field>
+         <field name="name">ratio_fondo_maniobra_deuda_corto</field>
+         <field name="description">Ratio de fondo de maniobra sobre deudas a corto plazo</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000) / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5090</field>
+         <field name="name">ratio_fondo_maniobra</field>
+         <field name="description">Fondo de maniobra</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es12000-es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5100</field>
+         <field name="name">ratio_fondo_maniobra_ventas</field>
+         <field name="description">Fondo de maniobra sobre ventas</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000)/balp[70%]</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_activo_corriente_circulante" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5110</field>
+         <field name="name">ratio_fondo_maniobra_activo_corriente_circulante</field>
+         <field name="description">Fondo de maniobra sobre activo corriente o circulante</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000) / es12000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">6000</field>
+         <field name="name">ratios_endeudamiento</field>
+         <field name="description">2) RATIOS DE ENDEUDAMIENTO</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6010</field>
+         <field name="name">ratio_endeudamiento</field>
+         <field name="description">Ratio de endeudamiento</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000+es31000) / (es20000 + es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_autonomia" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6020</field>
+         <field name="name">ratio_autonomia</field>
+         <field name="description">Ratio de autonomía</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es21000 / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_calidad_deuda" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6030</field>
+         <field name="name">ratio_calidad_deuda</field>
+         <field name="description">Ratio de calidad de la deuda</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000 / es30000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_peso_recursos_permanentes" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6040</field>
+         <field name="name">peso_recursos_permanentes</field>
+         <field name="description">Peso de los recursos permanentes</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es20000+es31000) / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_rotacion_activos" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">7000</field>
+         <field name="name">ratios_rotacion_activos</field>
+         <field name="description">3) RATIOS DE ROTACIÓN DE ACTIVOS</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_rotacion_activo_no_corriente" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">7010</field>
+         <field name="name">ratio_rotacion_activo_no_corriente</field>
+         <field name="description">Rotación del activo no corriente</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">balp[70%] / es11000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_es_balance_pymes_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">4000</field>
+         <field name="name">ventas</field>
+         <field name="description">Ventas</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> balp[700%,701%,702%,703%,704%,706%,708%,709%]</field>
+      </record>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_balance_sme.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_balance_sme.xml
@@ -1,0 +1,706 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+   <data>
+      <record id="mis_report_es_balance_pymes" model="mis.report">
+         <field name="name">Balance PYMEs (PGCE 2008)</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_base"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">10</field>
+         <field name="name">es11000</field>
+         <field name="description">A) ACTIVO NO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es11100 +es11200 +es11300 +es11400 +es11500 +es11600 +es11700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">20</field>
+         <field name="name">es11100</field>
+         <field name="description">I. Inmovilizado intangible</field>
+         <field name="expression">+bale[20%,280%,290%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">30</field>
+         <field name="name">es11200</field>
+         <field name="description">II. Inmovilizado material</field>
+         <field name="expression">+bale[21%,281%,291%,23%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">40</field>
+         <field name="name">es11300</field>
+         <field name="description">III. Inversiones inmobiliarias</field>
+         <field name="expression">+bale[22%,282%,292%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">50</field>
+         <field name="name">es11400</field>
+         <field name="description">IV. Inversiones en empresas del grupo y asociadas a largo plazo</field>
+         <field name="expression">+bale[2403%,2404%,2413%,2414%,2423%,2424%,2493%,2494%,2933%,2934%,2943%,2944%,2953%,2954%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">60</field>
+         <field name="name">es11500</field>
+         <field name="description">V. Inversiones financieras a largo plazo</field>
+         <field name="expression">+bale[2405%,2415%,2425%,2495%,250%,251%,252%,253%,254%,255%,258%,259%,26%,2935%,2945%,2955%,296%,297%,298%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">70</field>
+         <field name="name">es11600</field>
+         <field name="description">VI. Activos por impuesto diferido</field>
+         <field name="expression">+bale[474%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_11700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">80</field>
+         <field name="name">es11700</field>
+         <field name="description">VII. Deudores comerciales no corrientes</field>
+         <field name="expression">+bale[11700%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">90</field>
+         <field name="name">es12000</field>
+         <field name="description">B) ACTIVO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es12200 +es12300 +es12400 +es12500 +es12600 +es12700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">100</field>
+         <field name="name">es12200</field>
+         <field name="description">I. Existencias</field>
+         <field name="expression">+bale[30%,31%,32%,33%,34%,35%,36%,39%,407%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">110</field>
+         <field name="name">es12300</field>
+         <field name="description">II. Deudores comerciales y otras cuentas a cobrar</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es12380 +es12370 +es12390</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12380" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">120</field>
+         <field name="name">es12380</field>
+         <field name="description">1. Clientes por ventas y prestaciones de servicios</field>
+         <field name="expression">+bale[430%,431%,432%,433%,434%,435%,436%,437%,490%,493%] +es12381 +es12382</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12381" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">130</field>
+         <field name="name">es12381</field>
+         <field name="description">a) Clientes por ventas y prestaciones de servicios a largo plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12382" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">140</field>
+         <field name="name">es12382</field>
+         <field name="description">b) Clientes por ventas y prestaciones de servicios a corto plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12370" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">150</field>
+         <field name="name">es12370</field>
+         <field name="description">2. Accionistas (socios) por desembolsos exigidos</field>
+         <field name="expression">+bale[5580%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12390" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">160</field>
+         <field name="name">es12390</field>
+         <field name="description">3. Otros deudores</field>
+         <field name="expression">+bale[44%,460%,470%,471%,472%,473%,544%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">170</field>
+         <field name="name">es12400</field>
+         <field name="description">III. Inversiones en empresas del grupo y asociadas a corto plazo</field>
+         <field name="expression">+bale[5303%,5304%,5313%,5314%,5323%,5324%,5333%,5334%,5343%,5344%,5353%,5354%,5393%,5394%,5933%,5934%,5943%,5944%,5953%,5954%] + pbale[5523%] + pbale[5524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">180</field>
+         <field name="name">es12500</field>
+         <field name="description">IV. Inversiones financieras a corto plazo</field>
+         <field name="expression">+bale[5305%,5315%,5325%,5335%,5345%,5355%,5395%,540%,541%,542%,543%,545%,546%,547%,548%,549%,5590%,565%,566%,5935%,5945%,5955%,596%,597%,598%] + pbale[550%] + pbale[551%] + pbale[554%] + pbale[5525%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">190</field>
+         <field name="name">es12600</field>
+         <field name="description">V. Periodificaciones a corto plazo</field>
+         <field name="expression">+bale[480%,567%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_12700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">200</field>
+         <field name="name">es12700</field>
+         <field name="description">VI. Efectivo y otros activos líquidos equivalentes</field>
+         <field name="expression">+bale[57%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_10000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">210</field>
+         <field name="name">es10000</field>
+         <field name="description">TOTAL ACTIVO (A + B)</field>
+         <field name="expression">+es11000+es12000</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_20000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">220</field>
+         <field name="name">es20000</field>
+         <field name="description">A) PATRIMONIO NETO</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21000 +es22000 +es23000</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">230</field>
+         <field name="name">es21000</field>
+         <field name="description">A-1) Fondos propios</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21100 +es21200 +es21300 +es21400 +es21500 +es21600 +es21700 +es21800</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">240</field>
+         <field name="name">es21100</field>
+         <field name="description">I. Capital</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es21110 +es21120</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21110" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">250</field>
+         <field name="name">es21110</field>
+         <field name="description">1. Capital escriturado</field>
+         <field name="expression">-bale[100%,101%,102%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21120" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">260</field>
+         <field name="name">es21120</field>
+         <field name="description">2. (Capital no exigido)</field>
+         <field name="expression">-bale[1030%,1040%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">270</field>
+         <field name="name">es21200</field>
+         <field name="description">II. Prima de emisión</field>
+         <field name="expression">-bale[110%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">280</field>
+         <field name="name">es21300</field>
+         <field name="description">III. Reservas</field>
+         <field name="expression">-bale[112%,113%,114%,119%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">290</field>
+         <field name="name">es21400</field>
+         <field name="description">IV. (Acciones y participaciones en patrimonio propias)</field>
+         <field name="expression">-bale[108%,109%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">300</field>
+         <field name="name">es21500</field>
+         <field name="description">V. Resultados de ejercicios anteriores</field>
+         <field name="expression">-bale[120%,121%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">310</field>
+         <field name="name">es21600</field>
+         <field name="description">VI. Otras aportaciones de socios</field>
+         <field name="expression">-bale[118%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">320</field>
+         <field name="name">es21700</field>
+         <field name="description">VII. Resultado del ejercicio</field>
+         <field name="expression">-bale[129%,6%,7%]-balu[6%,7%]</field>
+         <field name="auto_expand_accounts">False</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_21800" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">330</field>
+         <field name="name">es21800</field>
+         <field name="description">VIII. (Dividendo a cuenta)</field>
+         <field name="expression">-bale[557%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_22000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">340</field>
+         <field name="name">es22000</field>
+         <field name="description">A-2) Ajustes en patrimonio neto</field>
+         <field name="expression">-bale[137%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_23000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">350</field>
+         <field name="name">es23000</field>
+         <field name="description">A-3) Subvenciones, donaciones y legados recibidos</field>
+         <field name="expression">-bale[130%,131%,132%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">360</field>
+         <field name="name">es31000</field>
+         <field name="description">B) PASIVO NO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es31100 +es31200 +es31300 +es31400 +es31500 +es31600 +es31700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">370</field>
+         <field name="name">es31100</field>
+         <field name="description">I. Provisiones a largo plazo</field>
+         <field name="expression">-bale[14%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">380</field>
+         <field name="name">es31200</field>
+         <field name="description">II. Deudas a largo plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es31220 +es31230 +es31290</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31220" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">390</field>
+         <field name="name">es31220</field>
+         <field name="description">1. Deudas con entidades de crédito</field>
+         <field name="expression">-bale[1605%,170%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31230" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">400</field>
+         <field name="name">es31230</field>
+         <field name="description">2. Acreedores por arrendamiento financiero</field>
+         <field name="expression">-bale[1625%,174%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31290" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">410</field>
+         <field name="name">es31290</field>
+         <field name="description">3. Otras deudas a largo plazo</field>
+         <field name="expression">-bale[1615%,1635%,171%,172%,173%,175%,176%,177%,179%,180%,185%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">420</field>
+         <field name="name">es31300</field>
+         <field name="description">III. Deudas con empresas del grupo y asociadas a largo plazo</field>
+         <field name="expression">-bale[1603%,1604%,1613%,1614%,1623%,1624%,1633%,1634%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">430</field>
+         <field name="name">es31400</field>
+         <field name="description">IV. Pasivos por impuesto diferido</field>
+         <field name="expression">-bale[479%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">440</field>
+         <field name="name">es31500</field>
+         <field name="description">V. Periodificaciones a largo plazo</field>
+         <field name="expression">-bale[181%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">450</field>
+         <field name="name">es31600</field>
+         <field name="description">VI. Acreedores comerciales no corrientes</field>
+         <field name="expression">-bale[31600%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_31700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">460</field>
+         <field name="name">es31700</field>
+         <field name="description">VII. Deuda con características especiales a largo plazo</field>
+         <field name="expression">-bale[15%,5585%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">470</field>
+         <field name="name">es32000</field>
+         <field name="description">C) PASIVO CORRIENTE</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es32200 +es32300 +es32400 +es32500 +es32600 +es32700</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">480</field>
+         <field name="name">es32200</field>
+         <field name="description">I. Provisiones a corto plazo</field>
+         <field name="expression">-bale[499%,529%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">490</field>
+         <field name="name">es32300</field>
+         <field name="description">II. Deudas a corto plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es32320 +es32330 +es32390</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32320" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">500</field>
+         <field name="name">es32320</field>
+         <field name="description">1. Deudas con entidades de crédito</field>
+         <field name="expression">-bale[5105%,520%,527%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32330" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">510</field>
+         <field name="name">es32330</field>
+         <field name="description">2. Acreedores por arrendamiento financiero</field>
+         <field name="expression">-bale[5125%,524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32390" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">520</field>
+         <field name="name">es32390</field>
+         <field name="description">3. Otras deudas a corto plazo</field>
+         <field name="expression">-bale[1034%,1044%,190%,192%,194%,500%,505%,506%,509%,5115%,5135%,5145%,521%,522%,523%,525%,526%,528%,555%,5565%,5566%,5595%,560%,561%] - nbale[550%%] - nbale[551%] - nbale[554%] - nbale[5525%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">530</field>
+         <field name="name">es32400</field>
+         <field name="description">III. Deudas con empresas del grupo y asociadas a corto plazo</field>
+         <field name="expression">-bale[5103%,5104%,5113%,5114%,5123%,5124%,5133%,5134%,5143%,5144%,5563%,5564%] - nbale[5523%] - nbale[5524%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">540</field>
+         <field name="name">es32500</field>
+         <field name="description">IV. Acreedores comerciales y otras cuentas a pagar</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es32580 +es32590</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32580" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">550</field>
+         <field name="name">es32580</field>
+         <field name="description">1. Proveedores</field>
+         <field name="expression">-bale[400%,401%,403%,404%,405%,406%] +es32581 +es32582</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32581" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">560</field>
+         <field name="name">es32581</field>
+         <field name="description">a) Proveedores a largo plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32582" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">570</field>
+         <field name="name">es32582</field>
+         <field name="description">b) Proveedores a corto plazo</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32590" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">580</field>
+         <field name="name">es32590</field>
+         <field name="description">2. Otros acreedores</field>
+         <field name="expression">-bale[41%,438%,465%,475%,476%,477%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">590</field>
+         <field name="name">es32600</field>
+         <field name="description">V. Periodificaciones a corto plazo</field>
+         <field name="expression">-bale[485%,568%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_32700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">600</field>
+         <field name="name">es32700</field>
+         <field name="description">VI. Deuda con características especiales a corto plazo</field>
+         <field name="expression">-bale[195%,197%,199%,502%,507%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_30000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">610</field>
+         <field name="name">es30000</field>
+         <field name="description">TOTAL PATRIMONIO NETO Y PASIVO (A + B + C)</field>
+         <field name="expression">+es20000+es31000+es32000</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+   </data>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_balance_sme_ratios.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_balance_sme_ratios.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+      <record id="l10n_es_mis_report_kpi.mis_report_es_balance_pymes" model="mis.report">
+         <field name="name">Ratios de Balance PYMEs (PGCE 2008)</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_liquidez" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">5010</field>
+         <field name="name">ratios_liquidez</field>
+         <field name="description">1) RATIOS DE LIQUIDEZ</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_liquidez" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5020</field>
+         <field name="name">ratio_liquidez</field>
+         <field name="description">Ratio de liquidez</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> es12000 / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_disponibilidad" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5030</field>
+         <field name="name">ratio_disponibilidad</field>
+         <field name="description">Ratio de disponibilidad</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> es12700 / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_tesoreria" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5040</field>
+         <field name="name">ratio_tesoreria</field>
+         <field name="description">Ratio de tesorería</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12300+ es12700) / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5050</field>
+         <field name="name">ratio_endeudamiento</field>
+         <field name="description">Ratio de endeudamiento</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000+es31000) / (es20000 + es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_autonomia" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5060</field>
+         <field name="name">ratio_autonomia</field>
+         <field name="description">Ratio de autonomía</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es21000 / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_activo)" model="mis.report.kpi">
+          <field name="report_id" ref="mis_report_es_balance_pymes"/>
+          <field name="type">num</field>
+          <field name="compare_method">pct</field>
+          <field name="sequence">5070</field>
+          <field name="name">ratio_fondo_maniobra_activo</field>
+          <field name="description">Ratio de fondo de maniobra sobre activo</field>
+          <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+          <field name="expression">(es12000-es32000) / es10000</field>
+          <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_corto)" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5080</field>
+         <field name="name">ratio_fondo_maniobra_deuda_corto</field>
+         <field name="description">Ratio de fondo de maniobra sobre deudas a corto plazo</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000) / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5090</field>
+         <field name="name">ratio_fondo_maniobra</field>
+         <field name="description">Fondo de maniobra</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es12000-es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5100</field>
+         <field name="name">ratio_fondo_maniobra_ventas</field>
+         <field name="description">Fondo de maniobra sobre ventas</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000)/balp[70%]</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_activo_corriente_circulante" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5110</field>
+         <field name="name">ratio_fondo_maniobra_activo_corriente_circulante</field>
+         <field name="description">Fondo de maniobra sobre activo corriente o circulante</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000) / es12000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">6000</field>
+         <field name="name">ratios_endeudamiento</field>
+         <field name="description">2) RATIOS DE ENDEUDAMIENTO</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6010</field>
+         <field name="name">ratio_endeudamiento</field>
+         <field name="description">Ratio de endeudamiento</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000+es31000) / (es20000 + es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_autonomia" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6020</field>
+         <field name="name">ratio_autonomia</field>
+         <field name="description">Ratio de autonomía</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es21000 / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_calidad_deuda" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6030</field>
+         <field name="name">ratio_calidad_deuda</field>
+         <field name="description">Ratio de calidad de la deuda</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000 / es30000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_peso_recursos_permanentes" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6040</field>
+         <field name="name">peso_recursos_permanentes</field>
+         <field name="description">Peso de los recursos permanentes</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es20000+es31000) / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_rotacion_activos" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">7000</field>
+         <field name="name">ratios_rotacion_activos</field>
+         <field name="description">3) RATIOS DE ROTACIÓN DE ACTIVOS</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_rotacion_activo_no_corriente" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">7010</field>
+         <field name="name">ratio_rotacion_activo_no_corriente</field>
+         <field name="description">Rotación del activo no corriente</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">balp[70%] / es11000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_es_balance_pymes_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">4000</field>
+         <field name="name">ventas</field>
+         <field name="description">Ventas</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> balp[700%,701%,702%,703%,704%,706%,708%,709%]</field>
+      </record>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_pyg_abreviated.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_pyg_abreviated.xml
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+   <data>
+      <record id="mis_report_es_pyg_abreviado" model="mis.report">
+         <field name="name">Pérdidas y ganancias abreviado (PGCE 2008)</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_base"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_40100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">10</field>
+         <field name="name">es40100</field>
+         <field name="description">1. Importe neto de la cifra de negocios</field>
+         <field name="expression">-balp[700%,701%,702%,703%,704%,705%,706%,708%,709%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_40200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">20</field>
+         <field name="name">es40200</field>
+         <field name="description">2. Variación de existencias de productos terminados y en curso de fabricación</field>
+         <field name="expression">-balp[6930%,71%,7930%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_40300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">30</field>
+         <field name="name">es40300</field>
+         <field name="description">3. Trabajos realizados por la empresa para su activo</field>
+         <field name="expression">-balp[73%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_40400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">40</field>
+         <field name="name">es40400</field>
+         <field name="description">4. Aprovisionamientos</field>
+         <field name="expression">-balp[600%,601%,602%,606%,607%,608%,609%,61%,6931%,6932%,6933%,7931%,7932%,7933%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_40500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">50</field>
+         <field name="name">es40500</field>
+         <field name="description">5. Otros ingresos de explotación</field>
+         <field name="expression">-balp[740%,747%,75%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_40600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">60</field>
+         <field name="name">es40600</field>
+         <field name="description">6. Gastos de personal</field>
+         <field name="expression">-balp[64%,7950%,7957%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_40700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">70</field>
+         <field name="name">es40700</field>
+         <field name="description">7. Otros gastos de explotación</field>
+         <field name="expression">-balp[62%,631%,634%,636%,639%,65%,694%,695%,794%,7954%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_40800" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">80</field>
+         <field name="name">es40800</field>
+         <field name="description">8. Amortización del inmovilizado</field>
+         <field name="expression">-balp[68%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_40900" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">90</field>
+         <field name="name">es40900</field>
+         <field name="description">9. Imputación de subvenciones de inmovilizado no financiero y otras</field>
+         <field name="expression">-balp[40900%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">100</field>
+         <field name="name">es41000</field>
+         <field name="description">10. Excesos de provisiones</field>
+         <field name="expression">-balp[7951%,7952%,7955%,7956%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">110</field>
+         <field name="name">es41100</field>
+         <field name="description">11. Deterioro y resultado por enajenaciones del inmovilizado</field>
+         <field name="expression">-balp[670%,671%,672%,690%,691%,692%,770%,771%,772%,790%,791%,792%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">120</field>
+         <field name="name">es41200</field>
+         <field name="description">12. Diferencia negativa de combinaciones de negocio</field>
+         <field name="expression">-balp[774%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">130</field>
+         <field name="name">es41300</field>
+         <field name="description">13. Otros resultados</field>
+         <field name="expression">-balp[678%,778%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_49100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">140</field>
+         <field name="name">es49100</field>
+         <field name="description">A) RESULTADO DE EXPLOTACIÓN (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13)</field>
+         <field name="expression">+es40100+es40200+es40300+es40400+es40500+es40600+es40700+es40800+es40900+es41000+es41100+es41200+es41300</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">150</field>
+         <field name="name">es41400</field>
+         <field name="description">14. Ingresos financieros</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es41430 +es41490</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41430" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">160</field>
+         <field name="name">es41430</field>
+         <field name="description">a) Imputación de subvenciones, donaciones y legados de carácter financiero</field>
+         <field name="expression">-balp[746%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41490" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">170</field>
+         <field name="name">es41490</field>
+         <field name="description">b) Otros ingresos financieros</field>
+         <field name="expression">-balp[760%,761%,762%,767%,769%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">180</field>
+         <field name="name">es41500</field>
+         <field name="description">15. Gastos financieros</field>
+         <field name="expression">-balp[660%,661%,662%,664%,665%,669%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">190</field>
+         <field name="name">es41600</field>
+         <field name="description">16. Variación de valor razonable en instrumentos financieros</field>
+         <field name="expression">-balp[663%,763%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">200</field>
+         <field name="name">es41700</field>
+         <field name="description">17. Diferencias de cambio</field>
+         <field name="expression">-balp[668%,768%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41800" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">210</field>
+         <field name="name">es41800</field>
+         <field name="description">18. Deterioro y resultado por enajenaciones de instrumentos financieros</field>
+         <field name="expression">-balp[666%,667%,673%,675%,696%,697%,698%,699%,766%,773%,775%,796%,797%,798%,799%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_49200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">220</field>
+         <field name="name">es49200</field>
+         <field name="description">B) RESULTADO FINANCIERO (14 + 15 + 16 + 17 + 18)</field>
+         <field name="expression">+es41400+es41500+es41600+es41700+es41800</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_49300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">230</field>
+         <field name="name">es49300</field>
+         <field name="description">C) RESULTADO ANTES DE IMPUESTOS (A + B)</field>
+         <field name="expression">+es49100+es49200</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_41900" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">240</field>
+         <field name="name">es41900</field>
+         <field name="description">19. Impuestos sobre beneficios</field>
+         <field name="expression">-balp[6300%,6301%,633%,638%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_abreviado_49500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_abreviado"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">250</field>
+         <field name="name">es49500</field>
+         <field name="description">D) RESULTADO DEL EJERCICIO (C + 19)</field>
+         <field name="expression">+es49300+es41900</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+   </data>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_pyg_abreviated_ratios.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_pyg_abreviated_ratios.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+      <record id="l10n_es_mis_report_kpi.mis_report_es_balance_pymes" model="mis.report">
+         <field name="name">Ratios de Balance PYMEs (PGCE 2008)</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_liquidez" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">5010</field>
+         <field name="name">ratios_liquidez</field>
+         <field name="description">1) RATIOS DE LIQUIDEZ</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_liquidez" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5020</field>
+         <field name="name">ratio_liquidez</field>
+         <field name="description">Ratio de liquidez</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> es12000 / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_disponibilidad" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5030</field>
+         <field name="name">ratio_disponibilidad</field>
+         <field name="description">Ratio de disponibilidad</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> es12700 / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_tesoreria" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5040</field>
+         <field name="name">ratio_tesoreria</field>
+         <field name="description">Ratio de tesorería</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12300+ es12700) / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5050</field>
+         <field name="name">ratio_endeudamiento</field>
+         <field name="description">Ratio de endeudamiento</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000+es31000) / (es20000 + es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_autonomia" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5060</field>
+         <field name="name">ratio_autonomia</field>
+         <field name="description">Ratio de autonomía</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es21000 / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_activo)" model="mis.report.kpi">
+          <field name="report_id" ref="mis_report_es_balance_pymes"/>
+          <field name="type">num</field>
+          <field name="compare_method">pct</field>
+          <field name="sequence">5070</field>
+          <field name="name">ratio_fondo_maniobra_activo</field>
+          <field name="description">Ratio de fondo de maniobra sobre activo</field>
+          <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+          <field name="expression">(es12000-es32000) / es10000</field>
+          <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_corto)" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5080</field>
+         <field name="name">ratio_fondo_maniobra_deuda_corto</field>
+         <field name="description">Ratio de fondo de maniobra sobre deudas a corto plazo</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000) / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5090</field>
+         <field name="name">ratio_fondo_maniobra</field>
+         <field name="description">Fondo de maniobra</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es12000-es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5100</field>
+         <field name="name">ratio_fondo_maniobra_ventas</field>
+         <field name="description">Fondo de maniobra sobre ventas</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000)/balp[70%]</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_activo_corriente_circulante" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5110</field>
+         <field name="name">ratio_fondo_maniobra_activo_corriente_circulante</field>
+         <field name="description">Fondo de maniobra sobre activo corriente o circulante</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000) / es12000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">6000</field>
+         <field name="name">ratios_endeudamiento</field>
+         <field name="description">2) RATIOS DE ENDEUDAMIENTO</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6010</field>
+         <field name="name">ratio_endeudamiento</field>
+         <field name="description">Ratio de endeudamiento</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000+es31000) / (es20000 + es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_autonomia" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6020</field>
+         <field name="name">ratio_autonomia</field>
+         <field name="description">Ratio de autonomía</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es21000 / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_calidad_deuda" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6030</field>
+         <field name="name">ratio_calidad_deuda</field>
+         <field name="description">Ratio de calidad de la deuda</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000 / es30000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_peso_recursos_permanentes" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6040</field>
+         <field name="name">peso_recursos_permanentes</field>
+         <field name="description">Peso de los recursos permanentes</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es20000+es31000) / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_rotacion_activos" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">7000</field>
+         <field name="name">ratios_rotacion_activos</field>
+         <field name="description">3) RATIOS DE ROTACIÓN DE ACTIVOS</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_rotacion_activo_no_corriente" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">7010</field>
+         <field name="name">ratio_rotacion_activo_no_corriente</field>
+         <field name="description">Rotación del activo no corriente</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">balp[70%] / es11000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_es_balance_pymes_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">4000</field>
+         <field name="name">ventas</field>
+         <field name="description">Ventas</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> balp[700%,701%,702%,703%,704%,706%,708%,709%]</field>
+      </record>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_pyg_normal.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_pyg_normal.xml
@@ -1,0 +1,674 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+   <data>
+      <record id="mis_report_es_pyg_normal" model="mis.report">
+         <field name="name">Pérdidas y ganancias completo (PGCE 2008)</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_base"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_a" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">10</field>
+         <field name="name">esA</field>
+         <field name="description">A) OPERACIONES CONTINUADAS</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es40100 +es40200 +es40300 +es40400 +es40500 +es40600 +es40700 +es40800 +es40900 +es41000 +es41100 +es41200 +es41300 +es41400 +es41500 +es41600 +es41700 +es41800 +es41900</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">20</field>
+         <field name="name">es40100</field>
+         <field name="description">1. Importe neto de la cifra de negocios</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es40110 +es40120</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40110" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">30</field>
+         <field name="name">es40110</field>
+         <field name="description">a) Ventas</field>
+         <field name="expression">-balp[700%,701%,702%,703%,704%,706%,708%,709%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40120" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">40</field>
+         <field name="name">es40120</field>
+         <field name="description">b) Prestaciones de servicios</field>
+         <field name="expression">-balp[705%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">50</field>
+         <field name="name">es40200</field>
+         <field name="description">2. Variación de existencias de productos terminados y en curso de fabricación</field>
+         <field name="expression">-balp[6930%,71%,7930%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">60</field>
+         <field name="name">es40300</field>
+         <field name="description">3. Trabajos realizados por la empresa para su activo</field>
+         <field name="expression">-balp[73%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">70</field>
+         <field name="name">es40400</field>
+         <field name="description">4. Aprovisionamientos</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es40410 +es40420 +es40430 +es40440</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40410" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">80</field>
+         <field name="name">es40410</field>
+         <field name="description">a) Consumo de mercaderías</field>
+         <field name="expression">-balp[600%,6060%,6080%,6090%,610%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40420" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">90</field>
+         <field name="name">es40420</field>
+         <field name="description">b) Consumo de materias primas y otras materias consumibles</field>
+         <field name="expression">-balp[601%,602%,6061%,6062%,6081%,6082%,6091%,6092%,611%,612%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40430" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">100</field>
+         <field name="name">es40430</field>
+         <field name="description">c) Trabajos realizados por otras empresas</field>
+         <field name="expression">-balp[607%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40440" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">110</field>
+         <field name="name">es40440</field>
+         <field name="description">d) Deterioro de mercaderías, materias primas y otros aprovisionamientos</field>
+         <field name="expression">-balp[6931%,6932%,6933%,7931%,7932%,7933%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">120</field>
+         <field name="name">es40500</field>
+         <field name="description">5. Otros ingresos de explotación</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es40510 +es40520</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40510" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">130</field>
+         <field name="name">es40510</field>
+         <field name="description">a) Ingresos accesorios y otros de gestión corriente</field>
+         <field name="expression">-balp[75%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40520" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">140</field>
+         <field name="name">es40520</field>
+         <field name="description">b) Subvenciones de explotación incorporadas al resultado del ejercicio</field>
+         <field name="expression">-balp[740%,747%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">150</field>
+         <field name="name">es40600</field>
+         <field name="description">6. Gastos de personal</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es40610 +es40620 +es40630</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40610" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">160</field>
+         <field name="name">es40610</field>
+         <field name="description">a) Sueldos, salarios y asimilados</field>
+         <field name="expression">-balp[640%,641%,6450%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40620" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">170</field>
+         <field name="name">es40620</field>
+         <field name="description">b) Cargas sociales</field>
+         <field name="expression">-balp[642%,643%,649%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40630" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">180</field>
+         <field name="name">es40630</field>
+         <field name="description">c) Provisiones</field>
+         <field name="expression">-balp[644%,6457%,7950%,7957%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">190</field>
+         <field name="name">es40700</field>
+         <field name="description">7. Otros gastos de explotación</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es40710 +es40720 +es40730 +es40740</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40710" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">200</field>
+         <field name="name">es40710</field>
+         <field name="description">a) Servicios exteriores</field>
+         <field name="expression">-balp[62%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40720" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">210</field>
+         <field name="name">es40720</field>
+         <field name="description">b) Tributos</field>
+         <field name="expression">-balp[631%,634%,636%,639%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40730" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">220</field>
+         <field name="name">es40730</field>
+         <field name="description">c) Pérdidas, deterioro y variación de provisiones por operaciones comerciales</field>
+         <field name="expression">-balp[650%,694%,695%,794%,7954%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40740" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">230</field>
+         <field name="name">es40740</field>
+         <field name="description">d) Otros gastos de gestión corriente </field>
+         <field name="expression">-balp[651%,659%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40800" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">240</field>
+         <field name="name">es40800</field>
+         <field name="description">8. Amortización del inmovilizado</field>
+         <field name="expression">-balp[68%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_40900" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">250</field>
+         <field name="name">es40900</field>
+         <field name="description">9. Imputación de subvenciones de inmovilizado no financiero y otras</field>
+         <field name="expression">-balp[746%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">260</field>
+         <field name="name">es41000</field>
+         <field name="description">10. Excesos de provisiones </field>
+         <field name="expression">-balp[7951%,7952%,7955%,7956%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">270</field>
+         <field name="name">es41100</field>
+         <field name="description">11. Deterioro y resultado por enajenaciones del inmovilizado</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es41110 +es41120</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41110" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">280</field>
+         <field name="name">es41110</field>
+         <field name="description">a) Deterioro y pérdidas</field>
+         <field name="expression">-balp[690%,691%,692%,790%,791%,792%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41120" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">290</field>
+         <field name="name">es41120</field>
+         <field name="description">b) Resultados por enajenaciones y otras</field>
+         <field name="expression">-balp[670%,671%,672%,770%,771%,772%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">300</field>
+         <field name="name">es41200</field>
+         <field name="description">12. Diferencia negativa de combinaciones de negocio</field>
+         <field name="expression">-balp[774%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">310</field>
+         <field name="name">es41300</field>
+         <field name="description">13. Otros resultados</field>
+         <field name="expression">-balp[678%,778%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_49100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">320</field>
+         <field name="name">es49100</field>
+         <field name="description">A.1)  RESULTADO DE EXPLOTACIÓN (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13)</field>
+         <field name="expression">+es40100+es40200+es40300+es40400+es40500+es40600+es40700+es40800+es40900+es41000+es41100+es41200+es41300</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">330</field>
+         <field name="name">es41400</field>
+         <field name="description">14. Ingresos financieros</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es41410 +es41420 +es41430</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41410" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">340</field>
+         <field name="name">es41410</field>
+         <field name="description">a) De participaciones en instrumentos de patrimonio</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es41411 +es41412</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41411" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">350</field>
+         <field name="name">es41411</field>
+         <field name="description">a 1) En empresas del grupo y asociadas</field>
+         <field name="expression">-balp[7600%,7601%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41412" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">360</field>
+         <field name="name">es41412</field>
+         <field name="description">a 2) En terceros</field>
+         <field name="expression">-balp[7602%,7603%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41420" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">370</field>
+         <field name="name">es41420</field>
+         <field name="description">b) De valores negociables y otros instrumentos financieros</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es41421 +es41422</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41421" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">380</field>
+         <field name="name">es41421</field>
+         <field name="description">b 1) De empresas del grupo y asociadas</field>
+         <field name="expression">-balp[7610%,7611%,76200%,76201%,76210%,76211%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41422" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">390</field>
+         <field name="name">es41422</field>
+         <field name="description">b 2) De terceros</field>
+         <field name="expression">-balp[7612%,7613%,76202%,76203%,76212%,76213%,767%,769%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41430" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">400</field>
+         <field name="name">es41430</field>
+         <field name="description">c) Imputación de subvenciones, donaciones y legados de carácter inanciero</field>
+         <field name="expression">-balp[746%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">410</field>
+         <field name="name">es41500</field>
+         <field name="description">15. Gastos financieros</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es41510 +es41520 +es41530</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41510" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">420</field>
+         <field name="name">es41510</field>
+         <field name="description">a) Por deudas con empresas del grupo y asociadas</field>
+         <field name="expression">-balp[6610%,6611%,6615%,6616%,6620%,6621%,6640%,6641%,6650%,6651%,6654%,6655%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41520" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">430</field>
+         <field name="name">es41520</field>
+         <field name="description">b) Por deudas con terceros</field>
+         <field name="expression">-balp[6612%,6613%,6617%,6618%,6622%,6623%,6624%,6642%,6643%,6652%,6653%,6656%,6657%,669%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41530" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">440</field>
+         <field name="name">es41530</field>
+         <field name="description">c) Por actualización de provisiones</field>
+         <field name="expression">-balp[660%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">450</field>
+         <field name="name">es41600</field>
+         <field name="description">16. Variación de valor razonable en instrumentos financieros</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es41610 +es41620</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41610" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">460</field>
+         <field name="name">es41610</field>
+         <field name="description">a) Cartera de negociación y otros </field>
+         <field name="expression">-balp[6630%,6631%,6633%,7630%,7631%,7633%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41620" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">470</field>
+         <field name="name">es41620</field>
+         <field name="description">b) Imputación al resultado del ejercicio por activos financieros disponibles para la venta</field>
+         <field name="expression">-balp[6632%,7632%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">480</field>
+         <field name="name">es41700</field>
+         <field name="description">17. Diferencias de cambio</field>
+         <field name="expression">-balp[668%,768%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41800" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">490</field>
+         <field name="name">es41800</field>
+         <field name="description">18. Deterioro y resultado por enajenaciones de instrumentos financieros</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es41810 +es41820</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41810" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">500</field>
+         <field name="name">es41810</field>
+         <field name="description">a) Deterioros y pérdidas</field>
+         <field name="expression">-balp[696%,697%,698%,699%,796%,797%,798%,799%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41820" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">510</field>
+         <field name="name">es41820</field>
+         <field name="description">b) Resultados por enajenaciones y otras</field>
+         <field name="expression">-balp[666%,667%,673%,675%,766%,773%,775%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_49200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">520</field>
+         <field name="name">es49200</field>
+         <field name="description">A.2) RESULTADO FINANCIERO (14 + 15 + 16 + 17 + 18)</field>
+         <field name="expression">+es41400+es41500+es41600+es41700+es41800</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_49300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">530</field>
+         <field name="name">es49300</field>
+         <field name="description">A.3) RESULTADO ANTES DE IMPUESTOS (A.1 + A.2)</field>
+         <field name="expression">+es49100+es49200</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_41900" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">540</field>
+         <field name="name">es41900</field>
+         <field name="description">19. Impuestos sobre beneficios</field>
+         <field name="expression">-balp[6300%,6301%,633%,638%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_49400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">550</field>
+         <field name="name">es49400</field>
+         <field name="description">A.4) RESULTADO DEL EJERCICIO PROCEDENTE DE OPERACIONES CONTINUADAS (A.3 + 19)</field>
+         <field name="expression">+es49300+es41900</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_b" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">560</field>
+         <field name="name">esB</field>
+         <field name="description">B) OPERACIONES INTERRUMPIDAS</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es42000</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_42000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">570</field>
+         <field name="name">es42000</field>
+         <field name="description">20. Resultado del ejercicio procedente de operaciones interrumpidas neto de impuestos</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_normal_49500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_normal"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">580</field>
+         <field name="name">es49500</field>
+         <field name="description">A.5) RESULTADO DEL EJERCICIO (A.4 + 20)</field>
+         <field name="expression">+es49400+es42000</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+   </data>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_pyg_normal_ratios.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_pyg_normal_ratios.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+      <record id="l10n_es_mis_report_kpi.mis_report_es_balance_pymes" model="mis.report">
+         <field name="name">Ratios de Balance PYMEs (PGCE 2008)</field>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_liquidez" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">5010</field>
+         <field name="name">ratios_liquidez</field>
+         <field name="description">1) RATIOS DE LIQUIDEZ</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_liquidez" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5020</field>
+         <field name="name">ratio_liquidez</field>
+         <field name="description">Ratio de liquidez</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> es12000 / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_disponibilidad" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5030</field>
+         <field name="name">ratio_disponibilidad</field>
+         <field name="description">Ratio de disponibilidad</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> es12700 / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_tesoreria" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5040</field>
+         <field name="name">ratio_tesoreria</field>
+         <field name="description">Ratio de tesorería</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12300+ es12700) / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5050</field>
+         <field name="name">ratio_endeudamiento</field>
+         <field name="description">Ratio de endeudamiento</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000+es31000) / (es20000 + es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_autonomia" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5060</field>
+         <field name="name">ratio_autonomia</field>
+         <field name="description">Ratio de autonomía</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es21000 / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_activo)" model="mis.report.kpi">
+          <field name="report_id" ref="mis_report_es_balance_pymes"/>
+          <field name="type">num</field>
+          <field name="compare_method">pct</field>
+          <field name="sequence">5070</field>
+          <field name="name">ratio_fondo_maniobra_activo</field>
+          <field name="description">Ratio de fondo de maniobra sobre activo</field>
+          <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+          <field name="expression">(es12000-es32000) / es10000</field>
+          <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_corto)" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5080</field>
+         <field name="name">ratio_fondo_maniobra_deuda_corto</field>
+         <field name="description">Ratio de fondo de maniobra sobre deudas a corto plazo</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000) / es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5090</field>
+         <field name="name">ratio_fondo_maniobra</field>
+         <field name="description">Fondo de maniobra</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es12000-es32000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5100</field>
+         <field name="name">ratio_fondo_maniobra_ventas</field>
+         <field name="description">Fondo de maniobra sobre ventas</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000)/balp[70%]</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_fondo_maniobra_activo_corriente_circulante" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5110</field>
+         <field name="name">ratio_fondo_maniobra_activo_corriente_circulante</field>
+         <field name="description">Fondo de maniobra sobre activo corriente o circulante</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es12000-es32000) / es12000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">6000</field>
+         <field name="name">ratios_endeudamiento</field>
+         <field name="description">2) RATIOS DE ENDEUDAMIENTO</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_endeudamiento" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6010</field>
+         <field name="name">ratio_endeudamiento</field>
+         <field name="description">Ratio de endeudamiento</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000+es31000) / (es20000 + es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_autonomia" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6020</field>
+         <field name="name">ratio_autonomia</field>
+         <field name="description">Ratio de autonomía</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es21000 / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_calidad_deuda" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6030</field>
+         <field name="name">ratio_calidad_deuda</field>
+         <field name="description">Ratio de calidad de la deuda</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es32000 / es30000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_peso_recursos_permanentes" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">6040</field>
+         <field name="name">peso_recursos_permanentes</field>
+         <field name="description">Peso de los recursos permanentes</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">(es20000+es31000) / (es32000+es31000)</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratios_group_rotacion_activos" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">7000</field>
+         <field name="name">ratios_rotacion_activos</field>
+         <field name="description">3) RATIOS DE ROTACIÓN DE ACTIVOS</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_rotacion_activo_no_corriente" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">7010</field>
+         <field name="name">ratio_rotacion_activo_no_corriente</field>
+         <field name="description">Rotación del activo no corriente</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">balp[70%] / es11000</field>
+         <field name="budgetable" eval="1"/>
+      </record>
+      <record id="mis_report_es_balance_pymes_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_balance_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">4000</field>
+         <field name="name">ventas</field>
+         <field name="description">Ventas</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> balp[700%,701%,702%,703%,704%,706%,708%,709%]</field>
+      </record>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_pyg_sme.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_pyg_sme.xml
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+   <data>
+      <record id="mis_report_es_pyg_pymes" model="mis.report">
+         <field name="name">Pérdidas y ganancias PYMEs (PGCE 2008)</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_base"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_40100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">10</field>
+         <field name="name">es40100</field>
+         <field name="description">1. Importe neto de la cifra de negocios</field>
+         <field name="expression">-balp[700%,701%,702%,703%,704%,705%,706%,708%,709%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_40200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">20</field>
+         <field name="name">es40200</field>
+         <field name="description">2. Variación de existencias de productos terminados y en curso de fabricación</field>
+         <field name="expression">-balp[6930%,71%,7930%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_40300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">30</field>
+         <field name="name">es40300</field>
+         <field name="description">3. Trabajos realizados por la empresa para su activo</field>
+         <field name="expression">-balp[73%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_40400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">40</field>
+         <field name="name">es40400</field>
+         <field name="description">4. Aprovisionamientos</field>
+         <field name="expression">-balp[600%,601%,602%,606%,607%,608%,609%,61%,6931%,6932%,6933%,7931%,7932%,7933%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_40500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">50</field>
+         <field name="name">es40500</field>
+         <field name="description">5. Otros ingresos de explotación</field>
+         <field name="expression">-balp[740%,747%,75%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_40600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">60</field>
+         <field name="name">es40600</field>
+         <field name="description">6. Gastos de personal</field>
+         <field name="expression">-balp[64%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_40700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">70</field>
+         <field name="name">es40700</field>
+         <field name="description">7. Otros gastos de explotación </field>
+         <field name="expression">-balp[62%,631%,634%,636%,639%,65%,694%,695%,794%,7954%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_40800" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">80</field>
+         <field name="name">es40800</field>
+         <field name="description">8. Amortización del inmovilizado</field>
+         <field name="expression">-balp[68%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_40900" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">90</field>
+         <field name="name">es40900</field>
+         <field name="description">9. Imputación de subvenciones de inmovilizado no financiero y otras</field>
+         <field name="expression">-balp[746%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41000" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">100</field>
+         <field name="name">es41000</field>
+         <field name="description">10. Excesos de provisiones</field>
+         <field name="expression">-balp[7951%,7952%,7955%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">110</field>
+         <field name="name">es41100</field>
+         <field name="description">11. Deterioro y resultado por enajenaciones del inmovilizado</field>
+         <field name="expression">-balp[670%,671%,672%,690%,691%,692%,770%,771%,772%,790%,791%,792%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">120</field>
+         <field name="name">es41300</field>
+         <field name="description">12. Otros resultados</field>
+         <field name="expression">-balp[678%,778%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_49100" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">130</field>
+         <field name="name">es49100</field>
+         <field name="description">A) RESULTADO DE EXPLOTACIÓN (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12)</field>
+         <field name="expression">+es40100+es40200+es40300+es40400+es40500+es40600+es40700+es40800+es40900+es41000+es41100+es41300</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41400" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">140</field>
+         <field name="name">es41400</field>
+         <field name="description">13. Ingresos financieros</field>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="expression"> +es41430 +es41490</field>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41430" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">150</field>
+         <field name="name">es41430</field>
+         <field name="description">a) Imputación de subvenciones, donaciones y legados de carácter financiero</field>
+         <field name="expression">-balp[746%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41490" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">160</field>
+         <field name="name">es41490</field>
+         <field name="description">b) Otros ingresos financieros</field>
+         <field name="expression">-balp[760%,761%,762%,769%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">170</field>
+         <field name="name">es41500</field>
+         <field name="description">14. Gastos financieros</field>
+         <field name="expression">-balp[660%,661%,662%,664%,665%,669%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41600" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">180</field>
+         <field name="name">es41600</field>
+         <field name="description">15. Variación de valor razonable en instrumentos financieros</field>
+         <field name="expression">-balp[663%,763%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41700" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">190</field>
+         <field name="name">es41700</field>
+         <field name="description">16. Diferencias de cambio</field>
+         <field name="expression">-balp[668%,768%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41800" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">200</field>
+         <field name="name">es41800</field>
+         <field name="description">17. Deterioro y resultado por enajenaciones de instrumentos financieros</field>
+         <field name="expression">-balp[666%,667%,673%,675%,696%,697%,698%,699%,766%,773%,775%,796%,797%,798%,799%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_49200" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">210</field>
+         <field name="name">es49200</field>
+         <field name="description">B) RESULTADO FINANCIERO (13 + 14 + 15 + 16 + 17)</field>
+         <field name="expression">+es41400+es41500+es41600+es41700+es41800</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_49300" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">220</field>
+         <field name="name">es49300</field>
+         <field name="description">C) RESULTADO ANTES DE IMPUESTOS (A + B)</field>
+         <field name="expression">+es49100+es49200</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_41900" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">230</field>
+         <field name="name">es41900</field>
+         <field name="description">18. Impuestos sobre beneficios</field>
+         <field name="expression">-balp[6300%,6301%,633%,638%]</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+      <record id="mis_report_kpi_es_pyg_pymes_49500" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">240</field>
+         <field name="name">es49500</field>
+         <field name="description">D) RESULTADO DEL EJERCICIO (C + 18)</field>
+         <field name="expression">+es49300+es41900</field>
+         <field name="auto_expand_accounts">True</field>
+         <field name="auto_expand_accounts_style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+         <field name="style_id" ref="l10n_es_mis_report.mis_report_style_l10n_es_hide"/>
+      </record>
+   </data>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_pyg_sme_ratios.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_pyg_sme_ratios.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+      <record id="l10n_es_mis_report_kpi.mis_report_es_pyg_pymes" model="mis.report">
+         <field name="name">Ratios de Pérdidas y ganancias PYMEs (PGCE 2008)</field>
+      </record>
+      <record id="mis_report_es_pyg_pymes_ratios_group_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">str</field>
+         <field name="compare_method">none</field>
+         <field name="sequence">5010</field>
+         <field name="name">ratios_ventas</field>
+         <field name="description">1) RATIOS DE VENTAS</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_group_l2"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_ventas" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5020</field>
+         <field name="name">expansion_ventas</field>
+         <field name="description">Expansión de ventas</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression"> -balp[70%]</field>
+         <field name="budgetable" eval="0"/>
+      </record>
+      <record id="mis_report_kpi_es_balance_pymes_ratio_evolucion_beneficio_neto" model="mis.report.kpi">
+         <field name="report_id" ref="mis_report_es_pyg_pymes"/>
+         <field name="type">num</field>
+         <field name="compare_method">pct</field>
+         <field name="sequence">5030</field>
+         <field name="name">evolucion_beneficio_neto</field>
+         <field name="description">Evolución del beneficio neto</field>
+         <field name="style_id" ref="mis_report_style_l10n_es_ratio"/>
+         <field name="expression">es49500</field>
+         <field name="budgetable" eval="0"/>
+      </record>
+</odoo>

--- a/l10n_es_mis_report_kpi/data/mis_report_styles.xml
+++ b/l10n_es_mis_report_kpi/data/mis_report_styles.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="mis_report_style_l10n_es_group_l1" model="mis.report.style">
+        <field name="name">l10n_es ratio group l1</field>
+        <field name="background_color_inherit" eval="0"/>
+        <field name="background_color">#A16800</field>
+        <field name="color_inherit" eval="0"/>
+        <field name="color">#FFFFFF</field>
+        <field name="font_weight_inherit" eval="0"/>
+        <field name="font_weight">bold</field>
+    </record>
+    <record id="mis_report_style_l10n_es_group_l2" model="mis.report.style">
+        <field name="name">l10n_es ratio group l2</field>
+        <field name="background_color_inherit" eval="0"/>
+        <field name="background_color">#FFA500</field>
+        <field name="font_weight_inherit" eval="0"/>
+        <field name="font_weight">bold</field>
+        <field name="indent_level_inherit" eval="0"/>
+        <field name="indent_level">1</field>
+    </record>
+    <record id="mis_report_style_l10n_es_ratio" model="mis.report.style">
+        <field name="name">l10n_es ratio</field>
+        <field name="font_weight_inherit" eval="0"/>
+        <field name="hide_empty_inherit" eval="0"/>
+        <field name="hide_empty" eval="0"/>
+        <field name="indent_level_inherit" eval="0"/>
+        <field name="indent_level">2</field>
+    </record>
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -7,4 +7,4 @@ community-data-files
 partner-contact
 queue
 reporting-engine
-mis-builder
+mis-builder https://github.com/Eficent/mis-builder 11.0-hide_always


### PR DESCRIPTION
Plantillas MIS Builder para análisis contable español
=====================================================

Incluye las siguientes plantillas para el motor de informes provisto
por el módulo *mis_builder*:

    * Ratios de Balance PYMEs (PGCE 2008)
    * Ratios Cuenta de pérdidas y ganancias PYMEs (PGCE 2008)
    * Ratios de Balance abreviado (PGCE 2008)
    * Ratios de Cuenta de pérdidas y ganancias abreviado (PGCE 2008)
    * Ratios Balance normal (PGCE 2008)
    * Ratios de Cuenta de pérdidas y ganancias completo (PGCE 2008)
