### PR TITLE
[10.0][IMP] l10n_es_aeat_sii: Contraste de facturas 

### DIFF
--- a/l10n_es_aeat_sii/README.rst
+++ b/l10n_es_aeat_sii/README.rst
@@ -23,7 +23,7 @@ Suministro Inmediato de Información en el IVA
     :target: https://runbot.odoo-community.org/runbot/189/10.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 Módulo para la presentación inmediata del IVA
 https://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/V_1_1/SII_Descripcion_ServicioWeb_v1.1.pdf
@@ -144,6 +144,7 @@ Contributors
 * Santi Argüeso - Comunitea S.L. <santi@comunitea.com>
 * Angel Moya - PESOL <angel.moya@pesol.es>
 * Nacho Muñoz <nacmuro@gmail.com>
+* Abraham Anes <abraham@studio73.es>
 
 Maintainers
 ~~~~~~~~~~~
@@ -164,7 +165,7 @@ promote its widespread use.
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-pedrobaeza| 
+|maintainer-pedrobaeza|
 
 This module is part of the `OCA/l10n-spain <https://github.com/OCA/l10n-spain/tree/10.0/l10n_es_aeat_sii>`_ project on GitHub.
 

--- a/l10n_es_aeat_sii/__manifest__.py
+++ b/l10n_es_aeat_sii/__manifest__.py
@@ -65,6 +65,7 @@
         "views/account_fiscal_position_view.xml",
         "views/res_partner_views.xml",
         "views/aeat_sii_tax_agency_view.xml",
+        "views/aeat_sii_match_report.xml",
     ],
     "post_init_hook": "add_key_to_existing_invoices",
 }

--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -21,9 +21,98 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "01 - January"
+msgstr "01 - Enero"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "02 - February"
+msgstr "02 - Febrero"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "03 - March"
+msgstr "03 - Marzo"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "04 - April"
+msgstr "04 - Abril"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "05 - May"
+msgstr "05 - Mayo"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "06 - June"
+msgstr "06 - Junio"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "07 - July"
+msgstr "07 - Julio"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "08 - August"
+msgstr "08 - Agosto"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "09 - September"
+msgstr "09 - Septiembre"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "10 - October"
+msgstr "10 - Octubre"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "11 - November"
+msgstr "11 - Noviembre"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,period_type:0
+msgid "12 - December"
+msgstr "12 - Diciembre"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_company_sii_form
 msgid "AEAT SII Configuration"
 msgstr "Configuración AEAT SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.actions.act_window,name:l10n_es_aeat_sii.action_l10n_es_aeat_sii_match_report
+#: model:ir.ui.menu,name:l10n_es_aeat_sii.menu_aeat_sii_match_report
+msgid "AEAT SII Match"
+msgstr "Cuadre con AEAT"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model,name:l10n_es_aeat_sii.model_l10n_es_aeat_sii_match_result
+msgid "AEAT SII Match - Result"
+msgstr "Cuadre con AEAT - Resultado"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_report_id
+msgid "AEAT SII Match Report ID"
+msgstr "ID del informe de cuadre con AEAT"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model,name:l10n_es_aeat_sii.model_l10n_es_aeat_sii_match_report
+msgid "AEAT SII match Report"
+msgstr "Informe de cuadre SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_sii_contrast_state
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_sii_contrast_state
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_account_invoice_sii_filter
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+msgid "AEAT contrast state"
+msgstr "Estado contraste AEAT"
 
 #. module: l10n_es_aeat_sii
 #: selection:account.invoice,sii_state:0
@@ -154,8 +243,35 @@ msgid "By differences"
 msgstr "Por diferencias"
 
 #. module: l10n_es_aeat_sii
+#: selection:account.invoice,sii_refund_type:0
+msgid "By substitution"
+msgstr "Por sustitución"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_csv
+msgid "CSV"
+msgstr "CSV"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
+msgid "Calculate"
+msgstr "Calcular"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_calculate_date
+msgid "Calculate date"
+msgstr "Fecha de calculo"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_filter
+#: selection:l10n.es.aeat.sii.match.report,state:0
+msgid "Calculated"
+msgstr "Calculado"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.aeat_sii_send_first_semester_wizard
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.l10n_es_sii_password_wizard_view
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -166,6 +282,8 @@ msgstr "Cancelar envío"
 
 #. module: l10n_es_aeat_sii
 #: selection:account.invoice,sii_state:0
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_filter
+#: selection:l10n.es.aeat.sii.match.report,state:0
 msgid "Cancelled"
 msgstr "Anulada"
 
@@ -219,11 +337,18 @@ msgstr "Compañías"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_company_id
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_company_id
 msgid "Company"
 msgstr "Compañía"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_invoice_jobs_ids
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_sii_match_jobs_ids
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.invoice_sii_form
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.invoice_supplier_sii_form
 msgid "Connector Jobs"
@@ -235,11 +360,39 @@ msgid "Connector config"
 msgstr "Conector configuración"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.actions.server,name:l10n_es_aeat_sii.action_contrast_aeat
+msgid "Contrast Invoices with AEAT"
+msgstr "Contrastar factura con AEAT"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.invoice_sii_form
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.invoice_supplier_sii_form
+msgid "Contrast with AEAT"
+msgstr "Contrastar con AEAT"
+
+#. module: l10n_es_aeat_sii
+#: selection:account.invoice,sii_match_state:0
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,sii_match_state:0
+msgid "Contrasted"
+msgstr "Contrastada"
+
+#. module: l10n_es_aeat_sii
+#: selection:account.invoice,sii_contrast_state:0
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,sii_contrast_state:0
+msgid "Correct"
+msgstr "Correcto"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_map_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_map_lines_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_mapping_registration_keys_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_tax_agency_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_create_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_create_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_create_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_password_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_sii_first_semester_create_uid
 msgid "Created by"
@@ -251,13 +404,16 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_mapping_registration_keys_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_tax_agency_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_create_date
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_create_date
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_create_date
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_password_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_sii_first_semester_create_date
 msgid "Created on"
 msgstr "Creado en"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1360
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1400
 #, python-format
 msgid "Currently there's no support for multiple exempt causes."
 msgstr ""
@@ -299,13 +455,34 @@ msgstr "Configuración de descripción"
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_mapping_registration_keys_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_tax_agency_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_display_name
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_display_name
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_display_name
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_password_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_sii_first_semester_display_name
 msgid "Display Name"
 msgstr "Nombre mostrado"
 
 #. module: l10n_es_aeat_sii
+#: selection:account.invoice,sii_contrast_state:0
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,sii_contrast_state:0
+msgid "Doesn't exist"
+msgstr "No existe"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_filter
+#: selection:l10n.es.aeat.sii.match.report,state:0
+msgid "Done"
+msgstr "Realizado"
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/aeat_sii_match_report.py:283
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_filter
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
 #: selection:l10n.es.aeat.sii,state:0
+#: selection:l10n.es.aeat.sii.match.report,state:0
+#, python-format
 msgid "Draft"
 msgstr "Borrador"
 
@@ -325,6 +502,12 @@ msgstr "¿Activar SII para esta posición fiscal?"
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_date_end
 msgid "End Date"
 msgstr "Fecha hasta"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_filter
+#: selection:l10n.es.aeat.sii.match.report,state:0
+msgid "Error"
+msgstr "Error"
 
 #. module: l10n_es_aeat_sii
 #: code:addons/l10n_es_aeat_sii/models/aeat_sii_map.py:39
@@ -348,6 +531,11 @@ msgid "Fiscal Position"
 msgstr "Posición fiscal"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_fiscalyear
+msgid "Fiscal year"
+msgstr "Ejercicio fiscal"
+
+#. module: l10n_es_aeat_sii
 #: selection:res.company,sii_description_method:0
 msgid "Fixed"
 msgstr "Fijo"
@@ -364,6 +552,12 @@ msgid "General"
 msgstr "General"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_filter
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+msgid "Group By"
+msgstr "Agrupar por"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.aeat_sii_mapping_registration_keys_view_search
 msgid "Group By..."
 msgstr "Agrupar por..."
@@ -374,10 +568,25 @@ msgstr "Agrupar por..."
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_mapping_registration_keys_id
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_tax_agency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_id
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_id
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_id
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_id
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_password_id
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_sii_first_semester_id
 msgid "ID"
 msgstr "ID"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,invoice_type:0
+msgid "In invoice/refund"
+msgstr "Factura normal/rectificativa de proveedor"
+
+#. module: l10n_es_aeat_sii
+#: selection:account.invoice,sii_match_state:0
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,sii_match_state:0
+msgid "In process of contrast"
+msgstr "En proceso de contraste"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model.fields,help:l10n_es_aeat_sii.field_account_invoice_sii_send_failed
@@ -420,8 +629,14 @@ msgstr "Intracomunitario"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_account_invoice
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_invoice
 msgid "Invoice"
 msgstr "Factura"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model,name:l10n_es_aeat_sii.model_account_invoice_line
+msgid "Invoice Line"
+msgstr "Línea de factura"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_account_invoice_refund
@@ -433,6 +648,35 @@ msgstr "Factura rectificativa"
 #, fuzzy
 msgid "Invoice Tax"
 msgstr "Factura"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,invoice_location:0
+msgid "Invoice in Odoo"
+msgstr "Factura en Odoo"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,invoice_location:0
+msgid "Invoice in Odoo and SII"
+msgstr "Factura en Odoo y en el SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,invoice_location:0
+msgid "Invoice in SII"
+msgstr "Factura en el SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_invoice_location
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+msgid "Invoice location"
+msgstr "Ubicación de la factura"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_invoice_type
+msgid "Invoice type"
+msgstr "Tipo de factura"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_refund_sii_refund_type_required
@@ -450,11 +694,25 @@ msgid "Is Test Environment?"
 msgstr "¿Es un entorno de pruebas?"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
+msgid "Jobs"
+msgstr "Trabajos"
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1602
+#, python-format
+msgid "Las facturas tienen que estar enviadas y con CSV para poder ser contrastadas."
+msgstr "Las facturas tienen que estar enviadas y con CSV para poder ser contrastadas."
+
+#. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_map___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_map_lines___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_mapping_registration_keys___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_tax_agency___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii___last_update
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences___last_update
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report___last_update
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_password___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_sii_first_semester___last_update
 msgid "Last Modified on"
