### PR TITLE
[FIX] l10n_es_aeat_mod349: Syntax error

### DIFF
--- a/l10n_es_aeat_mod349/views/account_invoice_view.xml
+++ b/l10n_es_aeat_mod349/views/account_invoice_view.xml
@@ -33,7 +33,7 @@
 
         <record id="view_invoice_line_form" model="ir.ui.view">
             <field name="model">account.invoice.line</field>
-            <field name="groups_id" eval="[(4, ref('account.group_account_invoice')]"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="inherit_id" ref="account.view_invoice_line_form"/>
             <field name="arch" type="xml">
                 <field name="invoice_line_tax_ids" position="after">


### PR DESCRIPTION
A bug that was producing this error:

    odoo.tools.convert.ParseError: "unexpected EOF while parsing
    ('', 1, 42, "[(4, ref('account.group_account_invoice')]")" while parsing /opt/odoo/auto/addons/l10n_es_aeat_mod349/views/account_invoice_view.xml:34, near
    <record id="view_invoice_line_form" model="ir.ui.view">
        <field name="model">account.invoice.line</field>
        <field name="groups_id" eval="[(4, ref('account.group_account_invoice')]"/>
        <field name="inherit_id" ref="account.view_invoice_line_form"/>
        <field name="arch" type="xml">
            <field name="invoice_line_tax_ids" position="after">
                <field name="l10n_es_aeat_349_operation_key"/>
            </field>
        </field>
    </record>

@Tecnativa