### PR TITLE
[8.0][IMP] l10n_es_dua: Modificar tipo impuesto dua

### DIFF
--- a/l10n_es_dua/data/taxes_dua.xml
+++ b/l10n_es_dua/data/taxes_dua.xml
@@ -7,7 +7,8 @@
   <field name="type_tax_use">purchase</field>
   <field name="name">DUA Exento</field>
   <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
-  <field name="type">none</field>
+  <field eval="0.00" name="amount"/>
+  <field name="type">percent</field>
 </record>
 
 </data>


### PR DESCRIPTION
Hola @pedrobaeza ,

Que te parece si hacemos este cambio en el impuesto dua para homogeneizar la definición del mismo en todas las versiones (8, 9, 10).

Ahora mismo se asigna como tipo "none" en v8 y como tipo porcentaje en las siguientes y da problemas en las migraciones (v8 > v9).

Por ejemplo, creo que la incidencia OCA/OpenUpgrade#1337 viene por esto.

Saludos