### PR TITLE
[12.0][FIX] l10n_es_vat_book: Update report to Bootstrap v4

### DIFF
--- a/l10n_es_vat_book/report/common_templates.xml
+++ b/l10n_es_vat_book/report/common_templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="l10n_es_vat_book.vat_book_dates">
-          <div class="col-xs-12 text-center" id="dates_div">
+          <div class="col-12 text-center" id="dates_div">
               <table class="detail_table" id="fiscal_periods_table">
                   <tbody class="invoice_tbody">
                       <tr>
@@ -34,7 +34,7 @@
     </template>
 
     <template id="l10n_es_vat_book.vat_book_contact">
-        <div class="col-xs-12 text-center" id="vat_book_contact_div">
+        <div class="col-12 text-center" id="vat_book_contact_div">
           <table class="detail_table" id="vat_book_contact_table">
               <tbody class="invoice_tbody">
                   <tr>

--- a/l10n_es_vat_book/report/vat_book_invoices_issued.xml
+++ b/l10n_es_vat_book/report/vat_book_invoices_issued.xml
@@ -18,7 +18,7 @@
            </style>
             <div class="row">
 
-              <div class="col-xs-12 text-center" id="title">
+              <div class="col-12 text-center" id="title">
                   <h3>BOOK REGISTER OF INVOICES ISSUED</h3>
               </div>
             </div>
@@ -27,13 +27,13 @@
               <t t-call="l10n_es_vat_book.vat_book_contact"/>
             </div>
             <div class="row">
-              <div class="col-xs-12 mt32" id="title_invoices_issued">
+              <div class="col-12 mt32" id="title_invoices_issued">
                 <h4>Issued Invoices</h4>
               </div>
             </div>
             <div class="row">
-              <div class="col-xs-12" id="invoices_issued_detail_div">
-                <table class="table table-condensed"
+              <div class="col-12" id="invoices_issued_detail_div">
+                <table class="table table-sm"
                        id="invoices_issued_detail_table">
                     <t t-call="l10n_es_vat_book.vat_book_invoices_head"/>
                     <tbody>
@@ -45,15 +45,15 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-xs-12 mt32"
+              <div class="col-12 mt32"
                    id="title_rectification_invoices_issued">
                 <h4>Issued Refund Invoices</h4>
               </div>
             </div>
             <div class="row">
-              <div class="col-xs-12"
+              <div class="col-12"
                    id="rectification_invoices_issued_detail_div">
-                <table class="table table-condensed"
+                <table class="table table-sm"
                        id="rectification_invoices_issued_detail_table">
                     <t t-call="l10n_es_vat_book.vat_book_invoices_head"/>
                     <tbody>
@@ -65,13 +65,13 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-xs-12 mt32" id="title_summary_invoices">
+              <div class="col-12 mt32" id="title_summary_invoices">
                 <h4>Summary</h4>
               </div>
             </div>
             <div class="row">
-              <div class="col-xs-12" id="div_summary_invoices">
-                  <table class="table table-condensed" id="table_sumary_invoices">
+              <div class="col-12" id="div_summary_invoices">
+                  <table class="table table-sm" id="table_sumary_invoices">
                       <t t-call="l10n_es_vat_book.vat_book_taxes_head"/>
                       <tbody>
                         <tr t-foreach="o.issued_tax_summary_ids"

--- a/l10n_es_vat_book/report/vat_book_invoices_received.xml
+++ b/l10n_es_vat_book/report/vat_book_invoices_received.xml
@@ -14,7 +14,7 @@
                }
            </style>
             <div class="row">
-              <div class="col-xs-12 text-center" id="title">
+              <div class="col-12 text-center" id="title">
                   <h3>BOOK REGISTER OF INVOICES RECEIVED</h3>
               </div>
             </div>
@@ -23,14 +23,14 @@
               <t t-call="l10n_es_vat_book.vat_book_contact"/>
             </div>
             <div class="row">
-              <div class="col-xs-12 mt32"
+              <div class="col-12 mt32"
                    id="title_invoices_received">
                 <h4>Received Invoices</h4>
               </div>
             </div>
             <div class="row">
-              <div class="col-xs-12" id="detail_div">
-                <table class="table table-condensed" id="detail_table">
+              <div class="col-12" id="detail_div">
+                <table class="table table-sm" id="detail_table">
                     <t t-call="l10n_es_vat_book.vat_book_invoices_head"/>
                     <tbody>
                         <tr t-foreach="o.received_line_ids" t-as="l">
@@ -41,15 +41,15 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-xs-12 mt32"
+              <div class="col-12 mt32"
                    id="title_rectification_invoices_received">
                 <h4>Received Refund Invoices</h4>
               </div>
             </div>
             <div class="row">
-                <div class="col-xs-12"
+                <div class="col-12"
                    id="rectification_invoices_received_detail_div">
-                <table class="table table-condensed"
+                <table class="table table-sm"
                        id="rectification_invoices_received_detail_table">
                     <t t-call="l10n_es_vat_book.vat_book_invoices_head"/>
                     <tbody>
@@ -61,11 +61,13 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-xs-12 mt32" id="title_summary_invoices">
+              <div class="col-12 mt32" id="title_summary_invoices">
                 <h4>Summary</h4>
               </div>
-              <div class="col-xs-12" id="div_summary_invoices">
-                  <table class="table table-condensed" id="table_summary_invoices">
+            </div>
+            <div class="row">
+              <div class="col-12" id="div_summary_invoices">
+                  <table class="table table-sm" id="table_summary_invoices">
                       <t t-call="l10n_es_vat_book.vat_book_taxes_head"/>
                       <tbody>
                         <tr t-foreach="o.received_tax_summary_ids"


### PR DESCRIPTION
**Antes:**
![l10n_es_vat_book_report_before](https://user-images.githubusercontent.com/29223264/77534073-51855b80-6e98-11ea-826a-c48805df3b91.png)


**Después:**
![l10n_es_vat_book_report_after](https://user-images.githubusercontent.com/29223264/77534085-56e2a600-6e98-11ea-841a-b8aa956ac190.png)
