### PR TITLE
[FIX] l10n_es_aeat: Create sequences when new company is created

### DIFF
--- a/l10n_es_aeat/models/__init__.py
+++ b/l10n_es_aeat/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import res_company
 from . import res_partner_bank
 from . import l10n_es_aeat_map_tax
 from . import l10n_es_aeat_map_tax_line

--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2011 Pexego Sistemas Informáticos - Luis Manuel Angueira
 # Copyright 2013 - Acysos S.L. - Ignacio Ibeas (Migración a v7)
-# Copyright 2014-2017 Tecnativa - Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2014-2019 Tecnativa - Pedro M. Baeza
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -384,8 +384,9 @@ class L10nEsAeatReport(models.AbstractModel):
         return (phone or '').replace(" ", "")[-9:]
 
     @api.model_cr
-    def _register_hook(self):
-        res = super(L10nEsAeatReport, self)._register_hook()
+    def _register_hook(self, companies=None):
+        if not companies:
+            res = super(L10nEsAeatReport, self)._register_hook()
         if self._name in ('l10n.es.aeat.report',
                           'l10n.es.aeat.report.tax.mapping'):
             return res
@@ -397,7 +398,8 @@ class L10nEsAeatReport(models.AbstractModel):
             ))
         seq_obj = self.env['ir.sequence']
         sequence = "aeat%s-sequence" % aeat_num
-        companies = self.env['res.company'].search([])
+        if not companies:
+            companies = self.env['res.company'].search([])
         for company in companies:
             seq = seq_obj.search([
                 ('name', '=', sequence), ('company_id', '=', company.id),

--- a/l10n_es_aeat/models/res_company.py
+++ b/l10n_es_aeat/models/res_company.py
@@ -1,0 +1,22 @@
+# Copyright 2019 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    @api.model
+    def create(self, values):
+        """Create immediately all the AEAT sequences when creating company."""
+        company = super().create(values)
+        models = self.env['ir.model'].search([
+            ('model', '=like', 'l10n.es.aeat.%.report'),
+        ])
+        for model in models:
+            try:
+                self.env[model.model]._register_hook(companies=company)
+            except Exception:
+                pass
+        return company

--- a/l10n_es_aeat/tests/test_l10n_es_aeat_report.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_report.py
@@ -1,16 +1,54 @@
 # Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields
-from odoo.tests import common
+from odoo import fields, models
+from odoo.tests import common, tagged
 from odoo import exceptions
 
+TEST_MODEL_NAME = 'l10n.es.aeat.mod999.report'
 
-class TestL10nEsAeatReport(common.TransactionCase):
-    def setUp(self):
-        super(TestL10nEsAeatReport, self).setUp()
-        self.AeatReport = self.env["l10n.es.aeat.report"]
-        self.period_types = {
+
+class L10nEsAeatTestReport(models.TransientModel):
+    _name = TEST_MODEL_NAME
+    _inherit = 'l10n.es.aeat.report'
+    _aeat_number = '999'
+
+
+@tagged('post_install', '-at_install')
+class TestL10nEsAeatReport(common.SavepointCase):
+    def _init_test_model(cls, model_cls):
+        """ It builds a model from model_cls in order to test abstract models.
+        Note that this does not actually create a table in the database, so
+        there may be some unidentified edge cases.
+
+        Requirements: test to be executed at post_install.
+
+        : Args:
+            model_cls (odoo.models.BaseModel): Class of model to initialize
+        Returns:
+            Instance
+        """
+        registry = cls.env.registry
+        cls.env.cr.execute(
+            "INSERT INTO ir_model (model, name) VALUES (%s, %s)",
+            (TEST_MODEL_NAME, 'Test AEAT model'),
+        )
+        inst = model_cls._build_model(registry, cls.env.cr)
+        model = cls.env[model_cls._name].with_context(todo=[])
+        model._prepare_setup()
+        model._setup_base()
+        model._setup_fields()
+        model._setup_complete()
+        model._auto_init()
+        model.init()
+        return inst
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._init_test_model(cls, L10nEsAeatTestReport)
+        cls.AeatReport = cls.env["l10n.es.aeat.report"]
+        cls.period_types = {
             '0A': ('2016-01-01', '2016-12-31'),
             '1T': ('2016-01-01', '2016-03-31'),
             '2T': ('2016-04-01', '2016-06-30'),
@@ -55,3 +93,13 @@ class TestL10nEsAeatReport(common.TransactionCase):
         })
         with self.assertRaises(exceptions.UserError):
             report._check_previous_number()
+
+    def test_new_company(self):
+        self.assertTrue(TEST_MODEL_NAME in self.env)
+        company = self.env['res.company'].create({'name': 'Test company'})
+        self.assertTrue(
+            self.env['ir.sequence'].search([
+                ('name', '=', "aeat999-sequence"),
+                ('company_id', '=', company.id),
+            ]),
+        )


### PR DESCRIPTION
When a new company is created, its sequences are not populated, so an Odoo service restart is needed for being able to use AEAT models. With this, you don't need this restart.

It includes a test with a hack for populating a model in the test itself for testing complete flow.

cc @Tecnativa