### PR TITLE
[8.0] [l10n_aeat_sii] Adaptaciones para SII versión 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ docs/_build/
 # Backup files
 *~
 *.swp
+

--- a/l10n_es_aeat_sii/data/ir_config_parameter.xml
+++ b/l10n_es_aeat_sii/data/ir_config_parameter.xml
@@ -15,37 +15,37 @@
         </record>
         <record id="config_parameter_sii_wsdl_out" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_out</field>
-            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroFactEmitidas.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroFactEmitidas.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_in" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_in</field>
-            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroFactRecibidas.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroFactRecibidas.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_pi" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_pi</field>
-            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroBienesInversion.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroBienesInversion.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_ic" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_ic</field>
-            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroOpIntracomunitarias.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroOpIntracomunitarias.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_pr" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_pr</field>
-            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroCobrosEmitidas.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroCobrosEmitidas.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_ott" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_ott</field>
-            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroOpTrascendTribu.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroOpTrascendTribu.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
         <record id="config_parameter_sii_wsdl_ps" model="ir.config_parameter" forcecreate="True">
             <field name="key">l10n_es_aeat_sii.wsdl_ps</field>
-            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroPagosRecibidas.wsdl</field>
+            <field name="value">https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii_1_1/fact/ws/SuministroPagosRecibidas.wsdl</field>
             <field name="group_ids" eval="[(6, False, [ref('account.group_account_invoice')])]" />
         </record>
     </data>

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -34,10 +34,8 @@ except ImportError:
     _logger.debug('Can not `import connector`.')
     import functools
 
-
     def empty_decorator_factory(*argv, **kwargs):
         return functools.partial
-
 
     job = empty_decorator_factory
 
@@ -468,11 +466,12 @@ class AccountInvoice(models.Model):
         default_no_taxable_cause = self._get_no_taxable_cause()
         # Check if refund type is 'By differences'. Negative amounts!
         sign = self._get_sii_sign()
+        distinct_exempt_causes = {}
         for inv_line in self.invoice_line:
             exempt_cause = self._get_sii_exempt_cause(inv_line.product_id)
             for tax_line in inv_line.invoice_line_tax_id:
                 breakdown_taxes = (
-                        taxes_sfesb + taxes_sfesisp + taxes_sfens + taxes_sfesbe
+                    taxes_sfesb + taxes_sfesisp + taxes_sfens + taxes_sfesbe
                 )
                 if tax_line in breakdown_taxes:
                     tax_breakdown = taxes_dict.setdefault(
@@ -487,11 +486,18 @@ class AccountInvoice(models.Model):
                         sub_dict = sub_dict.setdefault('Exenta',
                                                        {'DetalleExenta': []})
                         det_dict = {'BaseImponible':
-                                        inv_line._get_sii_line_price_subtotal()
-                                    }
+                                    inv_line._get_sii_line_price_subtotal()}
                         if exempt_cause:
