### PR TITLE
[11.0] l10n_es_aeat_sii: Se comprueba el campo correcto de núm. factura proveedor

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -250,7 +250,7 @@ class AccountInvoice(models.Model):
                               "the invoice and create a new one with the "
                               "correct supplier")
                             )
-                elif 'supplier_invoice_number' in vals:
+                elif 'reference' in vals:
                     raise exceptions.Warning(
                         _("You cannot change the supplier invoice number of "
                           "an invoice already registered at the SII. You must "


### PR DESCRIPTION
Hola,

Esta comprobación parece que ha quedado sin migrar, ya que ahora el campo que se usa como número de factura de proveedor es "reference" y es el que se está enviando al SII como tal.

