### PR TITLE
[11.0][FIX] l10n_es_aeat_mod349: refund groups

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -206,7 +206,7 @@ class Mod349(models.Model):
                     lambda d: d.report_id == report)
                 origin_amount = sum(original_details.mapped('amount_untaxed'))
                 period_type = report.period_type
-                year = report.year
+                year = str(report.year)
             else:
                 # There's no previous 349 declaration report in Odoo
                 original_amls = move_line_obj.search([


### PR DESCRIPTION
El campo **year** es numérico mientras que en la siguiente condición la asignación a **year** es una string. El error viene a la hora de crear la variable **key** para agrupar , que si es numérico o string los toma como diferentes.
https://github.com/OCA/l10n-spain/blob/12.0/l10n_es_aeat_mod349/models/mod349.py#L237