### PR TITLE
[11.0][IMP] l10n_es_vat_book: Avoid error on irregular cases of taxes combination

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -264,13 +264,14 @@ class L10nEsVatBook(models.Model):
             base_line = next(filter(
                 lambda l: not l['special_tax_group'], implied_lines))
             special_line = next(filter(
-                lambda l: l['special_tax_group'], implied_lines))
-            base_line.update({
-                'special_tax_id': special_line['tax_id'],
-                'special_tax_amount': special_line['tax_amount'],
-                'total_amount_special_include':
-                    base_line['total_amount'] + special_line['tax_amount'],
-            })
+                lambda l: l['special_tax_group'], implied_lines), None)
+            if special_line:
+                base_line.update({
+                    'special_tax_id': special_line['tax_id'],
+                    'special_tax_amount': special_line['tax_amount'],
+                    'total_amount_special_include':
+                        base_line['total_amount'] + special_line['tax_amount'],
+                })
 
     def _clear_old_data(self):
         """


### PR DESCRIPTION
En determinados casos se pueden encontrar apuntes asociados a la base impuestos especiales que no tienen apunte correspondiente a la cuota del impuesto por ser 0.
Con esta modificación se evita el error al calcular el libro de IVA, aunque lo ideal sería no tener este tipo de incoherencias en la contabilidad.

@Tecnativa TT22924