-                            det_dict['CausaExencion'] = exempt_cause
-                        sub_dict['DetalleExenta'].append(det_dict)
+                            if exempt_cause not in distinct_exempt_causes:
+                                det_dict['CausaExencion'] = exempt_cause
+                                distinct_exempt_causes[exempt_cause] = det_dict
+                                sub_dict['DetalleExenta'].append(det_dict)
+                            else:
+                                ex_dict = distinct_exempt_causes[exempt_cause]
+                                ex_dict['BaseImponible'] += (
+                                    det_dict['BaseImponible'])
+                        else:
+                            sub_dict['DetalleExenta'].append(det_dict)
                     else:
                         sub_dict.setdefault('NoExenta', {
                             'TipoNoExenta': (
@@ -533,7 +539,7 @@ class AccountInvoice(models.Model):
                             'Exenta',
                             {'DetalleExenta': []})
                         det_dict = {'BaseImponible':
-                                        inv_line._get_sii_line_price_subtotal()
+                                    inv_line._get_sii_line_price_subtotal()
                                     }
                         if exempt_cause:
                             det_dict['CausaExencion'] = exempt_cause
@@ -557,7 +563,7 @@ class AccountInvoice(models.Model):
                             'NoSujeta', {'ImporteTAIReglasLocalizacion': 0},
                         )
                         nsub_dict['ImporteTAIReglasLocalizacion'] += (
-                                inv_line._get_sii_line_price_subtotal() * sign
+                            inv_line._get_sii_line_price_subtotal() * sign
                         )
         for val in taxes_f.values() + taxes_to.values():
             val['CuotaRepercutida'] = round(
@@ -589,7 +595,8 @@ class AccountInvoice(models.Model):
             services_dict = type_breakdown['PrestacionServicios']
             if 'Sujeta' in services_dict \
                     and 'Exenta' in services_dict['Sujeta']:
-                exempt_dict = services_dict['Sujeta']['Exenta']['DetalleExenta']
+                exempt_dict = (
+                    services_dict['Sujeta']['Exenta']['DetalleExenta'])
                 for line in exempt_dict:
                     line['BaseImponible'] = \
                         round(
@@ -769,9 +776,7 @@ class AccountInvoice(models.Model):
                 },
                 # On cancelled invoices, number is not filled
                 "NumSerieFacturaEmisor": (
-                                                 self.number or
-                                                 self.internal_number or ''
-                                         )[0:60],
+                    self.number or self.internal_number or '')[0:60],
                 "FechaExpedicionFacturaEmisor": invoice_date,
             },
             "PeriodoLiquidacion": {
@@ -800,17 +805,17 @@ class AccountInvoice(models.Model):
             if self.sii_registration_key_additional1:
                 inv_dict["FacturaExpedida"]. \
                     update({'ClaveRegimenEspecialOTrascendenciaAdicional1': (
-                    self.sii_registration_key_additional1.code)})
+                            self.sii_registration_key_additional1.code)})
             if self.sii_registration_key_additional2:
                 inv_dict["FacturaExpedida"]. \
                     update({'ClaveRegimenEspecialOTrascendenciaAdicional2': (
-                    self.sii_registration_key_additional2.code)})
+                            self.sii_registration_key_additional2.code)})
             if self.sii_registration_key.code in ['12', '13']:
                 inv_dict["FacturaExpedida"]['DatosInmueble'] = {
                     'DetalleInmueble': {
                         'SituacionInmueble': self.sii_property_location,
                         'ReferenciaCatastral': (
-                                self.sii_property_cadastrial_code or '')
+                            self.sii_property_cadastrial_code or '')
                     }
                 }
             exp_dict = inv_dict['FacturaExpedida']
@@ -827,7 +832,7 @@ class AccountInvoice(models.Model):
                     exp_dict['ImporteRectificacion'] = {
                         'BaseRectificada': sum(
                             self.
-                                mapped('origin_invoices_ids.cc_amount_untaxed')
+                            mapped('origin_invoices_ids.cc_amount_untaxed')
                         ),
                         'CuotaRectificada': sum(
                             self.mapped('origin_invoices_ids.cc_amount_tax')
@@ -896,20 +901,20 @@ class AccountInvoice(models.Model):
                 "FechaRegContable": reg_date,
                 "ImporteTotal": self.cc_amount_total * sign,
                 "CuotaDeducible": (self.period_id.date_start >=
-                                   SII_START_DATE and round(
-                                    float_round(tax_amount * sign, 2), 2)
-                                   or 0.0),
+                                   SII_START_DATE
+                                   and round(float_round(tax_amount * sign,
+                                                         2), 2) or 0.0),
             }
             if self.sii_macrodata:
                 inv_dict["FacturaExpedida"].update(Macrodato="S")
             if self.sii_registration_key_additional1:
                 inv_dict["FacturaRecibida"]. \
                     update({'ClaveRegimenEspecialOTrascendenciaAdicional1': (
-                    self.sii_registration_key_additional1.code)})
+                            self.sii_registration_key_additional1.code)})
             if self.sii_registration_key_additional2:
                 inv_dict["FacturaRecibida"]. \
                     update({'ClaveRegimenEspecialOTrascendenciaAdicional2': (
-                    self.sii_registration_key_additional2.code)})
+                            self.sii_registration_key_additional2.code)})
             # Uso condicional de IDOtro/NIF
             inv_dict['FacturaRecibida']['Contraparte'].update(ident)
             if self.type == 'in_refund':
@@ -923,7 +928,7 @@ class AccountInvoice(models.Model):
                     rec_dict['ImporteRectificacion'] = {
                         'BaseRectificada': sum(
                             self.
-                                mapped('origin_invoices_ids.cc_amount_untaxed')
+                            mapped('origin_invoices_ids.cc_amount_untaxed')
                         ),
                         'CuotaRectificada': refund_tax_amount,
                     }
@@ -989,12 +994,12 @@ class AccountInvoice(models.Model):
         # en entorno de pruebas
         invoices = self.filtered(
             lambda i: (
-                    i.company_id.sii_test or
-                    i.period_id.date_start >= SII_START_DATE or
-                    (i.sii_registration_key.type == 'sale' and
-                     i.sii_registration_key.code == '16') or
-                    (i.sii_registration_key.type == 'purchase' and
-                     i.sii_registration_key.code == '14')
+                i.company_id.sii_test or
+                i.period_id.date_start >= SII_START_DATE or
+                (i.sii_registration_key.type == 'sale' and
+                 i.sii_registration_key.code == '16') or
+                (i.sii_registration_key.type == 'purchase' and
+                 i.sii_registration_key.code == '14')
             )
         )
         queue_obj = self.env['queue.job'].sudo()
