### PR TITLE
[10.0][FIX] l10n_es_aeat_mod347: Remove non existing fields

### DIFF
--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -82,22 +82,6 @@
                 <strong  class="text-right">Amount:</strong>
                 <p class="text-right" t-field="o.cash_amount"/>
               </div>
-              <div class="col-xs-2">
-                <strong  class="text-right">Amount 1Q:</strong>
-                <p class="text-right" t-field="o.first_quarter_cash_amount"/>
-              </div>
-              <div class="col-xs-2">
-                <strong  class="text-right">Amount 2Q:</strong>
-                <p class="text-right" t-field="o.second_quarter_cash_amount"/>
-              </div>
-              <div class="col-xs-2">
-                <strong  class="text-right">Amount 3Q:</strong>
-                <p class="text-right" t-field="o.third_quarter_cash_amount"/>
-              </div>
-              <div class="col-xs-2">
-                <strong  class="text-right">Amount 4Q:</strong>
-                <p class="text-right" t-field="o.fourth_quarter_cash_amount"/>
-              </div>
             </div>
 
             <t t-if="o.cash_record_ids">


### PR DESCRIPTION
Se han eliminado los campos del informe dado que ya no existen y daba error al imprimir. De esta manera el informe ahora queda como el de la 12.0 https://github.com/OCA/l10n-spain/blob/4b668a8791992cb60c8bbeee1f81fb4a3ded17ad/l10n_es_aeat_mod347/views/report_347_partner.xml#L77-L85