### PR TITLE
[8.0][FIX] account_balance_reporting: Language format

### DIFF
--- a/account_balance_reporting/report/report_generic.xml
+++ b/account_balance_reporting/report/report_generic.xml
@@ -8,7 +8,7 @@
         <t t-call="report.html_container">
             <t t-foreach="docs" t-as="o">
                 <div class="header" style="font-size:120%;width:100%;text-align:center;background-color:#ccc;border:1px solid black;">
-                    <strong><span t-esc="o.name"/></strong>
+                    <strong><span t-field="o.name"/></strong>
                 </div>
                 <div class="page">
                     <div class="row">
@@ -26,16 +26,16 @@
                                 <tr t-foreach="o.line_ids" t-as="line" style="font-size:90%;page-break-inside:avoid;">
                                     <td style="border-right:1px solid black;">
                                         <t t-if="line.css_class == 'l4'">
-                                            <span t-esc="line.name"/>
+                                            <span t-field="line.name"/>
                                         </t>
                                         <t t-if="line.css_class != 'l4'">
-                                            <strong><span t-esc="line.name"/></strong>
+                                            <strong><span t-field="line.name"/></strong>
                                         </t>
                                     </td>
-                                    <td style="text-align:center;border-right:1px solid black;"><strong><span t-esc="line.code"/></strong></td>
-                                    <td style="text-align:center;border-right:1px solid black;"><span t-esc="line.notes"/></td>
-                                    <td style="text-align:right;border-right:1px solid black;padding-right:3px;"><span t-esc="'%.2f' % line.current_value"/></td>
-                                    <td style="text-align:right;padding-right:3px;"><span t-esc="'%.2f' % line.previous_value"/></td>
+                                    <td style="text-align:center;border-right:1px solid black;"><strong><span t-field="line.code"/></strong></td>
+                                    <td style="text-align:center;border-right:1px solid black;"><span t-field="line.notes"/></td>
+                                    <td style="text-align:right;border-right:1px solid black;padding-right:3px;"><span t-field="line.current_value"/></td>
+                                    <td style="text-align:right;padding-right:3px;"><span t-field="line.previous_value"/></td>
                                 </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
Fix language format.
Before:
![image](https://user-images.githubusercontent.com/36861439/48891820-b52eed00-ee3c-11e8-8cab-36538a86150a.png)

After:
![image](https://user-images.githubusercontent.com/36861439/48891780-9a5c7880-ee3c-11e8-8600-97c31fc69d4d.png)
