### PR TITLE
[12.0] l10n_es_facturae: Aligerar dependencias

### DIFF
--- a/l10n_es_facturae/README.rst
+++ b/l10n_es_facturae/README.rst
@@ -53,7 +53,7 @@ Informacion sobre el formato:
 Installation
 ============
 
-Este módulo depende del módulo *account_payment_partner*, *account_banking_mandate* y sus
+Este módulo depende del módulo *account_payment_partner* y sus
 dependencias, que se encuentran en https://github.com/OCA/bank-payment.
 
 Para generar el archivo XML, hace falta el módulo *report_xml* que se encuentra
@@ -62,6 +62,10 @@ en https://github.com/OCA/reporting-engine.
 En el caso de querer firmar el formato FacturaE desde Odoo, debe instalarse la
 última versión de xmlsig mediante el comando ´pip install xmlsig´. La versión
 mínima de la misma debe ser 0.1.2.
+
+Si se instalan los módulos *account_banking_mandate* o *partner_firstname*, se
+utilizará para el XML generado la cuenta bancaria de los mandatos o los
+apellidos respectivamente.
 
 Configuration
 =============

--- a/l10n_es_facturae/__manifest__.py
+++ b/l10n_es_facturae/__manifest__.py
@@ -27,7 +27,6 @@
         "partner_firstname",
         "report_xml",
         "report_qweb_parameter",
-        "account_banking_mandate"
     ],
     "data": [
         "data/log_counter.xml",

--- a/l10n_es_facturae/__manifest__.py
+++ b/l10n_es_facturae/__manifest__.py
@@ -24,7 +24,6 @@
         "l10n_es",
         "base_iso3166",
         "base_vat",
-        "partner_firstname",
         "report_xml",
         "report_qweb_parameter",
     ],

--- a/l10n_es_facturae/models/account_invoice.py
+++ b/l10n_es_facturae/models/account_invoice.py
@@ -208,16 +208,7 @@ class AccountInvoice(models.Model):
             raise ValidationError(_('Company vat is too small'))
         if not self.payment_mode_id:
             raise ValidationError(_('Payment mode is required'))
-        if self.payment_mode_id.facturae_code == '02':
-            if not self.mandate_id:
-                raise ValidationError(_('Mandate is missing'))
-            if not self.mandate_id.partner_bank_id:
-                raise ValidationError(_('Partner bank in mandate is missing'))
-            if len(self.mandate_id.partner_bank_id.bank_id.bic) != 11:
-                raise ValidationError(_('Mandate account BIC must be 11'))
-            if len(self.mandate_id.partner_bank_id.acc_number) < 5:
-                raise ValidationError(_('Mandate account is too small'))
-        else:
+        if self.payment_mode_id.facturae_code:
             partner_bank = self.partner_banks_to_show()[:1]
             if not partner_bank:
                 raise ValidationError(_('Partner bank is missing'))

--- a/l10n_es_facturae/readme/INSTALL.rst
+++ b/l10n_es_facturae/readme/INSTALL.rst
@@ -1,4 +1,4 @@
-Este módulo depende del módulo *account_payment_partner*, *account_banking_mandate* y sus
+Este módulo depende del módulo *account_payment_partner* y sus
 dependencias, que se encuentran en https://github.com/OCA/bank-payment.
 
 Para generar el archivo XML, hace falta el módulo *report_xml* que se encuentra
@@ -7,3 +7,7 @@ en https://github.com/OCA/reporting-engine.
 En el caso de querer firmar el formato FacturaE desde Odoo, debe instalarse la
 última versión de xmlsig mediante el comando ´pip install xmlsig´. La versión
 mínima de la misma debe ser 0.1.2.
+
+Si se instalan los módulos *account_banking_mandate* o *partner_firstname*, se
+utilizará para el XML generado la cuenta bancaria de los mandatos o los
+apellidos respectivamente.

--- a/l10n_es_facturae/static/description/index.html
+++ b/l10n_es_facturae/static/description/index.html
@@ -405,13 +405,16 @@ a su destino. La administración le proporcionará estos datos.</p>
 </div>
 <div class="section" id="installation">
 <h1><a class="toc-backref" href="#id1">Installation</a></h1>
-<p>Este módulo depende del módulo <em>account_payment_partner</em>, <em>account_banking_mandate</em> y sus
+<p>Este módulo depende del módulo <em>account_payment_partner</em> y sus
 dependencias, que se encuentran en <a class="reference external" href="https://github.com/OCA/bank-payment">https://github.com/OCA/bank-payment</a>.</p>
 <p>Para generar el archivo XML, hace falta el módulo <em>report_xml</em> que se encuentra
 en <a class="reference external" href="https://github.com/OCA/reporting-engine">https://github.com/OCA/reporting-engine</a>.</p>
 <p>En el caso de querer firmar el formato FacturaE desde Odoo, debe instalarse la
 última versión de xmlsig mediante el comando ´pip install xmlsig´. La versión
 mínima de la misma debe ser 0.1.2.</p>
+<p>Si se instalan los módulos <em>account_banking_mandate</em> o <em>partner_firstname</em>, se
+utilizará para el XML generado la cuenta bancaria de los mandatos o los
+apellidos respectivamente.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#id2">Configuration</a></h1>

--- a/l10n_es_facturae/tests/test_l10n_es_facturae.py
+++ b/l10n_es_facturae/tests/test_l10n_es_facturae.py
@@ -65,21 +65,11 @@ class TestL10nEsFacturae(common.TransactionCase):
                 'bank_id': self.env['res.bank'].search(
                     [('bic', '=', 'PSSTFRPPXXX')], limit=1).id
             })
