### PR TITLE
[10.0][FIX]l10n_es_account_bank_statement_import_n43: fix inconsistency between type of exception raised adn type of exception catched

### DIFF
--- a/l10n_es_account_bank_statement_import_n43/__manifest__.py
+++ b/l10n_es_account_bank_statement_import_n43/__manifest__.py
@@ -6,7 +6,7 @@
 {
     'name': 'Importación de extractos bancarios españoles (Norma 43)',
     'category': 'Accounting & Finance',
-    'version': '10.0.1.1.2',
+    'version': '10.0.1.1.3',
     'license': 'AGPL-3',
     'author': 'Spanish Localization Team,'
               'Tecnativa,'

--- a/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
+++ b/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
@@ -180,7 +180,7 @@ class AccountBankStatementImport(models.TransientModel):
                 # CTRL-Z (^Z), is often used as an end-of-file marker in DOS
                 continue
             else:  # pragma: no cover
-                raise exceptions.UserError(
+                raise exceptions.ValidationError(
                     _('Record type %s is not valid.') % raw_line[0:2])
             # Update the record counter
             st_data['_num_records'] += 1


### PR DESCRIPTION
The exception raised is not consistent with exception catched:
https://github.com/OCA/l10n-spain/blob/10.0/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py#L193