### PR TITLE
[8.0] l10n_es_partner: Backport to only hide HTTP errors and add xlrd dependency

### DIFF
--- a/l10n_es_partner/__openerp__.py
+++ b/l10n_es_partner/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Adaptación de los clientes, proveedores y bancos para España",
-    "version": "8.0.1.5.3",
+    "version": "8.0.1.6.0",
     "author": "ZikZak,"
               "Acysos,"
               "Tecnativa,"
@@ -18,6 +18,7 @@
     "external_dependencies": {
         'python': [
             'requests',
+            'xlrd',
         ],
     },
     "depends": [

--- a/l10n_es_partner/wizard/l10n_es_partner_wizard.py
+++ b/l10n_es_partner/wizard/l10n_es_partner_wizard.py
@@ -2,11 +2,14 @@
 # © 2013-2016 Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3).
 
+import logging
 from openerp import models, fields, api, _
 from openerp import tools
 from ..gen_src.gen_data_banks import gen_bank_data_xml
 import tempfile
 import os
+
+_logger = logging.getLogger(__name__)
 
 
 class L10nEsPartnerImportWizard(models.TransientModel):
@@ -33,8 +36,7 @@ class L10nEsPartnerImportWizard(models.TransientModel):
             response = requests.get(
                 'http://www.bde.es/f/webbde/IFI/servicio/regis/ficheros/es/'
                 'REGBANESP_CONESTAB_A.XLS')
-            if not response.ok:
-                raise Exception()
+            response.raise_for_status()
             src_file.write(response.content)
             src_file.close()
             # Generate XML and reopen it
@@ -42,7 +44,8 @@ class L10nEsPartnerImportWizard(models.TransientModel):
             tools.convert_xml_import(
                 self._cr, 'l10n_es_partner', dest_file.name, {}, 'init',
                 noupdate=True)
-        except:
+        except requests.exceptions.HTTPError:
+            _logger.exception()
             self.import_fail = True
             return {
                 'name': _('Import spanish bank data'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ pycrypto
 six>=1.9.0
 unidecode
 unicodecsv
+xlrd
 zeep
 pyOpenSSL


### PR DESCRIPTION
This is a backport from v9's #994 and #1004. Just 3 cherry-picks with needed adjustments.

@Tecnativa