### PR TITLE
[8.0][FIX] l10n_es_aeat_sii: Exempt group

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -538,23 +538,18 @@ class AccountInvoice(models.Model):
                     if tax_line in taxes_sfesse:
                         service_dict = service_dict['Sujeta'].setdefault(
                             'Exenta',
-                            {'DetalleExenta': []})
-                        det_dict = {'BaseImponible':
-                                    inv_line._get_sii_line_price_subtotal()
-                                    }
+                            {'DetalleExenta': [{'BaseImponible': 0}]})
+                        det_dict = service_dict['DetalleExenta'][0]
                         if exempt_cause:
                             if exempt_cause not in distinct_exempt_causes_serv:
                                 det_dict['CausaExencion'] = exempt_cause
                                 distinct_exempt_causes_serv[exempt_cause] = (
                                     det_dict)
-                                service_dict['DetalleExenta'].append(det_dict)
                             else:
-                                ex_dict = (
+                                det_dict = (
                                     distinct_exempt_causes_serv[exempt_cause])
-                                ex_dict['BaseImponible'] += (
-                                    det_dict['BaseImponible'])
-                        else:
-                            service_dict['DetalleExenta'].append(det_dict)
+                        det_dict['BaseImponible'] += (
+                            inv_line._get_sii_line_price_subtotal())
                     if tax_line in taxes_sfess:
                         # TODO l10n_es_ no tiene impuesto ISP de servicios
                         # if tax_line in taxes_sfesisps:


### PR DESCRIPTION
En caso de que no hubiera causa de exención no agrupaba, dando error al enviar la factura al SII.
`ValidationError: Expected at most 1 items (maxOccurs check) (SuministroLRFacturasEmitidas.RegistroLRFacturasEmitidas.FacturaExpedida.TipoDesglose.PrestacionServicios.Sujeta.Exenta.DetalleExenta)`


Me he basado en los cambios realizados en el commit 8c1721331f058ccb632de285372d6939a00e6cd9 de la 10.0