### PR TITLE
[10.0][FIX] l10n_es_partner: changing comercial changes display name

### DIFF
--- a/l10n_es_partner/__manifest__.py
+++ b/l10n_es_partner/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Adaptación de los clientes, proveedores y bancos para España",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.1.0",
     "author": "ZikZak,"
               "Acysos,"
               "Tecnativa,"

--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -14,6 +14,11 @@ class ResPartner(models.Model):
 
     comercial = fields.Char('Trade name', size=128, index=True)
 
+    @api.depends('comercial')
+    def _compute_display_name(self):
+        """Include dependencies of comercial"""
+        super(ResPartner, self)._compute_display_name()
+
     @api.model
     def search(self, args, offset=0, limit=None, order=None, count=False):
         """Include commercial name in direct name search."""

--- a/l10n_es_partner/tests/test_l10n_es_partner.py
+++ b/l10n_es_partner/tests/test_l10n_es_partner.py
@@ -144,3 +144,9 @@ class TestL10nEsPartner(common.SavepointCase):
         self.assertEqual(
             partner2.display_name, 'Nombre comercial (Empresa de prueba)',
         )
+        partner2.write({
+            'comercial': 'Nuevo nombre',
+        })
+        self.assertEqual(
+            partner2.display_name, 'Nuevo nombre (Empresa de prueba)',
+        )


### PR DESCRIPTION
Changes display_name when comercial (trade name) is changed.

cc @Tecnativa