### PR TITLE
[11.0][FIX] l10n_es_facturae: The bank code should be obtained from the mandate in direct debits

### DIFF
--- a/l10n_es_facturae/readme/CONTRIBUTORS.rst
+++ b/l10n_es_facturae/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
 * Javi Melendez <javimelex@gmail.com>
 * Enric Tobella <etobella@creublanca.es>
 * Adrián Gómez <adrian.gomez@pesol.es>
+* Eric Antones <eantones@nuobit.com>

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -335,7 +335,7 @@
                                 <PaymentMeans t-esc="invoice.payment_mode_id.facturae_code"/>
                                 <AccountToBeDebited t-if="invoice.payment_mode_id.facturae_code == '02'">
                                     <IBAN t-minlength="5" t-length="34" t-esc="''.join(invoice.mandate_id.partner_bank_id.acc_number.split())"/>
-                                    <BankCode t-length="60" t-esc="invoice.partner_bank_id.bank_id.code"/>
+                                    <BankCode t-length="60" t-esc="invoice.mandate_id.partner_bank_id.bank_id.code"/>
                                     <BranchCode t-length="60" t-if="False"/>
                                     <BIC t-minlength="11" t-length="11" t-esc="invoice.mandate_id.partner_bank_id.bank_id.bic"/>
                                     <PaymentReconciliationReference t-length="60" t-if="False"/>


### PR DESCRIPTION
The bank code is being acquired from the field `partner_bank_id` of the invoice but this field can be null. 

The bank code must be acquired from the same field `partner_bank_id` but from the mandate `mandate_id` just as the other bank data as IBAN and BIC.

Can you review it please?

cc @etobella @pedrobaeza