### PR TITLE
[IMP] l10n_es_aeat_sii: Default refund specific type

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -129,6 +129,7 @@ class AccountInvoice(models.Model):
             ('R1', 'Error based on law and Art. 80 One and Two LIVA (R1)'),
             ('R2', 'Art. 80 Three LIVA - Bankruptcy (R2)'),
             ('R3', 'Art. 80 Four LIVA - Bad debt (R3)'),
+            ('R4', 'Rest of causes (R4)'),
         ],
         help="Fill this field when the refund are one of the specific cases"
              " of article 80 of LIVA for notifying to SII with the proper"
@@ -1375,6 +1376,8 @@ class AccountInvoice(models.Model):
             res['sii_refund_type'] = sii_refund_type
         if supplier_invoice_number_refund:
             res['reference'] = supplier_invoice_number_refund
+        if res['type'] == 'out_refund':
+            res['sii_refund_specific_invoice_type'] = 'R1'
 
         return res
 


### PR DESCRIPTION
Buenas,

Como ya se habló en #974 con @SoniaViciana y @albertgafic, la mayoría de las devoluciones se ciñen a los apartados 1, 2 y 6 del artículo 80 de LIVA, siendo lo correcto aplicar el tipo específico R1 de facturas rectificativas, y siendo R4 relegado a las facturas que no se acojan a ninguno de los otros casos, que serían la ínfima parte.
Por todo ello, proponemos seleccionar por defecto la opción R1 cuando se quiera crear una rectificativa a partir de una factura de cliente, permitiendo aun así seleccionar el tipo R4 posteriormente.

Un saludo.