### PR TITLE
[FIX] l10n_es_partner: Hide only HTTP errors and declare xlrd dependency

### DIFF
--- a/l10n_es_partner/__openerp__.py
+++ b/l10n_es_partner/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Adaptación de los clientes, proveedores y bancos para España",
-    "version": "9.0.1.0.1",
+    "version": "9.0.1.1.0",
     "author": "ZikZak,"
               "Acysos,"
               "Tecnativa,"
@@ -18,6 +18,7 @@
     "external_dependencies": {
         'python': [
             'requests',
+            'xlrd',
         ],
     },
     "depends": [

--- a/l10n_es_partner/wizard/l10n_es_partner_wizard.py
+++ b/l10n_es_partner/wizard/l10n_es_partner_wizard.py
@@ -2,11 +2,14 @@
 # © 2013-2016 Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3).
 
+import logging
 from openerp import models, fields, api, _
 from openerp import tools
 from ..gen_src.gen_data_banks import gen_bank_data_xml
 import tempfile
 import os
+
+_logger = logging.getLogger(__name__)
 
 
 class L10nEsPartnerImportWizard(models.TransientModel):
@@ -33,8 +36,7 @@ class L10nEsPartnerImportWizard(models.TransientModel):
             response = requests.get(
                 'http://www.bde.es/f/webbde/IFI/servicio/regis/ficheros/es/'
                 'REGBANESP_CONESTAB_A.XLS')
-            if not response.ok:
-                raise Exception()
+            response.raise_for_status()
             src_file.write(response.content)
             src_file.close()
             # Generate XML and reopen it
@@ -42,7 +44,8 @@ class L10nEsPartnerImportWizard(models.TransientModel):
             tools.convert_xml_import(
                 self._cr, 'l10n_es_partner', dest_file.name, {}, 'init',
                 noupdate=True)
-        except:
+        except requests.exceptions.HTTPError:
+            _logger.exception()
             self.import_fail = True
             return {
                 'name': _('Import spanish bank data'),


### PR DESCRIPTION
Esto era demasiado laxo a la hora de ignorar excepciones.

Ahora solo ignora las excepciones HTTP, y eso me ha permitido encontrar este error:

```
2019-01-29 09:53:36,995 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: ERROR: test_import_banks (openerp.addons.l10n_es_partner.tests.test_l10n_es_partner.TestL10nEsPartner)
2019-01-29 09:53:36,995 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: Traceback (most recent call last):
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: `   File "/opt/odoo/auto/addons/l10n_es_partner/tests/test_l10n_es_partner.py", line 136, in test_import_banks
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: `     self.wizard.execute()
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: `   File "/opt/odoo/custom/src/odoo/openerp/api.py", line 248, in wrapper
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: `     return new_api(self, *args, **kwargs)
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: `   File "/opt/odoo/auto/addons/l10n_es_partner/wizard/l10n_es_partner_wizard.py", line 43, in execute
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: `     gen_bank_data_xml(src_file.name, dest_file.name)
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: `   File "/opt/odoo/auto/addons/l10n_es_partner/gen_src/gen_data_banks.py", line 67, in gen_bank_data_xml
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: `     reader = XlsDictReader(os.path.join(os.path.dirname(__file__), "bics.xls"))
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: `   File "/opt/odoo/auto/addons/l10n_es_partner/gen_src/gen_data_banks.py", line 25, in __init__
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: `     raise Exception("Librería xlrd no encontrada.")
2019-01-29 09:53:36,996 46 ERROR test openerp.addons.l10n_es_partner.tests.test_l10n_es_partner: ` Exception: Librería xlrd no encontrada.
```

Lo cual revela que faltaba una dependencia externa, que ahora ya está también declarada.

@Tecnativa