### PR TITLE
[11.0][ADD] l10n_es_aeat: aeat certificate

### DIFF
--- a/l10n_es_aeat/README.rst
+++ b/l10n_es_aeat/README.rst
@@ -21,6 +21,7 @@ Módulo base para declaraciones de la AEAT, que incluye:
 * Motor de cálculo de importes por impuestos.
 * Generador del asiento de regularización con cargo a un proveedor "Agencia
   Estatal de Administración Tributaria" creado al efecto.
+* Certificado para las declaraciones de la AEAT
 
 Configuración
 =============
@@ -64,6 +65,12 @@ Para poder visualizar un archivo BOE, hay que:
    correspondiente a dicha línea, y si es un importe numérico, su cifra
    asociada.
 
+Para importar el certificado, hay que:
+
+#. Entrar en *Facturación > Configuración > AEAT > Certificados*
+#. Crear uno nuevo. Rellenas los datos del formulurio y subir el archivo p12
+#. Pulsar obtener claves e introducir la contraseña del certificado
+
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/189/11.0
@@ -100,6 +107,8 @@ Contribudores
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
 * Juan Vicente Pascual <jvpascual@puntsistemes.es>
 * Abraham Anes <abraham@studio73.es>
+* Diagram Software S.L.
+* Consultoría Informática Studio 73 S.L.
 
 Maintainer
 ----------

--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2011 Luis Manuel Angueira Blanco - Pexego
-# Copyright 2013 Ignacio Ibeas - Acysos S.L. (http://acysos.com)
+# Copyright 2013-2019 Ignacio Ibeas - Acysos S.L. (http://acysos.com)
 # Copyright 2015 Ainara Galdona <agaldona@avanzosc.com>
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # Copyright 2013-2018 Pedro M. Baeza <pedro.baeza@tecnativa.com>
@@ -10,9 +10,9 @@
 {
     'name': "AEAT Base",
     'summary': "Modulo base para declaraciones de la AEAT",
-    'version': "11.0.2.0.0",
+    'version': "11.0.2.0.1",
     'author': "Pexego,"
-              "Acysos,"
+              "Acysos S.L.,"
               "AvanzOSC,"
               "Tecnativa,"
               "Odoo Community Association (OCA)",
@@ -26,7 +26,7 @@
         'l10n_es',
     ],
     'external_dependencies': {
-        'python': ['unidecode'],
+        'python': ['unidecode', 'OpenSSL'],
     },
     'data': [
         'security/aeat_security.xml',
@@ -34,6 +34,7 @@
         'data/aeat_partner.xml',
         'wizard/export_to_boe_wizard.xml',
         'wizard/compare_boe_file_views.xml',
+        'wizard/aeat_certificate_password_view.xml',
         'views/aeat_menuitem.xml',
         'views/aeat_report_view.xml',
         'views/aeat_tax_line_view.xml',
@@ -41,6 +42,7 @@
         'views/aeat_tax_code_mapping_view.xml',
         'views/account_move_line_view.xml',
         'views/report_template.xml',
+        'views/aeat_certificate_view.xml',
     ],
     'installable': True,
 }

--- a/l10n_es_aeat/i18n/es.po
+++ b/l10n_es_aeat/i18n/es.po
@@ -1,23 +1,21 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_es_aeat
+# 	* l10n_es_aeat
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-10 03:41+0000\n"
-"PO-Revision-Date: 2019-02-04 16:50+0000\n"
-"Last-Translator: Marta Vázquez Rodríguez <vazrodmar@gmail.com>\n"
-"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
-"Language: es\n"
+"POT-Creation-Date: 2019-06-24 21:26+0000\n"
+"PO-Revision-Date: 2019-06-24 23:27+0200\n"
+"Last-Translator: Ignacio Ibeas - Acysos S.L. <ignacio@acysos.com>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.4\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"Language: es\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. module: l10n_es_aeat
 #: code:addons/l10n_es_aeat/wizard/export_to_boe.py:142
@@ -58,14 +56,11 @@ msgid "AEAT manager"
 msgstr "Responsable AEAT"
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:259
 #: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:264
 #, python-format
-msgid ""
-"AEAT model sequence not found. You can try to restart your Odoo service for "
-"recreating the sequences."
-msgstr ""
-"No se ha encontrado la secuencia del modelo AEAT. Puede intentar reiniciar "
-"su servicio Odoo para recrear las secuencias."
+msgid "AEAT model sequence not found. You can try to restart your Odoo service for recreating the sequences."
+msgstr "No se ha encontrado la secuencia del modelo AEAT. Puede intentar reiniciar su servicio Odoo para recrear las secuencias."
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_form
@@ -91,24 +86,20 @@ msgstr "Declaraciones AEAT"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_move_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_move_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_move_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_move_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_move_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_move_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_move_id_9414
 msgid "Account entry"
 msgstr "Asiento contable"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_active
+#: selection:l10n.es.aeat.certificate,state:0
 msgid "Active"
-msgstr ""
+msgstr "Activo"
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.aeat_model_export_config_line_form
@@ -127,16 +118,11 @@ msgstr "Todos"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_allow_posting
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_allow_posting
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_allow_posting
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_allow_posting
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_allow_posting
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_allow_posting_9411
 msgid "Allow Posting"
 msgstr "Permite el registro"
 
@@ -181,21 +167,16 @@ msgstr "Configuraciones de exportación a BOE"
 #. module: l10n_es_aeat
 #: model:ir.model,name:l10n_es_aeat.model_res_partner_bank
 msgid "Bank Accounts"
-msgstr "Cuentas bancarias"
+msgstr "Cuentas Bancarias"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_partner_bank_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_partner_bank_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_partner_bank_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_partner_bank_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_partner_bank_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_partner_bank_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_partner_bank_id_9415
 msgid "Bank account"
 msgstr "Cuenta bancaria"
 
@@ -217,7 +198,7 @@ msgstr "Booleano"
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.map.tax.line,field_type:0
 msgid "Both"
-msgstr ""
+msgstr "Ambos"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.map.tax.line,sum_type:0
@@ -236,20 +217,16 @@ msgstr "Calcular"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_calculation_date
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_calculation_date
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_calculation_date
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_calculation_date
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_calculation_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_calculation_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_calculation_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_calculation_date
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_calculation_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_calculation_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_calculation_date
 msgid "Calculation date"
 msgstr "Fecha de cálculo"
 
 #. module: l10n_es_aeat
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_form
 #: model:ir.ui.view,arch_db:l10n_es_aeat.wizard_aeat_export
 #: model:ir.ui.view,arch_db:l10n_es_aeat.wizard_compare_boe_file
@@ -259,24 +236,25 @@ msgstr "Cancelar"
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: selection:l10n.es.aeat.mod111.report,state:0
-#: selection:l10n.es.aeat.mod115.report,state:0
-#: selection:l10n.es.aeat.mod123.report,state:0
-#: selection:l10n.es.aeat.mod216.report,state:0
-#: selection:l10n.es.aeat.mod296.report,state:0
 #: selection:l10n.es.aeat.mod303.report,state:0
 #: selection:l10n.es.aeat.mod347.report,state:0
 #: selection:l10n.es.aeat.mod349.report,state:0
-#: selection:l10n.es.aeat.mod390.report,state:0
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 #: selection:l10n.es.vat.book,state:0
 msgid "Cancelled"
-msgstr "Cancelada"
+msgstr "Cancelado"
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
 msgid "Cancelled models"
 msgstr "Declaraciones canceladas"
+
+#. module: l10n_es_aeat
+#: model:ir.actions.act_window,name:l10n_es_aeat.l10n_es_certificate_action
+#: model:ir.ui.menu,name:l10n_es_aeat.l10n_es_aeat_certificate_menu
+msgid "Certificates"
+msgstr "Certificados"
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.wizard_aeat_export
@@ -286,41 +264,29 @@ msgstr "Cerrar"
 
 #. module: l10n_es_aeat
 #: model:ir.model,name:l10n_es_aeat.model_res_company
