### PR TITLE
[11.0] l10n_es_aeat_*: [FIX] Caracteres no válidos 'NIF Empresa Desar…

### DIFF
--- a/l10n_es_aeat_mod111/data/aeat_export_mod111_data.xml
+++ b/l10n_es_aeat_mod111/data/aeat_export_mod111_data.xml
@@ -629,7 +629,7 @@
         <field name="sequence">9</field>
         <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
         <field name="name">Versión del programa</field>
-        <field name="fixed_value">9.0</field>
+        <field name="fixed_value">odoo</field>
         <field name="export_type">string</field>
         <field name="size">4</field>
         <field name="alignment">left</field>
@@ -649,7 +649,7 @@
         <field name="sequence">11</field>
         <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
         <field name="name">NIF Empresa Desarrollo</field>
-        <field name="fixed_value">Odoo</field>
+        <field name="fixed_value">G87846952</field>
         <field name="export_type">string</field>
         <field name="size">9</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod115/data/aeat_export_mod115_data.xml
+++ b/l10n_es_aeat_mod115/data/aeat_export_mod115_data.xml
@@ -335,7 +335,7 @@
         <field name="sequence">9</field>
         <field name="export_config_id" ref="aeat_mod115_main_export_config"/>
         <field name="name">Versión del programa</field>
-        <field name="fixed_value">11.0</field>
+        <field name="fixed_value">odoo</field>
         <field name="export_type">string</field>
         <field name="size">4</field>
         <field name="alignment">left</field>
@@ -355,7 +355,7 @@
         <field name="sequence">11</field>
         <field name="export_config_id" ref="aeat_mod115_main_export_config"/>
         <field name="name">NIF Empresa Desarrollo</field>
-        <field name="fixed_value">Odoo</field>
+        <field name="fixed_value">G87846952</field>
         <field name="export_type">string</field>
         <field name="size">9</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod123/data/aeat_export_mod123_data.xml
+++ b/l10n_es_aeat_mod123/data/aeat_export_mod123_data.xml
@@ -367,7 +367,7 @@
             <field name="sequence">9</field>
             <field name="export_config_id" ref="aeat_mod123_main_export_config"/>
             <field name="name">Versión del programa</field>
-            <field name="fixed_value">11.0</field>
+            <field name="fixed_value">odoo</field>
             <field name="export_type">string</field>
             <field name="size">4</field>
             <field name="alignment">left</field>
@@ -387,7 +387,7 @@
             <field name="sequence">11</field>
             <field name="export_config_id" ref="aeat_mod123_main_export_config"/>
             <field name="name">NIF Empresa Desarrollo</field>
-            <field name="fixed_value">Odoo</field>
+            <field name="fixed_value">G87846952</field>
             <field name="export_type">string</field>
             <field name="size">9</field>
             <field name="alignment">left</field>

--- a/l10n_es_aeat_mod130/data/aeat_export_mod130_data.xml
+++ b/l10n_es_aeat_mod130/data/aeat_export_mod130_data.xml
@@ -488,7 +488,7 @@
         <field name="sequence">9</field>
         <field name="export_config_id" ref="aeat_mod130_export_config"/>
         <field name="name">Versión del Programa</field>
-        <field name="fixed_value">11.0</field>
+        <field name="fixed_value">odoo</field>
         <field name="export_type">string</field>
         <field name="size">4</field>
         <field name="alignment">left</field>
@@ -508,7 +508,7 @@
         <field name="sequence">11</field>
         <field name="export_config_id" ref="aeat_mod130_export_config"/>
         <field name="name">NIF Empresa Desarrollo</field>
-        <field name="fixed_value">Odoo</field>
+        <field name="fixed_value">G87846952</field>
         <field name="export_type">string</field>
         <field name="size">9</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2018_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2018_data.xml
@@ -2747,7 +2747,7 @@
         <field name="sequence">9</field>
         <field name="export_config_id" ref="aeat_mod303_2018_main_export_config"/>
         <field name="name">Versión del Programa: </field>
-        <field name="fixed_value">Odoo</field>
+        <field name="fixed_value">odoo</field>
         <field name="export_type">string</field>
         <field name="size">4</field>
         <field name="alignment">left</field>
@@ -2767,7 +2767,7 @@
         <field name="sequence">11</field>
         <field name="export_config_id" ref="aeat_mod303_2018_main_export_config"/>
         <field name="name">NIF Empresa Desarrollo</field>
-        <field name="fixed_value">A00000000</field>
+        <field name="fixed_value">G87846952</field>
         <field name="export_type">string</field>
         <field name="size">9</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2019_main_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2019_main_data.xml
@@ -94,7 +94,7 @@
         <field name="sequence">9</field>
         <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
         <field name="name">Versión del programa</field>
-        <field name="fixed_value">11.0</field>
+        <field name="fixed_value">odoo</field>
         <field name="export_type">string</field>
         <field name="size">4</field>
         <field name="alignment">left</field>
@@ -114,7 +114,7 @@
         <field name="sequence">11</field>
         <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
         <field name="name">NIF Empresa Desarrollo</field>
-        <field name="fixed_value"/>
+        <field name="fixed_value">G87846952</field>
         <field name="export_type">string</field>
         <field name="size">9</field>
         <field name="alignment">left</field>


### PR DESCRIPTION
Se crea PR para aplicar los cambios realizados en la v12 para corregir el error de "NIF de empresa de desarrollo" en la presentación de las declaraciones desde fichero a la agenciatributaria.es. Este PR asigna como NIF el de la Asociación Española de Odoo como solución.

