### PR TITLE
[8.0][FIX] l10n_es_aeat_mod347: datos erróneos en clave B cuando un p…

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -77,6 +77,7 @@ class L10nEsAeatMod347Report(models.Model):
 
         Create from income (from supplier) invoices
         """
+        vals = vals.copy()
         partner_record_obj = self.env['l10n.es.aeat.mod347.partner_record']
         record = False
         vals['operation_key'] = 'A'
@@ -96,6 +97,7 @@ class L10nEsAeatMod347Report(models.Model):
 
         Create from outcome (from customer) invoices and cash movements
         """
+        vals = vals.copy()
         partner_record_obj = self.env['l10n.es.aeat.mod347.partner_record']
         cash_record_obj = self.env['l10n.es.aeat.mod347.cash_record']
         records = []


### PR DESCRIPTION
…artner tiene facturas en clave A pero solo movimientos de caja en clave B

Ejemplo: 
- 2 facturas de proveedor cuyo suma es mayor que el límite --> clave A
- 1 factura de cliente --> clave B
- 1 factura rectificativa de cliente --> clave B
- 1 movimiento de caja con importe superior al límite --> clave B
- La "suma" del importe de ambas facturas de la clave B es 0 y por tanto en ese registro no es necesario detallarlas.

Con el código actual al llamar al método `_partner_record_b_create` después de haber pasado por `_partner_record_a_create`, la variable `vals` contiene la clave `invoice_record_ids` con las facturas de cliente.
En el método `_partner_record_b_create` al no entrar por el if porque el importe no supera el límite, esa clave no se actualiza. Al entrar en la parte en la que se detallan los movimientos de caja, se añaden nuevas claves al diccionario `vals` y se crea el registro (`l10n.es.aeat.mod347.partner_record`). El problema es que se arrastran las facturas que se han incluido en el registro de la clave a porque siguen estando en la variable `vals`.

Haciendo un copy de `vals` en cada uno de los métodos solucionamos el problema. En realidad en el método `_partner_record_b_create` no sería necesario, pero por consistencia.