-#, fuzzy
-#| msgid "Company"
 msgid "Companies"
-msgstr "Compañía"
+msgstr "Compañías"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_company_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_company_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_company_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_company_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_company_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_company_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_company_id_9394
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
 msgid "Company"
 msgstr "Compañía"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod111_report_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod115_report_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod123_report_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod216_report_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod296_report_partner_bank_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod303_report_partner_bank_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod347_report_partner_bank_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod349_report_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod390_report_partner_bank_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_partner_bank_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_partner_bank_id
+#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_partner_bank_id_9415
 msgid "Company bank account used for the presentation"
 msgstr "Cuenta bancaria de la compañía usada para la presentación"
 
@@ -346,15 +312,15 @@ msgid "Compare file"
 msgstr "Comparar archivo"
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_company_id
+msgid "Compañía"
+msgstr "Compañía"
+
+#. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,type:0
-#: selection:l10n.es.aeat.mod115.report,type:0
-#: selection:l10n.es.aeat.mod123.report,type:0
-#: selection:l10n.es.aeat.mod216.report,type:0
-#: selection:l10n.es.aeat.mod296.report,type:0
 #: selection:l10n.es.aeat.mod303.report,type:0
 #: selection:l10n.es.aeat.mod347.report,type:0
 #: selection:l10n.es.aeat.mod349.report,type:0
-#: selection:l10n.es.aeat.mod390.report,type:0
 #: selection:l10n.es.aeat.report,type:0
 #: selection:l10n.es.aeat.report.tax.mapping,type:0
 #: selection:l10n.es.vat.book,type:0
@@ -398,17 +364,12 @@ msgstr "Datos de contacto"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_contact_email
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_contact_email
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_contact_email
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_contact_email
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_contact_email
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_email
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_email_9399
 msgid "Contact email"
 msgstr "Correo electrónico"
 
@@ -419,16 +380,11 @@ msgstr "Contenido"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_counterpart_account_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_counterpart_account_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_counterpart_account_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_counterpart_account_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_counterpart_account_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_counterpart_account_id_9412
 msgid "Counterpart account"
 msgstr "Cuenta contrapartida"
 
@@ -440,6 +396,8 @@ msgstr "Crear asiento"
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_create_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_create_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_create_uid
@@ -452,6 +410,8 @@ msgstr "Creado por"
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_create_date
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_create_date
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_create_date
@@ -459,7 +419,7 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_export_to_boe_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_tax_line_create_date
 msgid "Created on"
-msgstr "Creado el"
+msgstr "Creado en"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.map.tax.line,sum_type:0
@@ -468,29 +428,20 @@ msgstr "Haber"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_currency_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_currency_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_currency_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_currency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_currency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_currency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_currency_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_currency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_currency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_currency_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_currency_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_currency_id_9416
 msgid "Currency"
 msgstr "Moneda"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,support_type:0
-#: selection:l10n.es.aeat.mod115.report,support_type:0
-#: selection:l10n.es.aeat.mod123.report,support_type:0
-#: selection:l10n.es.aeat.mod216.report,support_type:0
-#: selection:l10n.es.aeat.mod296.report,support_type:0
 #: selection:l10n.es.aeat.mod303.report,support_type:0
 #: selection:l10n.es.aeat.mod347.report,support_type:0
 #: selection:l10n.es.aeat.mod349.report,support_type:0
-#: selection:l10n.es.aeat.mod390.report,support_type:0
 #: selection:l10n.es.aeat.report,support_type:0
 #: selection:l10n.es.aeat.report.tax.mapping,support_type:0
 #: selection:l10n.es.vat.book,support_type:0
@@ -515,6 +466,8 @@ msgstr "Declaración"
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_display_name
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_display_name
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_display_name
@@ -524,19 +477,14 @@ msgstr "Declaración"
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_tax_line_display_name
 msgid "Display Name"
-msgstr "Nombre a mostrar"
+msgstr "Nombre mostrado"
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: selection:l10n.es.aeat.mod111.report,state:0
-#: selection:l10n.es.aeat.mod115.report,state:0
-#: selection:l10n.es.aeat.mod123.report,state:0
-#: selection:l10n.es.aeat.mod216.report,state:0
-#: selection:l10n.es.aeat.mod296.report,state:0
 #: selection:l10n.es.aeat.mod303.report,state:0
 #: selection:l10n.es.aeat.mod347.report,state:0
 #: selection:l10n.es.aeat.mod349.report,state:0
-#: selection:l10n.es.aeat.mod390.report,state:0
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 #: selection:l10n.es.vat.book,state:0
@@ -546,15 +494,11 @@ msgstr "Realizada"
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_form
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
+#: selection:l10n.es.aeat.certificate,state:0
 #: selection:l10n.es.aeat.mod111.report,state:0
-#: selection:l10n.es.aeat.mod115.report,state:0
-#: selection:l10n.es.aeat.mod123.report,state:0
-#: selection:l10n.es.aeat.mod216.report,state:0
-#: selection:l10n.es.aeat.mod296.report,state:0
 #: selection:l10n.es.aeat.mod303.report,state:0
 #: selection:l10n.es.aeat.mod347.report,state:0
 #: selection:l10n.es.aeat.mod349.report,state:0
-#: selection:l10n.es.aeat.mod390.report,state:0
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 #: selection:l10n.es.vat.book,state:0
@@ -567,19 +511,19 @@ msgid "Draft models"
 msgstr "Declaraciones borrador"
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_date_end
+msgid "End Date"
+msgstr "Fecha final"
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_date_end
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_date_end_9410
 msgid "Ending date"
 msgstr "Fecha final"
 
@@ -587,19 +531,12 @@ msgstr "Fecha final"
 #: code:addons/l10n_es_aeat/models/l10n_es_aeat_map_tax.py:45
 #, python-format
 msgid "Error! The dates of the record overlap with an existing record."
-msgstr ""
-"Error! Las fechas de los registros se solapan con un registro existente."
+msgstr "Error! Las fechas de los registros se solapan con un registro existente."
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.wizard_compare_boe_file
-msgid ""
-"Escoja el archivo para comparar con el actual formato de exportación. NOTA: "
-"Solo es válido de momento para formatos sin partes condicionales ni "
-"subpartes con bucle de repetición."
-msgstr ""
-"Escoja el archivo para comparar con el formato actual de exportación. NOTA: "
-"Por el momento sólo es válido para formatos sin partes condicionales ni sub-"
-"partes con bucle de repetición."
+msgid "Escoja el archivo para comparar con el actual formato de exportación. NOTA: Solo es válido de momento para formatos sin partes condicionales ni subpartes con bucle de repetición."
+msgstr "Escoja el archivo para comparar con el formato actual de exportación. NOTA: Por el momento sólo es válido para formatos sin partes condicionales ni sub-partes con bucle de repetición."
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_exigible_type
@@ -625,17 +562,12 @@ msgstr "Exportar declaración al formato BOE"
 #. module: l10n_es_aeat
 #: model:ir.actions.act_window,name:l10n_es_aeat.action_aeat_export_config
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_export_config_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_export_config_id_9407
 msgid "Export config"
 msgstr "Configuración de exportación"
 
@@ -692,6 +624,7 @@ msgid "Field type"
 msgstr "Tipo de campo"
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_file
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_data
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_export_to_boe_data
 msgid "File"
@@ -700,7 +633,7 @@ msgstr "Archivo"
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_export_to_boe_name
 msgid "File name"
-msgstr "Nombre de archivo"
+msgstr "File name"
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
@@ -719,29 +652,31 @@ msgid "Fixed: {}"
 msgstr "Fijo: {}"
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_folder
+msgid "Folder Name"
+msgstr "Nombre Carpeta"
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_date_from
 msgid "From Date"
 msgstr "Desde la fecha"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_contact_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_contact_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_contact_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_contact_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_contact_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_name
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_name_9397
 msgid "Full Name"
 msgstr "Nombre completo"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_id