@@ -1122,8 +1127,8 @@ class AccountInvoice(models.Model):
     def send_sii(self):
         invoices = self.filtered(
             lambda i: (
-                    i.sii_enabled and i.state in ['open', 'paid'] and
-                    i.sii_state not in ['sent', 'cancelled']
+                i.sii_enabled and i.state in ['open', 'paid'] and
+                i.sii_state not in ['sent', 'cancelled']
             )
         )
         if not invoices._cancel_invoice_jobs():
@@ -1346,15 +1351,15 @@ class AccountInvoice(models.Model):
     @api.multi
     def _get_no_taxable_cause(self):
         self.ensure_one()
-        return self.fiscal_position.sii_no_taxable_cause or \
-               'ImportePorArticulos7_14_Otros'
+        return (self.fiscal_position.sii_no_taxable_cause or
+                'ImportePorArticulos7_14_Otros')
 
     @api.multi
     def _get_sii_country_code(self):
         self.ensure_one()
         country_code = (
-                self.partner_id.commercial_partner_id.country_id.code or
-                (self.partner_id.vat or '')[:2]
+            self.partner_id.commercial_partner_id.country_id.code or
+            (self.partner_id.vat or '')[:2]
         ).upper()
         return SII_COUNTRY_CODE_MAPPING.get(country_code, country_code)
 
@@ -1372,7 +1377,7 @@ class AccountInvoice(models.Model):
                 description += (invoice.company_id.sii_description or '/')
             elif method == 'manual':
                 description = (
-                        invoice.sii_manual_description or description or '/'
+                    invoice.sii_manual_description or description or '/'
                 )
             else:  # auto method
                 if invoice.invoice_line:
@@ -1396,9 +1401,9 @@ class AccountInvoice(models.Model):
         for invoice in self:
             if invoice.company_id.sii_enabled:
                 invoice.sii_enabled = (
-                        (invoice.fiscal_position and
-                         invoice.fiscal_position.sii_active) or
-                        not invoice.fiscal_position
+                    (invoice.fiscal_position and
+                     invoice.fiscal_position.sii_active) or
+                    not invoice.fiscal_position
                 )
             else:
                 invoice.sii_enabled = False

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -527,10 +527,9 @@ class AccountInvoice(models.Model):
                         type_breakdown['PrestacionServicios'].setdefault(
                             'Sujeta', {}
                         )
-                    service_dict = type_breakdown[
-                        'PrestacionServicios']['Sujeta']
+                    service_dict = type_breakdown['PrestacionServicios']
                     if tax_line in taxes_sfesse:
-                        service_dict = service_dict.setdefault(
+                        service_dict = service_dict['Sujeta'].setdefault(
                             'Exenta',
                             {'DetalleExenta': []})
                         det_dict = {'BaseImponible':

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -161,7 +161,7 @@ class AccountInvoice(models.Model):
         string="MacroData",
         help="Check to confirm that the invoice has an absolute amount "
              "greater o equal to 100 000 000,00 euros.",
-        compute='_compute_macrodata', store=True
+        compute='_compute_macrodata',
     )
     invoice_jobs_ids = fields.Many2many(
         comodel_name='queue.job', column1='invoice_id', column2='job_id',

--- a/l10n_es_aeat_sii/models/aeat_sii_map.py
+++ b/l10n_es_aeat_sii/models/aeat_sii_map.py
@@ -10,9 +10,12 @@ class AeatSiiMap(models.Model):
     _name = 'aeat.sii.map'
     _description = 'Aeat SII Map'
 
-    @api.one
     @api.constrains('date_from', 'date_to')
     def _unique_date_range(self):
+        for rec in self:
+            rec._unique_date_range_single()
+
+    def _unique_date_range_single(self):
         # Based in l10n_es_aeat module
         domain = [('id', '!=', self.id)]
         if self.date_from and self.date_to:
@@ -36,8 +39,8 @@ class AeatSiiMap(models.Model):
         date_lst = self.search(domain)
         if date_lst:
             raise exceptions.Warning(
-                _("Error! The dates of the record overlap with an existing "
-                  "record."))
+                _("Error! The dates of the record overlap with an existing"
+                  " record."))
 
     name = fields.Char(string='Model', required=True)
     date_from = fields.Date(string='Date from')

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -27,6 +27,7 @@ def _deep_sort(obj):
 class TestL10nEsAeatSii(common.TransactionCase):
     def setUp(self):
         super(TestL10nEsAeatSii, self).setUp()
+        self.maxDiff = None
         self.partner = self.env['res.partner'].create({
             'name': 'Test partner',
             'vat': 'ESF35999705'
@@ -99,7 +100,8 @@ class TestL10nEsAeatSii(common.TransactionCase):
             'name': 'Test user',
             'login': 'test_user',
             'groups_id': [
-                (4, self.env.ref('account.group_account_invoice').id)
+                (4, self.env.ref('account.group_account_manager').id),
+                (4, self.env.ref('l10n_es_aeat.group_account_aeat').id)
             ],
             'email': 'somebody@somewhere.com',
         })
@@ -145,7 +147,7 @@ class TestL10nEsAeatSii(common.TransactionCase):
                 'ClaveRegimenEspecialOTrascendencia': special_regime,
                 'ImporteTotal': self.invoice.cc_amount_total,
             },
