### PR TITLE
[12.0][FIX] l10n_es_aeat_sii: queue_job wrong eta value

### DIFF
--- a/l10n_es_aeat_sii/models/queue_job.py
+++ b/l10n_es_aeat_sii/models/queue_job.py
@@ -10,7 +10,7 @@ class QueueJob(models.Model):
 
     @api.multi
     def do_now(self):
-        self.sudo().write({'eta': 0})
+        self.sudo().write({'eta': False})
 
     @api.multi
     def cancel_now(self):


### PR DESCRIPTION
Corrige el error al pulsar el botón "Enviar ahora":

<img width="583" alt="Captura de pantalla 2019-04-11 a las 11 44 55" src="https://user-images.githubusercontent.com/4355395/55947707-49181e80-5c4f-11e9-9b3e-75f8bbbbcb34.png">

cc @Jortolsa 