### PR TITLE
[FIX] l10n_es_vat_book: No funcionaba correctamente con suplidos.

### DIFF
--- a/l10n_es_vat_book/__manifest__.py
+++ b/l10n_es_vat_book/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Libro de IVA",
-    "version": "11.0.2.0.0",
+    "version": "11.0.2.0.1",
     "author": "PRAXYA, "
               "Eficent, "
               "Tecnativa, "

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -174,14 +174,16 @@ class L10nEsVatBook(models.Model):
         ref = move.ref
         ext_ref = ''
         invoice = move.line_ids.mapped('invoice_id')[:1]
+        partner = move.partner_id
         if invoice:
+            partner = invoice.partner_id
             ref = invoice.number
             ext_ref = invoice.reference
         return {
             'line_type': line_type,
             'invoice_date': move.date,
-            'partner_id': move.partner_id.id,
-            'vat_number': move.partner_id.vat,
+            'partner_id': partner.id,
+            'vat_number': partner.vat,
             'invoice_id': invoice.id,
             'ref': ref,
             'external_ref': ext_ref,

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -176,7 +176,7 @@ class L10nEsVatBook(models.Model):
         invoice = move.line_ids.mapped('invoice_id')[:1]
         partner = move.partner_id
         if invoice:
-            partner = invoice.partner_id
+            partner = invoice.commercial_partner_id
             ref = invoice.number
             ext_ref = invoice.reference
         return {


### PR DESCRIPTION
Cuando se tienen suplidos OCA/account-invoicing#385, el libro de iva no se estaba exportando correctamente.

Con este cambio, utiliza el partner de la factura si lo encuentra y, sinó, el partner del movimiento contable.