### PR TITLE
[11.0][FIX] l10n-spain: campo BaseImponibleACoste obligatorio con ^ClaveReg…

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -657,7 +657,8 @@ class AccountInvoice(models.Model):
     def _get_sii_base_cost(self):
         self.ensure_one()
         return sum(
-            self.invoice_line_ids.mapped('price_subtotal')
+            self.tax_line_ids.filtered(
+                lambda x: not x.tax_id.include_base_amount).mapped('base')
         )
 
     @api.multi


### PR DESCRIPTION
…imenEspecialOTrascendencia.*$ = 06

Como consecuencia de los cambios efectuados en la nueva versión del SII en vigor desde el 1 de octubre de 2019, se introducen nuevas validaciones que anteriormente eran opcionales y ahora son obligatorias.

Este PR se enfoca en resolver los siguientes errores relativos al campo "BaseImponibleACoste":

- 1272: "El campo BaseImponibleACoste es obligatorio cuando el valor de ClaveRegimenEspecialOTrascendencia o alguna ClaveRegimenEspecialOTrascendenciaAdicional sea 06"
- 1275: "Si el campo ClaveRegimenEspecialOTrascendencia o algunaClaveRegimenEspecialOTrascendenciaAdicional en facturas recibidas tiene un valor igual a 06 el campo BaseImponibleACoste se debe informar"

Se trata de la primera aproximación funcional pero muy poco testeada, un punto de partida a la espera de vuestros comentarios, correcciones y mejoras.

Muchas gracias