### PR TITLE
[12.0][l10n_es_account_asset] Calcular correctamente importes

### DIFF
--- a/l10n_es_account_asset/__manifest__.py
+++ b/l10n_es_account_asset/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Gestión de activos fijos para España",
-    "version": "12.0.1.0.1",
+    "version": "12.0.2.0.0",
     "depends": [
         "account_asset_management",
     ],

--- a/l10n_es_account_asset/models/account_asset.py
+++ b/l10n_es_account_asset/models/account_asset.py
@@ -139,8 +139,8 @@ class AccountAssetAsset(models.Model):
             self.method_time = 'percentage'
 
     def _get_amount_linear(
-            self, depreciation_start_date, depreciation_stop_date):
+            self, depreciation_start_date, depreciation_stop_date, entry):
         if self.env.context.get('use_percentage', False):
             return self.depreciation_base * self.annual_percentage / 100
         return super(AccountAssetAsset, self)._get_amount_linear(
-            depreciation_start_date, depreciation_stop_date)
+            depreciation_start_date, depreciation_stop_date, entry)

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,5 +1,5 @@
 account-financial-reporting
-account-financial-tools https://github.com/Eficent/account-financial-tools 12.0-account_asset_management-hook
+account-financial-tools
 bank-payment
 community-data-files
 mis-builder

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,5 +1,5 @@
 account-financial-reporting
-account-financial-tools
+account-financial-tools https://github.com/Eficent/account-financial-tools 12.0-account_asset_management-hook
 bank-payment
 community-data-files
 mis-builder


### PR DESCRIPTION
Con esta corrección los importes basados en el método por porcentaje fijo se ejecutan correctamente.

Antes de esta corrección la aplicación daba error si dejabas el número de años vacío.

Dependencias:
* [x] https://github.com/OCA/account-financial-tools/pull/852