### PR TITLE
[FIX] l10n_es: continue migrating if records cannot be deleted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 cache: pip
 
 addons:
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility


### PR DESCRIPTION
In a database being migrated from v6.1, the `ir.sequence` record being deleted in this migration script was being used in an `account.journal` record:

```
2020-01-21 09:56:52,217 1 INFO prod openerp.modules.migration: module l10n_es: Running migration [>7.0.4.0] Delete old account chart template data
2020-01-21 09:56:52,219 1 ERROR prod openerp.sql_db: bad query: DELETE FROM
                          ir_sequence
                      WHERE
                          id
                      IN
                          (SELECT res_id FROM ir_model_data AS imd
                           WHERE imd.module='l10n_es'
                           AND imd.model='ir.sequence')

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/openerp/sql_db.py", line 226, in execute
    res = self._obj.execute(query, params)
IntegrityError: null value in column "sequence_id" violates not-null constraint
DETAIL:  Failing row contains (2, 1, 2012-08-15 17:17:08.013515, 2012-08-31 10:19:09.034845, 6, null, GRAL, 3, null, null, f, t, 1, General, f, f, 1, f, general, null, null, f, null, null, t, f, f, null, null).
CONTEXT:  SQL statement "UPDATE ONLY "public"."account_journal" SET "sequence_id" = NULL WHERE $1 OPERATOR(pg_catalog.=) "sequence_id""
```

To avoid this problem, instead of blindly removing all this data, I just set it as `noupdate=0` to let the normal update process to delete it safely automatically.

@Tecnativa TT18838