@@ -751,34 +686,24 @@ msgstr "Nombre completo"
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_tax_line_id
 msgid "ID"
-msgstr "ID"
+msgstr "ID (identificación)"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_aeat_model_export_config_line_repeat_expression
-msgid ""
-"If set, this expression will be used for getting the list of elements to "
-"iterate on"
-msgstr ""
-"Si está establecida, esta expresión se usará para obtener una lista de los "
-"elementos por los que iterar"
+msgid "If set, this expression will be used for getting the list of elements to iterate on"
+msgstr "Si está establecida, esta expresión se usará para obtener una lista de los elementos por los que iterar"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_aeat_model_export_config_line_conditional_expression
-msgid ""
-"If set, this expression will be used to evaluate if this line should be added"
-msgstr ""
-"Si está establecida, esta expresión será usada para evaluar si la línea debe "
-"ser añadida"
+msgid "If set, this expression will be used to evaluate if this line should be added"
+msgstr "Si está establecida, esta expresión será usada para evaluar si la línea debe ser añadida"
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:198
 #: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:203
 #, python-format
-msgid ""
-"If this declaration is complementary or substitutive, a previous declaration "
-"number should be provided."
-msgstr ""
-"Si esta declaración es complementaria o substitutiva, debe proporcionar el "
-"número de la declaración anterior."
+msgid "If this declaration is complementary or substitutive, a previous declaration number should be provided."
+msgstr "Si esta declaración es complementaria o substitutiva, debe proporcionar el número de la declaración anterior."
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
@@ -792,11 +717,15 @@ msgstr "Declaraciones en proceso"
 
 #. module: l10n_es_aeat
 #: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_report_tax_mapping
-msgid ""
-"Inheritable abstract model to add taxes by code mapping in any AEAT report"
-msgstr ""
-"Modelo abstracto heredable para añadir impuestos por mapeo de código in "
-"cualquier declaración AEAT"
+msgid "Inheritable abstract model to add taxes by code mapping in any AEAT report"
+msgstr "Modelo abstracto heredable para añadir impuestos por mapeo de código in cualquier declaración AEAT"
+
+#. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_certificate.py:36
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
+#, python-format
+msgid "Insert Password"
+msgstr "Introduzca Contraseña"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_inverse
@@ -805,33 +734,23 @@ msgstr "Invertir el signo de la suma"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_journal_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_journal_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_journal_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_journal_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_journal_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_journal_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_journal_id_9413
 msgid "Journal"
 msgstr "Diario"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod111_report_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod115_report_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod123_report_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod216_report_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod296_report_journal_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod303_report_journal_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod347_report_journal_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod349_report_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod390_report_journal_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_journal_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_journal_id
+#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_journal_id_9413
 msgid "Journal in which post the move."
 msgstr "Diario en el que publicar el asiento."
 
@@ -842,23 +761,20 @@ msgstr "Apuntes contables"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_representative_vat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_representative_vat_9400
 msgid "L.R. VAT number"
 msgstr "NIF repr. legal"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line___last_update
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate___last_update
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report___last_update
@@ -873,6 +789,8 @@ msgstr "Última modificación en"
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_write_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_write_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_line_write_uid
@@ -880,11 +798,13 @@ msgstr "Última modificación en"
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_export_to_boe_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_tax_line_write_uid
 msgid "Last Updated by"
-msgstr "Última actualización por"
+msgstr "Última actualización de"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_write_date
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_write_date
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_line_write_date
@@ -892,7 +812,7 @@ msgstr "Última actualización por"
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_export_to_boe_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_tax_line_write_date
 msgid "Last Updated on"
-msgstr "Última actualización el"
+msgstr "Última actualización en"
 
 #. module: l10n_es_aeat
 #: selection:aeat.model.export.config.line,alignment:0
@@ -901,17 +821,12 @@ msgstr "Izquierda"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod111_report_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod115_report_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod123_report_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod216_report_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod296_report_representative_vat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod303_report_representative_vat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod347_report_representative_vat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod349_report_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod390_report_representative_vat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_representative_vat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_representative_vat
+#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_representative_vat_9400
 msgid "Legal Representative VAT number."
 msgstr "NIF del representante legal."
 
@@ -920,6 +835,11 @@ msgstr "NIF del representante legal."
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_line_ids
 msgid "Lines"
 msgstr "Líneas"
+
+#. module: l10n_es_aeat
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+msgid "Load Certificate"
+msgstr "Cargar Certificado"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_map_parent_id
@@ -943,36 +863,28 @@ msgstr "Líneas de mapeo"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_tax_line_model
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_tax_line_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_model_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_model_id_9406
 msgid "Model"
 msgstr "Modelo"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_model_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_number
 msgid "Model number"
 msgstr "Nº modelo"
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:396
 #: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:401
 #, python-format
 msgid "Modelo no válido: %s. Debe declarar una variable '_aeat_number'"
@@ -980,23 +892,19 @@ msgstr "Modelo no válido: %s. Debe declarar una variable '_aeat_number'"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod111_report_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod115_report_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod123_report_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod216_report_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod296_report_contact_name
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod303_report_contact_name
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod347_report_contact_name
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod349_report_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod390_report_contact_name
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_contact_name
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_contact_name
+#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_contact_name_9397
 msgid "Must have name and surname."
 msgstr "Debe tener apellidos y nombre."
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_name
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_line_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_line_wizard_id
@@ -1017,14 +925,9 @@ msgstr "Ninguna configuración de exportación seleccionada."
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,type:0
-#: selection:l10n.es.aeat.mod115.report,type:0
-#: selection:l10n.es.aeat.mod123.report,type:0
-#: selection:l10n.es.aeat.mod216.report,type:0
-#: selection:l10n.es.aeat.mod296.report,type:0
 #: selection:l10n.es.aeat.mod303.report,type:0
 #: selection:l10n.es.aeat.mod347.report,type:0
 #: selection:l10n.es.aeat.mod349.report,type:0
-#: selection:l10n.es.aeat.mod390.report,type:0
 #: selection:l10n.es.aeat.report,type:0
 #: selection:l10n.es.aeat.report.tax.mapping,type:0
 #: selection:l10n.es.vat.book,type:0
@@ -1047,6 +950,12 @@ msgid "Number without decimals"
 msgstr "Número sin decimales"
 
 #. module: l10n_es_aeat
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
+msgid "Obtain Keys"
+msgstr "Obtener Claves"
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_model_id
 msgid "Odoo model"
 msgstr "Modelo Odoo"
@@ -1062,11 +971,17 @@ msgid "Only non-exigible amounts"
 msgstr "Sólo cantidades no exigibles"
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:366
 #: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:371
 #, python-format
 msgid "Only reports in 'draft' or 'cancelled' state can be removed"
