### PR TITLE
[10.0][IMP] l10n_es_aeat_sii: No enviar al SII el mismo contenido

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1084,17 +1084,27 @@ class AccountInvoice(models.Model):
                 raise
 
     @api.multi
+    def _sii_invoice_dict_modified(self):
+        self.ensure_one()
+        inv_dict = self._get_sii_invoice_dict()
+        sii_content_sent = json.dumps(inv_dict, indent=4)
+        return sii_content_sent == self.sii_content_sent
+
+    @api.multi
     def invoice_validate(self):
         res = super(AccountInvoice, self).invoice_validate()
         for invoice in self.filtered('sii_enabled'):
-            if invoice.sii_state == 'sent':
-                invoice.sii_state = 'sent_modified'
-            elif invoice.sii_state == 'cancelled':
-                invoice.sii_state = 'cancelled_modified'
-            company = invoice.company_id
-            if company.sii_method != 'auto':
-                continue
-            invoice._process_invoice_for_sii_send()
+            if self._sii_invoice_dict_modified():
+                if invoice.sii_state == 'sent':
+                    invoice.sii_state = 'sent_modified'
+                elif invoice.sii_state == 'cancelled':
+                    invoice.sii_state = 'cancelled_modified'
+                company = invoice.company_id
+                if company.sii_method != 'auto':
+                    continue
+                invoice._process_invoice_for_sii_send()
+            else:
+                invoice.sii_state = 'sent'
         return res
 
     @api.multi

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1094,17 +1094,19 @@ class AccountInvoice(models.Model):
     def invoice_validate(self):
         res = super(AccountInvoice, self).invoice_validate()
         for invoice in self.filtered('sii_enabled'):
-            if self._sii_invoice_dict_modified():
-                if invoice.sii_state == 'sent':
-                    invoice.sii_state = 'sent_modified'
-                elif invoice.sii_state == 'cancelled':
-                    invoice.sii_state = 'cancelled_modified'
-                company = invoice.company_id
-                if company.sii_method != 'auto':
-                    continue
-                invoice._process_invoice_for_sii_send()
-            else:
-                invoice.sii_state = 'sent'
+            if invoice.sii_state in ['sent_modified', 'sent'] and \
+                    self._sii_invoice_dict_modified():
+                if invoice.sii_state == 'sent_modified':
+                    invoice.sii_state = 'sent'
+                continue
+            if invoice.sii_state == 'sent':
+                invoice.sii_state = 'sent_modified'
+            elif invoice.sii_state == 'cancelled':
+                invoice.sii_state = 'cancelled_modified'
+            company = invoice.company_id
+            if company.sii_method != 'auto':
+                continue
+            invoice._process_invoice_for_sii_send()
         return res
 
     @api.multi


### PR DESCRIPTION
Este PR corrige a #770 según indicaciones de @pedrobaeza.

Ahora, cuando se valida una factura y se procede al cambio del `sii_state` se revisa si el contenido que se quiere enviar es el mismo que el enviado anteriormente, de ser el mismo (esto se puede deber a haber modificado un campo que no afecta al SII), directamente el `sii_state` pasa a ser `sent` y no se genera ningún job sobre esta factura.