### PR TITLE
[11.0][FIX] payment_redsys: Fix signature

### DIFF
--- a/payment_redsys/README.rst
+++ b/payment_redsys/README.rst
@@ -72,6 +72,7 @@ Contribuidores
 
 * Sergio Teruel <sergio.teruel@tecnativa.com>
 * Carlos Dauden <carlos.dauden@tecnativa.com>
+* Isaac Gallart <igallart@puntsistemes.es>
 
 Financiadores
 -------------

--- a/payment_redsys/__manifest__.py
+++ b/payment_redsys/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Redsys Payment Acquirer',
     'category': 'Payment Acquirer',
     'summary': 'Payment Acquirer: Redsys Implementation',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'author': "Tecnativa,"
               "Odoo Community Association (OCA)",
     'depends': [

--- a/payment_redsys/models/redsys.py
+++ b/payment_redsys/models/redsys.py
@@ -184,10 +184,8 @@ class AcquirerRedsys(models.Model):
             mode=DES3.MODE_CBC,
             IV=b'\0\0\0\0\0\0\0\0')
         diff_block = len(order) % 8
-        zeros = diff_block and (b'\0' * (8 - diff_block)) or ''
-        key = cipher.encrypt(
-            str.encode(order + zeros.decode())
-        )
+        zeros = diff_block and (b'\0' * (8 - diff_block)) or b''
+        key = cipher.encrypt(str.encode(order + zeros.decode()))
         if isinstance(params64, str):
             params64 = params64.encode()
         dig = hmac.new(


### PR DESCRIPTION
When we have an order sequence of length six (SO123456), the signature process fails with the following message:

Server Error:
We are not able to redirect you to the payment form. 'str' object has no attribute 'decode'