-msgstr ""
-"Sólo los informes en estado 'borrador' o 'cancelado' pueden ser eliminados"
+msgstr "Sólo los informes en estado 'borrador' o 'cancelado' pueden ser eliminados"
+
+#. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/wizard/aeat_certificate_password.py:70
+#, python-format
+msgid "OpenSSL version is not supported. Upgrade to 0.15 or greater."
+msgstr "Versión de OpenSSL no soportada. Actualice a la 0.15 o superior."
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_move_type
@@ -1080,64 +995,46 @@ msgstr "Otros parámetros"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_partner_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_partner_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_partner_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_partner_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_partner_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_partner_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_partner_id_9417
 msgid "Partner"
 msgstr "Empresa"
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_password
+msgid "Password"
+msgstr "Contraseña"
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_period_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_period_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_period_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_period_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_period_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_period_type
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_period_type_9408
 msgid "Period type"
 msgstr "Tipo de periodo"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_contact_phone
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_contact_phone
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_contact_phone
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_contact_phone
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_contact_phone
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_phone
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_phone_9398
 msgid "Phone"
 msgstr "Teléfono"
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.wizard_aeat_export
-msgid ""
-"Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el "
-"programa <strong>Informativas</strong> o pulsando en el botón "
-"<strong>Optativo: Importar datos de fichero</strong> en el formulario on-"
-"line."
-msgstr ""
-"Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el "
-"programa  <strong>Informativas</strong> o pulsando en el botón "
-"<strong>Optativo: Importar datos de fichero</strong> en el formulario on-"
-"line."
+msgid "Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el programa <strong>Informativas</strong> o pulsando en el botón <strong>Optativo: Importar datos de fichero</strong> en el formulario on-line."
+msgstr "Ponga este archivo dentro de su carpeta personal de la AEAT, y úselo en el programa  <strong>Informativas</strong> o pulsando en el botón <strong>Optativo: Importar datos de fichero</strong> en el formulario on-line."
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_position
@@ -1151,14 +1048,9 @@ msgstr "Carácter del signo positivo"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,state:0
-#: selection:l10n.es.aeat.mod115.report,state:0
-#: selection:l10n.es.aeat.mod123.report,state:0
-#: selection:l10n.es.aeat.mod216.report,state:0
-#: selection:l10n.es.aeat.mod296.report,state:0
 #: selection:l10n.es.aeat.mod303.report,state:0
 #: selection:l10n.es.aeat.mod347.report,state:0
 #: selection:l10n.es.aeat.mod349.report,state:0
-#: selection:l10n.es.aeat.mod390.report,state:0
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 #: selection:l10n.es.vat.book,state:0
@@ -1167,30 +1059,25 @@ msgstr "Contabilizado"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_previous_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_previous_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_previous_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_previous_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_previous_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_previous_number
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_previous_number_9396
 msgid "Previous declaration number"
 msgstr "Nº previo de declaración"
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_private_key
+msgid "Private Key"
+msgstr "Clave privada"
+
+#. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,state:0
-#: selection:l10n.es.aeat.mod115.report,state:0
-#: selection:l10n.es.aeat.mod123.report,state:0
-#: selection:l10n.es.aeat.mod216.report,state:0
-#: selection:l10n.es.aeat.mod296.report,state:0
 #: selection:l10n.es.aeat.mod303.report,state:0
 #: selection:l10n.es.aeat.mod347.report,state:0
 #: selection:l10n.es.aeat.mod349.report,state:0
-#: selection:l10n.es.aeat.mod390.report,state:0
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 #: selection:l10n.es.vat.book,state:0
@@ -1198,13 +1085,14 @@ msgid "Processed"
 msgstr "Procesada"
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_public_key
+msgid "Public Key"
+msgstr "Clave pública"
+
+#. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.wizard_aeat_export
-msgid ""
-"Pulse el botón <strong>Exportar</strong> para iniciar el proceso de "
-"exportación del archivo BOE de la AEAT."
-msgstr ""
-"Pulse el botón <strong>Exportar</strong> para iniciar el proceso de "
-"exportación del archivo BOE de la AEAT."
+msgid "Pulse el botón <strong>Exportar</strong> para iniciar el proceso de exportación del archivo BOE de la AEAT."
+msgstr "Pulse el botón <strong>Exportar</strong> para iniciar el proceso de exportación del archivo BOE de la AEAT."
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_form
@@ -1244,24 +1132,19 @@ msgstr "Informe"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_name
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_name_9405
 msgid "Report identifier"
 msgstr "Identificador del informe"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_tax_line_res_id
 msgid "Resource ID"
-msgstr "ID recurso"
+msgstr "ID del Recurso"
 
 #. module: l10n_es_aeat
 #: selection:aeat.model.export.config.line,alignment:0
@@ -1285,53 +1168,44 @@ msgid "Show move"
 msgstr "Ver asiento"
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_date_start
+msgid "Start Date"
+msgstr "Fecha de inicio"
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_date_start
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_date_start_9409
 msgid "Starting date"
 msgstr "Fecha inicial"
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_export_to_boe_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_state
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_state_9404
 msgid "State"
 msgstr "Estado"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_type
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_type_9402
 msgid "Statement Type"
 msgstr "Tipo de declaración"
 
@@ -1343,14 +1217,9 @@ msgstr "Sub-configuración"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,type:0
-#: selection:l10n.es.aeat.mod115.report,type:0
-#: selection:l10n.es.aeat.mod123.report,type:0
-#: selection:l10n.es.aeat.mod216.report,type:0
-#: selection:l10n.es.aeat.mod296.report,type:0
 #: selection:l10n.es.aeat.mod303.report,type:0
 #: selection:l10n.es.aeat.mod347.report,type:0
 #: selection:l10n.es.aeat.mod349.report,type:0
-#: selection:l10n.es.aeat.mod390.report,type:0
 #: selection:l10n.es.aeat.report,type:0
 #: selection:l10n.es.aeat.report.tax.mapping,type:0
 #: selection:l10n.es.vat.book,type:0
@@ -1364,17 +1233,12 @@ msgstr "Tipo de suma"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_support_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_support_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_support_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_support_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_support_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_support_type
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_support_type_9403
 msgid "Support Type"
 msgstr "Tipo de soporte"
 
@@ -1390,12 +1254,7 @@ msgstr "Líneas de mapeo de impuestos"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_tax_line_ids
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_tax_line_ids
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_tax_line_ids
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_tax_line_ids
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_tax_line_ids
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_tax_line_ids
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_tax_line_ids
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_tax_line_ids
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_tax_line_form
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_tax_line_tree
@@ -1427,14 +1286,9 @@ msgstr "Plantillas de impuestos"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,support_type:0
-#: selection:l10n.es.aeat.mod115.report,support_type:0
-#: selection:l10n.es.aeat.mod123.report,support_type:0
-#: selection:l10n.es.aeat.mod216.report,support_type:0
-#: selection:l10n.es.aeat.mod296.report,support_type:0
 #: selection:l10n.es.aeat.mod303.report,support_type:0
 #: selection:l10n.es.aeat.mod347.report,support_type:0
 #: selection:l10n.es.aeat.mod349.report,support_type:0
-#: selection:l10n.es.aeat.mod390.report,support_type:0
 #: selection:l10n.es.aeat.report,support_type:0
 #: selection:l10n.es.aeat.report.tax.mapping,support_type:0
 #: selection:l10n.es.vat.book,support_type:0
@@ -1446,32 +1300,27 @@ msgstr "Telemática"
 #: code:addons/l10n_es_aeat/wizard/export_to_boe.py:109
 #, python-format
 msgid "The formated string must match the given length"
-msgstr "La cadena formateada debe satisfacer el tamaño dado."
+msgstr "La cadena formateada debe satisfacer el tamaño dado"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod111_report_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod115_report_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod123_report_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod216_report_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod296_report_counterpart_account_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod347_report_counterpart_account_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod349_report_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod390_report_counterpart_account_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_counterpart_account_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_counterpart_account_id
-msgid ""
-"This account will be the counterpart for all the journal items that are "
-"regularized when posting the report."
-msgstr ""
-"Esta cuenta será la contrapartida para todos los elementos del diario que "
-"están regularizados al contabilizar el informe."
+#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_counterpart_account_id_9412
+msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
+msgstr "Esta cuenta será la contrapartida para todos los elementos del diario que están regularizados al contabilizar el informe."
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_form
 msgid "This button creates the regularization move for the selected report"
-msgstr ""
-"Este botón crea el movimiento de regularización para el informe seleccionado"
+msgstr "Este botón crea el movimiento de regularización para el informe seleccionado"
+
+#. module: l10n_es_aeat
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+msgid "To Active"
+msgstr "Activar"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_date_to
@@ -1496,17 +1345,12 @@ msgstr "Total impuestos (Cuota)"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_company_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_company_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_company_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_company_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_company_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_company_vat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_company_vat_9395
 msgid "VAT number"
 msgstr "NIF"
 
@@ -1534,17 +1378,12 @@ msgstr "Opción de alineamiento errónea. Debería ser < o >"
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_year
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_year
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_year
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_year
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_year
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_year
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_year_9401
 msgid "Year"
 msgstr "Año"
 
