### PR TITLE
Importación de múltiples extractos en un mismo n43

### DIFF
--- a/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
+++ b/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
@@ -298,8 +298,8 @@ class AccountBankStatementImport(models.TransientModel):
             self.env.context.get('journal_id', [])
         )
         vals_bank_statements = []
-        transactions = []
         for group in n43:
+            transactions = []
             for line in group['lines']:
                 conceptos = []
                 for concept_line in line['conceptos']:

--- a/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
+++ b/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
@@ -297,6 +297,7 @@ class AccountBankStatementImport(models.TransientModel):
         journal = self.env['account.journal'].browse(
             self.env.context.get('journal_id', [])
         )
+        vals_bank_statements = []
         transactions = []
         for group in n43:
             for line in group['lines']:
@@ -320,12 +321,15 @@ class AccountBankStatementImport(models.TransientModel):
                 if not vals_line['name']:
                     vals_line['name'] = vals_line['ref']
                 transactions.append(vals_line)
-        vals_bank_statement = {
-            'transactions': transactions,
-            'balance_start': n43 and n43[0]['saldo_ini'] or 0.0,
-            'balance_end_real': n43 and n43[-1]['saldo_fin'] or 0.0,
-        }
-        return None, None, [vals_bank_statement]
+            vals_bank_statements.append({
+                'name': self.filename + '  ('
+                    + group['fecha_ini'].strftime('%Y.%m.%d') + ' - '
+                    + group['fecha_fin'].strftime('%Y.%m.%d') + ')',
+                'transactions': transactions,
+                'balance_start': group['saldo_ini'] or 0.0,
+                'balance_end_real': group['saldo_fin'] or 0.0,
+            })
+        return None, None, vals_bank_statements
 
     def _complete_stmts_vals(self, stmts_vals, journal, account_number):
         """Match partner_id if if hasn't been deducted yet."""


### PR DESCRIPTION
Permite que se importen los diferentes extractos de un mismo archivo .n43 como diferentes extractos en odoo en lugar de uno solamente.

También asigna el nombre del fichero concatenado con `fecha_ini` y `fecha_fin` en la Referencia del extracto, de esta forma se puede identificar cada extracto por separado.
Para el archivo `visa-1153.n43` con 3 extractos, se obtendrían los siguientes extractos:

```
visa-1153.n43  (2018.02.23 - 2018.03.22)
visa-1153.n43  (2018.03.23 - 2018.04.22)
visa-1153.n43  (2018.04.23 - 2018.05.22)
```