-            'PeriodoImpositivo': {
+            'PeriodoLiquidacion': {
                 'Periodo': str(self.invoice.period_id.code[:2]),
                 'Ejercicio': int(self.invoice.period_id.code[-4:])
             }
@@ -267,5 +269,5 @@ class TestL10nEsAeatSii(common.TransactionCase):
         )
 
     def test_permissions(self):
-        """This should work without errors"""
+        """Test permissions"""
         self.invoice.sudo(self.user).signal_workflow('invoice_open')

--- a/l10n_es_aeat_sii/views/account_invoice_view.xml
+++ b/l10n_es_aeat_sii/views/account_invoice_view.xml
@@ -21,11 +21,9 @@
                                 ('state', 'not in', ['cancel']),
                                 ('sii_state', 'not in', ['sent','sent_w_errors','sent_modified'])]}" />
                 </button>
-
                 <field name="supplier_invoice_number" position="attributes">
                     <attribute name="attrs">{'required':[('state','not in',['open','paid','cancel'])]}</attribute>
                 </field>
-
                 <notebook position="inside">
                     <page string="SII" groups="account.group_account_invoice"  attrs="{'invisible': [('sii_enabled', '=', False)]}">
                         <group string="SII Information">
@@ -37,6 +35,7 @@
                             <field name="sii_registration_key_additional1" domain="[('type', '=', 'purchase')]" widget="selection"/>
                             <field name="sii_registration_key_additional2" domain="[('type', '=', 'purchase')]" widget="selection"/>
                             <field name="sii_enabled" invisible="1"/>
+                            <field name="sii_macrodata"/>
                         </group>
                         <group string="SII Result" groups="l10n_es_aeat.group_account_aeat">
                             <notebook>
@@ -59,13 +58,11 @@
                                 </page>
                             </notebook>
                         </group>
-
                         <group string="Connector Jobs" groups="l10n_es_aeat.group_account_aeat">
                             <field name="invoice_jobs_ids"
                                    nolabel="1"
                                    readonly="1"
-                                   context="{'tree_view_ref': 'l10n_es_aeat_sii.view_queue_job_sii'}"
-                            />
+                                   context="{'tree_view_ref': 'l10n_es_aeat_sii.view_queue_job_sii'}"/>
                         </group>
                     </page>
                 </notebook>
@@ -106,6 +103,7 @@
                             <field name="sii_property_cadastrial_code"
                                    attrs="{'invisible': [('sii_registration_key_code', 'not in', ['12', '13'])],
                                            'required': [('sii_registration_key_code', 'in', ['12', '13']), ('sii_property_location', 'in', ['1', '2'])]}"/>
+                            <field name="sii_macrodata"/>
                         </group>
                         <group string="SII Result" groups="l10n_es_aeat.group_account_aeat">
                             <notebook>
@@ -127,13 +125,11 @@
                                 </page>
                             </notebook>
                         </group>
-
                         <group string="Connector Jobs" groups="l10n_es_aeat.group_account_aeat">
                             <field name="invoice_jobs_ids"
                                    nolabel="1"
                                    readonly="1"
-                                   context="{'tree_view_ref': 'l10n_es_aeat_sii.view_queue_job_sii'}"
-                            />
+                                   context="{'tree_view_ref': 'l10n_es_aeat_sii.view_queue_job_sii'}"/>
                         </group>
                     </page>
                 </notebook>


### PR DESCRIPTION
PR para recoger diversas adaptaciones de SII para la versión 1.1:

- [X] Cambio de nombres de etiquetas.

- [X] Macrodato, para informar facturas iguales o superiores a 100 000 euros

- [X] Cambiar el número de version del XML generado a 1.1.

- [X] Cambiar los URIs de los archivos WSDL de la AEAT.

Toda aportación por parte de la comunidad es bienvenida.