@@ -1567,12 +1406,22 @@ msgstr "aeat.model.export.config.line"
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report.compare_boe_file,state:0
 msgid "compare"
-msgstr "Comparar"
+msgstr "comparar"
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.report.export_to_boe,state:0
 msgid "get"
 msgstr "obtener"
+
+#. module: l10n_es_aeat
+#: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_certificate
+msgid "l10n.es.aeat.certificate"
+msgstr "l10n.es.aeat.certificate"
+
+#. module: l10n_es_aeat
+#: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_certificate_password
+msgid "l10n.es.aeat.certificate.password"
+msgstr "l10n.es.aeat.certificate.password"
 
 #. module: l10n_es_aeat
 #: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_map_tax
@@ -1596,9 +1445,7 @@ msgid "open"
 msgstr "abierto"
 
 #. module: l10n_es_aeat
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
 #: model:ir.ui.view,arch_db:l10n_es_aeat.wizard_aeat_export
 msgid "or"
 msgstr "o"
-
-#~ msgid "Exception message"
-#~ msgstr "Mensaje de excepción"

--- a/l10n_es_aeat/i18n/l10n_es_aeat.pot
+++ b/l10n_es_aeat/i18n/l10n_es_aeat.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-06-24 21:25+0000\n"
+"PO-Revision-Date: 2019-06-24 21:25+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -52,6 +54,7 @@ msgid "AEAT manager"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:259
 #: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:264
 #, python-format
 msgid "AEAT model sequence not found. You can try to restart your Odoo service for recreating the sequences."
@@ -81,22 +84,18 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_move_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_move_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_move_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_move_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_move_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_move_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_move_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_move_id_9414
 msgid "Account entry"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_active
+#: selection:l10n.es.aeat.certificate,state:0
 msgid "Active"
 msgstr ""
 
@@ -117,16 +116,11 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_allow_posting
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_allow_posting
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_allow_posting
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_allow_posting
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_allow_posting
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_allow_posting
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_allow_posting_9411
 msgid "Allow Posting"
 msgstr ""
 
@@ -175,17 +169,12 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_partner_bank_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_partner_bank_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_partner_bank_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_partner_bank_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_partner_bank_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_partner_bank_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_partner_bank_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_partner_bank_id_9415
 msgid "Bank account"
 msgstr ""
 
@@ -226,20 +215,16 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_calculation_date
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_calculation_date
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_calculation_date
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_calculation_date
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_calculation_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_calculation_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_calculation_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_calculation_date
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_calculation_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_calculation_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_calculation_date
 msgid "Calculation date"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_form
 #: model:ir.ui.view,arch_db:l10n_es_aeat.wizard_aeat_export
 #: model:ir.ui.view,arch_db:l10n_es_aeat.wizard_compare_boe_file
@@ -249,14 +234,9 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: selection:l10n.es.aeat.mod111.report,state:0
-#: selection:l10n.es.aeat.mod115.report,state:0
-#: selection:l10n.es.aeat.mod123.report,state:0
-#: selection:l10n.es.aeat.mod216.report,state:0
-#: selection:l10n.es.aeat.mod296.report,state:0
 #: selection:l10n.es.aeat.mod303.report,state:0
 #: selection:l10n.es.aeat.mod347.report,state:0
 #: selection:l10n.es.aeat.mod349.report,state:0
-#: selection:l10n.es.aeat.mod390.report,state:0
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 #: selection:l10n.es.vat.book,state:0
@@ -266,6 +246,12 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
 msgid "Cancelled models"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: model:ir.actions.act_window,name:l10n_es_aeat.l10n_es_certificate_action
+#: model:ir.ui.menu,name:l10n_es_aeat.l10n_es_aeat_certificate_menu
+msgid "Certificates"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -281,34 +267,24 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_company_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_company_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_company_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_company_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_company_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_company_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_company_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_company_id_9394
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
 msgid "Company"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod111_report_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod115_report_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod123_report_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod216_report_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod296_report_partner_bank_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod303_report_partner_bank_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod347_report_partner_bank_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod349_report_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod390_report_partner_bank_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_partner_bank_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_partner_bank_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_partner_bank_id
+#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_partner_bank_id_9415
 msgid "Company bank account used for the presentation"
 msgstr ""
 
@@ -334,15 +310,15 @@ msgid "Compare file"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_company_id
+msgid "Compañía"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,type:0
-#: selection:l10n.es.aeat.mod115.report,type:0
-#: selection:l10n.es.aeat.mod123.report,type:0
-#: selection:l10n.es.aeat.mod216.report,type:0
-#: selection:l10n.es.aeat.mod296.report,type:0
 #: selection:l10n.es.aeat.mod303.report,type:0
 #: selection:l10n.es.aeat.mod347.report,type:0
 #: selection:l10n.es.aeat.mod349.report,type:0
-#: selection:l10n.es.aeat.mod390.report,type:0
 #: selection:l10n.es.aeat.report,type:0
 #: selection:l10n.es.aeat.report.tax.mapping,type:0
 #: selection:l10n.es.vat.book,type:0
@@ -386,17 +362,12 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_contact_email
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_contact_email
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_contact_email
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_contact_email
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_contact_email
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_contact_email
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_email
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_email_9399
 msgid "Contact email"
 msgstr ""
 
@@ -407,16 +378,11 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_counterpart_account_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_counterpart_account_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_counterpart_account_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_counterpart_account_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_counterpart_account_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_counterpart_account_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_counterpart_account_id_9412
 msgid "Counterpart account"
 msgstr ""
 
@@ -428,6 +394,8 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_create_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_create_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_create_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_create_uid
@@ -440,6 +408,8 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_create_date
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_create_date
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_create_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_create_date
@@ -456,29 +426,20 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_currency_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_currency_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_currency_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_currency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_currency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_currency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_currency_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_currency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_currency_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_currency_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_currency_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_currency_id_9416
 msgid "Currency"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,support_type:0
-#: selection:l10n.es.aeat.mod115.report,support_type:0
-#: selection:l10n.es.aeat.mod123.report,support_type:0
-#: selection:l10n.es.aeat.mod216.report,support_type:0
-#: selection:l10n.es.aeat.mod296.report,support_type:0
 #: selection:l10n.es.aeat.mod303.report,support_type:0
 #: selection:l10n.es.aeat.mod347.report,support_type:0
 #: selection:l10n.es.aeat.mod349.report,support_type:0
-#: selection:l10n.es.aeat.mod390.report,support_type:0
 #: selection:l10n.es.aeat.report,support_type:0
 #: selection:l10n.es.aeat.report.tax.mapping,support_type:0
 #: selection:l10n.es.vat.book,support_type:0
@@ -503,6 +464,8 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_display_name
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_display_name
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_display_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_display_name
@@ -517,14 +480,9 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
 #: selection:l10n.es.aeat.mod111.report,state:0
-#: selection:l10n.es.aeat.mod115.report,state:0
-#: selection:l10n.es.aeat.mod123.report,state:0
-#: selection:l10n.es.aeat.mod216.report,state:0
-#: selection:l10n.es.aeat.mod296.report,state:0
 #: selection:l10n.es.aeat.mod303.report,state:0
 #: selection:l10n.es.aeat.mod347.report,state:0
 #: selection:l10n.es.aeat.mod349.report,state:0
-#: selection:l10n.es.aeat.mod390.report,state:0
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 #: selection:l10n.es.vat.book,state:0
@@ -534,15 +492,11 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_form
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_search
+#: selection:l10n.es.aeat.certificate,state:0
 #: selection:l10n.es.aeat.mod111.report,state:0
-#: selection:l10n.es.aeat.mod115.report,state:0
-#: selection:l10n.es.aeat.mod123.report,state:0
-#: selection:l10n.es.aeat.mod216.report,state:0
-#: selection:l10n.es.aeat.mod296.report,state:0
 #: selection:l10n.es.aeat.mod303.report,state:0
 #: selection:l10n.es.aeat.mod347.report,state:0
 #: selection:l10n.es.aeat.mod349.report,state:0
