### PR TITLE
[l10n_es_aeat_mod349] permisos al empleado para aeat.349.map.line

### DIFF
--- a/l10n_es_aeat_mod349/security/ir.model.access.csv
+++ b/l10n_es_aeat_mod349/security/ir.model.access.csv
@@ -9,6 +9,9 @@
 "access_l10n_es_aeat_mod349_partner_refund_manager","AEAT 349 Model: Partner refund - Account Manager","model_l10n_es_aeat_mod349_partner_refund","account.group_account_manager",1,1,1,1
 "access_l10n_es_aeat_mod349_partner_refund_detail_user","AEAT 349 Model: Partner refund detail - Account User","model_l10n_es_aeat_mod349_partner_refund_detail","account.group_account_user",1,0,0,0
 "access_l10n_es_aeat_mod349_partner_refund_detail_manager","AEAT 349 Model: Partner refund detail - Account Manager","model_l10n_es_aeat_mod349_partner_refund_detail","account.group_account_manager",1,1,1,1
+"access_l10n_es_aeat_mod349_aeat_349_map_line_internal_user","AEAT 349 Model: Operation key Map - Internal User","model_aeat_349_map_line","base.group_user",1,0,0,0
+"access_l10n_es_aeat_mod349_account_tax_internal_user","Account Tax - Internal User","account.model_account_tax","base.group_user",1,0,0,0
+"access_l10n_es_aeat_mod349_account_tax_template_internal_user","Account Tax Template - Internal User","account.model_account_tax_template","base.group_user",1,0,0,0
 "access_l10n_es_aeat_mod349_aeat_349_map_line_billing","AEAT 349 Model: Operation key Map - Billing User","model_aeat_349_map_line","account.group_account_invoice",1,0,0,0
 "access_l10n_es_aeat_mod349_aeat_349_map_line_user","AEAT 349 Model: Operation key Map - Account User","model_aeat_349_map_line","account.group_account_user",1,0,0,0
 "access_l10n_es_aeat_mod349_aeat_349_map_line_manager","AEAT 349 Model: Operation key Map - Account Manager","model_aeat_349_map_line","account.group_account_manager",1,1,1,1


### PR DESCRIPTION
Da permisos para empleados al modelo aeat.349.map.line,
dado que este modelo se referencia en account.tax, y este modelo
tiene permisos de lectura por otros grupos como el
group_sale_salesman del módulo sales.