@@ -465,6 +723,9 @@ msgstr "Últ. modificación en"
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_map_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_mapping_registration_keys_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_tax_agency_write_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_write_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_write_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_password_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_sii_first_semester_write_uid
@@ -476,6 +737,9 @@ msgstr "Últ. actualización por"
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_map_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_mapping_registration_keys_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_tax_agency_write_date
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_write_date
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_write_date
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_password_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_sii_first_semester_write_date
@@ -507,6 +771,13 @@ msgstr "Manual"
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.aeat_sii_map_view_form
 msgid "Mapping Lines"
 msgstr "Líneas de mapeo"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_sii_match_state
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_sii_match_state
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+msgid "Match state"
+msgstr "Estado cuadre"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_res_company_sii_method
@@ -561,7 +832,8 @@ msgid "Never sent to SII"
 msgstr "Nunca enviadas al SII"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:343
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:383
+#: code:addons/l10n_es_aeat_sii/models/aeat_sii_match_report.py:465
 #, python-format
 msgid "No VAT configured for the company '{}'"
 msgstr "La compañía '{}' no tiene ningún NIF establecido"
@@ -572,9 +844,23 @@ msgid "No sujeta - No sujeción artículo 7, 14, otros"
 msgstr "No sujeta - No sujeción artículo 7, 14, otros"
 
 #. module: l10n_es_aeat_sii
+#: selection:account.invoice,sii_match_state:0
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,sii_match_state:0
+msgid "No testable"
+msgstr "No contrastable"
+
+#. module: l10n_es_aeat_sii
 #: selection:product.template,sii_exempt_cause:0
 msgid "None"
 msgstr "Ninguno"
+
+#. module: l10n_es_aeat_sii
+#: selection:account.invoice,sii_match_state:0
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,sii_match_state:0
+msgid "Not contrasted"
+msgstr "No contrastada"
 
 #. module: l10n_es_aeat_sii
 #: selection:account.invoice,sii_state:0
@@ -586,6 +872,11 @@ msgstr "No registrada"
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.l10n_es_sii_password_wizard_view
 msgid "Obtain Keys"
 msgstr "Obtener claves"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_invoice_id
+msgid "Odoo invoice"
+msgstr "Factura de Odoo"
 
 #. module: l10n_es_aeat_sii
 #: selection:res.company,send_mode:0
@@ -604,6 +895,35 @@ msgid "Operaciones no sujetas en el TAI por reglas de localización"
 msgstr "Operaciones no sujetas en el TAI por reglas de localización"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_line_origin_line_ids
+msgid "Original invoice line"
+msgstr "Original invoice line"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,help:l10n_es_aeat_sii.field_account_invoice_line_origin_line_ids
+msgid "Original invoice line to which this refund invoice line is referred to"
+msgstr "Original invoice line to which this refund invoice line is referred to"
+
+#. module: l10n_es_aeat_sii
+#: selection:l10n.es.aeat.sii.match.report,invoice_type:0
+msgid "Out invoice/refund"
+msgstr "Factura normal/rectificativa de cliente"
+
+#. module: l10n_es_aeat_sii
+#: selection:account.invoice,sii_match_state:0
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,sii_match_state:0
+msgid "Partially contrasted"
+msgstr "Parcialmente contrastada"
+
+#. module: l10n_es_aeat_sii
+#: selection:account.invoice,sii_contrast_state:0
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: selection:l10n.es.aeat.sii.match.result,sii_contrast_state:0
+msgid "Partially correct"
+msgstr "Parcialmente correcto"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_res_partner
 msgid "Partner"
 msgstr "Empresa"
@@ -612,6 +932,11 @@ msgstr "Empresa"
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_password_password
 msgid "Password"
 msgstr "Contraseña"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_period_type
+msgid "Period type"
+msgstr "Tipo de periodo"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_private_key
@@ -639,6 +964,11 @@ msgid "Queue Job"
 msgstr "Trabajo de Cola"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
+msgid "Re-Calculate"
+msgstr "Re-Calcular"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_sii_property_cadastrial_code
 msgid "Real property cadastrial code"
 msgstr "Referencia catastral"
@@ -649,14 +979,106 @@ msgid "Real property location"
 msgstr "Situación del inmueble"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records
+msgid "Records"
+msgstr "Registros"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_contrasted
+msgid "Records contrasted"
+msgstr "Registros contrastados"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_correct
+msgid "Records corretly contrasted"
+msgstr "Registros correctamente contrastados"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_both
+msgid "Records in Odoo and SII"
+msgstr "Registros en Odoo y SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_in_process
+msgid "Records in process of contrast"
+msgstr "Registros en proceso de contraste"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_no_test
+msgid "Records no testables"
+msgstr "Registros no contrastables"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_not_contrasted
+msgid "Records not contasted"
+msgstr "Registros no contrastados"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_odoo
+msgid "Records only in Odoo"
+msgstr "Registros solo en Odoo"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_sii
+msgid "Records only in SII"
+msgstr "Registros solo en SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_partially
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_partially_contrasted
+msgid "Records partially contrasted"
+msgstr "Registros parcialmente contrastados"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_number_records_no_exist
+msgid "Records without contrast"
+msgstr "Registros no contrastados"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_line_refund_line_ids
+msgid "Refund invoice line"
+msgstr "Refund invoice line"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,help:l10n_es_aeat_sii.field_account_invoice_line_refund_line_ids
+msgid "Refund invoice lines created from this invoice line"
+msgstr "Refund invoice lines created from this invoice line"
+
+#. module: l10n_es_aeat_sii
 #: selection:account.invoice,sii_state:0
 msgid "Registered in SII but last modifications not sent"
 msgstr "Registro correcto en SII con modificaciones pendientes de comunicar"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_report_id
+msgid "Related SII match report"
+msgstr "Informe de cuadre de SII relacionado"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_invoice_id
+msgid "Related invoice"
+msgstr "Factura relacionada"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_name
+msgid "Report identifier"
+msgstr "Report identifier"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_queue_job_sii
 msgid "Requeue"
 msgstr "Re-encolar"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
+msgid "Result"
+msgstr "Resultado"
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/aeat_sii_match_report.py:539
+#, python-format
+msgid "Results"
+msgstr "Results"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.actions.act_window,name:l10n_es_aeat_sii.l10n_es_sii_action
@@ -712,6 +1134,25 @@ msgstr "Causa de exención SII"
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.invoice_supplier_sii_form
 msgid "SII Information"
 msgstr "Información SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_sii_match_result
+msgid "SII Match Result"
+msgstr "Resultado de cuadre de SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
+msgid "SII Match report"
+msgstr "Informe de cuadre de SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_filter
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_filter
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_form
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_tree
+msgid "SII Match result"
+msgstr "Resultado de cuadre de SII"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_fiscal_position_sii_no_taxable_cause
@@ -778,6 +1219,11 @@ msgid "SII failed"
 msgstr "SII fallo"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_sii_field
+msgid "SII field name"
+msgstr "Nombre del campo del SII"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_account_invoice_sii_filter
 msgid "SII filters"
 msgstr "Filtros SII"
@@ -798,6 +1244,27 @@ msgid "SII manual description"
 msgstr "Descripción manual SII"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_sii_match_differences
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_result_sii_match_differences
+msgid "SII match differences"
+msgstr "Diferencias encontradas con el SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_sii_match_return
+msgid "SII match return"
+msgstr "Resultado de cuadre de SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_sii_match_sent
+msgid "SII match sent"
+msgstr "Filtro de cuadre enviado al SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_account_invoice_sii_filter
+msgid "SII match state"
+msgstr "Estado cuadre SII"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_account_invoice_sii_filter
 msgid "SII not sent"
 msgstr "No enviadas SII"
@@ -813,6 +1280,11 @@ msgid "SII registration key"
 msgstr "Clave de registro SII"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_sii_return_field_value
+msgid "SII return field value"
+msgstr "SII valor recibido del campo"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_sii_send_failed
 msgid "SII send failed"
 msgstr "Envío SII fallido"
@@ -826,6 +1298,11 @@ msgstr "Estado de envío SII"
 #: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_account_invoice_sii_filter
 msgid "SII sent"
 msgstr "Enviadas SII"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_differences_sii_sent_field_value
+msgid "SII sent field value"
+msgstr "SII valor enviado del campo"
 
 #. module: l10n_es_aeat_sii
 #: selection:aeat.sii.mapping.registration.keys,type:0
@@ -913,7 +1390,9 @@ msgid "Start Date"
 msgstr "Fecha de inicio"
 
 #. module: l10n_es_aeat_sii
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_match_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_state
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_filter
 msgid "State"
 msgstr "Estado"
 
@@ -1023,6 +1502,11 @@ msgid "SuministroPagosRecibidas WSDL"
 msgstr ""
 
 #. module: l10n_es_aeat_sii
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
+msgid "Summary"
+msgstr "Resumen"
+
+#. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_account_invoice_refund_supplier_invoice_number_refund
 msgid "Supplier Invoice Number"
 msgstr "Nº de factura del proveedor"
@@ -1064,31 +1548,31 @@ msgid "The last attemp to sent to SII has failed"
 msgstr "El último intento de envío al SII ha fallado"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:718
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:758
 #, python-format
 msgid "The partner has not a VAT configured."
 msgstr "La empresa no tiene un NIF establecido."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:734
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:774
 #, python-format
 msgid "The supplier number invoice is required"
 msgstr "El nº de factura del proveedor es obligatorio"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:373
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:413
 #, python-format
 msgid "There's a mismatch in taxes for RE. Check them."
 msgstr "Hay un cruce erróneo para tasas en RE. Chequéelas."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:726
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:766
 #, python-format
 msgid "This company doesn't have SII enabled."
 msgstr "Esta compañía no tiene habilitado el SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:730
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:770
 #, python-format
 msgid "This invoice is not SII enabled."
 msgstr "Esta factura no está habilitada para el SII."
@@ -1124,6 +1608,10 @@ msgstr "Usar conector"
 msgid "WSDL"
 msgstr ""
 
+#: model:ir.ui.view,arch_db:l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_report_form
+msgid "View full tree"
+msgstr "Ver vista completa"
+
 #. module: l10n_es_aeat_sii
 #: selection:res.company,send_mode:0
 msgid "With delay"
@@ -1136,12 +1624,19 @@ msgstr "Modificaciones no enviadas al SII"
 
 #. module: l10n_es_aeat_sii
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1241
+#: code:addons/l10n_es_aeat_sii/models/aeat_sii_match_report.py:512
+#, python-format
+msgid "You can not calculate at this moment because there is a job running!"
+msgstr "En este momento no puede calcularlo porque hay un trabajo ejecutándose!"
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1281
 #, python-format
 msgid "You can not cancel this invoice because there is a job running!"
 msgstr "¡No puede cancelar una factura porque hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1211
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1251
 #, python-format
 msgid ""
 "You can not communicate the cancellation of this invoice at this moment "
