### PR TITLE
[10.0][FIX]l10n_es_aeat_mod347: Buscar solo los regisros de cash del modelo…

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -289,7 +289,8 @@ class L10nEsAeatMod347Report(models.Model):
                 move_lines = move_line_obj.search(cash_group['__domain'])
                 partner_record = partner_record_obj.search([
                     ('partner_id', '=', partner.id),
-                    ('operation_key', '=', 'B')
+                    ('operation_key', '=', 'B'),
+                    ('report_id', '=', self.id)
                 ])
                 if partner_record:
                     partner_record.write({


### PR DESCRIPTION
… actual, no de todos los existentes.

Si calculas un 347 de el ejercicio 2019 por ejemplo, se verán afectados los registros de cash del año 2018 si la empresa existía en este también.

Solo se debería hacer la búsqueda en los registros de empresas del modelo actual.