### PR TITLE
[FIX] tipo de cuenta en cuenta bancaria

### DIFF
--- a/l10n_es_aeat/models/res_partner_bank.py
+++ b/l10n_es_aeat/models/res_partner_bank.py
@@ -7,4 +7,4 @@ from odoo import fields, models
 class ResPartnerBank(models.Model):
     _inherit = "res.partner.bank"
 
-    acc_type = fields.Char(store=True)
+    acc_type = fields.Selection(store=True)


### PR DESCRIPTION
El tipo de cuenta es campo selection, que puede ser normal o iban.

El funcionamiento normal es que cuando se pone una cuenta bancaria iban, se calcula automáticamente si es iban en caso que sea una cuenta iban correcta, y se completa el campo banco relacionado.

Al hacer ese campo stored (seguramente para poder realizar busquedas sobre este campo) se ha redefinido como char, esto hace que en la vista se muestre un input de texto y no funcione lo anterior.