@@ -1151,7 +1646,8 @@ msgstr ""
 "hay un trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1150
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1585
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1595
 #, python-format
 msgid ""
 "You can not communicate this invoice at this moment because there is a job "
@@ -1161,7 +1657,7 @@ msgstr ""
 "ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1257
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1297
 #, python-format
 msgid "You can not set to draft this invoice because there is a job running!"
 msgstr ""
@@ -1169,13 +1665,13 @@ msgstr ""
 "trabajo ejecutándose!"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:713
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:753
 #, python-format
 msgid "You can't make a supplier simplified invoice."
 msgstr "No puede realizar una factura simplificada a un proveedor."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:229
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:269
 #, python-format
 msgid ""
 "You cannot change the invoice date of an invoice already registered at the "
@@ -1185,7 +1681,7 @@ msgstr ""
 "cancelar la factura y crear una nueva con la fecha correcta"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:246
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:286
 #, python-format
 msgid ""
 "You cannot change the supplier invoice number of an invoice already "
@@ -1196,7 +1692,7 @@ msgstr ""
 "al SII. Debe cancelar la factura y crear una nueva con el número correcto"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:239
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:279
 #, python-format
 msgid ""
 "You cannot change the supplier of an invoice already registered at the SII. "
@@ -1206,19 +1702,25 @@ msgstr ""
 "la factura y crear una nueva con el proveedor correcto"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:263
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:303
 #, python-format
 msgid "You cannot delete an invoice already registered at the SII."
 msgstr "No puede eliminar una factura enviada al SII."
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:721
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:1507
+#, python-format
+msgid "You have not installed deepdiff library, please install it in order to use this feature"
+msgstr "La librería deepdiff no está instalada, debe instalarla para poder usar esta funcionalidad."
+
+#. module: l10n_es_aeat_sii
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:761
 #, python-format
 msgid "You have to select what account chart template use this company."
 msgstr "Debe seleccionar qué plan contable utiliza esta compañía"
 
 #. module: l10n_es_aeat_sii
-#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:197
+#: code:addons/l10n_es_aeat_sii/models/account_invoice.py:237
 #, python-format
 msgid "You must have at least one refunded invoice"
 msgstr "Debe tener al menos una factura rectificada"
@@ -1294,6 +1796,11 @@ msgstr "[E6] Otros"
 #: model:ir.model,name:l10n_es_aeat_sii.model_l10n_es_aeat_sii
 msgid "l10n.es.aeat.sii"
 msgstr "l10n.es.aeat.sii"
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model,name:l10n_es_aeat_sii.model_l10n_es_aeat_sii_match_differences
+msgid "l10n.es.aeat.sii.match.differences"
+msgstr "l10n.es.aeat.sii.match.differences"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model,name:l10n_es_aeat_sii.model_l10n_es_aeat_sii_password

--- a/l10n_es_aeat_sii/models/__init__.py
+++ b/l10n_es_aeat_sii/models/__init__.py
@@ -7,6 +7,8 @@ from . import aeat_sii_tax_agency
 from . import res_company
 from . import aeat_sii
 from . import aeat_sii_mapping_registration_keys
+from . import aeat_sii_match_differences
+from . import aeat_sii_match_report
 from . import aeat_sii_map
 from . import product_product
 from . import queue_job

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -4,6 +4,7 @@
 # Copyright 2017 Studio73 - Jordi Tolsà <jordi@studio73.es>
 # Copyright 2018 Javi Melendez <javimelex@gmail.com>
 # Copyright 2018 PESOL - Angel Moya <angel.moya@pesol.es>
+# Copyright 2018 Abraham Anes <abraham@studio73.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
@@ -18,9 +19,16 @@ from odoo.modules.registry import RegistryManager
 _logger = logging.getLogger(__name__)
 
 try:
+    from deepdiff import DeepDiff
+except ImportError as err:
+    DeepDiff = False
+    _logger.debug(err)
+
+try:
     from zeep import Client
     from zeep.transports import Transport
     from zeep.plugins import HistoryPlugin
+    from zeep.helpers import serialize_object
 except (ImportError, IOError) as err:
     _logger.debug(err)
 
@@ -176,6 +184,38 @@ class AccountInvoice(models.Model):
     invoice_jobs_ids = fields.Many2many(
         comodel_name='queue.job', column1='invoice_id', column2='job_id',
         string="Connector Jobs", copy=False,
+    )
+    sii_match_sent = fields.Text(
+        string="SII match sent", copy=False, readonly=True,
+    )
+    sii_match_return = fields.Text(
+        string="SII match return", copy=False, readonly=True,
+    )
+    sii_match_state = fields.Selection(
+        string="Match state",
+        readonly=True, copy=False,
+        selection=[
+            ('1', 'No testable'),
+            ('2', 'In process of contrast'),
+            ('3', 'Not contrasted'),
+            ('4', 'Partially contrasted'),
+            ('5', 'Contrasted'),
+        ],
+    )
+    sii_contrast_state = fields.Selection(
+        string="AEAT contrast state",
+        readonly=True, copy=False,
+        selection=[
+            ('correct', 'Correct'),
+            ('no_exist', 'Doesn\'t exist'),
+            ('partially', 'Partially correct'),
+        ],
+    )
+    sii_match_differences = fields.One2many(
+        string="SII match differences",
+        readonly=True, copy=False,
+        comodel_name='l10n.es.aeat.sii.match.differences',
+        inverse_name='invoice_id',
     )
 
     @api.depends('amount_total')
@@ -1458,6 +1498,242 @@ class AccountInvoice(models.Model):
         return -1.0 if self.sii_refund_type == 'I' and 'refund' in self.type \
             else 1.0
 
+    @api.multi
+    def _get_diffs(self, odoo_values, sii_values):
+        sii_values = json.loads(json.dumps((serialize_object(sii_values))))
+        dp = self.env['decimal.precision'].precision_get('Account')
+        res = []
+        if not DeepDiff:
+            raise exceptions.Warning(_(
+                "You have not installed deepdiff library, "
+                "please install it in order to use this feature"
+            ))
+        diff = DeepDiff(odoo_values, sii_values)
+        differences = diff.get('type_changes', {})
+        differences.update(diff.get('values_changed', {}))
+        for label, value in differences.items():
+            sii_value = value['new_value']
+            odoo_value = value['old_value']
+            label = label.split("['")[-1].replace("']", "")
+            if sii_value is not None:
+                # We made an explicit case for TipoImpositivo because we get
+                # always 2 numbers as strings, one with decimal point separator
+                # and another without
+                if label == 'TipoImpositivo' or isinstance(odoo_value, float):
+                    sii_value = round(float(sii_value), dp)
+                    odoo_value = round(float(odoo_value), dp)
+                elif isinstance(odoo_value, basestring):
+                    sii_value = sii_value.strip()
+                    odoo_value = odoo_value.strip()
+                if sii_value != odoo_value:
+                    res.append({
+                        'sii_field': label,
+                        'sii_return_field_value': sii_value,
+                        'sii_sent_field_value': odoo_value,
+                    })
+        return res
+
+    @api.multi
+    def _get_diffs_values(self, sii_values):
+        self.ensure_one()
+        res = []
+        if self.sii_content_sent:
+            odoo_values = json.loads(self.sii_content_sent)
+            if self.type in ['out_invoice', 'out_refund']:
+                res += self._get_diffs(odoo_values['FacturaExpedida'],
+                                       sii_values['DatosFacturaEmitida'])
+            elif self.type in ['in_invoice', 'in_refund']:
+                res += self._get_diffs(odoo_values['FacturaRecibida'],
+                                       sii_values['DatosFacturaRecibida'])
+        return list((0, 0, r) for r in res)
+
+    @api.multi
+    def _invoice_started_jobs(self):
+        for queue in self.mapped('invoice_jobs_ids'):
+            if queue.state == 'started':
+                return False
+        return True
+
+    @api.multi
+    def _process_invoice_for_contrast_aeat(self):
+        """Process invoices for contrast to the AEAT. Adds general checks from
+        configuration parameters and invoice availability for SII"""
+        queue_obj = self.env['queue.job'].sudo()
+        for invoice in self:
+            company = invoice.company_id
+            new_delay = invoice.sudo().with_context(
+                company_id=company.id
+            ).with_delay(
+                eta=False,
+            ).contrast_one_invoice()
+            job = queue_obj.search([
+                ('uuid', '=', new_delay.uuid)
+            ], limit=1)
+            invoice.sudo().invoice_jobs_ids |= job
+
+    @api.multi
+    def contrast_aeat(self):
+        invoices = self.filtered(
+            lambda i: (
+                i.sii_state == 'sent' and
+                i.state in ['open', 'paid'] and
+                i.sii_csv and
+                i.sii_enabled
+            )
+        )
+        if not invoices._invoice_started_jobs():
+            raise exceptions.Warning(_(
+                'You can not contrast this invoice at this moment '
+                'because there is a job running!'))
+        invoices._process_invoice_for_contrast_aeat()\
+
+
+    @api.multi
+    def direct_contrast_aeat(self):
+        self.ensure_one()
+        if not self._invoice_started_jobs():
+            raise exceptions.Warning(_(
+                'You can not contrast this invoice at this moment '
+                'because there is a job running!'))
+        if self.sii_csv and self.sii_enabled and self.sii_state == 'sent' and \
+                self.state in ['open', 'paid']:
+            self._contrast_invoice_to_aeat()
+        else:
+            raise Warning(_(
+                'Las facturas tienen que estar enviadas y con CSV para poder '
+                'ser contrastadas.'
+            ))
+
+    @api.multi
+    def _get_contrast_invoice_dict_out(self):
+        """Build dict with data to send to AEAT WS for invoice types:
+        out_invoice and out_refund.
+        :return: invoices (dict) : Dict XML with data for this invoice.
+        """
+        self.ensure_one()
+        invoice_date = self._change_date_format(self.date_invoice)
+        partner = self.partner_id.commercial_partner_id
+        company = self.company_id
+        ejercicio = fields.Date.from_string(self.date).year
+        periodo = '%02d' % fields.Date.from_string(self.date).month
+        inv_dict = {
+            "FiltroConsulta": {},
+            "PeriodoImpositivo": {
+                "Ejercicio": ejercicio,
+                "Periodo": periodo,
+            },
+            "IDFactura": {
+                "IDEmisorFactura": {
+                    "NIF": company.vat[2:],
+                },
+                "NumSerieFacturaEmisor":
+                    (self.number or self.internal_number or '')[0:60],
+                "FechaExpedicionFacturaEmisor": invoice_date,
+            },
+        }
+        if not partner.sii_simplified_invoice:
+            # Simplified invoices don't have counterpart
+            inv_dict["Contraparte"] = {"NombreRazon": partner.name[0:120]}
+            # Uso condicional de IDOtro/NIF
+            inv_dict['Contraparte'].update(self._get_sii_identifier())
+        return inv_dict
+
+    @api.multi
+    def _get_contrast_invoice_dict_in(self):
+        """Build dict with data to send to AEAT WS for invoice types:
+        in_invoice and in_refund.
+        :return: invoices (dict) : Dict XML with data for this invoice.
+        """
+        self.ensure_one()
+        invoice_date = self._change_date_format(self.date_invoice)
+        ejercicio = fields.Date.from_string(self.date).year
+        periodo = '%02d' % fields.Date.from_string(self.date).month
+        inv_dict = {
+            "FiltroConsulta": {},
+            "IDFactura": {
+                "IDEmisorFactura": {
+                    "NombreRazon":
+                        self.partner_id.commercial_partner_id.name[0:120],
+                },
+                "NumSerieFacturaEmisor": (
+                    (self.reference or '')[:60]
+                ),
+                "FechaExpedicionFacturaEmisor": invoice_date},
+            "PeriodoImpositivo": {
+                "Ejercicio": ejercicio,
+                "Periodo": periodo
+            },
+        }
+        # Uso condicional de IDOtro/NIF
+        ident = self._get_sii_identifier()
+        inv_dict['IDFactura']['IDEmisorFactura'].update(ident)
+        return inv_dict
+
+    @api.multi
+    def _get_contrast_invoice_dict(self):
+        self.ensure_one()
+        self._sii_check_exceptions()
+        if self.type in ['out_invoice', 'out_refund']:
+            return self._get_contrast_invoice_dict_out()
+        elif self.type in ['in_invoice', 'in_refund']:
+            return self._get_contrast_invoice_dict_in()
+        return {}
+
+    @api.multi
+    def _contrast_invoice_to_aeat(self):
+        for invoice in self.filtered(lambda i: i.state in ['open', 'paid']):
+            serv = invoice._connect_sii(invoice.type)
+            header = invoice._get_sii_header(False, True)
+            inv_vals = {}
+            try:
+                inv_dict = invoice._get_contrast_invoice_dict()
+                inv_vals['sii_match_sent'] = json.dumps(inv_dict, indent=4)
+                res_line = False
+                if invoice.type in ['out_invoice', 'out_refund']:
+                    res = serv.ConsultaLRFacturasEmitidas(header, inv_dict)
+                    res_line = \
+                        res['RegistroRespuestaConsultaLRFacturasEmitidas'][0]
+                elif invoice.type in ['in_invoice', 'in_refund']:
+                    res = serv.ConsultaLRFacturasRecibidas(header, inv_dict)
+                    res_line = \
+                        res['RegistroRespuestaConsultaLRFacturasRecibidas'][0]
+                inv_vals.update({
+                    'sii_contrast_state': 'no_exist',
+                    'sii_match_state': False,
+                })
+                if res_line:
+                    if res_line['DatosPresentacion']['CSV'] == self.sii_csv:
+                        cuadre_state = res_line['EstadoFactura'] and res_line[
+                            'EstadoFactura']['EstadoCuadre'] or False
+                        if cuadre_state:
+                            inv_vals.update({
+                                'sii_match_state':
+                                    res_line['EstadoFactura']['EstadoCuadre'],
+                                'sii_contrast_state': 'correct',
+                            })
+                            diffs = invoice._get_diffs_values(res_line)
+                            if diffs:
+                                inv_vals['sii_match_differences'] = diffs
+                                inv_vals.update(
+                                    {'sii_contrast_state': 'partially', })
+                invoice.sii_match_differences.unlink()
+                inv_vals['sii_match_return'] = json.dumps(
+                    serialize_object(res), indent=4)
+                invoice.write(inv_vals)
+            except Exception as fault:
+                new_cr = RegistryManager.get(self.env.cr.dbname).cursor()
+                env = api.Environment(new_cr, self.env.uid, self.env.context)
+                invoice = env['account.invoice'].browse(self.id)
+                inv_vals.update({
+                    'sii_match_return': str(fault),
+                    'sii_contrast_state': False,
+                    'sii_match_state': False,
+                })
+                invoice.write(inv_vals)
+                new_cr.commit()
+                new_cr.close()
+                raise
+
     @job(default_channel='root.invoice_validate_sii')
     @api.multi
     def confirm_one_invoice(self):
