### PR TITLE
[IMP] l10n_es_partner: Add a context hook in order to hide commercial

### DIFF
--- a/l10n_es_partner/__manifest__.py
+++ b/l10n_es_partner/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Adaptación de los clientes, proveedores y bancos para España",
-    "version": "11.0.2.1.0",
+    "version": "11.0.2.1.1",
     "author": "ZikZak,"
               "Acysos,"
               "Tecnativa,"

--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -63,7 +63,10 @@ class ResPartner(models.Model):
         result = []
         name_pattern = self.env['ir.config_parameter'].sudo().get_param(
             'l10n_es_partner.name_pattern', default='')
-        orig_name = dict(super(ResPartner, self).name_get())
+        origin = super(ResPartner, self).name_get()
+        if self.env.context.get('no_display_commercial', False):
+            return origin
+        orig_name = dict(origin)
         for partner in self:
             name = orig_name[partner.id]
             comercial = partner.comercial

--- a/l10n_es_partner/tests/test_l10n_es_partner.py
+++ b/l10n_es_partner/tests/test_l10n_es_partner.py
@@ -61,3 +61,9 @@ class TestL10nEsPartner(common.SavepointCase):
         self.assertEqual(
             partner2.display_name, 'Nuevo nombre (Empresa de prueba)',
         )
+        names = dict(partner2.with_context(
+            no_display_commercial=True).name_get())
+        self.assertEqual(names.get(partner2.id), 'Empresa de prueba')
+        names = dict(partner2.name_get())
+        self.assertEqual(
+            names.get(partner2.id), 'Nuevo nombre (Empresa de prueba)')


### PR DESCRIPTION
Añado un hook en _get_name para ocultar el nombre del comercial. Sería útil para las facturas.