### PR TITLE
[11.0][FIX] l10n_es_aeat_mod347: Handle VAT correctly

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -11,7 +11,6 @@
 
 from odoo import fields, models, api, exceptions, _
 
-import re
 from datetime import datetime
 from calendar import monthrange
 import odoo.addons.decimal_precision as dp
@@ -190,29 +189,23 @@ class L10nEsAeatMod347Report(models.Model):
 
     @api.model
     def _get_partner_347_identification(self, partner):
-        partner_country_code, partner_vat = (
-            re.match(r"([A-Z]{0,2})(.*)", partner.vat or '').groups()
-        )
-        community_vat = ''
-        if not partner_country_code:
-            partner_country_code = partner.country_id.code
-        if partner_country_code == 'ES':
-            # Odoo Spanish states codes use car license plates approach
-            # (CR, A, M...), instead of ZIP (01, 02...), so we need to convert
-            # them, but fallbacking in the existing one if not found.
-            partner_state_code = self.SPANISH_STATES.get(
-                partner.state_id.code, partner.state_id.code,
-            )
+        country_code, _, vat = partner._parse_aeat_vat_info()
+        if country_code == 'ES':
+            return {
+                'partner_vat': vat,
+                # Odoo Spanish states codes use car license plates approach
+                # (CR, A, M...), instead of ZIP (01, 02...), so we need to
+                # convert them, but fallbacking in existing one if not found.
+                'partner_state_code': self.SPANISH_STATES.get(
+                    partner.state_id.code, partner.state_id.code),
+                'partner_country_code': country_code,
+            }
         else:
-            partner_vat = ''
-            community_vat = partner.vat
-            partner_state_code = 99
-        return {
-            'partner_vat': partner_vat,
-            'community_vat': community_vat,
-            'partner_state_code': partner_state_code,
-            'partner_country_code': partner_country_code,
-        }
+            return {
+                'community_vat': vat,
+                'partner_state_code': 99,
+                'partner_country_code': country_code,
+            }
 
     def _create_partner_records(self, key, map_ref, partner_record=None):
         partner_record_obj = self.env['l10n.es.aeat.mod347.partner_record']

--- a/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
+++ b/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
@@ -21,15 +21,26 @@ class TestL10nEsAeatMod347(TestL10nEsAeatModBase):
             'date_start': '2019-01-01',
             'date_end': '2019-12-31',
         })
-        self.customer_2 = self.customer.copy({'name': 'Test customer 2'})
+        self.customer_2 = self.customer.copy({
+            'name': 'Test customer 2',
+            'vat': 'ES12345678Z',
+        })
         self.customer_3 = self.customer.copy({'name': 'Test customer 3'})
-        self.customer_4 = self.customer.copy({'name': 'Test customer 4'})
+        self.customer_4 = self.customer.copy({
+            'name': 'Test customer 4',
+            'vat': 'ESB29805314',
+        })
         self.customer_5 = self.customer.copy({
             'name': 'Test customer 5',
             # For testing spanish states mapping
             'country_id': self.env.ref('base.es').id,
+            'vat': '12345678Z',
         })
-        self.customer_6 = self.customer.copy({'name': 'Test customer 6'})
+        self.customer_6 = self.customer.copy({
+            'name': 'Test customer 6',
+            'country_id': self.env.ref('base.es').id,
+            'vat': 'B29805314',
+        })
         self.supplier_2 = self.supplier.copy({'name': 'Test supplier 2'})
         # Invoice lower than the limit
         self.taxes_sale = {
@@ -116,6 +127,23 @@ class TestL10nEsAeatMod347(TestL10nEsAeatModBase):
             self.assertAlmostEqual(partner_record.second_quarter, vals[5])
             self.assertAlmostEqual(partner_record.third_quarter, vals[6])
             self.assertAlmostEqual(partner_record.fourth_quarter, vals[7])
+        # Check VAT handle
+        partner_record = self.model347.partner_record_ids.filtered(
+            lambda x: x.partner_id == self.customer_2)
+        self.assertEqual(partner_record.partner_vat, '12345678Z')
+        self.assertEqual(partner_record.partner_country_code, 'ES')
+        partner_record = self.model347.partner_record_ids.filtered(
+            lambda x: x.partner_id == self.customer_4)
+        self.assertEqual(partner_record.partner_vat, 'B29805314')
+        self.assertEqual(partner_record.partner_country_code, 'ES')
+        partner_record = self.model347.partner_record_ids.filtered(
+            lambda x: x.partner_id == self.customer_5)
+        self.assertEqual(partner_record.partner_vat, '12345678Z')
+        self.assertEqual(partner_record.partner_country_code, 'ES')
+        partner_record = self.model347.partner_record_ids.filtered(
+            lambda x: x.partner_id == self.customer_6)
+        self.assertEqual(partner_record.partner_vat, 'B29805314')
+        self.assertEqual(partner_record.partner_country_code, 'ES')
         # Export to BOE
         export_to_boe = self.env['l10n.es.aeat.report.export_to_boe'].create({
             'name': 'test_export_to_boe.txt',


### PR DESCRIPTION
Since v11, Odoo doesn't need the country code in VATs for performing the checks. You must fill country + putting the VAT with or without the country code.

This model doesn't work properly for the case where you don't introduce the country code.

We now use the method created for centralizing all the partner identification stuff that was introduced with VAT book for performing a proper recognition.

Included tests for checking all of the identification stuff.

cc @Tecnativa TT22153