@@ -1467,3 +1743,8 @@ class AccountInvoice(models.Model):
     @api.multi
     def cancel_one_invoice(self):
         self._cancel_invoice_to_sii()
+
+    @job(default_channel='root.invoice_validate_sii')
+    @api.multi
+    def contrast_one_invoice(self):
+        self._contrast_invoice_to_aeat()

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1618,7 +1618,7 @@ class AccountInvoice(models.Model):
         periodo = '%02d' % fields.Date.from_string(self.date).month
         inv_dict = {
             "FiltroConsulta": {},
-            "PeriodoImpositivo": {
+            "PeriodoLiquidacion": {
                 "Ejercicio": ejercicio,
                 "Periodo": periodo,
             },
@@ -1659,7 +1659,7 @@ class AccountInvoice(models.Model):
                     (self.reference or '')[:60]
                 ),
                 "FechaExpedicionFacturaEmisor": invoice_date},
-            "PeriodoImpositivo": {
+            "PeriodoLiquidacion": {
                 "Ejercicio": ejercicio,
                 "Periodo": periodo
             },

--- a/l10n_es_aeat_sii/models/aeat_sii_match_differences.py
+++ b/l10n_es_aeat_sii/models/aeat_sii_match_differences.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Abraham Anes <abraham@studio73.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class SiiMatchDifferences(models.Model):
+    _name = 'l10n.es.aeat.sii.match.differences'
+
+    invoice_id = fields.Many2one(
+        string="Related invoice", comodel_name='account.invoice'
+    )
+    report_id = fields.Many2one(
+        string="Related SII match report",
+        comodel_name='l10n.es.aeat.sii.match.result'
+    )
+    sii_field = fields.Char(
+        string="SII field name", copy=False,
+    )
+    sii_return_field_value = fields.Char(
+        string="SII return field value", copy=False,
+    )
+    sii_sent_field_value = fields.Char(
+        string="SII sent field value", copy=False,
+    )

--- a/l10n_es_aeat_sii/models/aeat_sii_match_report.py
+++ b/l10n_es_aeat_sii/models/aeat_sii_match_report.py
@@ -33,7 +33,7 @@ except ImportError:
         return functools.partial
     job = empty_decorator_factory
 
-SII_VERSION = '1.0'
+SII_VERSION = '1.1'
 
 
 class SiiMatchReport(models.Model):
@@ -155,7 +155,7 @@ class SiiMatchReport(models.Model):
         self.ensure_one()
         inv_dict = {
             "FiltroConsulta": {},
-            "PeriodoImpositivo": {
+            "PeriodoLiquidacion": {
                 "Ejercicio": str(self.fiscalyear),
                 "Periodo": self.period_type,
             },

--- a/l10n_es_aeat_sii/models/aeat_sii_match_report.py
+++ b/l10n_es_aeat_sii/models/aeat_sii_match_report.py
@@ -1,0 +1,606 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Abraham Anes <abraham@studio73.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+import json
+import copy
+
+from dateutil.relativedelta import relativedelta
+
+from odoo import _, api, fields, exceptions, models
+from requests import Session
+
+from odoo.modules.registry import RegistryManager
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from zeep import Client
+    from zeep.transports import Transport
+    from zeep.plugins import HistoryPlugin
+    from zeep.helpers import serialize_object
+except (ImportError, IOError) as err:
+    _logger.debug(err)
+
+try:
+    from odoo.addons.queue_job.job import job
+except ImportError:
+    _logger.debug('Can not `import queue_job`.')
+    import functools
+
+    def empty_decorator_factory(*argv, **kwargs):
+        return functools.partial
+    job = empty_decorator_factory
+
+SII_VERSION = '1.0'
+
+
+class SiiMatchReport(models.Model):
+    _name = "l10n.es.aeat.sii.match.report"
+    _description = "AEAT SII match Report"
+
+    def _default_company_id(self):
+        company_obj = self.env['res.company']
+        return company_obj._company_default_get(
+            'l10n.es.aeat.sii.match.report')
+
+    name = fields.Char(string='Report identifier', required=True,)
+    state = fields.Selection(
+        selection=[('draft', 'Draft'),
+                   ('calculated', 'Calculated'),
+                   ('done', 'Done'),
+                   ('error', 'Error'),
+                   ('cancelled', 'Cancelled')],
+        string='State', default='draft',
+    )
+    period_type = fields.Selection(
+        selection=[('01', '01 - January'),
+                   ('02', '02 - February'),
+                   ('03', '03 - March'),
+                   ('04', '04 - April'),
+                   ('05', '05 - May'),
+                   ('06', '06 - June'),
+                   ('07', '07 - July'),
+                   ('08', '08 - August'),
+                   ('09', '09 - September'),
+                   ('10', '10 - October'),
+                   ('11', '11 - November'),
+                   ('12', '12 - December')],
+        string="Period type", required=True,
+        readonly=True, states={'draft': [('readonly', False)]},
+    )
+    fiscalyear = fields.Integer(
+        string='Fiscal year', lenght=4, required=True,
+        default=fields.Date.from_string(fields.Date.today()).year,
+        readonly=True, states={'draft': [('readonly', False)]},
+    )
+    company_id = fields.Many2one(
+        comodel_name='res.company', default=_default_company_id,
+        string='Company', required=True,
+        readonly=True, states={'draft': [('readonly', False)]},
+    )
+    calculate_date = fields.Datetime(
+        string='Calculate date',
+        readonly=True, states={'draft': [('readonly', False)]},
+    )
+    sii_match_result = fields.One2many(
+        comodel_name='l10n.es.aeat.sii.match.result',
+        inverse_name='report_id',
+        string='SII Match Result',
+        readonly=True,
+    )
+    invoice_type = fields.Selection(
+        selection=[('out', 'Out invoice/refund'),
+                   ('in', 'In invoice/refund')],
+        string='Invoice type', required=True,
+        readonly=True, states={'draft': [('readonly', False)]},
+    )
+    number_records = fields.Integer(string='Records', readonly=True, )
+    number_records_both = fields.Integer(
+        string='Records in Odoo and SII', readonly=True,
+    )
+    number_records_odoo = fields.Integer(
+        string='Records only in Odoo', readonly=True,
+    )
+    number_records_sii = fields.Integer(
+        string='Records only in SII', readonly=True,
+    )
+    number_records_correct = fields.Integer(
+        string='Records corretly contrasted', readonly=True,
+    )
+    number_records_no_exist = fields.Integer(
+        string='Records without contrast', readonly=True,
+    )
+    number_records_partially = fields.Integer(
+        string='Records partially contrasted', readonly=True,
+    )
+    number_records_no_test = fields.Integer(
+        string='Records no testables', readonly=True,
+    )
+    number_records_in_process = fields.Integer(
+        string='Records in process of contrast', readonly=True,
+    )
+    number_records_not_contrasted = fields.Integer(
+        string='Records not contasted', readonly=True,
+    )
+    number_records_partially_contrasted = fields.Integer(
+        string='Records partially contrasted', readonly=True,
+    )
+    number_records_contrasted = fields.Integer(
+        string='Records contrasted', readonly=True,
+    )
+    sii_match_jobs_ids = fields.Many2many(
+        comodel_name='queue.job', column1='sii_match_id', column2='job_id',
+        string="Connector Jobs", copy=False,
+    )
+
+    @api.multi
+    def _process_invoices_from_sii(self):
+        queue_obj = self.env['queue.job'].sudo()
+        for match_report in self:
+            company = match_report.company_id
+            new_delay = match_report.sudo().with_context(
+                company_id=company.id
+            ).with_delay(
+                eta=False,
+            ).get_invoice_aeat()
+            job = queue_obj.search([
+                ('uuid', '=', new_delay.uuid)
+            ], limit=1)
+            match_report.sudo().sii_match_jobs_ids |= job
+
+    @api.multi
+    def _get_invoice_dict(self):
+        self.ensure_one()
+        inv_dict = {
+            "FiltroConsulta": {},
+            "PeriodoImpositivo": {
+                "Ejercicio": str(self.fiscalyear),
+                "Periodo": self.period_type,
+            },
+        }
+        return inv_dict
+
+    @api.multi
+    def _get_aeat_odoo_invoices_by_csv(self, sii_response):
+        matched_invoices = {}
+        left_invoices = []
+        for invoice in sii_response:
+            invoice = json.loads(json.dumps(serialize_object(invoice)))
+            csv = invoice['DatosPresentacion']['CSV']
+            invoice_state = invoice['EstadoFactura']['EstadoRegistro']
+            odoo_invoice = self.env['account.invoice'].search(
+                [('sii_csv', '=', csv)])
+            if odoo_invoice:
+                matched_invoices[odoo_invoice.id] = invoice
+            elif invoice_state != 'Anulada':
+                left_invoices.append(invoice)
+        return matched_invoices, left_invoices
+
+    @api.multi
+    def _get_aeat_odoo_invoices_by_num(self, left_invoices, matched_invoices):
+        left_results = []
+        for invoice in left_invoices:
+            name = invoice['IDFactura']['NumSerieFacturaEmisor']
+            if self.invoice_type == 'out':
+                odoo_invoice = self.env['account.invoice'].search([
+                    ('number', '=', name),
+                    ('type', 'in', ['out_invoice', 'out_refund'])
+                ], limit=1)
+            else:
+                odoo_invoice = self.env['account.invoice'].search([
+                    ('reference', '=', name),
+                    ('type', 'in', ['in_invoice', 'in_refund'])
+                ], limit=1)
+            if odoo_invoice and odoo_invoice.id not in matched_invoices.keys():
+                matched_invoices[odoo_invoice.id] = invoice
+            else:
+                left_results.append(invoice)
+        return matched_invoices, left_results
+
+    @api.multi
+    def _get_aeat_odoo_invoices(self, sii_response):
+        matched_invoices, left_invoices = self._get_aeat_odoo_invoices_by_csv(
+            sii_response)
+        matched_invoices, left_invoices = self._get_aeat_odoo_invoices_by_num(
+            left_invoices, matched_invoices)
+        res = []
+        invoices_list = {}
+        for odoo_inv_id, invoice in matched_invoices.items():
+            name = invoice['IDFactura']['NumSerieFacturaEmisor']
+            csv = invoice['DatosPresentacion']['CSV']
+            match_state = invoice['EstadoFactura']['EstadoCuadre']
+            odoo_invoice = self.env['account.invoice'].browse([odoo_inv_id])
+            inv_location = 'both'
+            contrast_state = 'correct'
+            diffs = odoo_invoice._get_diffs_values(invoice)
+            if diffs:
+                contrast_state = 'partially'
+            invoices_list[odoo_invoice.id] = {
+                'sii_match_return': json.dumps(str(invoice), indent=4),
+                'sii_match_state': match_state,
+                'sii_contrast_state': contrast_state,
+                'sii_match_differences': copy.deepcopy(diffs),
+            }
+            res.append({
+                'invoice': name,
+                'invoice_id': odoo_invoice.id,
+                'csv': csv,
+                'invoice_location': inv_location,
+                'sii_match_differences': diffs,
+                'sii_match_state': match_state,
+                'sii_contrast_state': contrast_state,
+            })
+        for invoice in left_invoices:
+            name = invoice['IDFactura']['NumSerieFacturaEmisor']
+            csv = invoice['DatosPresentacion']['CSV']
+            match_state = invoice['EstadoFactura']['EstadoCuadre']
+            contrast_state = 'no_exist'
+            inv_location = 'sii'
+            diffs = []
+            res.append({
+                'invoice': name,
+                'invoice_id': False,
+                'csv': csv,
+                'invoice_location': inv_location,
+                'sii_match_differences': diffs,
+                'sii_match_state': match_state,
+                'sii_contrast_state': contrast_state,
+            })
+        return res, invoices_list
+
+    @api.multi
+    def _get_not_in_sii_invoices(self, invoices):
+        self.ensure_one()
+        start_date = fields.Date.from_string(
+            '%s-%s-01' % (str(self.fiscalyear), self.period_type))
+        date_from = fields.Date.to_string(start_date)
+        date_to = fields.Date.to_string(
+            start_date + relativedelta(months=1)
+        )
+        res = []
+        inv_type = [
+            'out_invoice', 'out_refund'] if self.invoice_type == 'out' else [
+            'in_invoice', 'in_refund']
+        invoice_ids = self.env['account.invoice'].search([
+            ('date', '>=', date_from),
+            ('date', '<', date_to),
+            ('company_id', '=', self.company_id.id),
+            ('id', 'not in', invoices.keys()),
+            ('type', 'in', inv_type),
+        ])
+        for invoice in invoice_ids:
+            if invoice.sii_enabled:
+                if 'out_invoice' in inv_type:
+                    number = invoice.number or _('Draft')
+                else:
+                    number = invoice.reference
+                res.append({
+                    'invoice': number,
+                    'invoice_id': invoice.id,
+                    'sii_contrast_state': 'no_exist',
+                    'invoice_location': 'odoo',
+                })
+        return res
+
+    @api.multi
+    def _update_odoo_invoices(self, invoices):
+        self.ensure_one()
+        for invoice_id, values in invoices.items():
+            invoice = self.env['account.invoice'].browse([invoice_id])
+            invoice.sii_match_differences.unlink()
+            invoice.write(values)
+        return []
+
+    @api.multi
+    def _get_match_result_values(self, sii_response):
+        self.ensure_one()
+        vals = []
+        invoices, matched_invoices = self._get_aeat_odoo_invoices(sii_response)
+        invoices += self._get_not_in_sii_invoices(matched_invoices)
+        self._update_odoo_invoices(matched_invoices)
+        summary = {
+            'total': len(invoices),
+            'both': len(
+                filter(lambda i: i['invoice_location'] == 'both', invoices)
+            ),
+            'sii': len(
+                filter(lambda i: i['invoice_location'] == 'sii', invoices)
+            ),
+            'odoo': len(
+                filter(lambda i: i['invoice_location'] == 'odoo', invoices)
+            ),
+            'correct': len(
+                filter(
+                    lambda i: i['sii_contrast_state'] == 'correct',
+                    invoices
+                )
+            ),
+            'no_exist': len(
+                filter(
+                    lambda i: i['sii_contrast_state'] == 'no_exist',
+                    invoices
+                )
+            ),
+            'partially': len(
+                filter(
+                    lambda i: i['sii_contrast_state'] == 'partially',
+                    invoices
+                )
+            ),
+            'no_test': len(
+                filter(
+                    lambda i: (i.get('sii_match_state', False) and
+                               i['sii_match_state'] == '1'),
+                    invoices
+                )
+            ),
+            'in_process': len(
+                filter(
+                    lambda i: (i.get('sii_match_state', False) and
+                               i['sii_match_state'] == '2'),
+                    invoices
+                )
+            ),
+            'not_contrasted': len(
+                filter(
+                    lambda i: (i.get('sii_match_state', False) and
+                               i['sii_match_state'] == '3'),
+                    invoices
+                )
+            ),
+            'partially_contrasted': len(
+                filter(
+                    lambda i: (i.get('sii_match_state', False) and
+                               i['sii_match_state'] == '4'),
+                    invoices
+                )
+            ),
+            'contrasted': len(
+                filter(
+                    lambda i: (i.get('sii_match_state', False)
+                               and i['sii_match_state'] == '5'),
+                    invoices
+                )
+            ),
+        }
+        for l in filter(
+            lambda i: (i['sii_contrast_state'] != 'correct'
+                       or i['sii_match_state'] == '4'),
+            invoices
+        ):
+            vals.append((0, 0, l))
+        return vals, summary
+
+    @api.multi
+    def _get_invoices_from_sii(self):
+        for sii_match_report in self.filtered(
+                lambda r: r.state in ['draft', 'error', 'calculated']):
+            company = sii_match_report.company_id
+            port_name = ''
+            wsdl = ''
+            if sii_match_report.invoice_type == 'out':
+                wsdl = self.env['ir.config_parameter'].get_param(
+                    'l10n_es_aeat_sii.wsdl_out', False)
+                port_name = 'SuministroFactEmitidas'
+                if company.sii_test:
+                    port_name += 'Pruebas'
+            elif sii_match_report.invoice_type == 'in':
+                wsdl = self.env['ir.config_parameter'].get_param(
+                    'l10n_es_aeat_sii.wsdl_in', False)
+                port_name = 'SuministroFactRecibidas'
+                if company.sii_test:
+                    port_name += 'Pruebas'
+            client = self._connect_sii(wsdl)
+            serv = client.bind('siiService', port_name)
+            header = sii_match_report._get_sii_header()
+            match_vals = {}
+            summary = {}
+            try:
+                inv_dict = sii_match_report._get_invoice_dict()
+                if sii_match_report.invoice_type == 'out':
+                    res = serv.ConsultaLRFacturasEmitidas(header, inv_dict)
+                    res_line = \
+                        res['RegistroRespuestaConsultaLRFacturasEmitidas']
+                elif sii_match_report.invoice_type == 'in':
+                    res = serv.ConsultaLRFacturasRecibidas(header, inv_dict)
+                    res_line = \
+                        res['RegistroRespuestaConsultaLRFacturasRecibidas']
+                if res_line:
+                    match_vals['sii_match_result'], summary = \
+                        sii_match_report._get_match_result_values(res_line)
+                match_vals['number_records'] = \
+                    summary and summary['total'] or 0
+                match_vals['number_records_both'] = \
+                    summary and summary['both'] or 0
+                match_vals['number_records_odoo'] = \
+                    summary and summary['odoo'] or 0
+                match_vals['number_records_sii'] = \
+                    summary and summary['sii'] or 0
+                match_vals['number_records_correct'] = \
+                    summary and summary['correct'] or 0
+                match_vals['number_records_no_exist'] = \
+                    summary and summary['no_exist'] or 0
+                match_vals['number_records_partially'] = \
+                    summary and summary['partially'] or 0
+                match_vals['number_records_no_test'] = \
+                    summary and summary['no_test'] or 0
+                match_vals['number_records_in_process'] = \
+                    summary and summary['in_process'] or 0
+                match_vals['number_records_not_contrasted'] = \
+                    summary and summary['not_contrasted'] or 0
+                match_vals['number_records_partially_contrasted'] = \
+                    summary and summary['partially_contrasted'] or 0
+                match_vals['number_records_contrasted'] = \
+                    summary and summary['contrasted']
+                sii_match_report.sii_match_result.mapped(
+                    'sii_match_differences').unlink()
+                sii_match_report.sii_match_result.unlink()
+                match_vals['state'] = 'calculated'
+                match_vals['calculate_date'] = fields.Datetime.now()
+                sii_match_report.write(match_vals)
+            except Exception:
+                new_cr = RegistryManager.get(self.env.cr.dbname).cursor()
+                env = api.Environment(new_cr, self.env.uid, self.env.context)
+                sii_match_report = env['l10n.es.aeat.sii.match.report'].browse(
+                    self.id)
+                match_vals.update({
+                    'state': 'error',
+                })
+                sii_match_report.write(match_vals)
+                new_cr.commit()
+                new_cr.close()
+                raise
+
+    @api.multi
+    def _get_sii_header(self):
+        """Builds SII send header
+
+        :return Dict with header data depending on cancellation
+        """
+        self.ensure_one()
+        company = self.company_id
+        if not company.vat:
+            raise exceptions.Warning(_(
+                "No VAT configured for the company '{}'").format(company.name))
+        header = {
+            "IDVersionSii": SII_VERSION,
+            "Titular": {
+                "NombreRazon": self.company_id.name[0:120],
+                "NIF": self.company_id.vat[2:]}
+        }
+        return header
+
+    @api.multi
+    def _connect_sii(self, wsdl):
+        today = fields.Date.today()
+        sii_config = self.env['l10n.es.aeat.sii'].search([
+            ('company_id', '=', self.company_id.id),
+            ('public_key', '!=', False),
+            ('private_key', '!=', False),
+            '|',
+            ('date_start', '=', False),
+            ('date_start', '<=', today),
+            '|',
+            ('date_end', '=', False),
+            ('date_end', '>=', today),
+            ('state', '=', 'active'),
+        ], limit=1)
+        if sii_config:
+            public_crt = sii_config.public_key
+            private_key = sii_config.private_key
+        else:
+            public_crt = self.env['ir.config_parameter'].get_param(
+                'l10n_es_aeat_sii.publicCrt', False)
+            private_key = self.env['ir.config_parameter'].get_param(
+                'l10n_es_aeat_sii.privateKey', False)
+        session = Session()
+        session.cert = (public_crt, private_key)
+        transport = Transport(session=session)
+        history = HistoryPlugin()
+        client = Client(wsdl=wsdl, transport=transport, plugins=[history])
+        return client
+
+    @api.multi
+    def button_calculate(self):
+        for match in self:
+            for queue in match.mapped('sii_match_jobs_ids'):
+                if queue.state in ('pending', 'enqueued', 'failed'):
+                    queue.sudo().unlink()
+                elif queue.state == 'started':
+                    raise exceptions.Warning(_(
+                        'You can not calculate at this moment '
+                        'because there is a job running!'))
+        self._process_invoices_from_sii()
+        return []
+
+    @api.multi
+    def button_cancel(self):
+        self.write({'state': 'cancelled'})
+        return []
+
+    @api.multi
+    def button_recover(self):
+        self.write({'state': 'draft'})
+        return []
+
+    @api.multi
+    def button_confirm(self):
+        self.write({'state': 'done'})
+        return []
+
+    @api.multi
+    def open_result(self):
+        self.ensure_one()
+        tree_view = self.env.ref(
+            'l10n_es_aeat_sii.view_l10n_es_aeat_sii_match_result_tree')
+        return {
+            'name': _('Results'),
+            'view_type': 'form',
+            'view_mode': 'tree, form',
+            'res_model': 'l10n.es.aeat.sii.match.result',
+            'views': [(tree_view and tree_view.id or False, "tree"),
+                      (False, "form")],
+            'type': 'ir.actions.act_window',
+            'domain': [('id', 'in', self.sii_match_result.ids)],
+            'context': {},
+        }
+
+    @job(default_channel='root.invoice_validate_sii')
+    @api.multi
+    def get_invoice_aeat(self):
+        self._get_invoices_from_sii()
+
+
+class SiiMatchResult(models.Model):
+    _name = 'l10n.es.aeat.sii.match.result'
+    _description = 'AEAT SII Match - Result'
+    _order = 'invoice asc'
+
+    report_id = fields.Many2one(
+        comodel_name='l10n.es.aeat.sii.match.report',
+        string='AEAT SII Match Report ID',
+        ondelete="cascade"
+    )
+    invoice = fields.Char(string='Invoice')
+    invoice_id = fields.Many2one(
+        string='Odoo invoice',
+        comodel_name='account.invoice'
+    )
+    csv = fields.Char(string='CSV')
+    sii_match_state = fields.Selection(
+        string="Match state",
+        readonly=True, copy=False,
+        selection=[
+            ('1', 'No testable'),
+            ('2', 'In process of contrast'),
+            ('3', 'Not contrasted'),
+            ('4', 'Partially contrasted'),
+            ('5', 'Contrasted'),
+        ],
+    )
+    sii_contrast_state = fields.Selection(
+        string="AEAT contrast state",
+        readonly=True, copy=False,
+        selection=[
+            ('correct', 'Correct'),
+            ('no_exist', 'Doesn\'t exist'),
+            ('partially', 'Partially correct'),
+        ],
+    )
+    invoice_location = fields.Selection(
+        string="Invoice location",
+        readonly=True, copy=False,
+        selection=[
+            ('both', 'Invoice in Odoo and SII'),
+            ('odoo', 'Invoice in Odoo'),
+            ('sii', 'Invoice in SII'),
+        ],
+    )
+    sii_match_differences = fields.One2many(
+        string="SII match differences",
+        readonly=True, copy=False,
+        comodel_name='l10n.es.aeat.sii.match.differences',
+        inverse_name='report_id',
+    )

--- a/l10n_es_aeat_sii/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_sii/readme/CONTRIBUTORS.rst
@@ -11,3 +11,4 @@
 * Santi Argüeso - Comunitea S.L. <santi@comunitea.com>
 * Angel Moya - PESOL <angel.moya@pesol.es>
 * Nacho Muñoz <nacmuro@gmail.com>
+* Abraham Anes <abraham@studio73.es>

--- a/l10n_es_aeat_sii/readme/DESCRIPTION.rst
+++ b/l10n_es_aeat_sii/readme/DESCRIPTION.rst
@@ -1,2 +1,11 @@
 Módulo para la presentación inmediata del IVA
 https://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/V_1_1/SII_Descripcion_ServicioWeb_v1.1.pdf
+
+Sistema de comprobación y contraste
+***********************************
+
+* El módulo recupera los datos enviados a la AEAT mediante peticiones unitarias o por meses (como una declaración AEAT)
+* Los datos recibidos se procesan intentando asociarlos mediante su CSV (Código Seguro de Verificación) y si no encuentra el CSV, busca por número de factura/fecha/partner
+* El módulo muestra aquellos registros que no han conseguido asociarse, así como aquellas facturas en Odoo que no tienen su correspondiente registro en los datos recibidos.
+* En segundo lugar se exponen los registros que tienen diferencias entre Odoo y AEAT
+* Por último se muestran por separado facturas 'No contrastadas' o 'Parcialmente contrastadas', es decir, las que la propia AEAT no haya podido cotejar entre el emisor de la factura y el receptor, siendo los dos obligados a declarar en el sistema SII.

--- a/l10n_es_aeat_sii/readme/INSTALL.rst
+++ b/l10n_es_aeat_sii/readme/INSTALL.rst
@@ -3,3 +3,4 @@ Para instalar esté módulo necesita:
 #. Libreria Python Zeep, se puede instalar con el comando 'pip install zeep'
 #. Libreria Python Requests, se puede instalar con el comando 'pip install requests'
 #. Libreria pyOpenSSL, versión 0.15 o posterior
+#. Libreria Python DeepDiff, se puede instalar con el comando 'pip install deepdiff', es opcional, pero sin ella no podremos utilizar la opcion de contraste.

--- a/l10n_es_aeat_sii/readme/USAGE.rst
+++ b/l10n_es_aeat_sii/readme/USAGE.rst
@@ -1,2 +1,10 @@
 Cuando se valida una factura automáticamente envia la comunicación al servidor
 de AEAT.
+
+Sistema de comprobación y contraste
+***********************************
+
+* Cada factura tiene un boton 'Contrastar con AEAT' al pulsarlo crea un Job y al finalizar se muestra en los campos "Estado cuadre" y "Estado contraste AEAT" el resultado global.
+* "Estado cuadre": son los estados que proporciona la AEAT para saber si la contraparte ha enviado los mismo datos.
+* "Estado contraste AEAT": comprueba si los datos en el servidor de la AEAT son los mismos que en Odoo, puede ocurrir que algún empleado o asesor externo entre en el sitio web de la AEAT y realice cambios sin pasar por Odoo.
+* Desde el menú Declaraciones AEAT también existe la opción de realizar una comprobación por meses de todas las facturas, en este caso se muestra el resumen de datos globales y el detalle de aquellas facturas que no han podido contrastarse por alguno de los problemas arriba indicados.

--- a/l10n_es_aeat_sii/security/aeat_sii.xml
+++ b/l10n_es_aeat_sii/security/aeat_sii.xml
@@ -11,7 +11,7 @@
     <record id="queue_job_sii_rule" model="ir.rule">
         <field name="name">Queue job AEAT SII visibility</field>
         <field name="model_id" ref="queue_job.model_queue_job"/>
-        <field name="domain_force">[('channel', '=', 'root.invoice_validate_sii')]</field>
+        <field name="domain_force">['|', ('channel', '=', 'root.invoice_validate_sii'), '|', ('channel', '=', 'root.invoice_contrast_aeat'), ('channel', '=', 'root.get_invoice_aeat')]</field>
         <field name="groups" eval="[(4, ref('l10n_es_aeat.group_account_aeat'))]"/>
     </record>
 

--- a/l10n_es_aeat_sii/security/ir.model.access.csv
+++ b/l10n_es_aeat_sii/security/ir.model.access.csv
@@ -11,3 +11,9 @@ access_l10n_es_aeat_sii_aeat,l10n.es.aeat.sii aeat,model_l10n_es_aeat_sii,l10n_e
 access_queue_job,access_queue_job aeat,queue_job.model_queue_job,l10n_es_aeat.group_account_aeat,1,0,0,0
 access_aeat_sii_tax_agency_account,access_aeat_sii_tax_agency_account,model_aeat_sii_tax_agency,account.group_account_invoice,1,0,0,0
 access_aeat_sii_tax_agency_system,access_aeat_sii_tax_agency_system,model_aeat_sii_tax_agency,base.group_system,1,1,1,1
+access_model_l10n_es_aeat_sii_match_report_admin,l10n.es.aeat.sii.match.report admin,model_l10n_es_aeat_sii_match_report,base.group_system,1,1,1,1
+access_model_l10n_es_aeat_sii_match_report_aeat,l10n.es.aeat.sii.match.report aeat,model_l10n_es_aeat_sii_match_report,l10n_es_aeat.group_account_aeat,1,1,1,1
+access_model_l10n_es_aeat_sii_match_result_admin,l10n.es.aeat.sii.match.result admin,model_l10n_es_aeat_sii_match_result,base.group_system,1,1,1,1
+access_model_l10n_es_aeat_sii_match_result_aeat,l10n.es.aeat.sii.match.result aeat,model_l10n_es_aeat_sii_match_result,l10n_es_aeat.group_account_aeat,1,1,1,1
+access_model_l10n_es_aeat_sii_match_differences_all,l10n.es.aeat.sii.match.differences all,model_l10n_es_aeat_sii_match_differences,l10n_es_aeat.group_account_aeat,1,1,1,1
+access_model_l10n_es_aeat_sii_match_differences_group_account_invoice,l10n.es.aeat.sii.match.differences group_account_invoice,model_l10n_es_aeat_sii_match_differences,account.group_account_invoice,1,1,1,1

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -36,16 +36,36 @@
                             <field name="sii_registration_key_additional1" domain="[('type', '=', 'purchase')]" widget="selection"/>
                             <field name="sii_registration_key_additional2" domain="[('type', '=', 'purchase')]" widget="selection"/>
                             <field name="sii_enabled" invisible="1"/>
+                            <button type="object" string="Contrast with AEAT"
+                                    name="direct_contrast_aeat" colspan="2"
+                                    groups="l10n_es_aeat.group_account_aeat"
+                                    attrs="{'invisible': ['|','|',
+                                            ('state', 'not in', ['open','paid']),
+                                            ('sii_enabled', '=', False),
+                                            ('sii_csv', '=', False)]}" />
                         </group>
                         <group string="SII Result" groups="l10n_es_aeat.group_account_aeat">
                             <notebook>
                                 <page name="page_sii_result_general" string="General">
                                     <group>
                                         <field name="sii_state" />
+                                        <field name="sii_match_state" />
+                                        <field name="sii_contrast_state" />
                                         <field name="sii_account_registration_date" />
                                         <field name="sii_send_failed" attrs="{'invisible': [('sii_send_failed', '=', False)]}" />
                                         <field name="sii_send_error" attrs="{'invisible': [('sii_send_failed', '=', False)]}" />
                                         <field name="sii_csv"/>
+                                        <group col="1" colspan="2"
+                                            attrs="{'invisible': [('sii_match_differences', '=', [])]}">
+                                            <label for="sii_match_differences" colspan="2" />
+                                            <field name="sii_match_differences" colspan="2" nolabel="1">
+                                                <tree>
+                                                    <field name="sii_field" />
+                                                    <field name="sii_return_field_value" />
+                                                    <field name="sii_sent_field_value" />
+                                                </tree>
+                                            </field>
+                                        </group>
                                     </group>
                                 </page>
                                 <page name="page_sii_result_technical" string="Technical" groups="base.group_no_one">
@@ -55,6 +75,10 @@
                                     <field name="sii_content_sent"/>
                                     <group><label for="sii_return"/></group>
                                     <field name="sii_return" />
+                                    <group><label for="sii_match_sent" /></group>
+                                    <field name="sii_match_sent" />
+                                    <group><label for="sii_match_return" /></group>
+                                    <field name="sii_match_return" />
                                 </page>
                             </notebook>
                         </group>
@@ -100,6 +124,13 @@
                             <field name="sii_registration_key_additional2" domain="[('type', '=', 'sale')]" widget="selection"/>
                             <field name="sii_registration_key_code" invisible="1"/>
                             <field name="sii_enabled" invisible="1"/>
+                            <button type="object" string="Contrast with AEAT"
+                                    name="direct_contrast_aeat" colspan="2"
+                                    groups="l10n_es_aeat.group_account_aeat"
+                                    attrs="{'invisible': ['|','|',
+                                            ('state', 'not in', ['open','paid']),
+                                            ('sii_enabled', '=', False),
+                                            ('sii_csv', '=', False)]}" />
                             <field name="sii_property_location"
                                    attrs="{'invisible': [('sii_registration_key_code', 'not in', ['12', '13'])], 'required': [('sii_registration_key_code', 'in', ['12', '13'])]}"/>
                             <field name="sii_property_cadastrial_code"
