### PR TITLE
[10.0][FIX] round on _compute_partner_refund_ok

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -13,7 +13,7 @@
 
 import re
 from odoo import models, fields, api, exceptions, _
-from odoo.tools import float_is_zero
+from odoo.tools import float_is_zero, float_round
 
 
 def _format_partner_vat(partner_vat=None, country=None):
@@ -504,11 +504,14 @@ class Mod349PartnerRefund(models.Model):
                  'total_origin_amount')
     def _compute_partner_refund_ok(self):
         """Checks if partner refund line have all fields filled."""
+        rounding = self.env.user.company_id.currency_id.rounding
         for record in self:
             record.partner_refund_ok = bool(
                 record.partner_vat and record.country_id and
-                record.total_operation_amount >= 0.0 and
-                record.total_origin_amount >= 0.0
+                float_round(record.total_operation_amount,
+                            precision_rounding=rounding) >= 0.0 and
+                float_round(record.total_origin_amount,
+                            precision_rounding=rounding) >= 0.0
             )
 
     @api.depends('refund_detail_ids')


### PR DESCRIPTION
Buenas,

en una implantación tenemos  mas de 30 facturas rectificativas que suman el importe de la factura original, en la función _compute_partner_refund_ok se hace una comparación para ver si el importe es mayor o igual que cero, pero parece que por el redondeo da un importe menor que cero. Con el round se soluciona, peor no se si habrá una forma mejor de hacerlo.

Lo propongo en V10.0, pero cuando se valide vendría bien en el resto de versiones.

Saludos