### PR TITLE
[FIX] l10n_es_aeat_mod347

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -717,6 +717,7 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
             )
             del vals['community_vat']
             del vals['partner_country_code']
+            vals.update({'state_code': vals.pop('partner_state_code')})
             self.update(vals)
 
 

--- a/l10n_es_aeat_mod347/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod347/readme/CONTRIBUTORS.rst
@@ -10,3 +10,6 @@
   * Antonio Espinosa
   * Pedro M. Baeza
   * Cristina Martín
+* `Punt Sistemes <https://www.puntsistemes.es/>`_:
+
+  * Pedro Montagud <pmontagud@puntsistemes.es>


### PR DESCRIPTION
[FIX] l10n_es_aeat_mod347: this commit fix the error in the form when you are adding a real state record and you select a partner.