### PR TITLE
[FIX] l10n_es_facturae_face: Disable allow to specify the mimetype

### DIFF
--- a/l10n_es_facturae_face/models/account_invoice_integration_method.py
+++ b/l10n_es_facturae_face/models/account_invoice_integration_method.py
@@ -22,7 +22,7 @@ class AccountInvoiceIntegrationMethod(models.Model):
                 raise exceptions.UserError(
                     _('Certificate password must be added for company'))
             invoice_file, file_name = invoice.get_facturae(True)
-            attachment = self.env['ir.attachment'].create({
+            attachment = self.env['ir.attachment'].sudo().create({
                 'name': file_name,
                 'datas': base64.b64encode(invoice_file),
                 'datas_fname': file_name,


### PR DESCRIPTION
Debido a esta [función](https://github.com/odoo/odoo/blob/9e64f9f9514194d74e166b032add8511182f2677/odoo/addons/base/ir/ir_attachment.py#L189) de odoo está dando errores cuando el usuario no es admin.
Este commit añade la opción de ignorar el código principal de odoo.