### PR TITLE
[IMP] l10n_es_pos: move simpl. inv. reference to standard field

### DIFF
--- a/l10n_es_pos/__manifest__.py
+++ b/l10n_es_pos/__manifest__.py
@@ -9,7 +9,7 @@
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "license": "AGPL-3",
-    "version": "11.0.1.0.1",
+    "version": "11.0.2.0.0",
     "depends": [
         "point_of_sale",
     ],

--- a/l10n_es_pos/migrations/11.0.2.0.0/pre-migration.py
+++ b/l10n_es_pos/migrations/11.0.2.0.0/pre-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2018 David Vidal <david.vidal@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    # Move simplified invoice info to pos_reference field.
+    cr.execute("""
+        UPDATE pos_order SET
+            pos_reference = l10n_es_simplified_invoice_number,
+            is_l10n_es_simplified_invoice = TRUE
+        WHERE (l10n_es_simplified_invoice_number IS NOT NULL OR
+               l10n_es_simplified_invoice_number <> '')
+    """)

--- a/l10n_es_pos/migrations/11.0.2.0.0/pre-migration.py
+++ b/l10n_es_pos/migrations/11.0.2.0.0/pre-migration.py
@@ -23,7 +23,7 @@ def migrate(cr, version):
     # Move simplified invoice info to pos_reference field.
     cr.execute("""
         UPDATE pos_order SET
-            pos_reference = %s,
+            pos_reference = %(s)s,
             is_l10n_es_simplified_invoice = TRUE
-        WHERE (%s IS NOT NULL OR %s <> '');
-    """ % simplified_invoice_field)
+        WHERE COALESCE(%(s)s, '') <> '';
+    """ % {'s': simplified_invoice_field})

--- a/l10n_es_pos/migrations/11.0.2.0.0/pre-migration.py
+++ b/l10n_es_pos/migrations/11.0.2.0.0/pre-migration.py
@@ -5,6 +5,11 @@
 def migrate(cr, version):
     if not version:
         return
+    # Add new column in advance
+    cr.execute("""
+        ALTER TABLE pos_order
+        ADD COLUMN is_l10n_es_simplified_invoice BOOLEAN;
+    """)
     # Move simplified invoice info to pos_reference field.
     cr.execute("""
         UPDATE pos_order SET

--- a/l10n_es_pos/static/src/js/models.js
+++ b/l10n_es_pos/static/src/js/models.js
@@ -49,13 +49,21 @@ odoo.define('l10n_es_pos.models', function (require) {
                 }
             });
             return pos_super._flush_orders.apply(this, arguments);
-        }
+        },
     });
 
     var order_super = models.Order.prototype;
     models.Order = models.Order.extend({
+        get_total_with_tax: function () {
+            var total = order_super.get_total_with_tax.apply(this, arguments);
+            var below_limit = total <= this.pos.config.l10n_es_simplified_invoice_limit;
+            this.is_simplified_invoice = below_limit && this.pos.config.iface_l10n_es_simplified_invoice;
+            return total;
+        },
         set_simple_inv_number: function () {
             this.simplified_invoice = this.pos.get_simple_inv_next_number();
+            this.name = this.simplified_invoice;
+            this.is_simplified_invoice = true;
         },
         get_base_by_tax: function () {
             var base_by_tax = {};
@@ -86,7 +94,7 @@ odoo.define('l10n_es_pos.models', function (require) {
                 res.simplified_invoice = this.simplified_invoice;
             }
             return res;
-        }
+        },
     });
 
     models.load_fields('res.company', ['street', 'city', 'state_id', 'zip']);

--- a/l10n_es_pos/static/src/js/screens.js
+++ b/l10n_es_pos/static/src/js/screens.js
@@ -22,7 +22,7 @@ odoo.define('l10n_es_pos.screens', function (require) {
                 }
             }
             this._super(force_validate);
-        }
+        },
     });
 
 });

--- a/l10n_es_pos/static/src/xml/pos.xml
+++ b/l10n_es_pos/static/src/xml/pos.xml
@@ -2,11 +2,10 @@
 <templates id="template" xml:space="preserve">
 
     <t t-extend="PosTicket">
-        <t t-jquery="div.pos-center-align:first" t-operation="after">
-            <div class="pos-center-align"
-                 t-if="widget.pos.config.iface_l10n_es_simplified_invoice and !order.is_to_invoice() and order.simplified_invoice">
-                  Simplified invoice: <t t-esc="order.simplified_invoice"/>
-            </div>
+        <t t-jquery="t[t-esc='order.name']" t-operation="before">
+            <t t-if="widget.pos.config.iface_l10n_es_simplified_invoice and !order.is_to_invoice() and order.is_simplified_invoice">
+                <br/><span>Simplified invoice: </span>
+            </t>
         </t>
         <t t-jquery="t[t-esc='widget.pos.company.name']" t-operation="after">
             <t t-if="widget.pos.company.vat">
