### PR TITLE
[12.0][FIX] 303,facturas rectivicativas en 93 y 94

### DIFF
--- a/l10n_es_aeat_mod303/data/tax_code_map_mod303_data.xml
+++ b/l10n_es_aeat_mod303/data/tax_code_map_mod303_data.xml
@@ -647,7 +647,7 @@
         <field name="map_parent_id" ref="aeat_mod303_map"/>
         <field name="field_number">93</field>
         <field name="name">Entregas intracomunitarias exentas</field>
-        <field name="move_type">regular</field>
+        <field name="move_type">all</field>
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="False"/>
@@ -657,7 +657,7 @@
         <field name="map_parent_id" ref="aeat_mod303_map"/>
         <field name="field_number">94</field>
         <field name="name">Exportaciones y otras operaciones exentas con derecho a deducción</field>
-        <field name="move_type">regular</field>
+        <field name="move_type">all</field>
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="False"/>


### PR DESCRIPTION
Un cliente me comenta que en estas casillas se tienen que tener en cuenta facturas rectificativas, posiblemente en 83 y 96 también.

Algún contable por favor que revise y confirme si es así.