### PR TITLE
[11.0] l10n_es_pos: prevenir pedidos desaparecidos

### DIFF
--- a/l10n_es_pos/__manifest__.py
+++ b/l10n_es_pos/__manifest__.py
@@ -9,7 +9,7 @@
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "license": "AGPL-3",
-    "version": "11.0.2.0.0",
+    "version": "11.0.2.0.1",
     "depends": [
         "point_of_sale",
     ],

--- a/l10n_es_pos/static/src/js/screens.js
+++ b/l10n_es_pos/static/src/js/screens.js
@@ -14,7 +14,7 @@ odoo.define('l10n_es_pos.screens', function (require) {
             var below_limit = this.pos.get_order().get_total_with_tax() <= this.pos.config.l10n_es_simplified_invoice_limit;
             if (this.pos.config.iface_l10n_es_simplified_invoice) {
                 var order = this.pos.get_order();
-                if (below_limit) {
+                if (below_limit && !order.to_invoice) {
                     order.set_simple_inv_number();
                 } else {
                     // Force invoice above limit. Online is needed.


### PR DESCRIPTION
- Si se resetea una secuencia de factura simplificada al repetirse los números de factura, se perderían los pedidos en la sincronización. Con esto podemos llegar a tener dos números factura iguales (lo cual debería ser erróneo), pero es preferible esto a perder los pedidos.
- También en este PR un commit (incluído en v12) para corregir que se cree factura simp. si se hace factura normal.

cc @Tecnativa