### PR TITLE
[11.0][FIX] l10n_es_aeat_mod349: operation key not computed on custom taxes

### DIFF
--- a/l10n_es_aeat_mod349/README.rst
+++ b/l10n_es_aeat_mod349/README.rst
@@ -127,6 +127,10 @@ Contribudores
 
 * Aitor Bouzas <aitor.bouzas@adaptivecity.com>
 
+* NuoBiT Solutions, S.L.
+
+  * Eric Antones <eantones@nuobit.com>
+
 Mantenedor
 ----------
 

--- a/l10n_es_aeat_mod349/models/account_tax.py
+++ b/l10n_es_aeat_mod349/models/account_tax.py
@@ -24,7 +24,9 @@ class AccountTax(models.Model):
         map_349 = self.env['aeat.349.map.line'].search([])
         for tax in self:
             for line in map_349:
-                if any([tax.name == tmpl.name or tax.description == tmpl.name
+                if any([tax.name == tmpl.name or
+                        tax.description == tmpl.name or
+                        tax.description == tmpl.description
                         for tmpl in line.tax_tmpl_ids]):
                     tax.l10n_es_aeat_349_operation_key = line.operation_key
                     break


### PR DESCRIPTION
El campo "AEAT 349 Clave de operación" del impuesto no se actualiza en impuestos personalizados ya que, en el mapeo, únicamente se busca por el nombre del impuesto y no también por la descripción (que en la versión 11 seria el código del impuesto).