### PR TITLE
[11.0] l10n_es_vat_book: fix performance issue

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -285,11 +285,9 @@ class L10nEsVatBook(models.Model):
 
     def _get_account_moves(self, taxes):
         aml_obj = self.env['account.move.line']
-        account_move_obj = self.env['account.move']
         move_ids = aml_obj.read_group(
             self._account_move_line_domain(taxes), ['move_id'], ['move_id'])
-        move_ids = account_move_obj.browse([x['move_id'][0] for x in move_ids])
-        return move_ids
+        return self.env['account.move'].browse([x['move_id'][0] for x in move_ids])
 
     def _create_vat_book_records(self, move, line_type, taxes):
         line = self._create_vat_book_line(

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -285,8 +285,11 @@ class L10nEsVatBook(models.Model):
 
     def _get_account_moves(self, taxes):
         aml_obj = self.env['account.move.line']
-        amls = aml_obj.search(self._account_move_line_domain(taxes))
-        return amls.mapped('move_id')
+        account_move_obj = self.env['account.move']
+        move_ids = aml_obj.read_group(
+            self._account_move_line_domain(taxes), ['move_id'], ['move_id'])
+        move_ids = account_move_obj.browse([x['move_id'][0] for x in move_ids])
+        return move_ids
 
     def _create_vat_book_records(self, move, line_type, taxes):
         line = self._create_vat_book_line(

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -285,9 +285,11 @@ class L10nEsVatBook(models.Model):
 
     def _get_account_moves(self, taxes):
         aml_obj = self.env['account.move.line']
-        move_ids = aml_obj.read_group(
+        groups = aml_obj.read_group(
             self._account_move_line_domain(taxes), ['move_id'], ['move_id'])
-        return self.env['account.move'].browse([x['move_id'][0] for x in move_ids])
+        return self.env['account.move'].browse([
+            x['move_id'][0] for x in groups
+        ])
 
     def _create_vat_book_records(self, move, line_type, taxes):
         line = self._create_vat_book_line(


### PR DESCRIPTION
When a large amount of move lines are processed (hundreds of thousands)
it can lead to a MemoryError when we try to calculate the VAT book

cc @Tecnativa