### PR TITLE
[FIX] l10n_es_partner: Add xlrd dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ pycrypto
 unidecode
 unicodecsv
 requests
+xlrd
 zeep
 pyOpenSSL


### PR DESCRIPTION
As it was indicated in https://github.com/OCA/l10n-spain/pull/994,
I'm adding this required dependency here.

@Tecnativa