@@ -111,9 +142,22 @@
                                 <page name="page_sii_result_general" string="General">
                                     <group>
                                         <field name="sii_state" />
+                                        <field name="sii_match_state" />
+                                        <field name="sii_contrast_state" />
                                         <field name="sii_send_failed" attrs="{'invisible': [('sii_send_failed', '=', False)]}" />
                                         <field name="sii_send_error" attrs="{'invisible': [('sii_send_failed', '=', False)]}" />
                                         <field name="sii_csv"/>
+                                        <group col="1" colspan="2"
+                                            attrs="{'invisible': [('sii_match_differences', '=', [])]}">
+                                            <label for="sii_match_differences" colspan="2" />
+                                            <field name="sii_match_differences" colspan="2" nolabel="1">
+                                                <tree>
+                                                    <field name="sii_field" />
+                                                    <field name="sii_return_field_value" />
+                                                    <field name="sii_sent_field_value" />
+                                                </tree>
+                                            </field>
+                                        </group>
                                     </group>
                                 </page>
                                 <page name="page_sii_result_technical" string="Technical" groups="base.group_no_one">
@@ -123,6 +167,10 @@
                                     <field name="sii_content_sent"/>
                                     <group><label for="sii_return"/></group>
                                     <field name="sii_return" />
+                                    <group><label for="sii_match_sent" /></group>
+                                    <field name="sii_match_sent" />
+                                    <group><label for="sii_match_return" /></group>
+                                    <field name="sii_match_return" />
                                 </page>
                             </notebook>
                         </group>
