### PR TITLE
[FIX] facturae_efact: 22 digits of efact_code

### DIFF
--- a/l10n_es_facturae_efact/__manifest__.py
+++ b/l10n_es_facturae_efact/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Envío de Factura-e a e.FACT",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "author": "Creu Blanca, "
               "Odoo Community Association (OCA)",
     "category": "Accounting & Finance",

--- a/l10n_es_facturae_efact/models/res_partner.py
+++ b/l10n_es_facturae_efact/models/res_partner.py
@@ -32,6 +32,6 @@ class ResPartner(models.Model):
                         _('State must be defined in Spain in order to '
                           'send to e.Fact'))
             if not record.facturae_efact_code or len(
-                    record.facturae_efact_code) != 18:
+                    record.facturae_efact_code) != 22:
                 raise exceptions.ValidationError(
                     _('e.Fact code must be correctly defined'))

--- a/l10n_es_facturae_efact/models/res_partner.py
+++ b/l10n_es_facturae_efact/models/res_partner.py
@@ -11,7 +11,7 @@ class ResPartner(models.Model):
     facturae_efact_code = fields.Char(string='e.Fact code')
 
     @api.constrains('facturae', 'vat', 'country_id', 'state_id',
-                    'invoice_integration_method_ids', )
+                    'invoice_integration_method_ids', 'facturae_efact_code')
     def constrain_efact(self):
         efact = self.env.ref('l10n_es_facturae_efact.integration_efact')
         for record in self.filtered(

--- a/l10n_es_facturae_efact/tests/test_efact.py
+++ b/l10n_es_facturae_efact/tests/test_efact.py
@@ -59,12 +59,12 @@ class TestL10nEsFacturae(common.TransactionCase):
             'organo_gestor': 'U00000038',
             'unidad_tramitadora': 'U00000038',
             'oficina_contable': 'U00000038',
-            'facturae_efact_code': '012345678901234567',
+            'facturae_efact_code': '0123456789012345678901',
             'invoice_integration_method_ids': [(6, 0, [
                 self.env.ref('l10n_es_facturae_efact.integration_efact').id
             ])]
         })
-        main_company.partner_id.facturae_efact_code = '012345678901234567'
+        main_company.partner_id.facturae_efact_code = '0123456789012345678901'
         main_company.vat = "ESA12345674"
         main_company.partner_id.country_id = self.ref('base.uk')
         main_company.currency_id = self.ref('base.EUR')
@@ -153,6 +153,26 @@ class TestL10nEsFacturae(common.TransactionCase):
         self.invoice._onchange_invoice_line_ids()
         self.invoice.action_invoice_open()
         self.invoice.number = 'R/0001'
+
+    def test_constrain_factuare_code(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self.partner.facturae_efact_code = '01234'
+
+    def test_constrain_factuare(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self.partner.facturae = False
+
+    def test_constrain_vat(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self.partner.vat = False
+
+    def test_constrain_country(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self.partner.country_id = False
+
+    def test_constrain_state(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self.partner.state_id = False
 
     def test_efact_sending(self):
         class TestConnection:

--- a/l10n_es_facturae_efact/tests/test_efact.py
+++ b/l10n_es_facturae_efact/tests/test_efact.py
@@ -154,11 +154,15 @@ class TestL10nEsFacturae(common.TransactionCase):
         self.invoice.action_invoice_open()
         self.invoice.number = 'R/0001'
 
-    def test_constrain_factuare_code(self):
+    def test_constrain_facturae_code_01(self):
         with self.assertRaises(exceptions.ValidationError):
-            self.partner.facturae_efact_code = '01234'
+            self.partner.facturae_efact_code = False
 
-    def test_constrain_factuare(self):
+    def test_constrain_facturae_code_02(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self.partner.facturae_efact_code = '1'
+
+    def test_constrain_facturae(self):
         with self.assertRaises(exceptions.ValidationError):
             self.partner.facturae = False
 


### PR DESCRIPTION
El código de e.Fact es de 22 dígitos, no 18:
La confusión es que el código es 

- 4 dígitos de la plataforma
- 17 dígitos asignados al receptor
- 1 dígito de control (calculado sobre los 17 del receptor)