-#: selection:l10n.es.aeat.mod390.report,state:0
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 #: selection:l10n.es.vat.book,state:0
@@ -555,19 +509,19 @@ msgid "Draft models"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_date_end
+msgid "End Date"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_date_end
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_date_end
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_date_end
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_date_end_9410
 msgid "Ending date"
 msgstr ""
 
@@ -606,17 +560,12 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.actions.act_window,name:l10n_es_aeat.action_aeat_export_config
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_export_config_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_export_config_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_export_config_id_9407
 msgid "Export config"
 msgstr ""
 
@@ -673,6 +622,7 @@ msgid "Field type"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_file
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_data
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_export_to_boe_data
 msgid "File"
@@ -700,29 +650,31 @@ msgid "Fixed: {}"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_folder
+msgid "Folder Name"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_date_from
 msgid "From Date"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_contact_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_contact_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_contact_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_contact_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_contact_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_contact_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_name
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_name_9397
 msgid "Full Name"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_id
@@ -745,6 +697,7 @@ msgid "If set, this expression will be used to evaluate if this line should be a
 msgstr ""
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:198
 #: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:203
 #, python-format
 msgid "If this declaration is complementary or substitutive, a previous declaration number should be provided."
@@ -766,39 +719,36 @@ msgid "Inheritable abstract model to add taxes by code mapping in any AEAT repor
 msgstr ""
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/aeat_certificate.py:36
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
+#, python-format
+msgid "Insert Password"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_inverse
 msgid "Inverse summarize sign"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_journal_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_journal_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_journal_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_journal_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_journal_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_journal_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_journal_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_journal_id_9413
 msgid "Journal"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod111_report_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod115_report_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod123_report_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod216_report_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod296_report_journal_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod303_report_journal_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod347_report_journal_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod349_report_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod390_report_journal_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_journal_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_journal_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_journal_id
+#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_journal_id_9413
 msgid "Journal in which post the move."
 msgstr ""
 
@@ -809,23 +759,20 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_representative_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_representative_vat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_representative_vat_9400
 msgid "L.R. VAT number"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line___last_update
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate___last_update
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line___last_update
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report___last_update
@@ -840,6 +787,8 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_write_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_write_uid
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_write_uid
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_line_write_uid
@@ -852,6 +801,8 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_write_date
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_write_date
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_write_date
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_line_write_date
@@ -868,17 +819,12 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod111_report_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod115_report_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod123_report_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod216_report_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod296_report_representative_vat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod303_report_representative_vat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod347_report_representative_vat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod349_report_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod390_report_representative_vat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_representative_vat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_representative_vat
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_representative_vat
+#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_representative_vat_9400
 msgid "Legal Representative VAT number."
 msgstr ""
 
@@ -886,6 +832,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_config_line_ids
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_line_ids
 msgid "Lines"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+msgid "Load Certificate"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -910,36 +861,28 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_model_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_tax_line_model
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_tax_line_model_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_model_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_model_id_9406
 msgid "Model"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_model_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_number
 msgid "Model number"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:396
 #: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:401
 #, python-format
 msgid "Modelo no válido: %s. Debe declarar una variable '_aeat_number'"
@@ -947,23 +890,19 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod111_report_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod115_report_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod123_report_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod216_report_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod296_report_contact_name
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod303_report_contact_name
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod347_report_contact_name
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod349_report_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod390_report_contact_name
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_contact_name
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_contact_name
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_contact_name
+#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_contact_name_9397
 msgid "Must have name and surname."
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_name
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_map_tax_line_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_line_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_line_wizard_id
@@ -984,14 +923,9 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,type:0
-#: selection:l10n.es.aeat.mod115.report,type:0
-#: selection:l10n.es.aeat.mod123.report,type:0
-#: selection:l10n.es.aeat.mod216.report,type:0
-#: selection:l10n.es.aeat.mod296.report,type:0
 #: selection:l10n.es.aeat.mod303.report,type:0
 #: selection:l10n.es.aeat.mod347.report,type:0
 #: selection:l10n.es.aeat.mod349.report,type:0
-#: selection:l10n.es.aeat.mod390.report,type:0
 #: selection:l10n.es.aeat.report,type:0
 #: selection:l10n.es.aeat.report.tax.mapping,type:0
 #: selection:l10n.es.vat.book,type:0
@@ -1014,6 +948,12 @@ msgid "Number without decimals"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
+msgid "Obtain Keys"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_model_id
 msgid "Odoo model"
 msgstr ""
@@ -1029,9 +969,16 @@ msgid "Only non-exigible amounts"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:366
 #: code:addons/l10n_es_aeat/models/l10n_es_aeat_report.py:371
 #, python-format
 msgid "Only reports in 'draft' or 'cancelled' state can be removed"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: code:addons/l10n_es_aeat/wizard/aeat_certificate_password.py:70
+#, python-format
+msgid "OpenSSL version is not supported. Upgrade to 0.15 or greater."
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -1046,49 +993,39 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_partner_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_partner_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_partner_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_partner_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_partner_id
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_partner_id
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_partner_id
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_partner_id_9417
 msgid "Partner"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_password_password
+msgid "Password"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_period_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_period_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_period_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_period_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_period_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_period_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_period_type
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_period_type_9408
 msgid "Period type"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_contact_phone
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_contact_phone
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_contact_phone
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_contact_phone
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_contact_phone
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_contact_phone
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_phone
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_contact_phone_9398
 msgid "Phone"
 msgstr ""
 
@@ -1109,14 +1046,9 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,state:0
-#: selection:l10n.es.aeat.mod115.report,state:0
-#: selection:l10n.es.aeat.mod123.report,state:0
-#: selection:l10n.es.aeat.mod216.report,state:0
-#: selection:l10n.es.aeat.mod296.report,state:0
 #: selection:l10n.es.aeat.mod303.report,state:0
 #: selection:l10n.es.aeat.mod347.report,state:0
 #: selection:l10n.es.aeat.mod349.report,state:0
-#: selection:l10n.es.aeat.mod390.report,state:0
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 #: selection:l10n.es.vat.book,state:0
@@ -1125,34 +1057,34 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_previous_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_previous_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_previous_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_previous_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_previous_number
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_previous_number
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_previous_number
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_previous_number_9396
 msgid "Previous declaration number"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_private_key
+msgid "Private Key"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,state:0
-#: selection:l10n.es.aeat.mod115.report,state:0
-#: selection:l10n.es.aeat.mod123.report,state:0
-#: selection:l10n.es.aeat.mod216.report,state:0
-#: selection:l10n.es.aeat.mod296.report,state:0
 #: selection:l10n.es.aeat.mod303.report,state:0
 #: selection:l10n.es.aeat.mod347.report,state:0
 #: selection:l10n.es.aeat.mod349.report,state:0
-#: selection:l10n.es.aeat.mod390.report,state:0
 #: selection:l10n.es.aeat.report,state:0
 #: selection:l10n.es.aeat.report.tax.mapping,state:0
 #: selection:l10n.es.vat.book,state:0
 msgid "Processed"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_public_key
+msgid "Public Key"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -1198,17 +1130,12 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_name
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_name
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_name
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_name_9405
 msgid "Report identifier"
 msgstr ""
 
@@ -1239,53 +1166,44 @@ msgid "Show move"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_date_start
+msgid "Start Date"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_date_start
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_date_start
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_date_start
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_date_start_9409
 msgid "Starting date"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_certificate_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_compare_boe_file_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_export_to_boe_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_state
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_state
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_state
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_state_9404
 msgid "State"
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_type
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_type_9402
 msgid "Statement Type"
 msgstr ""
 
