### PR TITLE
[11.0][l10n_es_aeat_mod390][fix] Casilla 104 - Exportaciones y otras operaciones exentas con derecho a deducción. Debe considerar todos los tipos de operaciones.

### DIFF
--- a/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
+++ b/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
@@ -671,7 +671,7 @@
         <field name="map_parent_id" ref="aeat_mod390_map"/>
         <field name="field_number">104</field>
         <field name="name">Exportaciones y otras operaciones exentas con derecho a deducción</field>
-        <field name="move_type">regular</field>
+        <field name="move_type">all</field>
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="False"/>


### PR DESCRIPTION
En el modelo 303, la casilla [60] "Exportaciones y operaciones asimiladas - Base ventas considera todos los tipos de operaciones". https://github.com/OCA/l10n-spain/blob/11.0/l10n_es_aeat_mod303/data/tax_code_map_mod303_data.xml#L557

En cambio el 390 en la casilla [104] "Exportaciones y otras operaciones exentas con derecho a deducción. Debe considerar todos los tipos de operaciones." sólamente estaba considerando las facturas, y excluyendo las rectificativas.

