### PR TITLE
[11.0][FIX?] 347 onchange partner en registro de inmuebles

### DIFF
--- a/l10n_es_aeat_mod347/__manifest__.py
+++ b/l10n_es_aeat_mod347/__manifest__.py
@@ -10,7 +10,7 @@
 
 {
     'name': "AEAT modelo 347",
-    'version': "11.0.1.0.0",
+    'version': "11.0.1.0.1",
     'author': "Tecnativa,"
               "PESOL,"
               "Odoo Community Association (OCA)",

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -693,17 +693,18 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
     city = fields.Char(string='City', size=30)
     township = fields.Char(string='Township', size=30)
     township_code = fields.Char(string='Township Code', size=5)
-    state_code = fields.Char(string='State Code', size=2)
+    partner_state_code = fields.Char(
+        string='State Code', oldname='state_code', size=2)
     postal_code = fields.Char(string='Postal code', size=5)
     check_ok = fields.Boolean(
         compute="_compute_check_ok", string='Record is OK',
         store=True, help='Checked if this record is OK',
     )
 
-    @api.depends('state_code')
+    @api.depends('partner_state_code')
     def _compute_check_ok(self):
         for record in self:
-            record.check_ok = bool(record.state_code)
+            record.check_ok = bool(record.partner_state_code)
 
     @api.onchange('partner_id')
     def _onchange_partner_id(self):

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -246,7 +246,7 @@
                     </group>
                         <group>
                             <field name="city"/>
-                            <field name="state_code"/>
+                            <field name="partner_state_code"/>
 
                         </group>
                         <group>


### PR DESCRIPTION
En el onchange de la empresa al añadir un registro de inmuebles:

´´´
  File "/home/odoo/source/l10n-spain/l10n_es_aeat_mod347/models/mod347.py", line 717, in _onchange_partner_id
    self.update(vals)
  File "/home/odoo/source/odoo/odoo/models.py", line 4559, in update
    record[name] = value
  File "/home/odoo/source/odoo/odoo/models.py", line 4763, in __setitem__
    return self._fields[key].__set__(self, value)
KeyError: 'partner_state_code'
´´´
Por eso lo he añadido para borrar el registro antes de actualizar los valores