@@ -56,7 +55,7 @@
 
     <t t-extend="XmlReceipt">
         <t t-jquery="[t-if='!receipt.company.logo']" t-operation="after">
-            <t t-if="widget.pos.config.iface_l10n_es_simplified_invoice and !order.is_to_invoice() and order.simplified_invoice">
+            <t t-if="widget.pos.config.iface_l10n_es_simplified_invoice and !order.is_to_invoice() and order.is_simplified_invoice">
             <br/>
                 Simplified invoice <t t-esc="order.simplified_invoice"/>
             <br/>

--- a/l10n_es_pos/static/src/xml/pos.xml
+++ b/l10n_es_pos/static/src/xml/pos.xml
@@ -3,7 +3,7 @@
 
     <t t-extend="PosTicket">
         <t t-jquery="t[t-esc='order.name']" t-operation="before">
-            <t t-if="widget.pos.config.iface_l10n_es_simplified_invoice and !order.is_to_invoice() and order.is_simplified_invoice">
+            <t t-if="widget.pos.config.iface_l10n_es_simplified_invoice and !order.is_to_invoice()">
                 <br/><span>Simplified invoice: </span>
             </t>
         </t>
@@ -55,7 +55,7 @@
 
     <t t-extend="XmlReceipt">
         <t t-jquery="[t-if='!receipt.company.logo']" t-operation="after">
-            <t t-if="widget.pos.config.iface_l10n_es_simplified_invoice and !order.is_to_invoice() and order.is_simplified_invoice">
+            <t t-if="widget.pos.config.iface_l10n_es_simplified_invoice and !order.is_to_invoice()">
             <br/>
                 Simplified invoice <t t-esc="order.simplified_invoice"/>
             <br/>

--- a/l10n_es_pos/views/pos_views.xml
+++ b/l10n_es_pos/views/pos_views.xml
@@ -6,8 +6,8 @@
         <field name="model">pos.order</field>
         <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
-                <field name="l10n_es_simplified_invoice_number" readonly="1"/>
+            <field name="pos_reference" position="after">
+                <field name="is_l10n_es_simplified_invoice" readonly="1"/>
             </field>
         </field>
     </record>
@@ -18,7 +18,7 @@
         <field name="inherit_id" ref="point_of_sale.view_pos_order_tree"/>
         <field name="arch" type="xml">
             <field name="pos_reference" position="before">
-                <field name="l10n_es_simplified_invoice_number"/>
+                <field name="is_l10n_es_simplified_invoice" invisible="1"/>
             </field>
         </field>
     </record>
@@ -32,9 +32,9 @@
         <field name="arch" type="xml">
             <field name="user_id" position="before">
                 <separator/>
-                <filter string="Invoices" name="invoices" domain="[('l10n_es_simplified_invoice_number', '=', False)]"/>
-                <filter string="Simplified invoices" name="invoices" domain="[('l10n_es_simplified_invoice_number', '!=', False)]"/>
-                <field name="l10n_es_simplified_invoice_number"/>
+                <filter string="Invoices" name="invoices" domain="[('is_l10n_es_simplified_invoice', '=', False)]"/>
+                <filter string="Simplified invoices" name="invoices" domain="[('is_l10n_es_simplified_invoice', '!=', False)]"/>
+                <field name="is_l10n_es_simplified_invoice"/>
             </field>
         </field>
     </record>

--- a/l10n_es_pos/views/pos_views.xml
+++ b/l10n_es_pos/views/pos_views.xml
@@ -18,7 +18,7 @@
         <field name="inherit_id" ref="point_of_sale.view_pos_order_tree"/>
         <field name="arch" type="xml">
             <field name="pos_reference" position="before">
-                <field name="is_l10n_es_simplified_invoice" invisible="1"/>
+                <field name="is_l10n_es_simplified_invoice"/>
             </field>
         </field>
     </record>
@@ -34,7 +34,6 @@
                 <separator/>
                 <filter string="Invoices" name="invoices" domain="[('is_l10n_es_simplified_invoice', '=', False)]"/>
                 <filter string="Simplified invoices" name="invoices" domain="[('is_l10n_es_simplified_invoice', '!=', False)]"/>
-                <field name="is_l10n_es_simplified_invoice"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
De este modo no necesitamos módulos puente (ej.: https://github.com/OCA/l10n-spain/pull/938) cada vez que necesitamos operar sobre la referencia de factura simplificada o aprovechar una característica de otro módulo.

- Migramos `l10n_es_simplified_invoice_number` al estándar `pos_reference`
- Usamos el boolean `is_l10n_es_simplified_invoice` para marcar los tickets que son facturas simplificadas y así poder buscarlos, agruparlos, etc.

- 
cc @Tecnativa