### PR TITLE
[FIX] l10n_es_aeat_mod123 python expressions

### DIFF
--- a/l10n_es_aeat_mod123/data/aeat_export_mod123_data.xml
+++ b/l10n_es_aeat_mod123/data/aeat_export_mod123_data.xml
@@ -102,7 +102,7 @@
             <field name="sequence">10</field>
             <field name="export_config_id" ref="aeat_mod123_sub01_export_config"/>
             <field name="name">Identificación: Ejercicio</field>
-            <field name="expression">${object.date_start[:4]}</field>
+            <field name="expression">${str(object.date_start)[:4]}</field>
             <field name="export_type">string</field>
             <field name="size">4</field>
             <field name="alignment">left</field>
@@ -317,7 +317,7 @@
             <field name="sequence">4</field>
             <field name="export_config_id" ref="aeat_mod123_main_export_config"/>
             <field name="name">Ejercicio devengo (AAAA)</field>
-            <field name="expression">${object.date_start[:4]}</field>
+            <field name="expression">${str(object.date_start)[:4]}</field>
             <field name="export_type">string</field>
             <field name="size">4</field>
             <field name="alignment">left</field>
@@ -426,7 +426,7 @@
             <field name="sequence">15</field>
             <field name="export_config_id" ref="aeat_mod123_main_export_config"/>
             <field name="name">Constante: &lt;/T1230+Ejercicio+periodo+0000&gt;</field>
-            <field name="expression">&lt;/T1230${object.date_start[:4]}${object.period_type}0000&gt;</field>
+            <field name="expression">&lt;/T1230${str(object.date_start)[:4]}${object.period_type}0000&gt;</field>
             <field name="export_type">string</field>
             <field name="size">18</field>
             <field name="alignment">left</field>


### PR DESCRIPTION
Se han adaptado las expresiones a python 3, para poder realizar la exportación a BOE. 