### PR TITLE
[12.0][l10n_es_aeat_mod347] -  adquisiciones y prestaciones de servicios extracomunitarias.

### DIFF
--- a/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
+++ b/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
@@ -63,6 +63,7 @@
         ref('l10n_es.account_tax_template_s_iva10s'),
         ref('l10n_es.account_tax_template_s_req014'),
         ref('l10n_es.account_tax_template_s_req52'),
+        ref('l10n_es.account_tax_template_s_iva_e'),
         ref('l10n_es.account_tax_template_s_iva0_isp'),
         ])]"/>
   </record>


### PR DESCRIPTION
Relativo a Operaciones con Terceros Países no miembros de la UE, las Prestaciones/Adquisiciones de servicios a/de Terceros Países deben declararse en el modelo 347:

http://www.supercontable.com/envios/articulos/BOLETIN_SUPERCONTABLE_08_2016_Contenido_General_6.htm

Esto es natural, dado que estas operaciones no se están declarando explícitamente en ninguna otra declaración a AEAT.