@@ -136,6 +184,18 @@
                         </group>
                     </page>
                 </notebook>
+            </field>
+        </record>
+
+        <record id="invoice_sii_tree" model="ir.ui.view">
+            <field name="name">account.invoice.sii.match.tree</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_tree" />
+            <field name="arch" type="xml">
+                <field name="state" position="after">
+                    <field name="sii_match_state" invisible="1" />
+                    <field name="sii_contrast_state" invisible="1" />
+                </field>
             </field>
         </record>
 
@@ -164,6 +224,10 @@
                             domain="[('sii_state', 'in', ['cancelled','cancelled_modified'])]"
                             help="Cancelled invoices at SII"/>
                         <separator />
+                        <filter string="SII match state"
+                            context="{'group_by':'sii_match_state'}"/>
+                        <filter string="AEAT contrast state"
+                            context="{'group_by':'sii_contrast_state'}"/>
                     </group>
                 </filter>
                 <xpath expr="//group" position="inside">
@@ -194,6 +258,24 @@ if records:
             <field name="model">account.invoice</field>
             <field name="value"
                    eval="'ir.actions.server,%d' % ref('l10n_es_aeat_sii.action_send_sii_invoices')" />
+        </record>
+
+        <record id="action_contrast_aeat" model="ir.actions.server">
+            <field name="name">Contrast Invoices with AEAT</field>
+            <field name="model_id" ref="account.model_account_invoice" />
+            <field name="state">code</field>
+            <field name="code">
+                records.contrast_aeat()
+            </field>
+        </record>
+
+        <record id="action_contrast_aeat_value" model="ir.values">
+            <field name="name">Contrast Invoices with AEAT</field>
+            <field name="key">action</field>
+            <field name="key2">client_action_multi</field>
+            <field name="model">account.invoice</field>
+            <field name="value"
+                eval="'ir.actions.server,%d' % ref('l10n_es_aeat_sii.action_contrast_aeat')" />
         </record>
 
 </odoo>

