### PR TITLE
[8.0][FIX] l10n_es_aeat_sii - arreglo calculo subtotal

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1416,7 +1416,11 @@ class AccountInvoiceLine(models.Model):
         """Obtain the effective invoice line price after discount. Needed as
         we can modify the unit price via inheritance."""
         self.ensure_one()
-        return self._get_sii_line_price_unit() * self.quantity
+        price = self._get_sii_line_price_unit()
+        taxes = self.invoice_line_tax_id.compute_all(
+            price, self.quantity, product=self.product_id,
+            partner=self.invoice_id.partner_id)
+        return taxes['total']
 
     @api.multi
     def _get_sii_tax_line_req(self):


### PR DESCRIPTION
En relación con este issue aquí tratado https://github.com/OCA/l10n-spain/issues/882 

revisando un poco el codigo en https://github.com/OCA/l10n-spain/blob/8.0/l10n_es_aeat_sii/models/account_invoice.py#L1415 y en consecuencia la función a la que llama https://github.com/OCA/l10n-spain/blob/8.0/l10n_es_aeat_sii/models/account_invoice.py#L1399 hemos detectado que necesariamente no está devolviendo correctamente el subtotal, basta con tener en la linea un impuesto que esté configurado como "Precio incluye impuestos" para que el precio unitario tenga impuestos y por lo tanto lo declarado por ejemplo en las facturas "No sujeto" no sea la base sino el total de la factura siendo en consecuencia erróneo el valor enviado.

Un saludo.

Closes #882 