### PR TITLE
[11.0][FIX] l10n_es_aeat_sii: float_round error in BaseImponible

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -489,7 +489,7 @@ class AccountInvoice(models.Model):
                     if exempt_cause:
                         det_dict['CausaExencion'] = exempt_cause
                     det_dict['BaseImponible'] += (
-                        tax_line.base_company * sign)
+                        round(tax_line.base_company, 2) * sign)
                 else:
                     sub_dict.setdefault('NoExenta', {
                         'TipoNoExenta': (
@@ -515,7 +515,7 @@ class AccountInvoice(models.Model):
                     'NoSujeta', {default_no_taxable_cause: 0},
                 )
                 nsub_dict[default_no_taxable_cause] += (
-                    tax_line.base_company * sign)
+                    round(tax_line.base_company, 2) * sign)
             if tax in (taxes_sfess + taxes_sfesse + taxes_sfesns):
                 type_breakdown = taxes_dict.setdefault(
                     'DesgloseTipoOperacion', {
@@ -535,7 +535,7 @@ class AccountInvoice(models.Model):
                     if exempt_cause:
                         det_dict['CausaExencion'] = exempt_cause
                     det_dict['BaseImponible'] += (
-                        tax_line.base_company * sign)
+                        round(tax_line.base_company, 2) * sign)
                 if tax in taxes_sfess:
                     # TODO l10n_es_ no tiene impuesto ISP de servicios
                     # if tax in taxes_sfesisps:
@@ -608,7 +608,7 @@ class AccountInvoice(models.Model):
                     'DesgloseIVA', {'DetalleIVA': []},
                 )
                 sfrns_dict['DetalleIVA'].append({
-                    'BaseImponible': sign * tax_line.base_company,
+                    'BaseImponible': sign * round(tax_line.base_company, 2),
                 })
             elif tax in taxes_sfrsa:
                 sfrsa_dict = taxes_dict.setdefault(


### PR DESCRIPTION
Example on exempt invoices:

- "Invoice Lines" tab: 
    `{ quantity: 1, price_unit: 82.60, invoice_line_tax_ids: ['IVA Exento Repercutido'] }`
    
- "SII" tab:
    - **"General" tab**

        * Error de envio SII: 1100 | Valor o tipo incorrecto del campo: BaseImponible
        
    - **"Technical" tab**

        * _Último contenido enviado al SII_
        {
            "PeriodoLiquidacion": {
                "Ejercicio": 2019,
                "Periodo": "01"
            },
            "IDFactura": {
                "IDEmisorFactura": {
                    "NIF": "XXXXXXXX"
                },
                "FechaExpedicionFacturaEmisor": "07-01-2019",
                "NumSerieFacturaEmisor": "XXXXXXX"
            },
            "FacturaExpedida": {
                "TipoDesglose": {
                    "DesgloseTipoOperacion": {
                        "PrestacionServicios": {
                            "Sujeta": {
                                "Exenta": {
                                    "DetalleExenta": [
                                        {
                                            "BaseImponible": 82.60000000000001,
                                            "CausaExencion": "E1"
                                        }
                                    ]
                                }
                            }
                        }
                    }
                },
                "DescripcionOperacion": "/",
                "ImporteTotal": 82.6,
                "TipoFactura": "F2",
                "ClaveRegimenEspecialOTrascendencia": "01"
            }
        }

        * _Retorno SII_ 
        {
            'CSV': None,
            'DatosPresentacion': None,
            'Cabecera': {
                'IDVersionSii': '1.1',
                'Titular': {
                    'NombreRazon': 'XXXXXXXXXXXXXXXXXXXX',
                    'NIFRepresentante': None,
                    'NIF': 'XXXXXXXXXXX'
                },
                'TipoComunicacion': 'A0'
            },
            'EstadoEnvio': 'Incorrecto',
            'RespuestaLinea': [
                {
                    'IDFactura': {
                        'IDEmisorFactura': {
                            'NIF': 'XXXXXXXXXXX'
                        },
                        'NumSerieFacturaEmisor': 'XXXXXXXXXXXXX',
                        'NumSerieFacturaEmisorResumenFin': None,
                        'FechaExpedicionFacturaEmisor': '07-01-2019'
                    },
                    'RefExterna': None,
                    'EstadoRegistro': 'Incorrecto',
                    'CodigoErrorRegistro': 1100,
                    'DescripcionErrorRegistro': 'Valor o tipo incorrecto del campo: BaseImponible',
                    'CSV': None,
                    'RegistroDuplicado': None
                }
            ]
        }