### PR TITLE
[FIX] l10n_es_aeat_mod347: company_id not in domain. Error report_347_partner

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -6,6 +6,7 @@
 # Copyright 2016 Tecnativa - Angel Moya <odoo@tecnativa.com>
 # Copyright 2014-2019 Tecnativa - Pedro M. Baeza
 # Copyright 2018 PESOL - Angel Moya <info@pesol.es>
+# Copyright 2019 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields, models, api, exceptions, _
@@ -287,7 +288,8 @@ class L10nEsAeatMod347Report(models.Model):
                 move_lines = move_line_obj.search(cash_group['__domain'])
                 partner_record = partner_record_obj.search([
                     ('partner_id', '=', partner.id),
-                    ('operation_key', '=', 'B')
+                    ('operation_key', '=', 'B'),
+                    ('report_id', '=', self.id),
                 ])
                 if partner_record:
                     partner_record.write({

--- a/l10n_es_aeat_mod347/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod347/readme/CONTRIBUTORS.rst
@@ -10,3 +10,4 @@
   * Antonio Espinosa
   * Pedro M. Baeza
   * Cristina Martín
+  * Carlos Dauden

--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -81,22 +81,6 @@
                 <strong  class="text-right">Amount:</strong>
                 <p class="text-right" t-field="o.cash_amount"/>
               </div>
-              <div class="col-xs-2">
-                <strong  class="text-right">Amount 1Q:</strong>
-                <p class="text-right" t-field="o.first_quarter_cash_amount"/>
-              </div>
-              <div class="col-xs-2">
-                <strong  class="text-right">Amount 2Q:</strong>
-                <p class="text-right" t-field="o.second_quarter_cash_amount"/>
-              </div>
-              <div class="col-xs-2">
-                <strong  class="text-right">Amount 3Q:</strong>
-                <p class="text-right" t-field="o.third_quarter_cash_amount"/>
-              </div>
-              <div class="col-xs-2">
-                <strong  class="text-right">Amount 4Q:</strong>
-                <p class="text-right" t-field="o.fourth_quarter_cash_amount"/>
-              </div>
             </div>
 
             <t t-if="o.cash_record_ids">


### PR DESCRIPTION
with missed cash fields.

"Unlimited" l10n.es.aeat.mod347.partner_record search writes unrelated records.

This commit removes cash fields but keeps in report_347_partner:
https://github.com/OCA/l10n-spain/commit/7675cdd66873c7d415c9e17a077d7545407b1212#diff-c834a25f21d7443853d7e1fe772a628bL400
https://github.com/OCA/l10n-spain/commit/7675cdd66873c7d415c9e17a077d7545407b1212#diff-8ef6a673ea79b2a94e2a6d2cd77c6a19R84-R99

@Tecnativa TT20102