### PR TITLE
[FIX] l10n_es_pos: prevenir pérdida de pedidos y duplicados

### DIFF
--- a/l10n_es_pos/__manifest__.py
+++ b/l10n_es_pos/__manifest__.py
@@ -9,7 +9,7 @@
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "license": "AGPL-3",
-    "version": "11.0.2.0.2",
+    "version": "11.0.3.0.0",
     "depends": [
         "point_of_sale",
     ],

--- a/l10n_es_pos/i18n/es.po
+++ b/l10n_es_pos/i18n/es.po
@@ -1,16 +1,15 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* l10n_es_pos
+#	* l10n_es_pos
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-12 14:13+0000\n"
-"PO-Revision-Date: 2018-04-12 14:13+0000\n"
+"POT-Creation-Date: 2019-04-23 08:52+0000\n"
+"PO-Revision-Date: 2019-04-23 08:52+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -74,14 +73,14 @@ msgstr "Pedidos del Punto de Venta"
 #: code:addons/l10n_es_pos/static/src/xml/pos.xml:40
 #, python-format
 msgid "Product"
-msgstr ""
+msgstr "Product"
 
 #. module: l10n_es_pos
 #. openerp-web
 #: code:addons/l10n_es_pos/static/src/xml/pos.xml:41
 #, python-format
 msgid "Qty"
-msgstr ""
+msgstr "Ctd"
 
 #. module: l10n_es_pos
 #: model:ir.ui.view,arch_db:l10n_es_pos.view_pos_config_form
@@ -155,24 +154,39 @@ msgstr "Facturas simplificadas"
 #: code:addons/l10n_es_pos/static/src/xml/pos.xml:43
 #, python-format
 msgid "Subt"
-msgstr ""
+msgstr "Subt"
+
+#. module: l10n_es_pos
+#. openerp-web
+#: code:addons/l10n_es_pos/static/src/js/screens.js:32
+#, python-format
+msgid "The current order is already queued and thus it shouldn't be changed. Click on 'Validate' in order to finalize it."
+msgstr "Este pedido ya está en cola, de modo que no debería modificarse. Pulsa en 'Validar' para finalizarlo."
+
+#. module: l10n_es_pos
+#. openerp-web
+#: code:addons/l10n_es_pos/static/src/js/screens.js:31
+#, python-format
+msgid "The order is already queued"
+msgstr "El pedido ya está en cola"
 
 #. module: l10n_es_pos
 #: code:addons/l10n_es_pos/models/ir_sequence.py:20
 #, python-format
-msgid ""
-"There is already a simplified invoice sequence with that prefix and it "
-"should be unique."
-msgstr ""
-"Ya existe una secuencia de Factura Simplificada con ese prefijo y este "
-"debería ser único."
+msgid "There is already a simplified invoice sequence with that prefix and it should be unique."
+msgstr "Ya existe una secuencia de Factura Simplificada con ese prefijo y este debería ser único."
+
+#. module: l10n_es_pos
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_order_l10n_es_unique_id
+msgid "Unique Order ID"
+msgstr "ID único de pedido"
 
 #. module: l10n_es_pos
 #. openerp-web
 #: code:addons/l10n_es_pos/static/src/xml/pos.xml:42
 #, python-format
 msgid "Unit"
-msgstr ""
+msgstr "Ud."
 
 #. module: l10n_es_pos
 #: model:ir.model.fields,field_description:l10n_es_pos.field_pos_config_iface_l10n_es_simplified_invoice
@@ -205,13 +219,3 @@ msgstr "sobre"
 #: model:ir.model,name:l10n_es_pos.model_pos_config
 msgid "pos.config"
 msgstr "pos.config"
-
-#~ msgid ""
-#~ "There's already another POS config using the same Simplified Invoice "
-#~ "prefix. Try choosing another POS Name"
-#~ msgstr ""
-#~ "Ya existe otro TPV utilizando el mismo prefijo de Factura Simplifica. "
-#~ "Escoge otro nombre de Punto de Venta"
-
-#~ msgid "You need to define a simplified invoice prefix."
-#~ msgstr "Debes definir un prefijo de Factura Simplificada."

