### PR TITLE
[11.0][FIX] l10n_es_dua_sii: SII tab hidden when DUA's fiscal position has not been defined

### DIFF
--- a/l10n_es_dua_sii/readme/CONTRIBUTORS.rst
+++ b/l10n_es_dua_sii/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
 
   * Alexandre Díaz
   * Pedro M. Baeza
+* Eric Antones - NuoBiT Solutions, S.L. <eantones@nuobit.com>


### PR DESCRIPTION
The "Fiscal position" field of the invoice is not a mandatory field so it might be not defined, in this case, its default value is "Régimen nacional".
The original module assumes that the fiscal position of the DUA always exists and this may not be so, mainly in multicompany environments where not all companies use DUA and they don't need to have this fiscal position created.