@@ -1297,14 +1215,9 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,type:0
-#: selection:l10n.es.aeat.mod115.report,type:0
-#: selection:l10n.es.aeat.mod123.report,type:0
-#: selection:l10n.es.aeat.mod216.report,type:0
-#: selection:l10n.es.aeat.mod296.report,type:0
 #: selection:l10n.es.aeat.mod303.report,type:0
 #: selection:l10n.es.aeat.mod347.report,type:0
 #: selection:l10n.es.aeat.mod349.report,type:0
-#: selection:l10n.es.aeat.mod390.report,type:0
 #: selection:l10n.es.aeat.report,type:0
 #: selection:l10n.es.aeat.report.tax.mapping,type:0
 #: selection:l10n.es.vat.book,type:0
@@ -1318,17 +1231,12 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_support_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_support_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_support_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_support_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_support_type
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_support_type
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_support_type
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_support_type_9403
 msgid "Support Type"
 msgstr ""
 
@@ -1344,12 +1252,7 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_tax_line_ids
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_tax_line_ids
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_tax_line_ids
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_tax_line_ids
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_tax_line_ids
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_tax_line_ids
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_tax_line_ids
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_tax_line_ids
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_tax_line_form
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_tax_line_tree
@@ -1381,14 +1284,9 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: selection:l10n.es.aeat.mod111.report,support_type:0
-#: selection:l10n.es.aeat.mod115.report,support_type:0
-#: selection:l10n.es.aeat.mod123.report,support_type:0
-#: selection:l10n.es.aeat.mod216.report,support_type:0
-#: selection:l10n.es.aeat.mod296.report,support_type:0
 #: selection:l10n.es.aeat.mod303.report,support_type:0
 #: selection:l10n.es.aeat.mod347.report,support_type:0
 #: selection:l10n.es.aeat.mod349.report,support_type:0
-#: selection:l10n.es.aeat.mod390.report,support_type:0
 #: selection:l10n.es.aeat.report,support_type:0
 #: selection:l10n.es.aeat.report.tax.mapping,support_type:0
 #: selection:l10n.es.vat.book,support_type:0
@@ -1404,22 +1302,22 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod111_report_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod115_report_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod123_report_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod216_report_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod296_report_counterpart_account_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod347_report_counterpart_account_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod349_report_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_mod390_report_counterpart_account_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_counterpart_account_id
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_counterpart_account_id
-#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_counterpart_account_id
+#: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_vat_book_counterpart_account_id_9412
 msgid "This account will be the counterpart for all the journal items that are regularized when posting the report."
 msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.ui.view,arch_db:l10n_es_aeat.view_l10n_es_aeat_report_form
 msgid "This button creates the regularization move for the selected report"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_form_view
+msgid "To Active"
 msgstr ""
 
 #. module: l10n_es_aeat
@@ -1445,17 +1343,12 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_company_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_company_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_company_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_company_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_company_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_company_vat
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_company_vat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_company_vat_9395
 msgid "VAT number"
 msgstr ""
 
@@ -1483,17 +1376,12 @@ msgstr ""
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod111_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod115_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod123_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod216_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod296_report_year
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod303_report_year
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod347_report_year
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod349_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_mod390_report_year
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping_year
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_year
-#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_year
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_vat_book_year_9401
 msgid "Year"
 msgstr ""
 
@@ -1524,6 +1412,16 @@ msgid "get"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_certificate
+msgid "l10n.es.aeat.certificate"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_certificate_password
+msgid "l10n.es.aeat.certificate.password"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: model:ir.model,name:l10n_es_aeat.model_l10n_es_aeat_map_tax
 msgid "l10n.es.aeat.map.tax"
 msgstr ""
@@ -1545,6 +1443,7 @@ msgid "open"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.ui.view,arch_db:l10n_es_aeat.l10n_es_aeat_certificate_password_wizard_view
 #: model:ir.ui.view,arch_db:l10n_es_aeat.wizard_aeat_export
 msgid "or"
 msgstr ""

--- a/l10n_es_aeat/models/__init__.py
+++ b/l10n_es_aeat/models/__init__.py
@@ -10,3 +10,4 @@ from . import l10n_es_aeat_report_tax_mapping
 from . import l10n_es_aeat_tax_line
 from . import l10n_es_aeat_export_config
 from . import l10n_es_aeat_export_config_line
+from . import aeat_certificate

--- a/l10n_es_aeat/models/aeat_certificate.py
+++ b/l10n_es_aeat/models/aeat_certificate.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Diagram Software S.L.
+# (c) 2017 Consultoría Informática Studio 73 S.L.
+# (c) 2019 Acysos S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import api, models, fields, _
+
+
+class L10nEsAeatCertificate(models.Model):
+    _name = 'l10n.es.aeat.certificate'
+
+    name = fields.Char(string="Name")
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('active', 'Active')
+    ], string="State", default="draft")
+    file = fields.Binary(string="File", required=True)
+    folder = fields.Char(string="Folder Name", required=True)
+    date_start = fields.Date(string="Start Date")
+    date_end = fields.Date(string="End Date")
+    public_key = fields.Char(string="Public Key", readonly=True)
+    private_key = fields.Char(string="Private Key", readonly=True)
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Compañía",
+        required=True,
+        default=lambda self: self.env.user.company_id.id
+    )
+
+    @api.multi
+    def load_password_wizard(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Insert Password'),
+            'res_model': 'l10n.es.aeat.certificate.password',
+            'view_mode': 'form',
+            'view_type': 'form',
+            'views': [(False, 'form')],
+            'target': 'new',
+        }
+
+    @api.multi
+    def action_active(self):
+        self.ensure_one()
+        other_configs = self.search([('id', '!=', self.id),
+                                     ('company_id', '=', self.company_id.id)])
+        for config_id in other_configs:
+            config_id.state = 'draft'
+        self.state = 'active'
+
+    @api.multi
+    def get_certificates(self, company = False):
+        if not company:
+            company = self.env.user.company_id
+        today = fields.Date.today()
+        aeat_certificate = self.search([
+            ('company_id', '=', company.id),
+            ('public_key', '!=', False),
+            ('private_key', '!=', False),
+            '|', ('date_start', '=', False),
+            ('date_start', '<=', today),
+            '|', ('date_end', '=', False),
+            ('date_end', '>=', today),
+            ('state', '=', 'active')
+        ], limit=1)
+        if aeat_certificate:
+            public_crt = aeat_certificate.public_key
+            private_key = aeat_certificate.private_key
+        else:
+            public_crt = self.env['ir.config_parameter'].get_param(
+                'l10n_es_aeat_certificate.publicCrt', False)
+            private_key = self.env['ir.config_parameter'].get_param(
+                'l10n_es_aeat_certificate.privateKey', False)
+        return public_crt, private_key
+        

--- a/l10n_es_aeat/models/aeat_certificate.py
+++ b/l10n_es_aeat/models/aeat_certificate.py
@@ -51,7 +51,7 @@ class L10nEsAeatCertificate(models.Model):
         self.state = 'active'
 
     @api.multi
-    def get_certificates(self, company = False):
+    def get_certificates(self, company=False):
         if not company:
             company = self.env.user.company_id
         today = fields.Date.today()
@@ -74,4 +74,3 @@ class L10nEsAeatCertificate(models.Model):
             private_key = self.env['ir.config_parameter'].get_param(
                 'l10n_es_aeat_certificate.privateKey', False)
         return public_crt, private_key
-        

--- a/l10n_es_aeat/security/aeat_security.xml
+++ b/l10n_es_aeat/security/aeat_security.xml
@@ -2,10 +2,17 @@
 <!-- License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 
-<record model="res.groups" id="group_account_aeat">
-    <field name="name">AEAT manager</field>
-    <field name="category_id" ref="base.module_category_hidden"/>
-    <field name="users" eval="[(4, ref('base.user_root'))]"/>
-</record>
+	<record model="res.groups" id="group_account_aeat">
+	    <field name="name">AEAT manager</field>
+	    <field name="category_id" ref="base.module_category_hidden"/>
+	    <field name="users" eval="[(4, ref('base.user_root'))]"/>
+	</record>
+
+    <record id="l10n_es_aeat_certificate_rule" model="ir.rule">
+        <field name="name">AEAT Certificate multi-company</field>
+        <field ref="model_l10n_es_aeat_certificate" name="model_id"/>
+        <field eval="True" name="global"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+    </record>
 
 </odoo>