--- a/l10n_es_pos/i18n/l10n_es_pos.pot
+++ b/l10n_es_pos/i18n/l10n_es_pos.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-04-23 08:57+0000\n"
+"PO-Revision-Date: 2019-04-23 08:57+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -155,9 +157,28 @@ msgid "Subt"
 msgstr ""
 
 #. module: l10n_es_pos
+#. openerp-web
+#: code:addons/l10n_es_pos/static/src/js/screens.js:32
+#, python-format
+msgid "The current order is already queued and thus it shouldn't be changed. Click on 'Validate' in order to finalize it."
+msgstr ""
+
+#. module: l10n_es_pos
+#. openerp-web
+#: code:addons/l10n_es_pos/static/src/js/screens.js:31
+#, python-format
+msgid "The order is already queued"
+msgstr ""
+
+#. module: l10n_es_pos
 #: code:addons/l10n_es_pos/models/ir_sequence.py:20
 #, python-format
 msgid "There is already a simplified invoice sequence with that prefix and it should be unique."
+msgstr ""
+
+#. module: l10n_es_pos
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_order_l10n_es_unique_id
+msgid "Unique Order ID"
 msgstr ""
 
 #. module: l10n_es_pos
@@ -198,4 +219,3 @@ msgstr ""
 #: model:ir.model,name:l10n_es_pos.model_pos_config
 msgid "pos.config"
 msgstr ""
-

--- a/l10n_es_pos/models/pos_order.py
+++ b/l10n_es_pos/models/pos_order.py
@@ -13,6 +13,10 @@ class PosOrder(models.Model):
         copy=False,
         default=False,
     )
+    l10n_es_unique_id = fields.Char(
+        'Unique Order ID',
+        copy=False,
+    )
 
     @api.model
     def _simplified_limit_check(self, amount_total, limit=3000):
@@ -30,6 +34,9 @@ class PosOrder(models.Model):
                 'pos_reference': ui_order['simplified_invoice'],
                 'is_l10n_es_simplified_invoice': True,
             })
+        res.update({
+            'l10n_es_unique_id': ui_order['uid'],
+        })
         return res
 
     @api.model
@@ -55,19 +62,22 @@ class PosOrder(models.Model):
         """Provide a context with the current session id"""
         if not orders:
             return super().create_from_ui(orders)
-        # We take the session from the first order in queue
-        pos_session_id = orders and orders[0]['data']['pos_session_id']
-        self_ctx = self.with_context(l10n_es_pos_session_id=pos_session_id)
+        # We take the uid from every order in the sync queue to discard only
+        # those orders that are really unique
+        # TODO: Duplicated simp. invoice ids shouldn't happen but in certain
+        # circumstances it can ocurr, so we choose to save them anyway.
+        submitted_uids = [o['data']['uid'] for o in orders]
+        self_ctx = self.with_context(l10n_es_pos_submitted_uids=submitted_uids)
         return super(PosOrder, self_ctx).create_from_ui(orders)
 
     @api.model
     def search(self, args, offset=0, limit=0, order=None, count=False):
         """If the context provided from create_from_ui() is given, we add
-           the session to the domain filter. This way, we prevent missing
+           the unique_uid to the domain filter. This way, we prevent missing
            orders if a sequence is reset. If they belong to another session
            we grant them for valid despite the duped sequence number"""
-        pos_session_id = self.env.context.get('l10n_es_pos_session_id')
-        if pos_session_id:
-            args += [('session_id', '=', pos_session_id)]
+        submitted_uids = self.env.context.get('l10n_es_pos_submitted_uids')
+        if submitted_uids:
+            args += [('l10n_es_unique_id', 'in', submitted_uids)]
         return super().search(args, offset=offset, limit=limit,
                               order=order, count=count)

--- a/l10n_es_pos/static/src/js/models.js
+++ b/l10n_es_pos/static/src/js/models.js
@@ -1,4 +1,5 @@
 /* Copyright 2016 David Gómez Quilón <david.gomez@aselcis.com>
+   Copyright 2018-19 Tecnativa - David Vidal
    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 */
 
