### PR TITLE
[11.0]l10n_es_aeat_mod349: control substitutive type

### DIFF
--- a/l10n_es_aeat_mod349/README.rst
+++ b/l10n_es_aeat_mod349/README.rst
@@ -126,6 +126,7 @@ Contribudores
   * Jordi Ballester <jordi.ballester@eficent.com>
 
 * Aitor Bouzas <aitor.bouzas@adaptivecity.com>
+* Jose Maria Alzaga <jose.alzaga@aselcis.com>
 
 Mantenedor
 ----------

--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -32,6 +32,7 @@ class Mod349(models.Model):
     _period_monthly = True
     _period_quarterly = True
     _period_yearly = True
+    _substitutive = True
     _aeat_number = '349'
 
     frequency_change = fields.Boolean(


### PR DESCRIPTION
Add variable _substitutive to allow this type of statement in AEAT mod 349 Ref. #947