-        self.mandate = self.env['account.banking.mandate'].create({
-            'company_id': main_company.id,
-            'format': 'basic',
-            'partner_id': self.partner.id,
-            'state': 'valid',
-            'partner_bank_id': self.bank.id,
-            'signature_date': '2016-03-12',
-        })
-
         self.payment_method = self.env['account.payment.method'].create({
             'name': 'inbound_mandate',
             'code': 'inbound_mandate',
             'payment_type': 'inbound',
             'bank_account_required': False,
-            'mandate_required': True,
             'active': True
         })
         payment_methods = self.env['account.payment.method'].search([
@@ -141,7 +131,6 @@ class TestL10nEsFacturae(common.TransactionCase):
             'date_invoice': '2016-03-12',
             'partner_bank_id': self.bank.id,
             'payment_mode_id': self.payment_mode_02.id,
-            'mandate_id': self.mandate.id
         })
 
         self.invoice_line_02 = self.env['account.invoice.line'].create({

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -333,17 +333,17 @@
                                 <InstallmentDueDate t-esc="invoice.date_due or invoice.date_invoice"/>
                                 <InstallmentAmount t-esc="'%.2f' % (invoice.residual)"/>
                                 <PaymentMeans t-esc="invoice.payment_mode_id.facturae_code"/>
+                                <t t-set="partner_bank" t-value="invoice.partner_banks_to_show()[:1]"/>
+                                <t t-set="bank" t-value="partner_bank.bank_id"/>
                                 <AccountToBeDebited t-if="invoice.payment_mode_id.facturae_code == '02'">
-                                    <IBAN t-minlength="5" t-length="34" t-esc="''.join(invoice.mandate_id.partner_bank_id.acc_number.split())"/>
-                                    <BankCode t-length="60" t-esc="invoice.partner_bank_id.bank_id.code"/>
+                                    <IBAN t-minlength="5" t-length="34" t-esc="''.join(partner_bank.acc_number.split())"/>
+                                    <BankCode t-length="60" t-esc="bank.code" t-if="bank.code"/>
                                     <BranchCode t-length="60" t-if="False"/>
-                                    <BIC t-minlength="11" t-length="11" t-esc="invoice.mandate_id.partner_bank_id.bank_id.bic"/>
+                                    <BIC t-minlength="11" t-length="11" t-esc="bank.bic" t-if="bank.bic"/>
                                     <PaymentReconciliationReference t-length="60" t-if="False"/>
                                 </AccountToBeDebited>
                                 <AccountToBeCredited t-if="invoice.payment_mode_id.facturae_code != '02'">
-                                    <t t-set="partner_bank" t-value="invoice.partner_banks_to_show()[:1]"/>
                                     <IBAN t-minlength="5" t-length="34" t-esc="''.join(partner_bank.acc_number.split())"/>
-                                    <t t-set="bank" t-value="partner_bank.bank_id"/>
                                     <BankCode t-length="60" t-esc="bank.code" t-if="bank.code"/>
                                     <BranchCode t-length="60" t-if="False"/>
                                     <BIC t-minlength="11" t-length="11" t-esc="bank.bic" t-if="bank.bic"/>

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -16,8 +16,8 @@
         <AdministrativeCentre>
             <CentreCode t-length="10" t-esc="centre_code"/>
             <RoleTypeCode t-esc="role_type_code"/>
-            <Name t-length="40" t-esc="partner.firstname" t-if="not partner.is_company"/>
-            <FirstSurname t-length="40" t-esc="partner.lastname" t-if="not partner.is_company"/>
+            <Name t-length="40" t-esc="partner.firstname if partner._fields.get('firstname') else partner.name" t-if="not partner.is_company"/>
+            <FirstSurname t-length="40" t-esc="partner.lastname if partner._fields.get('lastname') else ''" t-if="not partner.is_company"/>
             <SecondSurname t-if="False"/>
             <t t-call="l10n_es_facturae.address_contact">
                 <t t-set="partner" t-value="partner"/>
@@ -66,8 +66,8 @@
             </t>
         </LegalEntity>
         <Individual t-if="buyer_type == 'F'">
-            <Name t-length="40" t-esc="partner.firstname"/>
-            <FirstSurname t-length="40" t-esc="partner.lastname"/>
+            <Name t-length="40" t-esc="partner.firstname if partner._fields.get('firstname') else partner.name"/>
+            <FirstSurname t-length="40" t-esc="partner.lastname if partner._fields.get('lastname') else ''"/>
             <SecondSurname t-length="40" t-esc="''"/>
             <t t-call="l10n_es_facturae.address_contact">
             </t>


### PR DESCRIPTION
Básicamente es quitar como dependencias `account_banking_mandate` y `partner_firstname`, pero sin perder la funcionalidad. ¿Por qué? Porque no son necesarios realmente para generar FacturaE, y responde a flujos específicos. Sin querer estropear esos flujos, quitamos la necesidad de tener esos módulos, siendo uno de ellos además bastante injerente (el `partner_firstname`).

Texto de los commits:

* `account_banking_mandate`: Use same bank fetch criteria in both debited/credited

  Standard `account_payment_partner` code already takes into account specific mandate and this way we avoid a hard dependency that is not the main core of the module.

* `partner_firstname`: We keep compatibility through discovery in case of having it installed.

cc @Tecnativa TT22937