### PR TITLE
[FIX] l10n_es_vat_book: Missed copy dictionary method

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -234,7 +234,7 @@ class L10nEsVatBook(models.Model):
         if move_line.tax_line_id:
             key = self.get_book_line_tax_key(move_line, move_line.tax_line_id)
             if key not in tax_lines:
-                tax_lines[key] = vals
+                tax_lines[key] = vals.copy()
             else:
                 tax_lines[key]['tax_amount'] += vals['tax_amount']
                 tax_lines[key]['total_amount'] += vals['total_amount']
@@ -247,7 +247,7 @@ class L10nEsVatBook(models.Model):
                 continue
             key = self.get_book_line_tax_key(move_line, tax)
             if key not in tax_lines:
-                tax_lines[key] = vals
+                tax_lines[key] = vals.copy()
                 tax_lines[key]['tax_id'] = tax.id
             else:
                 tax_lines[key]['base_amount'] += vals['base_amount']


### PR DESCRIPTION
Resuelve este problema https://github.com/OCA/l10n-spain/issues/1221

- Crear una factura de con importe 0 y con algún recargo de equivalencia en los impuestos
- Calcular el Libro de IVA en un período que incluya esta factura.
- Se obtiene el error:

> File "/home/odoo/build/OCA/l10n-spain/l10n_es_vat_book/models/l10n_es_vat_book.py", line 265, in upsert_book_line_tax
> lambda l: not l['special_tax_group'], implied_lines))
> StopIteration

@Tecnativa