### PR TITLE
[l10n_es_aeat_mod349] permitir cancelar facturas

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -430,7 +430,8 @@ class Mod349PartnerRecordDetail(models.Model):
         string='Partner record', ondelete='set null', index=True)
     move_line_id = fields.Many2one(
         comodel_name='account.move.line', string='Journal Item',
-        required=True)
+        required=True, ondelete="cascade",
+    )
     invoice_id = fields.Many2one(
         comodel_name='account.invoice', string='Invoice',
         related='move_line_id.invoice_id',
@@ -551,7 +552,8 @@ class Mod349PartnerRefundDetail(models.Model):
     )
     refund_line_id = fields.Many2one(
         comodel_name='account.move.line', string='Journal Item',
-        required=True)
+        required=True, ondelete="cascade",
+    )
     invoice_id = fields.Many2one(
         comodel_name='account.invoice', string='Invoice',
         related='refund_line_id.invoice_id',


### PR DESCRIPTION
Con esta corrección se permite cancelar facturas que se reportan en el 349. Será necesario que el usuario haga un recálculo posteriormente.