--- a/l10n_es_aeat_sii/views/aeat_sii_match_report.xml
+++ b/l10n_es_aeat_sii/views/aeat_sii_match_report.xml
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_l10n_es_aeat_sii_match_report_form" model="ir.ui.view">
+        <field name="name">l10n_es.aeat.sii.match.report.form</field>
+        <field name="model">l10n.es.aeat.sii.match.report</field>
+        <field name="arch" type="xml">
+            <form string="SII Match report">
+                <header>
+                    <button name="button_calculate"
+                            type="object"
+                            string="Calculate"
+                            states="draft"
+                            icon="fa-cogs"/>
+                    <button name="button_calculate"
+                            type="object"
+                            string="Re-Calculate"
+                            states="calculated,error"
+                            icon="fa-cogs"/>
+                    <button name="button_confirm"
+                            string="Confirm"
+                            type="object"
+                            states="calculated"
+                            icon="fa-check"/>
+                    <button name="button_recover"
+                            string="Draft"
+                            type="object"
+                            states="cancelled"
+                            icon="fa-undo"/>
+                    <button name="button_cancel"
+                            string="Cancel"
+                            type="object"
+                            states="calculated,done,error"
+                            icon="fa-times"/>
+                    <field name="state"
+                           widget="statusbar"
+                           statusbar_visible="draft,calculated,done"/>
+                </header>
+                <sheet>
+                    <group>
+                        <group colspan="2" col="1">
+                            <label for="name" class="oe_edit_only"/>
+                            <h1>
+                                <field name="name" nolabel="1"/>
+                            </h1>
+                        </group>
+                        <group>
+                            <field name="period_type"/>
+                            <field name="fiscalyear"/>
+                            <field name="invoice_type"/>
+                        </group>
+                        <group>
+                            <field name="calculate_date"
+                                   attrs="{'invisible': ['|',('calculate_date', '=', False),('state','=','draft')]}"/>
+                            <field name="company_id"
+                                   required="1"
+                                   groups="base.group_multi_company"/>
+                        </group>
+                        <notebook colspan="2">
+                            <page string="Summary" name="summary"
+                                  attrs="{'invisible': [('state','not in',['calculated','done'])]}">
+                                <group col="3">
+                                    <group>
+                                        <field name="number_records"/>
+                                        <field name="number_records_both"/>
+                                        <field name="number_records_odoo"/>
+                                        <field name="number_records_sii"/>
+                                    </group>
+                                    <group>
+                                        <field name="number_records_correct"/>
+                                        <field name="number_records_no_exist"/>
+                                        <field name="number_records_partially"/>
+                                    </group>
+                                    <group>
+                                        <field name="number_records_no_test"/>
+                                        <field name="number_records_in_process"/>
+                                        <field name="number_records_not_contrasted"/>
+                                        <field name="number_records_partially_contrasted"/>
+                                        <field name="number_records_contrasted"/>
+                                    </group>
+                                </group>
+                            </page>
+                            <page string="Result" name="result"
+                                  attrs="{'invisible': ['|',('sii_match_result', '=', []),('state','not in',['calculated','done'])]}">
+                                <group col="1" colspan="2">
+                                    <button name="open_result"
+                                            string="View full tree"
+                                            type="object"
+                                            icon="fa-check"/>
+                                    <field name="sii_match_result" nolabel="1">
+                                        <tree string="SII Match result">
+                                            <field name="invoice"/>
+                                            <field name="invoice_id"/>
+                                            <field name="sii_match_state"/>
+                                            <field name="sii_contrast_state"/>
+                                            <field name="invoice_location"/>
+                                        </tree>
+                                    </field>
+                                </group>
+                            </page>
+                        </notebook>
+                        <group string="Jobs" col="1" colspan="2">
+                            <field name="sii_match_jobs_ids" nolabel="1"
+                                   readonly="1"
+                                   context="{'tree_view_ref': 'l10n_es_aeat_sii.view_queue_job_sii'}"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_l10n_es_aeat_sii_match_report_tree" model="ir.ui.view">
+        <field name="name">l10n_es.aeat.sii.match.report.tree</field>
+        <field name="model">l10n.es.aeat.sii.match.report</field>
+        <field name="arch" type="xml">
+            <tree colors="grey:state=='done';grey:state=='cancelled';green:state=='calculated';red:state=='error';blue:state=='draft'">
+                <field name="name"/>
+                <field name="period_type"/>
+                <field name="fiscalyear"/>
+                <field name="invoice_type"/>
+                <field name="calculate_date"/>
+                <field name="state"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_l10n_es_aeat_sii_match_report_filter" model="ir.ui.view">
+        <field name="name">l10n_es.aeat.sii.match.report.filter</field>
+        <field name="model">l10n.es.aeat.sii.match.report</field>
+        <field name="arch" type="xml">
+            <search string="SII Match result">
+                <field name="period_type"/>
+                <field name="fiscalyear"/>
+                <field name="company_id"/>
+                <field name="calculate_date"/>
+                <field name="name"/>
+                <separator />
+                <filter name="draft" string="Draft"
+                        domain="[('state', '=', 'draft')]"/>
+                <filter name="calculated" string="Calculated"
+                        domain="[('state', '=', 'calculated')]"/>
+                <filter name="done" string="Done"
+                        domain="[('state', '=', 'done')]"/>
+                <filter name="error" string="Error"
+                        domain="[('state', '=', 'error')]"/>
+                <filter name="cancelled" string="Cancelled"
+                        domain="[('state', '=', 'cancelled')]"/>
+                <group expand="0" string="Group By">
+                    <filter string="State" icon="terp-personal"
+                            domain="[]" context="{'group_by':'state'}"/>
+                </group>
+            </search>
+         </field>
+     </record>
+
+    <!-- Window action -->
+    <record id="action_l10n_es_aeat_sii_match_report" model="ir.actions.act_window">
+        <field name="name">AEAT SII Match</field>
+        <field name="res_model">l10n.es.aeat.sii.match.report</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <!-- ### MENU ACCESS ### -->
+    <menuitem
+        id="menu_aeat_sii_match_report"
+        parent="l10n_es_aeat.menu_root_aeat"
+        action="action_l10n_es_aeat_sii_match_report"
+        sequence="500"
+        name="AEAT SII Match"/>
+
+    <record id="view_l10n_es_aeat_sii_match_result_form" model="ir.ui.view">
+        <field name="name">l10n_es.aeat.sii.match.result.form</field>
+        <field name="model">l10n.es.aeat.sii.match.result</field>
+        <field name="arch" type="xml">
+            <form string="SII Match result"
+                  create="0" edit="0" delete="0">
+                <group>
+                    <group>
+                        <field name="invoice_location"/>
+                        <field name="invoice_id"/>
+                        <field name="invoice"/>
+                    </group>
+                    <group>
+                        <field name="csv"/>
+                        <field name="sii_match_state"/>
+                        <field name="sii_contrast_state"/>
+                    </group>
+                    <group col="1" colspan="2"
+                           attrs="{'invisible': [('sii_match_differences', '=', [])]}">
+                        <label for="sii_match_differences" colspan="2" />
+                        <field name="sii_match_differences" nolabel="1">
+                            <tree>
+                                <field name="sii_field"/>
+                                <field name="sii_return_field_value"/>
+                                <field name="sii_sent_field_value"/>
+                            </tree>
+                            <form>
+                                <group col="3">
+                                    <label for="sii_field"/>
+                                    <label for="sii_return_field_value"/>
+                                    <label for="sii_sent_field_value"/>
+                                    <field name="sii_field" nolabel="1"/>
+                                    <field name="sii_return_field_value" nolabel="1"/>
+                                    <field name="sii_sent_field_value" nolabel="1"/>
+                                </group>
+                            </form>
+                        </field>
+                    </group>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_l10n_es_aeat_sii_match_result_tree" model="ir.ui.view">
+        <field name="name">l10n_es.aeat.sii.match.result.tree</field>
+        <field name="model">l10n.es.aeat.sii.match.result</field>
+        <field name="arch" type="xml">
+            <tree string="SII Match result" create="0" delete="0">
+                <field name="invoice"/>
+                <field name="invoice_id"/>
+                <field name="sii_match_state"/>
+                <field name="sii_contrast_state"/>
+                <field name="invoice_location"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_l10n_es_aeat_sii_match_result_filter" model="ir.ui.view">
+        <field name="name">l10n_es.aeat.sii.match.result.filter</field>
+        <field name="model">l10n.es.aeat.sii.match.result</field>
+        <field name="arch" type="xml">
+            <search string="SII Match result">
+                <field name="invoice"/>
+                <field name="invoice_id"/>
+                <field name="sii_match_state"/>
+                <field name="sii_contrast_state"/>
+                <field name="invoice_location"/>
+                <separator />
+                <filter name="in_odoo" string="Invoice in Odoo"
+                        domain="[('invoice_location', '=', 'odoo')]"/>
+                <filter name="in_sii" string="Invoice in SII"
+                        domain="[('invoice_location', '=', 'sii')]"/>
+                <filter name="in_both" string="Invoice in Odoo and SII"
+                        domain="[('invoice_location', '=', 'both')]"/>
+                <separator />
+                <filter name="match_state_1" string="No testable"
+                        domain="[('sii_match_state', '=', '1')]"/>
+                <filter name="match_state_2" string="In process of contrast"
+                        domain="[('sii_match_state', '=', '2')]"/>
+                <filter name="match_state_3" string="Not contrasted"
+                        domain="[('sii_match_state', '=', '3')]"/>
+                <filter name="match_state_4" string="Partially contrasted"
+                        domain="[('sii_match_state', '=', '4')]"/>
+                <filter name="match_state_5" string="Contrasted"
+                        domain="[('sii_match_state', '=', '5')]"/>
+                <separator />
+                <filter name="contrast_state_correct" string="Correct"
+                        domain="[('sii_contrast_state', '=', 'correct')]"/>
+                <filter name="contrast_state_no_exist" string="Doesn't exist"
+                        domain="[('sii_contrast_state', '=', 'no_exist')]"/>
+                <filter name="contrast_state_partially" string="Partially correct"
+                        domain="[('sii_contrast_state', '=', 'partially')]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Invoice location" icon="terp-personal"
+                            domain="[]" context="{'group_by':'invoice_location'}"/>
+                    <filter string="Match state" icon="terp-personal"
+                            domain="[]" context="{'group_by':'sii_match_state'}"/>
+                    <filter string="AEAT contrast state" icon="terp-personal"
+                            domain="[]" context="{'group_by':'sii_contrast_state'}"/>
+                </group>
+            </search>
+         </field>
+     </record>
+</odoo>


### PR DESCRIPTION
## **Sistema de comprobación y contraste de facturas enviadas al SII**
* La mejora recupera los datos enviados a la AEAT mediante peticiones unitarias o por meses (como una declaración AEAT)
* Los datos recibidos se procesan intentando asociarlos mediante su CSV (Código Seguro de Verificación) y si no encuentra el CSV, busca por número de factura/fecha/partner
* La mejora muestra aquellos registros que no han conseguido asociarse, así como aquellas facturas en Odoo que no tienen su correspondiente registro en los datos recibidos.
* En segundo lugar se exponen los registros que tienen diferencias entre Odoo y AEAT
* Por último se muestran por separado facturas 'No contrastadas' o 'Parcialmente contrastadas', es decir, las que la propia AEAT no haya podido cotejar entre el emisor de la factura y el receptor, siendo los dos obligados a declarar en el sistema SII.

@omar7r @RamonGuiuGou @acysos @pedrobaeza @Jortolsa 