### PR TITLE
[FIX][l10n_es_aeat_mod390][11.0] ECRLF y E000060 al importar el fichero boe en la página de la AEAT

### DIFF
--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2018_main_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2018_main_data.xml
@@ -114,7 +114,7 @@
         <field name="sequence">11</field>
         <field name="export_config_id" ref="aeat_mod390_2018_main_export_config"/>
         <field name="name">NIF Empresa Desarrollo</field>
-        <field name="fixed_value">Odoo</field>
+        <field name="fixed_value"></field>
         <field name="export_type">string</field>
         <field name="size">9</field>
         <field name="alignment">left</field>
@@ -219,16 +219,6 @@
         <field name="expression">&lt;/T3900${object.year}${object.period_type}0000&gt;</field>
         <field name="export_type">string</field>
         <field name="size">18</field>
-        <field name="alignment">left</field>
-    </record>
-
-    <record id="aeat_mod390_2018_main_export_line_23" model="aeat.model.export.config.line">
-        <field name="sequence">23</field>
-        <field name="export_config_id" ref="aeat_mod390_2018_main_export_config"/>
-        <field name="name">Fin de Registro. Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
-        <field name="expression">${"\r\n".encode("ascii")}</field>
-        <field name="export_type">string</field>
-        <field name="size">2</field>
         <field name="alignment">left</field>
     </record>
 


### PR DESCRIPTION
Al importar el fichero boe generado por odoo en la página de la AEAT se generan los siguientes errores y el fichero no se importa:

- **ECRLF No se admiten saltos de linea en el fichero**
El fichero acaba con un salto de linea, y por algún motivo a la AEAT ahora no le gusta (aunque nunca formó de la especificación actual lo aceptaban).
Simplemente eliminamos la última linea de la configuración de exportación del 390 y resuelto.

- **E000060 Carácteres no válidos 'NIF empresa desarrollo'**
Por algún motivo ya no quieren que pongamos Odoo como hasta ahora. Si rellenamos el campo con espacios, el fichero es aceptado.
¿Deberíamos por aquí el nif de aeodoo?

Pregunta: La solución de eliminar la línea de configuración sirve con BD nuevas, pero me imagino que en una BD antigua habrá que eliminar esta linea de alguna forma ¿Alguien me sabe decir como se hace?

PS: ¡primera pr! espero no equivocarme demasiado.