### PR TITLE
[11.0] l10n_es_facturae: price_unit digits > 2

### DIFF
--- a/l10n_es_facturae/README.rst
+++ b/l10n_es_facturae/README.rst
@@ -43,7 +43,7 @@ a su destino. La administración le proporcionará estos datos.
 
 Informacion sobre el formato:
 
-* http://www.facturae.gob.es/formato/Versiones/Esquema_castellano_v3_2_x_17_11_2015_unificado.pdf
+* https://www.facturae.gob.es/formato/Versiones/Esquema_castellano_v3_2_x_06_06_2017_unificado.pdf
 
 **Table of contents**
 

--- a/l10n_es_facturae/__manifest__.py
+++ b/l10n_es_facturae/__manifest__.py
@@ -2,7 +2,7 @@
 # © 2015 Ismael Calvo <ismael.calvo@factorlibre.com>
 # © 2015 Tecon
 # © 2015 Omar Castiñeira (Comunitea)
-# © 2016 Tecnativa
+# Copyright 2016-2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {

--- a/l10n_es_facturae/readme/DESCRIPTION.rst
+++ b/l10n_es_facturae/readme/DESCRIPTION.rst
@@ -16,4 +16,4 @@ a su destino. La administración le proporcionará estos datos.
 
 Informacion sobre el formato:
 
-* http://www.facturae.gob.es/formato/Versiones/Esquema_castellano_v3_2_x_17_11_2015_unificado.pdf
+* https://www.facturae.gob.es/formato/Versiones/Esquema_castellano_v3_2_x_06_06_2017_unificado.pdf

--- a/l10n_es_facturae/static/description/index.html
+++ b/l10n_es_facturae/static/description/index.html
@@ -385,7 +385,7 @@ el órgano gestor y la unidad tramitadora, para que llegue correctamente
 a su destino. La administración le proporcionará estos datos.</p>
 <p>Informacion sobre el formato:</p>
 <ul class="simple">
-<li><a class="reference external" href="http://www.facturae.gob.es/formato/Versiones/Esquema_castellano_v3_2_x_17_11_2015_unificado.pdf">http://www.facturae.gob.es/formato/Versiones/Esquema_castellano_v3_2_x_17_11_2015_unificado.pdf</a></li>
+<li><a class="reference external" href="https://www.facturae.gob.es/formato/Versiones/Esquema_castellano_v3_2_x_06_06_2017_unificado.pdf">https://www.facturae.gob.es/formato/Versiones/Esquema_castellano_v3_2_x_06_06_2017_unificado.pdf</a></li>
 </ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">

--- a/l10n_es_facturae/tests/test_l10n_es_facturae.py
+++ b/l10n_es_facturae/tests/test_l10n_es_facturae.py
@@ -413,3 +413,54 @@ class TestL10nEsFacturae(common.SavepointCase):
         action = self.invoice_line.button_edit_facturae_fields()
         item = self.env[action['res_model']].browse(action['res_id'])
         self.assertEqual(item, self.invoice_line)
+
+    def _check_amounts(self, wo_discount, subtotal, base, tax, discount=0):
+        self.wizard.create_facturae_file()
+        facturae_xml = etree.fromstring(
+            base64.b64decode(self.wizard.facturae))
+        self.assertEqual(
+            facturae_xml.xpath('//InvoiceLine/TotalCost')[0].text, wo_discount,
+        )
+        self.assertEqual(
+            facturae_xml.xpath('//InvoiceLine/GrossAmount')[0].text, subtotal,
+        )
+        self.assertEqual(
+            facturae_xml.xpath(
+                '//TaxesOutputs//TaxableBase/TotalAmount')[0].text, base,
+        )
+        self.assertEqual(
+            facturae_xml.xpath(
+                '//TaxesOutputs//TaxAmount/TotalAmount')[0].text, tax,
+        )
+        if discount:
+            self.assertEqual(
+                facturae_xml.xpath(
+                    '//InvoiceLine//DiscountAmount')[0].text, discount,
+            )
+
+    def test_invoice_rounding(self):
+        self.company.tax_calculation_rounding_method = 'round_globally'
+        dp = self.env.ref('product.decimal_price')
+        dp.digits = 4
+        # We do this for refreshing the cached value in this env
+        self.assertEqual(dp.precision_get(dp.name), 4)
+        self.invoice_line.price_unit = 190.314
+        # Make sure the decimal precision is being applied
+        self.assertAlmostEqual(self.invoice_line.price_unit, 190.314, 4)
+        self.invoice.compute_taxes()
+        self._check_amounts('190.310000', '190.310000', '190.31', '39.97')
+
+    def test_invoice_rounding_with_discount(self):
+        self.company.tax_calculation_rounding_method = 'round_globally'
+        dp = self.env.ref('product.decimal_price')
+        dp.digits = 4
+        # We do this for refreshing the cached value in this env
+        self.assertEqual(dp.precision_get(dp.name), 4)
+        self.invoice_line.write({
+            'price_unit': 190.314,
+            'discount': 30,
+        })
+        self.invoice.compute_taxes()
+        self._check_amounts(
+            '190.310000', '133.220000', '133.22', '27.98', '57.090000',
+        )

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -274,12 +274,13 @@
                             <Quantity t-esc="line.quantity"/>
                             <UnitOfMeasure t-if="False"/>
                             <UnitPriceWithoutTax t-esc="'%.6f' % line.price_unit"/>
-                            <TotalCost t-esc="'%.6f' % (line.quantity * line.price_unit)"/>
+                            <t t-set="subtotal_gross" t-value="round(line.quantity * line.price_unit, line.company_currency_id.decimal_places)"/>
+                            <TotalCost t-esc="'%.6f' % subtotal_gross"/>
                             <DiscountsAndRebates t-if="line.discount != 0">
                                 <Discount>
                                     <DiscountReason t-esc="'Descuento'"/>
                                     <DiscountRate t-esc="'%.4f' % line.discount"/>
-                                    <DiscountAmount t-esc="'%.6f' % (line.price_unit * line.quantity - line.price_subtotal)"/>
+                                    <DiscountAmount t-esc="'%.6f' % (subtotal_gross - line.price_subtotal)"/>
                                 </Discount>
                             </DiscountsAndRebates>
                             <Charges t-if="False"/>


### PR DESCRIPTION
It turns out the information in the XML file gets incoherent in this case, having `GrossAmount` and `TotalCost` fields with different rounding.

After several attempts, the best approach is to simply apply the same rounding in the `TotalCost` (subtotal before discount) field (got from currency), and compute the discount amount substracting both.

This can lead to (`TotalCost` * discount percentage / 100) != discount amount, but there's no other way to make the rest correct, and services don't seem to perform this check, but the other, as these fields are mostly informative.

cc @Tecnativa