### PR TITLE
[12.0][FIX] l10n_es_vat_book: retocar informes del Libro de IVA para que el…

### DIFF
--- a/l10n_es_vat_book/report/vat_book_invoices_issued.xml
+++ b/l10n_es_vat_book/report/vat_book_invoices_issued.xml
@@ -21,13 +21,17 @@
               <div class="col-xs-12 text-center" id="title">
                   <h3>BOOK REGISTER OF INVOICES ISSUED</h3>
               </div>
-
+            </div>
+            <div class="row">
               <t t-call="l10n_es_vat_book.vat_book_dates"/>
               <t t-call="l10n_es_vat_book.vat_book_contact"/>
-
-              <div class="col-xs-12" id="title_invoices_issued">
+            </div>
+            <div class="row">
+              <div class="col-xs-12 mt32" id="title_invoices_issued">
                 <h4>Issued Invoices</h4>
               </div>
+            </div>
+            <div class="row">
               <div class="col-xs-12" id="invoices_issued_detail_div">
                 <table class="table table-condensed"
                        id="invoices_issued_detail_table">
@@ -39,10 +43,14 @@
                     </tbody>
                 </table>
               </div>
-              <div class="col-xs-12"
+            </div>
+            <div class="row">
+              <div class="col-xs-12 mt32"
                    id="title_rectification_invoices_issued">
                 <h4>Issued Refund Invoices</h4>
               </div>
+            </div>
+            <div class="row">
               <div class="col-xs-12"
                    id="rectification_invoices_issued_detail_div">
                 <table class="table table-condensed"
@@ -55,9 +63,13 @@
                     </tbody>
                 </table>
               </div>
-              <div class="col-xs-12" id="title_summary_invoices">
+            </div>
+            <div class="row">
+              <div class="col-xs-12 mt32" id="title_summary_invoices">
                 <h4>Summary</h4>
               </div>
+            </div>
+            <div class="row">
               <div class="col-xs-12" id="div_summary_invoices">
                   <table class="table table-condensed" id="table_sumary_invoices">
                       <t t-call="l10n_es_vat_book.vat_book_taxes_head"/>
@@ -72,8 +84,8 @@
                       </tbody>
                   </table>
               </div>
+            </div>
         </div>
-      </div>
     </template>
 
     <template id="report_vat_book_invoices_issued_pdf">

--- a/l10n_es_vat_book/report/vat_book_invoices_received.xml
+++ b/l10n_es_vat_book/report/vat_book_invoices_received.xml
@@ -14,16 +14,21 @@
                }
            </style>
             <div class="row">
-
               <div class="col-xs-12 text-center" id="title">
                   <h3>BOOK REGISTER OF INVOICES RECEIVED</h3>
               </div>
+            </div>
+            <div class="row">
               <t t-call="l10n_es_vat_book.vat_book_dates"/>
               <t t-call="l10n_es_vat_book.vat_book_contact"/>
-              <div class="col-xs-12"
+            </div>
+            <div class="row">
+              <div class="col-xs-12 mt32"
                    id="title_invoices_received">
                 <h4>Received Invoices</h4>
               </div>
+            </div>
+            <div class="row">
               <div class="col-xs-12" id="detail_div">
                 <table class="table table-condensed" id="detail_table">
                     <t t-call="l10n_es_vat_book.vat_book_invoices_head"/>
@@ -34,10 +39,14 @@
                     </tbody>
                 </table>
               </div>
-              <div class="col-xs-12"
+            </div>
+            <div class="row">
+              <div class="col-xs-12 mt32"
                    id="title_rectification_invoices_received">
                 <h4>Received Refund Invoices</h4>
               </div>
+            </div>
+            <div class="row">
                 <div class="col-xs-12"
                    id="rectification_invoices_received_detail_div">
                 <table class="table table-condensed"
@@ -50,7 +59,9 @@
                     </tbody>
                 </table>
               </div>
-              <div class="col-xs-12" id="title_summary_invoices">
+            </div>
+            <div class="row">
+              <div class="col-xs-12 mt32" id="title_summary_invoices">
                 <h4>Summary</h4>
               </div>
               <div class="col-xs-12" id="div_summary_invoices">
@@ -67,8 +78,8 @@
                       </tbody>
                   </table>
               </div>
+            </div>
         </div>
-      </div>
     </template>
 
     <template id="report_vat_book_invoices_received_pdf">


### PR DESCRIPTION
… wkhtmltopdf pueda imprimirlos correctamente
Son parte de los problemas #1144 y #1217 : los pdf salen en blanco.
El motivo: el wkhtmltopdf NO es capaz de evaluar los div con float:left como lo haría un navegador, es decir haciéndolos "saltar de línea", y lo que hace es ponerlos flotantes hacia la derecha hasta que se salen del área de impresión. Con ello ciertos datos "desaparecen" y el usuario cree que está en blanco.
Solución: poner un div con class="row" para forzarlo.