### PR TITLE
[FIX] [10.0] l10n_es_aeat_sii: always sending to the test environment

### DIFF
--- a/l10n_es_aeat_sii/__manifest__.py
+++ b/l10n_es_aeat_sii/__manifest__.py
@@ -13,7 +13,7 @@
 
 {
     "name": u"Suministro Inmediato de Información en el IVA",
-    "version": "10.0.3.3.0",
+    "version": "10.0.3.3.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -959,7 +959,8 @@ class AccountInvoice(models.Model):
         }
         agency = self.company_id.sii_tax_agency_id
         if agency:
-            params.update(agency._connect_params_sii(mapping_key))
+            params.update(agency._connect_params_sii(
+                mapping_key, self.company_id))
         if not params['address'] and self.company_id.sii_test:
             params['port_name'] += 'Pruebas'
         return params

--- a/l10n_es_aeat_sii/models/aeat_sii_tax_agency.py
+++ b/l10n_es_aeat_sii/models/aeat_sii_tax_agency.py
@@ -40,12 +40,15 @@ class AeatSiiTaxAgency(models.Model):
         string='SuministroPagosRecibidas Test Address')
 
     @api.multi
-    def _connect_params_sii(self, mapping_key):
+    def _connect_params_sii(self, mapping_key, company):
         self.ensure_one()
         wsdl_key = self.env['account.invoice'].SII_WDSL_MAPPING[mapping_key]
         wsdl_field = wsdl_key.split('.')[1]
         wsdl_test_field = wsdl_field + '_test_address'
         return {
             'wsdl': getattr(self, wsdl_field),
-            'address': getattr(self, wsdl_test_field),
+            'address': (
+                getattr(self, wsdl_test_field) if company.sii_test
+                else False
+            ),
         }

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -305,7 +305,7 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         address = proxy._binding_options['address']
         self.assertTrue(address)
         if company.sii_test and tax_agency:
-            params = tax_agency._connect_params_sii(invoice.type)
+            params = tax_agency._connect_params_sii(invoice.type, company)
             if params['address']:
                 self.assertEqual(address, params['address'])
 


### PR DESCRIPTION
Si tenemos seleccionada una agencia tributaria en el formulario de la compañía, todos los envíos del SII se están haciendo al entorno de pruebas. Independientemente del check "¿Es un entorno de pruebas?"