### PR TITLE
[11.0][FIX] l10n_es_account_invoice_sequence: Compute correct next number of sequence

### DIFF
--- a/l10n_es_account_invoice_sequence/models/account_journal.py
+++ b/l10n_es_account_invoice_sequence/models/account_journal.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2011 NaN Projectes de Programari Lliure, S.L.
 # Copyright 2013-2017 Pedro M. Baeza
+# Copyright 2019 Jose F. Fernandez
 
 from odoo import _, api, fields, exceptions, models
 
@@ -46,7 +47,7 @@ class AccountJournal(models.Model):
             return super(AccountJournal, self).create(vals)
         company = self.env['res.company'].browse(vals['company_id'])
         if company.chart_template_id.is_spanish_chart():
-            journal = self.search([('company_id', '=', company.id)], limit=1)
+            journal = self._get_company_journal(company)
             if journal:
                 vals['sequence_id'] = journal.sequence_id.id
                 vals['refund_sequence'] = False
@@ -57,3 +58,19 @@ class AccountJournal(models.Model):
             'sale',
             'purchase',
         ]
+
+    def _get_company_journal(self, company):
+        """Get an existing journal in the company to take it's counter."""
+        if not company:
+            return False
+        return self.search([('company_id', '=', company.id)], limit=1)
+
+    @api.model
+    def default_get(self, default_fields):
+        res = super(AccountJournal, self).default_get(default_fields)
+        company = self.env['res.company'].browse(res.get('company_id', False))
+        if company.chart_template_id.is_spanish_chart():
+            journal = self._get_company_journal(company)
+            if journal:
+                res['sequence_id'] = journal.sequence_id.id
+        return res


### PR DESCRIPTION
Cuando se crea un nuevo diario propone como número siguiente del contador el 1. 

El número por defecto correcto es el número actual del contador que se establece forzosamente (el de los demás diarios de la misma empresa, si se cumplen las condiciones, tal como está en el método create sobreescrito en el módulo)

De este modo se evita sobreescribir el valor del contador si el usuario no tiene el cuidado de consultar el valor actual y cambiar el valor incorrecto propuesto como valor por defecto.
