### PR TITLE
[11.0][FIX] l10n_es_aeat_sii: on send and cancel error management exception object is not properly cast to string

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1030,8 +1030,8 @@ class AccountInvoice(models.Model):
                 invoice = env['account.invoice'].browse(invoice.id)
                 inv_vals.update({
                     'sii_send_failed': True,
-                    'sii_send_error': fault[:60],
-                    'sii_return': fault,
+                    'sii_send_error': repr(fault)[:60],
+                    'sii_return': repr(fault),
                 })
                 invoice.write(inv_vals)
                 new_cr.commit()
@@ -1118,8 +1118,8 @@ class AccountInvoice(models.Model):
                 invoice = env['account.invoice'].browse(invoice.id)
                 inv_vals.update({
                     'sii_send_failed': True,
-                    'sii_send_error': fault[:60],
-                    'sii_return': fault,
+                    'sii_send_error': repr(fault)[:60],
+                    'sii_return': repr(fault),
                 })
                 invoice.write(inv_vals)
                 new_cr.commit()


### PR DESCRIPTION
En la gestión de un error enviando o cancelando una factura contra el SII, si el error se produce antes del envío propiamente dicho (falla una validación previa de la factura), la gestión de la excepción pretende grabar el error como tal en `sii_send_error` y `sii_return` a partir de la excepción producida, pero sin pasar adecuadamente la excepción generada a cadena.
El resultado es que se genera un nuevo error y en el registro de la factura finalmente no queda grabado el  el error ni la marca de envío fallido. Si se tiene conector, queda registrado en el trabajo la traza completa del error en vez del mensaje más específico.
Con la corrección del error la factura queda marcada como fallida al enviar y el mensaje de error producido.