### PR TITLE
[11.0][IMP] Importar N43: Poner fecha como la de inicio del fichero

### DIFF
--- a/l10n_es_account_bank_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
+++ b/l10n_es_account_bank_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
@@ -32,6 +32,7 @@ class L10nEsAccountBankStatementImportN43(common.SavepointCase):
         statement = self.env['account.bank.statement'].browse(
             action['context']['statement_ids'][0],
         )
+        self.assertEqual(statement.date, '2016-02-01')
         self.assertEqual(len(statement.line_ids), 3)
         self.assertEqual(statement.line_ids[0].date, '2016-05-25')
         self.assertAlmostEqual(statement.balance_start, 0, 2)

--- a/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
+++ b/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
@@ -319,7 +319,9 @@ class AccountBankStatementImport(models.TransientModel):
             self.env.context.get('journal_id', [])
         )
         transactions = []
+        date = False
         for group in n43:
+            date = fields.Date.to_string(group['fecha_ini'].date())
             for line in group['lines']:
                 conceptos = []
                 for concept_line in line['conceptos']:
@@ -346,6 +348,8 @@ class AccountBankStatementImport(models.TransientModel):
             'balance_start': n43 and n43[0]['saldo_ini'] or 0.0,
             'balance_end_real': n43 and n43[-1]['saldo_fin'] or 0.0,
         }
+        if date:
+            vals_bank_statement['date'] = date
         return None, None, [vals_bank_statement]
 
     def _complete_stmts_vals(self, stmts_vals, journal, account_number):


### PR DESCRIPTION
Con este PR añadimos la fecha del statement como la fecha de inicio del fichero.
Útil si importamos un fichero diario y en algun caso no hemos podido hacer un dia (festivos, etc..)