--- a/l10n_es_aeat/security/ir.model.access.csv
+++ b/l10n_es_aeat/security/ir.model.access.csv
@@ -8,3 +8,4 @@ access_model_l10n_es_aeat_map_tax_aeat,aeat.mod.map.tax.code aeat,model_l10n_es_
 access_model_l10n_es_aeat_map_tax_line_admin,aeat.mod.map.tax.code.line admin,model_l10n_es_aeat_map_tax_line,base.group_system,1,1,1,1
 access_model_l10n_es_aeat_map_taxe_line_aeat,aeat.mod.map.tax.code.line aeat,model_l10n_es_aeat_map_tax_line,group_account_aeat,1,0,0,0
 access_model_l10n_es_aeat_tax_line_aeat,l10n.es.aeat.tax.line aeat,model_l10n_es_aeat_tax_line,group_account_aeat,1,1,1,1
+access_l10n_es_aeat_certificate_manager,l10n_es_aeat_certificate manager,model_l10n_es_aeat_certificate,account.group_account_manager,1,1,1,1

--- a/l10n_es_aeat/views/aeat_certificate_view.xml
+++ b/l10n_es_aeat/views/aeat_certificate_view.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="l10n_es_aeat_certificate_form_view" model="ir.ui.view">
+            <field name="name">l10n.es.aeat.certificate.form</field>
+            <field name="model">l10n.es.aeat.certificate</field>
+            <field name="arch" type="xml">
+                <form string="Load Certificate">
+                    <header>
+                        <button name="load_password_wizard" type="object" string="Obtain Keys"/>
+                        <button name="action_active" type="object" string="To Active"/>
+                        <field name="state" widget="statusbar" statusbar_visible="draft,active"/>
+                    </header>
+                    <group>
+                        <group>
+                            <field name="name"/>
+                            <field name="file"/>
+                            <field name="folder"/>
+                        </group>
+                        <group>
+                            <field name="company_id" groups="base.group_multi_company"/>
+                            <field name="date_start"/>
+                            <field name="date_end"/>
+                        </group>
+                    </group>
+                    <group>
+                        <field name="private_key"/>
+                        <field name="public_key"/>
+                    </group>
+                 </form>
+            </field>
+        </record>
+
+        <record id="l10n_es_certificate_tree_view" model="ir.ui.view">
+            <field name="name">l10n.es.aeat.certificate.tree</field>
+            <field name="model">l10n.es.aeat.certificate</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="name"/>
+                    <field name="date_start"/>
+                    <field name="date_end"/>
+                    <field name="state"/>
+                 </tree>
+            </field>
+        </record>
+
+        <record id="l10n_es_certificate_action" model="ir.actions.act_window">
+            <field name="name">Certificates</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">l10n.es.aeat.certificate</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+        
+        <menuitem id="l10n_es_aeat_certificate_menu" name="Certificates"
+                  action="l10n_es_certificate_action" sequence="0"
+                  parent="l10n_es_aeat.menu_l10n_es_aeat_config" />
+
+    </data>
+</odoo>

--- a/l10n_es_aeat/wizard/__init__.py
+++ b/l10n_es_aeat/wizard/__init__.py
@@ -2,3 +2,4 @@
 
 from . import compare_boe_file
 from . import export_to_boe
+from . import aeat_certificate_password

--- a/l10n_es_aeat/wizard/aeat_certificate_password.py
+++ b/l10n_es_aeat/wizard/aeat_certificate_password.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Diagram Software S.L.
+# Copyright 2019 Acysos S.L.
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+
+from odoo import _, api, exceptions, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools import config
+from odoo import release
+import contextlib
+import os
+import tempfile
+import base64
+import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import OpenSSL.crypto
+except (ImportError, IOError) as err:
+    _logger.debug(err)
+
+if tuple(map(int, OpenSSL.__version__.split('.'))) < (0, 15):
+    _logger.warning(
+        'OpenSSL version is not supported. Upgrade to 0.15 or greater.')
+
+
+@contextlib.contextmanager
+def pfx_to_pem(file, pfx_password, directory=None):
+    with tempfile.NamedTemporaryFile(
+            prefix='private_', suffix='.pem', delete=False,
+            dir=directory) as t_pem:
+        f_pem = open(t_pem.name, 'wb')
+        p12 = OpenSSL.crypto.load_pkcs12(file, pfx_password)
+        f_pem.write(OpenSSL.crypto.dump_privatekey(
+            OpenSSL.crypto.FILETYPE_PEM, p12.get_privatekey()))
+        f_pem.close()
+        yield t_pem.name
+
+
+@contextlib.contextmanager
+def pfx_to_crt(file, pfx_password, directory=None):
+    with tempfile.NamedTemporaryFile(
+            prefix='public_', suffix='.crt', delete=False,
+            dir=directory) as t_crt:
+        f_crt = open(t_crt.name, 'wb')
+        p12 = OpenSSL.crypto.load_pkcs12(file, pfx_password)
+        f_crt.write(OpenSSL.crypto.dump_certificate(
+            OpenSSL.crypto.FILETYPE_PEM, p12.get_certificate()))
+        f_crt.close()
+        yield t_crt.name
+
+
+class L10nEsAeatCertificatePassword(models.TransientModel):
+    _name = 'l10n.es.aeat.certificate.password'
+
+    password = fields.Char(string="Password", required=True)
+
+    @api.multi
+    def get_keys(self):
+        record = self.env['l10n.es.aeat.certificate'].browse(
+            self.env.context.get('active_id'))
+        directory = os.path.join(
+            os.path.abspath(config['data_dir']), 'certificates',
+            release.series, self.env.cr.dbname, record.folder)
+        file = base64.decodestring(record.file)
+        if tuple(map(int, OpenSSL.__version__.split('.'))) < (0, 15):
+            raise exceptions.Warning(
+                _('OpenSSL version is not supported. Upgrade to 0.15 '
+                  'or greater.'))
+        try:
+            if directory and not os.path.exists(directory):
+                os.makedirs(directory)
+            with pfx_to_pem(file, self.password, directory) as private_key:
+                record.private_key = private_key
+            with pfx_to_crt(file, self.password, directory) as public_key:
+                record.public_key = public_key
+        except Exception as e:
+            if e.args:
+                args = list(e.args)
+            raise ValidationError(args[-1])

--- a/l10n_es_aeat/wizard/aeat_certificate_password_view.xml
+++ b/l10n_es_aeat/wizard/aeat_certificate_password_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="l10n_es_aeat_certificate_password_wizard_view" model="ir.ui.view">
+            <field name="name">l10n.es.aeat.certificate.password.wizard</field>
+            <field name="model">l10n.es.aeat.certificate.password</field>
+            <field name="arch" type="xml">
+                <form string="Insert Password">
+                    <group>
+                        <field name="password" password="True"/>
+                    </group>
+                    <footer>
+                        <button name="get_keys" type="object" string="Obtain Keys" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel"/>
+                    </footer>
+                 </form>
+            </field>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
Hola,

Añade el certificado general para todas las presentaciones via webservice de AEAT. Actualmente lo usaria el SII y la verificación de partners. Aunque se podrá utilizar para más módulo no desarrollados aún como aduanas, tgvi online, algunos impuestos especiales, modelo 179 y más modelos o servicios que AEAT implemente en el futuro.

Este es el primer PR de los tres que llevará la presentación que se hizo en las Jornadas Nacionales de Odoo https://www.youtube.com/watch?v=hj0Rs6cVNEM&t=1349s

Una vez aprobado se seguirán los siguientes PR:
- Webservice SOAP
- Verificación de partners

Saludos