### PR TITLE
[8.0][ADD] l10n_es_aeat: aeat certificate

### DIFF
--- a/l10n_es_aeat/README.rst
+++ b/l10n_es_aeat/README.rst
@@ -15,6 +15,7 @@ Módulo base para declaraciones de la AEAT, que incluye:
 * Motor de cálculo de importes por códigos de impuestos.
 * Generador del asiento de regularización con cargo a un proveedor "Agencia
   Estatal de Administración Tributaria" creado al efecto.
+* Certificado para las declaraciones de la AEAT
 
 Configuración
 =============
@@ -36,6 +37,12 @@ en la configuración de impuestos los conceptos que se regularizarán con el
 flag "to_regularize". Esto sólo es posible sobre los modelos que utilicen
 el cálculo de casillas por códigos de impuestos.
 
+Para importar el certificado, hay que:
+
+#. Entrar en *Contabilidad > Configuración > AEAT > Certificados*
+#. Crear uno nuevo. Rellenas los datos del formulurio y subir el archivo p12
+#. Pulsar obtener claves e introducir la contraseña del certificado
+
 Problemas conocidos / Hoja de ruta
 ==================================
 
@@ -50,9 +57,11 @@ Contribudores
 -------------
 
 * Pexego (http://www.pexego.es)
-* Acysos (http://www.acysos.com)
+* Ignacio Ibeas - Acysos S.L. (http://www.acysos.com)
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * AvanzOSC (http://www.avanzosc.es)
+* Diagram Software S.L.
+* Consultoría Informática Studio 73 S.L.
 
 Maintainer
 ----------

--- a/l10n_es_aeat/__openerp__.py
+++ b/l10n_es_aeat/__openerp__.py
@@ -4,9 +4,8 @@
 #    Copyright (C) 2004-2011
 #        Pexego Sistemas Informáticos. (http://pexego.es)
 #        Luis Manuel Angueira Blanco
-#    Copyright (C) 2013
+#    Copyright (C) 2013 - 2019
 #        Ignacio Ibeas - Acysos S.L. (http://acysos.com)
-#        Migración a OpenERP 7.0
 #    Copyright (C) 2013-2015
 #        Serv. Tecnol. Avanzados - Pedro M. Baeza (www.serviciosbaeza.com)
 #    Copyright (C) 2015
@@ -28,10 +27,11 @@
 ##############################################################################
 {
     'name': "AEAT Base",
-    'version': "8.0.1.9.4",
+    'version': "8.0.1.9.5",
     'author': "Pexego,"
               "Tecnativa,"
               "AvanzOSC,"
+              "Acysos S.L.,"
               "Odoo Community Association (OCA)",
     'license': "AGPL-3",
     'contributors': [
@@ -47,7 +47,7 @@
         "account",
     ],
     'external_dependencies': {
-        'python': ['unidecode'],
+        'python': ['unidecode', 'OpenSSL'],
     },
     'data': [
         'security/aeat_security.xml',
@@ -55,12 +55,14 @@
         'data/aeat_sequence_type.xml',
         'data/aeat_partner.xml',
         'wizard/export_to_boe_wizard.xml',
+        'wizard/aeat_certificate_password_view.xml',
         'views/aeat_menuitem.xml',
         'views/aeat_report_view.xml',
         'views/aeat_report_tax_mapping_view.xml',
         'views/aeat_export_configuration_view.xml',
         'views/aeat_tax_code_mapping_view.xml',
         'views/account_move_line_view.xml',
+        'views/aeat_certificate_view.xml',
     ],
     'installable': True,
 }

--- a/l10n_es_aeat/i18n/es.po
+++ b/l10n_es_aeat/i18n/es.po
@@ -1,31 +1,24 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat
+# 	* l10n_es_aeat
 #
-# Translators:
-# Antonio Trueba, 2016
-# Antonio Trueba, 2016
-# Carles Antoli <carlesantoli@hotmail.com>, 2015
-# Carles Antoli <carlesantoli@hotmail.com>, 2015
-# Fernando Lara <gennesis45@gmail.com>, 2017
-# Pedro M. Baeza <pedro.baeza@gmail.com>, 2015
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-spain (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-27 00:51+0000\n"
-"PO-Revision-Date: 2019-02-04 17:50+0000\n"
-"Last-Translator: Marta Vázquez Rodríguez <vazrodmar@gmail.com>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-l10n-spain-8-0/"
-"language/es/)\n"
-"Language: es\n"
+"POT-Creation-Date: 2019-06-25 16:16+0000\n"
+"PO-Revision-Date: 2019-06-25 18:19+0200\n"
+"Last-Translator: Ignacio Ibeas - Acysos S.L. <ignacio@acysos.com>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.4\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"Language: es\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/wizard/export_to_boe.py:211
 #: code:addons/l10n_es_aeat/wizard/export_to_boe.py:213
 #, python-format
 msgid "%s_report_%s.txt"
@@ -92,6 +85,11 @@ msgid "Account entry"
 msgstr "Entrada cuenta"
 
 #. module: l10n_es_aeat
+#: selection:l10n.es.aeat.certificate,state:0
+msgid "Active"
+msgstr "Activo"
+
+#. module: l10n_es_aeat
 #: view:aeat.model.export.config.line:l10n_es_aeat.aeat_model_export_config_line_form
 msgid "Advanced configuration"
 msgstr "Configuración avanzada"
@@ -105,7 +103,7 @@ msgstr "Alineación"
 #: field:l10n.es.aeat.report,allow_posting:0
 #: field:l10n.es.aeat.report.tax.mapping,allow_posting:0
 msgid "Allow posting"
-msgstr "Permitir publicación"
+msgstr "Allow posting"
 
 #. module: l10n_es_aeat
 #: selection:aeat.model.export.config.line,export_type:0
@@ -166,6 +164,7 @@ msgid "Calculation date"
 msgstr "Fecha de cálculo"
 
 #. module: l10n_es_aeat
+#: view:l10n.es.aeat.certificate.password:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
 msgid "Cancel"
@@ -184,6 +183,12 @@ msgid "Cancelled models"
 msgstr "Declaraciones canceladas"
 
 #. module: l10n_es_aeat
+#: model:ir.actions.act_window,name:l10n_es_aeat.l10n_es_certificate_action
+#: model:ir.ui.menu,name:l10n_es_aeat.l10n_es_aeat_certificate_menu
+msgid "Certificates"
+msgstr "Certificados"
+
+#. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
 msgid "Close"
 msgstr "Cerrar"
@@ -199,7 +204,12 @@ msgstr "Compañía"
 #: help:l10n.es.aeat.report,partner_bank_id:0
 #: help:l10n.es.aeat.report.tax.mapping,partner_bank_id:0
 msgid "Company bank account used for the presentation"
-msgstr "Cuenta bancaria de la empresa utilizada para la presentación"
+msgstr "Company bank account used for the presentation"
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,company_id:0
+msgid "Compañía"
+msgstr "Compañía"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report,type:0
@@ -258,6 +268,8 @@ msgstr "Crear asiento"
 #: field:aeat.mod.map.tax.code.line,create_uid:0
 #: field:aeat.model.export.config,create_uid:0
 #: field:aeat.model.export.config.line,create_uid:0
+#: field:l10n.es.aeat.certificate,create_uid:0
+#: field:l10n.es.aeat.certificate.password,create_uid:0
 #: field:l10n.es.aeat.report.export_to_boe,create_uid:0
 #: field:l10n.es.aeat.tax.line,create_uid:0
 msgid "Created by"
@@ -268,6 +280,8 @@ msgstr "Creado por"
 #: field:aeat.mod.map.tax.code.line,create_date:0
 #: field:aeat.model.export.config,create_date:0
 #: field:aeat.model.export.config.line,create_date:0
+#: field:l10n.es.aeat.certificate,create_date:0
+#: field:l10n.es.aeat.certificate.password,create_date:0
 #: field:l10n.es.aeat.report.export_to_boe,create_date:0
 #: field:l10n.es.aeat.tax.line,create_date:0
 msgid "Created on"
@@ -295,12 +309,14 @@ msgstr "Nº declaración"
 #: field:aeat.mod.map.tax.code.line,display_name:0
 #: field:aeat.model.export.config,display_name:0
 #: field:aeat.model.export.config.line,display_name:0
+#: field:l10n.es.aeat.certificate,display_name:0
+#: field:l10n.es.aeat.certificate.password,display_name:0
 #: field:l10n.es.aeat.report,display_name:0
 #: field:l10n.es.aeat.report.export_to_boe,display_name:0
 #: field:l10n.es.aeat.report.tax.mapping,display_name:0
 #: field:l10n.es.aeat.tax.line,display_name:0
 msgid "Display Name"
-msgstr "Display Name"
+msgstr "Nombre mostrado"
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_search
@@ -310,6 +326,7 @@ msgid "Done"
 msgstr "Realizada"
 
 #. module: l10n_es_aeat
+#: selection:l10n.es.aeat.certificate,state:0
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: selection:l10n.es.aeat.report,state:0
@@ -323,6 +340,11 @@ msgid "Draft models"
 msgstr "Declaraciones borrador"
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,date_end:0
+msgid "End Date"
+msgstr "Fecha hasta"
+
+#. module: l10n_es_aeat
 #: field:aeat.model.export.config,date_end:0
 msgid "End date"
 msgstr "Fecha final"
@@ -331,8 +353,7 @@ msgstr "Fecha final"
 #: code:addons/l10n_es_aeat/models/aeat_tax_code_mapping.py:56
 #, python-format
 msgid "Error! The dates of the record overlap with an existing record."
-msgstr ""
-"Error! Las fechas de los registros se solapan con un registro existente."
+msgstr "Error! Las fechas de los registros se solapan con un registro existente."
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
@@ -405,6 +426,7 @@ msgid "Field size"
 msgstr "Tamaño del campo"
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,file:0
 #: field:l10n.es.aeat.report.export_to_boe,data:0
 msgid "File"
 msgstr "Archivo"
@@ -433,6 +455,11 @@ msgid "Fixed: %s"
 msgstr "Fijo: %s"
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,folder:0
+msgid "Folder Name"
+msgstr "Nombre carpeta"
+
+#. module: l10n_es_aeat
 #: field:aeat.mod.map.tax.code,date_from:0
 msgid "From Date"
 msgstr "Desde la fecha"
@@ -446,27 +473,22 @@ msgstr "Nombre completo"
 #. module: l10n_es_aeat
 #: field:aeat.mod.map.tax.code,id:0 field:aeat.mod.map.tax.code.line,id:0
 #: field:aeat.model.export.config,id:0 field:aeat.model.export.config.line,id:0
-#: field:l10n.es.aeat.report,id:0 field:l10n.es.aeat.report.export_to_boe,id:0
+#: field:l10n.es.aeat.certificate,id:0
+#: field:l10n.es.aeat.certificate.password,id:0 field:l10n.es.aeat.report,id:0
+#: field:l10n.es.aeat.report.export_to_boe,id:0
 #: field:l10n.es.aeat.report.tax.mapping,id:0 field:l10n.es.aeat.tax.line,id:0
 msgid "ID"
 msgstr "ID"
 
 #. module: l10n_es_aeat
 #: help:aeat.model.export.config.line,repeat_expression:0
-msgid ""
-"If set, this expression will be used for getting the list of elements to "
-"iterate on"
-msgstr ""
-"Si está establecida, esta expresión se usará para obtener una lista de los "
-"elementos por los que iterar"
+msgid "If set, this expression will be used for getting the list of elements to iterate on"
+msgstr "Si está establecida, esta expresión se usará para obtener una lista de los elementos por los que iterar"
 
 #. module: l10n_es_aeat
 #: help:aeat.model.export.config.line,conditional_expression:0
-msgid ""
-"If set, this expression will be used to evaluate if this line should be added"
-msgstr ""
-"Si está establecida, esta expresión será usada para evaluar si la línea debe "
-"ser añadida"
+msgid "If set, this expression will be used to evaluate if this line should be added"
+msgstr "Si está establecida, esta expresión será usada para evaluar si la línea debe ser añadida"
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_search
@@ -485,23 +507,21 @@ msgstr "Informativas"
 
 #. module: l10n_es_aeat
 #: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_report_tax_mapping
-msgid ""
-"Inheritable abstract model to add taxes by code mapping in any AEAT report"
-msgstr ""
-"Modelo abstracto hereditario para agregar impuestos por mapeo de código en "
-"cualquier informe AEAT"
+msgid "Inheritable abstract model to add taxes by code mapping in any AEAT report"
+msgstr "Inheritable abstract model to add taxes by code mapping in any AEAT report"
+
+#. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_certificate.py:36
+#: view:l10n.es.aeat.certificate.password:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
+#, python-format
+msgid "Insert Password"
+msgstr "Introduzca Contraseña"
 
 #. module: l10n_es_aeat
 #: code:addons/l10n_es_aeat/models/aeat_report.py:208
 #, python-format
-msgid ""
-"It seems that you have defined quarterly periods or periods in the middle of "
-"the month. This cannot be automatically handled. You should select manually "
-"the periods."
-msgstr ""
-"Parece que ha definido periodos trimestrales o periodos en mitad del mes. "
-"Esto no se puede gestionar automáticamente, por lo que deberá seleccionar a "
-"mano los periodos."
+msgid "It seems that you have defined quarterly periods or periods in the middle of the month. This cannot be automatically handled. You should select manually the periods."
+msgstr "Parece que ha definido periodos trimestrales o periodos en mitad del mes. Esto no se puede gestionar automáticamente, por lo que deberá seleccionar a mano los periodos."
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,journal_id:0
@@ -531,18 +551,22 @@ msgstr "NIF repr. legal"
 #: field:aeat.mod.map.tax.code.line,__last_update:0
 #: field:aeat.model.export.config,__last_update:0
 #: field:aeat.model.export.config.line,__last_update:0
+#: field:l10n.es.aeat.certificate,__last_update:0
+#: field:l10n.es.aeat.certificate.password,__last_update:0
 #: field:l10n.es.aeat.report,__last_update:0
 #: field:l10n.es.aeat.report.export_to_boe,__last_update:0
 #: field:l10n.es.aeat.report.tax.mapping,__last_update:0
 #: field:l10n.es.aeat.tax.line,__last_update:0
 msgid "Last Modified on"
-msgstr "Last Modified on"
+msgstr "Últ. Act. en"
 
 #. module: l10n_es_aeat
 #: field:aeat.mod.map.tax.code,write_uid:0
 #: field:aeat.mod.map.tax.code.line,write_uid:0
 #: field:aeat.model.export.config,write_uid:0
 #: field:aeat.model.export.config.line,write_uid:0
+#: field:l10n.es.aeat.certificate,write_uid:0
+#: field:l10n.es.aeat.certificate.password,write_uid:0
 #: field:l10n.es.aeat.report.export_to_boe,write_uid:0
 #: field:l10n.es.aeat.tax.line,write_uid:0
 msgid "Last Updated by"
@@ -553,6 +577,8 @@ msgstr "Última actualización por"
 #: field:aeat.mod.map.tax.code.line,write_date:0
 #: field:aeat.model.export.config,write_date:0
 #: field:aeat.model.export.config.line,write_date:0
+#: field:l10n.es.aeat.certificate,write_date:0
+#: field:l10n.es.aeat.certificate.password,write_date:0
 #: field:l10n.es.aeat.report.export_to_boe,write_date:0
 #: field:l10n.es.aeat.tax.line,write_date:0
 msgid "Last Updated on"
@@ -573,6 +599,11 @@ msgstr "NIF del representante legal."
 #: field:aeat.model.export.config,config_lines:0
 msgid "Lines"
 msgstr "Líneas"
+
+#. module: l10n_es_aeat
+#: view:l10n.es.aeat.certificate:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+msgid "Load Certificate"
+msgstr "Cargar certificado"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.tax.line,map_line:0
@@ -616,7 +647,7 @@ msgstr "Debe tener apellidos y nombre."
 #: field:aeat.mod.map.tax.code.line,name:0
 #: field:aeat.model.export.config,name:0
 #: field:aeat.model.export.config.line,name:0
-#: field:l10n.es.aeat.tax.line,name:0
+#: field:l10n.es.aeat.certificate,name:0 field:l10n.es.aeat.tax.line,name:0
 msgid "Name"
 msgstr "Nombre"
 
@@ -647,6 +678,12 @@ msgid "Number without decimals"
 msgstr "Número sin decimales"
 
 #. module: l10n_es_aeat
+#: view:l10n.es.aeat.certificate:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+#: view:l10n.es.aeat.certificate.password:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
+msgid "Obtain Keys"
+msgstr "Obtener claves"
+
+#. module: l10n_es_aeat
 #: field:aeat.model.export.config,model:0
 msgid "Odoo model"
 msgstr "Modelo Odoo"
@@ -655,8 +692,13 @@ msgstr "Modelo Odoo"
 #: code:addons/l10n_es_aeat/models/aeat_report.py:341
 #, python-format
 msgid "Only reports in 'draft' or 'cancelled' state can be removed"
-msgstr ""
-"Sólo los informes en estado 'borrador' or 'cancelado' pueden ser eliminados"
+msgstr "Sólo los informes en estado 'borrador' or 'cancelado' pueden ser eliminados"
+
+#. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/wizard/aeat_certificate_password.py:69
+#, python-format
+msgid "OpenSSL version is not supported. Upgrade to 0.15 or greater."
+msgstr "Versión de OpenSSL no soportada. Actualice a la 0.15 o superior."
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
@@ -667,6 +709,11 @@ msgstr "Optativo: Importar datos de fichero"
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 msgid "Other parameters"
 msgstr "Otros parámetros"
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate.password,password:0
+msgid "Password"
+msgstr "Contraseña"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.report,period_type:0
@@ -688,12 +735,8 @@ msgstr "Teléfono"
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
-msgid ""
-"Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el "
-"programa"
-msgstr ""
-"Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el "
-"programa"
+msgid "Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el programa"
+msgstr "Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el programa"
 
 #. module: l10n_es_aeat
 #: field:aeat.model.export.config.line,position:0
@@ -718,10 +761,20 @@ msgid "Previous declaration number"
 msgstr "Nº previo de declaración"
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,private_key:0
+msgid "Private Key"
+msgstr "Clave privada"
+
+#. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 msgid "Processed"
 msgstr "Calculada"
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,public_key:0
+msgid "Public Key"
+msgstr "Clave pública"
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
@@ -734,6 +787,7 @@ msgid "Recalculate"
 msgstr "Recalcular"
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_report_tax_mapping.py:132
 #: code:addons/l10n_es_aeat/models/aeat_report_tax_mapping.py:145
 #, python-format
 msgid "Regularization"
@@ -758,7 +812,7 @@ msgstr "Declaración"
 #: field:l10n.es.aeat.report,name:0
 #: field:l10n.es.aeat.report.tax.mapping,name:0
 msgid "Report identifier"
-msgstr "Identificador del Informe"
+msgstr "Identificador del informe"
 
 #. module: l10n_es_aeat
 #: field:l10n.es.aeat.tax.line,res_id:0
@@ -788,12 +842,13 @@ msgstr "Ver movimiento"
 #. module: l10n_es_aeat
 #: code:addons/l10n_es_aeat/models/aeat_report.py:167
 #, python-format
-msgid ""
-"Split fiscal years cannot be automatically handled. You should select "
-"manually the periods."
-msgstr ""
-"Los ejercicios fiscales separados no pueden ser gestionados automáticamente. "
-"Debe seleccionar manualmente los periodos."
+msgid "Split fiscal years cannot be automatically handled. You should select manually the periods."
+msgstr "Los ejercicios fiscales separados no pueden ser gestionados automáticamente. Debe seleccionar manualmente los periodos."
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,date_start:0
+msgid "Start Date"
+msgstr "Fecha de Inicio"
 
 #. module: l10n_es_aeat
 #: field:aeat.model.export.config,date_start:0
@@ -801,7 +856,7 @@ msgid "Start date"
 msgstr "Fecha de inicio"
 
 #. module: l10n_es_aeat
-#: field:l10n.es.aeat.report,state:0
+#: field:l10n.es.aeat.certificate,state:0 field:l10n.es.aeat.report,state:0
 #: field:l10n.es.aeat.report.export_to_boe,state:0
 #: field:l10n.es.aeat.report.tax.mapping,state:0
 msgid "State"
@@ -876,12 +931,8 @@ msgstr "La cadena formateada debe satisfacer el tamaño dado."
 #. module: l10n_es_aeat
 #: code:addons/l10n_es_aeat/models/aeat_report.py:272
 #, python-format
-msgid ""
-"There is no period defined for the report. Please set at least one period "
-"and try again."
-msgstr ""
-"No hay periodo definido para el informe. Establezca un periodo y vuelva a "
-"intentarlo."
+msgid "There is no period defined for the report. Please set at least one period and try again."
+msgstr "No hay periodo definido para el informe. Establezca un periodo y vuelva a intentarlo."
 
 #. module: l10n_es_aeat
 #: code:addons/l10n_es_aeat/models/aeat_report.py:259
@@ -892,18 +943,18 @@ msgstr "No hay una declaración previa para el periodo %s."
 #. module: l10n_es_aeat
 #: help:l10n.es.aeat.report,counterpart_account:0
 #: help:l10n.es.aeat.report.tax.mapping,counterpart_account:0
-msgid ""
-"This account will be the counterpart for all the journal items that are "
-"regularized when posting the report."
-msgstr ""
-"Esta cuenta será la contrapartida para todos los elementos del diario que "
-"están regularizados al contabilizar el informe."
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
+msgstr "Esta cuenta será la contrapartida para todos los elementos del diario que están regularizados al contabilizar el informe."
 
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 msgid "This button creates the regularization move for the selected report"
-msgstr ""
-"Este botón crea el movimiento de regularización para el informe seleccionado"
+msgstr "Este botón crea el movimiento de regularización para el informe seleccionado"
+
+#. module: l10n_es_aeat
+#: view:l10n.es.aeat.certificate:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+msgid "To Active"
+msgstr "Activar"
 
 #. module: l10n_es_aeat
 #: field:aeat.mod.map.tax.code,date_to:0
@@ -957,6 +1008,7 @@ msgid "Wrong aling option. It should be < or >"
 msgstr "Opción de alineamiento errónea. Debería ser < o >"
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_report_tax_mapping.py:165
 #: code:addons/l10n_es_aeat/models/aeat_report_tax_mapping.py:178
 #, python-format
 msgid "You must fill both journal and counterpart account."
@@ -983,6 +1035,7 @@ msgid "open"
 msgstr "abierto"
 
 #. module: l10n_es_aeat
+#: view:l10n.es.aeat.certificate.password:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
 msgid "or"
 msgstr "o"

--- a/l10n_es_aeat/i18n/l10n_es_aeat.pot
+++ b/l10n_es_aeat/i18n/l10n_es_aeat.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-06-25 16:16+0000\n"
+"PO-Revision-Date: 2019-06-25 16:16+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,6 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/wizard/export_to_boe.py:211
 #: code:addons/l10n_es_aeat/wizard/export_to_boe.py:213
 #, python-format
 msgid "%s_report_%s.txt"
@@ -77,6 +80,11 @@ msgstr ""
 #: field:l10n.es.aeat.report,move_id:0
 #: field:l10n.es.aeat.report.tax.mapping,move_id:0
 msgid "Account entry"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: selection:l10n.es.aeat.certificate,state:0
+msgid "Active"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -154,6 +162,7 @@ msgid "Calculation date"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: view:l10n.es.aeat.certificate.password:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
 msgid "Cancel"
@@ -172,6 +181,12 @@ msgid "Cancelled models"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.actions.act_window,name:l10n_es_aeat.l10n_es_certificate_action
+#: model:ir.ui.menu,name:l10n_es_aeat.l10n_es_aeat_certificate_menu
+msgid "Certificates"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
 msgid "Close"
 msgstr ""
@@ -187,6 +202,11 @@ msgstr ""
 #: help:l10n.es.aeat.report,partner_bank_id:0
 #: help:l10n.es.aeat.report.tax.mapping,partner_bank_id:0
 msgid "Company bank account used for the presentation"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,company_id:0
+msgid "Compañía"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -246,6 +266,8 @@ msgstr ""
 #: field:aeat.mod.map.tax.code.line,create_uid:0
 #: field:aeat.model.export.config,create_uid:0
 #: field:aeat.model.export.config.line,create_uid:0
+#: field:l10n.es.aeat.certificate,create_uid:0
+#: field:l10n.es.aeat.certificate.password,create_uid:0
 #: field:l10n.es.aeat.report.export_to_boe,create_uid:0
 #: field:l10n.es.aeat.tax.line,create_uid:0
 msgid "Created by"
@@ -256,6 +278,8 @@ msgstr ""
 #: field:aeat.mod.map.tax.code.line,create_date:0
 #: field:aeat.model.export.config,create_date:0
 #: field:aeat.model.export.config.line,create_date:0
+#: field:l10n.es.aeat.certificate,create_date:0
+#: field:l10n.es.aeat.certificate.password,create_date:0
 #: field:l10n.es.aeat.report.export_to_boe,create_date:0
 #: field:l10n.es.aeat.tax.line,create_date:0
 msgid "Created on"
@@ -283,6 +307,8 @@ msgstr ""
 #: field:aeat.mod.map.tax.code.line,display_name:0
 #: field:aeat.model.export.config,display_name:0
 #: field:aeat.model.export.config.line,display_name:0
+#: field:l10n.es.aeat.certificate,display_name:0
+#: field:l10n.es.aeat.certificate.password,display_name:0
 #: field:l10n.es.aeat.report,display_name:0
 #: field:l10n.es.aeat.report.export_to_boe,display_name:0
 #: field:l10n.es.aeat.report.tax.mapping,display_name:0
@@ -298,6 +324,7 @@ msgid "Done"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: selection:l10n.es.aeat.certificate,state:0
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: selection:l10n.es.aeat.report,state:0
@@ -308,6 +335,11 @@ msgstr ""
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_search
 msgid "Draft models"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,date_end:0
+msgid "End Date"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -392,6 +424,7 @@ msgid "Field size"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,file:0
 #: field:l10n.es.aeat.report.export_to_boe,data:0
 msgid "File"
 msgstr ""
@@ -420,6 +453,11 @@ msgid "Fixed: %s"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,folder:0
+msgid "Folder Name"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: field:aeat.mod.map.tax.code,date_from:0
 msgid "From Date"
 msgstr ""
@@ -435,6 +473,8 @@ msgstr ""
 #: field:aeat.mod.map.tax.code.line,id:0
 #: field:aeat.model.export.config,id:0
 #: field:aeat.model.export.config.line,id:0
+#: field:l10n.es.aeat.certificate,id:0
+#: field:l10n.es.aeat.certificate.password,id:0
 #: field:l10n.es.aeat.report,id:0
 #: field:l10n.es.aeat.report.export_to_boe,id:0
 #: field:l10n.es.aeat.report.tax.mapping,id:0
@@ -473,6 +513,13 @@ msgid "Inheritable abstract model to add taxes by code mapping in any AEAT repor
 msgstr ""
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_certificate.py:36
+#: view:l10n.es.aeat.certificate.password:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
+#, python-format
+msgid "Insert Password"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: code:addons/l10n_es_aeat/models/aeat_report.py:208
 #, python-format
 msgid "It seems that you have defined quarterly periods or periods in the middle of the month. This cannot be automatically handled. You should select manually the periods."
@@ -506,6 +553,8 @@ msgstr ""
 #: field:aeat.mod.map.tax.code.line,__last_update:0
 #: field:aeat.model.export.config,__last_update:0
 #: field:aeat.model.export.config.line,__last_update:0
+#: field:l10n.es.aeat.certificate,__last_update:0
+#: field:l10n.es.aeat.certificate.password,__last_update:0
 #: field:l10n.es.aeat.report,__last_update:0
 #: field:l10n.es.aeat.report.export_to_boe,__last_update:0
 #: field:l10n.es.aeat.report.tax.mapping,__last_update:0
@@ -518,6 +567,8 @@ msgstr ""
 #: field:aeat.mod.map.tax.code.line,write_uid:0
 #: field:aeat.model.export.config,write_uid:0
 #: field:aeat.model.export.config.line,write_uid:0
+#: field:l10n.es.aeat.certificate,write_uid:0
+#: field:l10n.es.aeat.certificate.password,write_uid:0
 #: field:l10n.es.aeat.report.export_to_boe,write_uid:0
 #: field:l10n.es.aeat.tax.line,write_uid:0
 msgid "Last Updated by"
@@ -528,6 +579,8 @@ msgstr ""
 #: field:aeat.mod.map.tax.code.line,write_date:0
 #: field:aeat.model.export.config,write_date:0
 #: field:aeat.model.export.config.line,write_date:0
+#: field:l10n.es.aeat.certificate,write_date:0
+#: field:l10n.es.aeat.certificate.password,write_date:0
 #: field:l10n.es.aeat.report.export_to_boe,write_date:0
 #: field:l10n.es.aeat.tax.line,write_date:0
 msgid "Last Updated on"
@@ -547,6 +600,11 @@ msgstr ""
 #. module: l10n_es_aeat
 #: field:aeat.model.export.config,config_lines:0
 msgid "Lines"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: view:l10n.es.aeat.certificate:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+msgid "Load Certificate"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -592,6 +650,7 @@ msgstr ""
 #: field:aeat.mod.map.tax.code.line,name:0
 #: field:aeat.model.export.config,name:0
 #: field:aeat.model.export.config.line,name:0
+#: field:l10n.es.aeat.certificate,name:0
 #: field:l10n.es.aeat.tax.line,name:0
 msgid "Name"
 msgstr ""
@@ -623,6 +682,12 @@ msgid "Number without decimals"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: view:l10n.es.aeat.certificate:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+#: view:l10n.es.aeat.certificate.password:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
+msgid "Obtain Keys"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: field:aeat.model.export.config,model:0
 msgid "Odoo model"
 msgstr ""
@@ -634,6 +699,12 @@ msgid "Only reports in 'draft' or 'cancelled' state can be removed"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/wizard/aeat_certificate_password.py:69
+#, python-format
+msgid "OpenSSL version is not supported. Upgrade to 0.15 or greater."
+msgstr ""
+
+#. module: l10n_es_aeat
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
 msgid "Optativo: Importar datos de fichero"
 msgstr ""
@@ -641,6 +712,11 @@ msgstr ""
 #. module: l10n_es_aeat
 #: view:l10n.es.aeat.report:l10n_es_aeat.view_l10n_es_aeat_report_form
 msgid "Other parameters"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate.password,password:0
+msgid "Password"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -689,9 +765,19 @@ msgid "Previous declaration number"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,private_key:0
+msgid "Private Key"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 msgid "Processed"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,public_key:0
+msgid "Public Key"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -705,6 +791,7 @@ msgid "Recalculate"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_report_tax_mapping.py:132
 #: code:addons/l10n_es_aeat/models/aeat_report_tax_mapping.py:145
 #, python-format
 msgid "Regularization"
@@ -763,11 +850,17 @@ msgid "Split fiscal years cannot be automatically handled. You should select man
 msgstr ""
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,date_start:0
+msgid "Start Date"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: field:aeat.model.export.config,date_start:0
 msgid "Start date"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: field:l10n.es.aeat.certificate,state:0
 #: field:l10n.es.aeat.report,state:0
 #: field:l10n.es.aeat.report.export_to_boe,state:0
 #: field:l10n.es.aeat.report.tax.mapping,state:0
@@ -864,6 +957,11 @@ msgid "This button creates the regularization move for the selected report"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: view:l10n.es.aeat.certificate:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+msgid "To Active"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: field:aeat.mod.map.tax.code,date_to:0
 msgid "To Date"
 msgstr ""
@@ -915,6 +1013,7 @@ msgid "Wrong aling option. It should be < or >"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_report_tax_mapping.py:165
 #: code:addons/l10n_es_aeat/models/aeat_report_tax_mapping.py:178
 #, python-format
 msgid "You must fill both journal and counterpart account."
@@ -941,6 +1040,7 @@ msgid "open"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: view:l10n.es.aeat.certificate.password:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
 #: view:l10n.es.aeat.report.export_to_boe:l10n_es_aeat.wizard_aeat_export
 msgid "or"
 msgstr ""

--- a/l10n_es_aeat/models/__init__.py
+++ b/l10n_es_aeat/models/__init__.py
@@ -20,3 +20,4 @@ from . import aeat_report
 from . import aeat_report_tax_mapping
 from . import aeat_export_configuration
 from . import aeat_tax_code_mapping
+from . import aeat_certificate

--- a/l10n_es_aeat/models/aeat_certificate.py
+++ b/l10n_es_aeat/models/aeat_certificate.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Diagram Software S.L.
+# (c) 2017 Consultoría Informática Studio 73 S.L.
+# (c) 2019 Acysos S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, models, fields, _
+
+
+class L10nEsAeatCertificate(models.Model):
+    _name = 'l10n.es.aeat.certificate'
+
+    name = fields.Char(string="Name")
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('active', 'Active')
+    ], string="State", default="draft")
+    file = fields.Binary(string="File", required=True)
+    folder = fields.Char(string="Folder Name", required=True)
+    date_start = fields.Date(string="Start Date")
+    date_end = fields.Date(string="End Date")
+    public_key = fields.Char(string="Public Key", readonly=True)
+    private_key = fields.Char(string="Private Key", readonly=True)
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Compañía",
+        required=True,
+        default=lambda self: self.env.user.company_id.id
+    )
+
+    @api.multi
+    def load_password_wizard(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Insert Password'),
+            'res_model': 'l10n.es.aeat.certificate.password',
+            'view_mode': 'form',
+            'view_type': 'form',
+            'views': [(False, 'form')],
+            'target': 'new',
+        }
+
+    @api.multi
+    def action_active(self):
+        self.ensure_one()
+        other_configs = self.search([('id', '!=', self.id),
+                                     ('company_id', '=', self.company_id.id)])
+        for config_id in other_configs:
+            config_id.state = 'draft'
+        self.state = 'active'
+
+    @api.multi
+    def get_certificates(self, company = False):
+        if not company:
+            company = self.env.user.company_id
+        today = fields.Date.today()
+        aeat_certificate = self.search([
+            ('company_id', '=', company.id),
+            ('public_key', '!=', False),
+            ('private_key', '!=', False),
+            '|', ('date_start', '=', False),
+            ('date_start', '<=', today),
+            '|', ('date_end', '=', False),
+            ('date_end', '>=', today),
+            ('state', '=', 'active')
+        ], limit=1)
+        if aeat_certificate:
+            public_crt = aeat_certificate.public_key
+            private_key = aeat_certificate.private_key
+        else:
+            public_crt = self.env['ir.config_parameter'].get_param(
+                'l10n_es_aeat_certificate.publicCrt', False)
+            private_key = self.env['ir.config_parameter'].get_param(
+                'l10n_es_aeat_certificate.privateKey', False)
+        return public_crt, private_key
+        

--- a/l10n_es_aeat/models/aeat_certificate.py
+++ b/l10n_es_aeat/models/aeat_certificate.py
@@ -51,7 +51,7 @@ class L10nEsAeatCertificate(models.Model):
         self.state = 'active'
 
     @api.multi
-    def get_certificates(self, company = False):
+    def get_certificates(self, company=False):
         if not company:
             company = self.env.user.company_id
         today = fields.Date.today()
@@ -74,4 +74,3 @@ class L10nEsAeatCertificate(models.Model):
             private_key = self.env['ir.config_parameter'].get_param(
                 'l10n_es_aeat_certificate.privateKey', False)
         return public_crt, private_key
-        

--- a/l10n_es_aeat/security/aeat_security.xml
+++ b/l10n_es_aeat/security/aeat_security.xml
@@ -7,6 +7,13 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
+    <record id="l10n_es_aeat_certificate_rule" model="ir.rule">
+        <field name="name">AEAT Certificate multi-company</field>
+        <field ref="model_l10n_es_aeat_certificate" name="model_id"/>
+        <field eval="True" name="global"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+    </record>
+
 </data>
 </openerp>
 

--- a/l10n_es_aeat/security/ir.model.access.csv
+++ b/l10n_es_aeat/security/ir.model.access.csv
@@ -8,3 +8,4 @@ access_model_aeat_mod_map_tax_code_aeat,aeat.mod.map.tax.code aeat,model_aeat_mo
 access_model_aeat_mod_map_tax_code_line_admin,aeat.mod.map.tax.code.line admin,model_aeat_mod_map_tax_code_line,base.group_system,1,1,1,1
 access_model_aeat_mod_map_tax_code_line_aeat,aeat.mod.map.tax.code.line aeat,model_aeat_mod_map_tax_code_line,group_account_aeat,1,0,0,0
 access_model_l10n_es_aeat_tax_line_aeat,l10n.es.aeat.tax.line aeat,model_l10n_es_aeat_tax_line,group_account_aeat,1,1,1,1
+access_l10n_es_aeat_certificate_manager,l10n_es_aeat_certificate manager,model_l10n_es_aeat_certificate,account.group_account_manager,1,1,1,1

--- a/l10n_es_aeat/views/aeat_certificate_view.xml
+++ b/l10n_es_aeat/views/aeat_certificate_view.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Ignacio Ibeas <ignacio@acysos.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<openerp>
+    <data>
+        <record id="l10n_es_aeat_certificate_form_view" model="ir.ui.view">
+            <field name="name">l10n.es.aeat.certificate.form</field>
+            <field name="model">l10n.es.aeat.certificate</field>
+            <field name="arch" type="xml">
+                <form string="Load Certificate">
+                    <header>
+                        <button name="load_password_wizard" type="object" string="Obtain Keys"/>
+                        <button name="action_active" type="object" string="To Active"/>
+                        <field name="state" widget="statusbar" statusbar_visible="draft,active"/>
+                    </header>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="file"/>
+                            <field name="folder"/>
+                        </group>
+                        <group>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                            <field name="date_start"/>
+                            <field name="date_end"/>
+                        </group>
+                    </group>
+                    <group>
+                        <field name="private_key"/>
+                        <field name="public_key"/>
+                    </group>
+                 </form>
+            </field>
+        </record>
+
+        <record id="l10n_es_certificate_tree_view" model="ir.ui.view">
+            <field name="name">l10n.es.aeat.certificate.tree</field>
+            <field name="model">l10n.es.aeat.certificate</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="name"/>
+                    <field name="date_start"/>
+                    <field name="date_end"/>
+                    <field name="state"/>
+                 </tree>
+            </field>
+        </record>
+
+        <record id="l10n_es_certificate_action" model="ir.actions.act_window">
+            <field name="name">Certificates</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">l10n.es.aeat.certificate</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+        
+        <menuitem id="l10n_es_aeat_certificate_menu" name="Certificates"
+                  action="l10n_es_certificate_action" sequence="0"
+                  parent="l10n_es_aeat.menu_l10n_es_aeat_config" />
+
+    </data>
+</openerp>

--- a/l10n_es_aeat/wizard/__init__.py
+++ b/l10n_es_aeat/wizard/__init__.py
@@ -19,3 +19,4 @@
 #
 ##############################################################################
 from . import export_to_boe
+from . import aeat_certificate_password

--- a/l10n_es_aeat/wizard/aeat_certificate_password.py
+++ b/l10n_es_aeat/wizard/aeat_certificate_password.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Diagram Software S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+
+from openerp import _, api, exceptions, fields, models
+from openerp.exceptions import ValidationError
+from openerp.tools import config
+from openerp import release
+import contextlib
+import os
+import tempfile
+import base64
+import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import OpenSSL.crypto
+except (ImportError, IOError) as err:
+    _logger.debug(err)
+
+if tuple(map(int, OpenSSL.__version__.split('.'))) < (0, 15):
+    _logger.warning(
+        'OpenSSL version is not supported. Upgrade to 0.15 or greater.')
+
+
+@contextlib.contextmanager
+def pfx_to_pem(file, pfx_password, directory=None):
+    with tempfile.NamedTemporaryFile(
+            prefix='private_', suffix='.pem', delete=False,
+            dir=directory) as t_pem:
+        f_pem = open(t_pem.name, 'wb')
+        p12 = OpenSSL.crypto.load_pkcs12(file, pfx_password)
+        f_pem.write(OpenSSL.crypto.dump_privatekey(
+            OpenSSL.crypto.FILETYPE_PEM, p12.get_privatekey()))
+        f_pem.close()
+        yield t_pem.name
+
+
+@contextlib.contextmanager
+def pfx_to_crt(file, pfx_password, directory=None):
+    with tempfile.NamedTemporaryFile(
+            prefix='public_', suffix='.crt', delete=False,
+            dir=directory) as t_crt:
+        f_crt = open(t_crt.name, 'wb')
+        p12 = OpenSSL.crypto.load_pkcs12(file, pfx_password)
+        f_crt.write(OpenSSL.crypto.dump_certificate(
+            OpenSSL.crypto.FILETYPE_PEM, p12.get_certificate()))
+        f_crt.close()
+        yield t_crt.name
+
+
+class L10nEsAeatCertificatePassword(models.TransientModel):
+    _name = 'l10n.es.aeat.certificate.password'
+
+    password = fields.Char(string="Password", required=True)
+
+    @api.multi
+    def get_keys(self):
+        record = self.env['l10n.es.aeat.certificate'].browse(
+            self.env.context.get('active_id'))
+        directory = os.path.join(
+            os.path.abspath(config['data_dir']), 'certificates',
+            release.series, self.env.cr.dbname, record.folder)
+        file = base64.decodestring(record.file)
+        if tuple(map(int, OpenSSL.__version__.split('.'))) < (0, 15):
+            raise exceptions.Warning(
+                _('OpenSSL version is not supported. Upgrade to 0.15 '
+                  'or greater.'))
+        try:
+            if directory and not os.path.exists(directory):
+                os.makedirs(directory)
+            with pfx_to_pem(file, self.password, directory) as private_key:
+                record.private_key = private_key
+            with pfx_to_crt(file, self.password, directory) as public_key:
+                record.public_key = public_key
+        except Exception as e:
+            if e.args:
+                args = list(e.args)
+            raise ValidationError(args[-1])

--- a/l10n_es_aeat/wizard/aeat_certificate_password_view.xml
+++ b/l10n_es_aeat/wizard/aeat_certificate_password_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="l10n_es_aeat_certificate_password_wizard_view" model="ir.ui.view">
+            <field name="name">l10n.es.aeat.certificate.password.wizard</field>
+            <field name="model">l10n.es.aeat.certificate.password</field>
+            <field name="arch" type="xml">
+                <form string="Insert Password">
+                    <group>
+                        <field name="password" password="True"/>
+                    </group>
+                    <footer>
+                        <button name="get_keys" type="object" string="Obtain Keys" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel"/>
+                    </footer>
+                 </form>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Hola,

Añade el certificado general para todas las presentaciones via webservice de AEAT. Actualmente lo usaria el SII y la verificación de partners. Aunque se podrá utilizar para más módulo no desarrollados aún como aduanas, tgvi online, algunos impuestos especiales, modelo 179 y más modelos o servicios que AEAT implemente en el futuro.

Este es el primer PR de los tres que llevará la presentación que se hizo en las Jornadas Nacionales de Odoo https://www.youtube.com/watch?v=hj0Rs6cVNEM&t=1349s

Una vez aprobado se seguirán los siguientes PR:
- Webservice SOAP
- Verificación de partners

Saludos