### PR TITLE
[11.0]l10n_es_aeat: control susbtitutive type

### DIFF
--- a/l10n_es_aeat/README.rst
+++ b/l10n_es_aeat/README.rst
@@ -27,6 +27,9 @@ Configuración
 Todos aquellos modelos que se especifiquen en los módulos adicionales y
 hereden el AEAT base, deberán definir una variable interna que se llame
 '_aeat_number' asignándole como valor, el número del modelo (130, 340, 347...).
+Así mismo, todos los modelos de la AEAT que incluyan la sustitutiva como tipo
+de declaración deberán definir una variable interna que se llame
+'_substitutive' asignándole el valor True.
 
 Para poder utilizar el motor genérico de cálculo de casillas por impuestos
 (como el 303), hay que heredar del modelo "l10n.es.aeat.report.tax.mapping" en
@@ -88,6 +91,7 @@ Contribudores
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
 * Juan Vicente Pascual <jvpascual@puntsistemes.es>
 * Abraham Anes <abraham@studio73.es>
+* Jose Maria Alzaga <jose.alzaga@aselcis.com>
 
 Maintainer
 ----------

--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -20,6 +20,7 @@ class L10nEsAeatReport(models.AbstractModel):
     _period_quarterly = True
     _period_monthly = True
     _period_yearly = False
+    _substitutive = False
 
     def _default_company_id(self):
         company_obj = self.env['res.company']
@@ -76,6 +77,17 @@ class L10nEsAeatReport(models.AbstractModel):
     def _default_export_config_id(self):
         return self._get_export_config(fields.Date.today())
 
+    def get_type_selection(self):
+        types = []
+        if self._substitutive:
+            types += [('N', 'Normal'),
+                      ('C', 'Complementaria'),
+                      ('S', 'Sustitutiva')]
+        else:
+            types += [('N', 'Normal'),
+                      ('C', 'Complementaria')]
+        return types
+
     company_id = fields.Many2one(
         comodel_name='res.company', string="Company", required=True,
         readonly=True, default=_default_company_id,
@@ -106,11 +118,8 @@ class L10nEsAeatReport(models.AbstractModel):
         string="Year", default=_default_year, required=True, readonly=True,
         states={'draft': [('readonly', False)]})
     type = fields.Selection(
-        selection=[
-            ('N', 'Normal'),
-            ('C', 'Complementary'),
-            ('S', 'Substitutive'),
-        ], string="Statement Type", default='N', readonly=True, required=True,
+        selection='get_type_selection'
+        , string="Statement Type", default='N', readonly=True, required=True,
         states={'draft': [('readonly', False)]})
     support_type = fields.Selection(
         selection=[


### PR DESCRIPTION
Add controls to prevent substitutive type in AEAT models where it cannot be applied, such as AEAT 303, AEAT 111. Ref. #947
Models suitable to use susbstitutive types need to include a variable. (Indicated in README.rst)