@@ -6,7 +7,6 @@ odoo.define('l10n_es_pos.models', function (require) {
     "use strict";
 
     var models = require('point_of_sale.models');
-
 
     var pos_super = models.PosModel.prototype;
     models.PosModel = models.PosModel.extend({
@@ -56,8 +56,10 @@ odoo.define('l10n_es_pos.models', function (require) {
     models.Order = models.Order.extend({
         get_total_with_tax: function () {
             var total = order_super.get_total_with_tax.apply(this, arguments);
-            var below_limit = total <= this.pos.config.l10n_es_simplified_invoice_limit;
-            this.is_simplified_invoice = below_limit && this.pos.config.iface_l10n_es_simplified_invoice;
+            var below_limit = total <=
+                this.pos.config.l10n_es_simplified_invoice_limit;
+            this.is_simplified_invoice =
+                below_limit && this.pos.config.iface_l10n_es_simplified_invoice;
             return total;
         },
         set_simple_inv_number: function () {

--- a/l10n_es_pos/static/src/js/screens.js
+++ b/l10n_es_pos/static/src/js/screens.js
@@ -10,8 +10,12 @@ odoo.define('l10n_es_pos.screens', function (require) {
 
 
     screens.PaymentScreenWidget.include({
+        // When the order total is above the simplified invoice limit, wich
+        // will be the legal one on each case, it's mandatory to force the
+        // invoice in any case.
         validate_order: function (force_validate) {
-            var below_limit = this.pos.get_order().get_total_with_tax() <= this.pos.config.l10n_es_simplified_invoice_limit;
+            var below_limit = this.pos.get_order().get_total_with_tax() <=
+                this.pos.config.l10n_es_simplified_invoice_limit;
             if (this.pos.config.iface_l10n_es_simplified_invoice) {
                 var order = this.pos.get_order();
                 if (below_limit && !order.to_invoice) {


### PR DESCRIPTION
- En algunas circunstancias insospechadas, como por ejemplo: https://github.com/odoo/odoo/commit/39fd19ffd7799301b94199390e7dfc10f9762254 o https://github.com/odoo/odoo/commit/605b94e64c202d7dbb335ce37280fae87a3a6d87, se podría producir una pérdida del pedido quedando la secuencia de factura simplificada en desfase: correría una posición por detrás de la serie grabada, por lo que se perderían pedido siempre que se actualizase el punto de venta.

  **Optamos en este caso por grabar el pedido igualmente como mal menor**, de modo que se detecte el problema de la forma más rápida posible.

- Por otro lado, cuando se produce un error en una factura normal hecha desde el Punto de Venta, hay varios resquicios de interfaz por los que un usuario podría llegar a generar un ticket duplicado.

  Cuando la factura falla (error de red, no se graba el pedido a tiempo o lo que sea), queda en cola de sincronización. Desde este momento pueden suceder varias cosas:
  - Ideal: el usuario pulsa el botón "validar" de nuevo; el pedido se graba y la factura se imprime correctamente
  - Tampoco está mal: el usuario pulsa en el botón de sincronización de pedidos en cola y la factura se graba en la base de datos. Al pulsar en validar, el Punto de Venta lanza una advertencia de que ya ha sido grabado.
 - Pedido duplicado:  el usuario desmarca el botón de factura en el Punto de Venta y pulsa el botón validar. Se graba un pedido con la referencia de la factura normal y otro con la referencia de factura simplificada que toque. **Prevenimos que esto pase comprobando que el pedido no esté ya en cola**
 - Pedido duplicado: el usuario pulsa en el botón de sincronización de pedidos en cola y la factura se graba en la base de datos; el usuario desmarca el botón de factura en el Punto de Venta y pulsa el botón validar. Se graba un pedido con la referencia de la factura normal y otro con la referencia de factura simplificada que toque. Es ligeramente distinto, ya que no se puede prevenir.
cc @Tecnativa