### PR TITLE
[8.0] l10n_es_aeat_*: [FIX] Caracteres no válidos 'NIF Empresa Desarr…

### DIFF
--- a/l10n_es_aeat_mod111/data/aeat_export_mod111_data.xml
+++ b/l10n_es_aeat_mod111/data/aeat_export_mod111_data.xml
@@ -625,7 +625,7 @@
             <field name="sequence">9</field>
             <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
             <field name="name">Versión del programa</field>
-            <field name="fixed_value">8.0</field>
+            <field name="fixed_value">odoo</field>
             <field name="export_type">string</field>
             <field name="size">4</field>
             <field name="alignment">left</field>
@@ -645,7 +645,7 @@
             <field name="sequence">11</field>
             <field name="export_config_id" ref="aeat_mod111_main_export_config"/>
             <field name="name">NIF Empresa Desarrollo</field>
-            <field name="fixed_value">Odoo</field>
+            <field name="fixed_value">G87846952</field>
             <field name="export_type">string</field>
             <field name="size">9</field>
             <field name="alignment">left</field>

--- a/l10n_es_aeat_mod115/data/aeat_export_mod115_2017_data.xml
+++ b/l10n_es_aeat_mod115/data/aeat_export_mod115_2017_data.xml
@@ -321,7 +321,7 @@
         <field name="sequence">9</field>
         <field name="export_config_id" ref="aeat_mod115_2017_main_export_config"/>
         <field name="name">Versión del Programa: </field>
-        <field name="fixed_value">8.0</field>
+        <field name="fixed_value">odoo</field>
         <field name="export_type">string</field>
         <field name="size">4</field>
         <field name="alignment">left</field>
@@ -341,7 +341,7 @@
         <field name="sequence">11</field>
         <field name="export_config_id" ref="aeat_mod115_2017_main_export_config"/>
         <field name="name">NIF Empresa Desarrollo</field>
-        <field name="fixed_value">Odoo</field>
+        <field name="fixed_value">G87846952</field>
         <field name="export_type">string</field>
         <field name="size">9</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod115/data/aeat_export_mod115_2017_data.xml
+++ b/l10n_es_aeat_mod115/data/aeat_export_mod115_2017_data.xml
@@ -321,7 +321,7 @@
         <field name="sequence">9</field>
         <field name="export_config_id" ref="aeat_mod115_2017_main_export_config"/>
         <field name="name">Versión del Programa: </field>
-        <field name="fixed_value">odoo</field>
+        <field name="fixed_value">8.0</field>
         <field name="export_type">string</field>
         <field name="size">4</field>
         <field name="alignment">left</field>
@@ -341,7 +341,7 @@
         <field name="sequence">11</field>
         <field name="export_config_id" ref="aeat_mod115_2017_main_export_config"/>
         <field name="name">NIF Empresa Desarrollo</field>
-        <field name="fixed_value">G87846952</field>
+        <field name="fixed_value">Odoo</field>
         <field name="export_type">string</field>
         <field name="size">9</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod123/data/aeat_export_mod123_data.xml
+++ b/l10n_es_aeat_mod123/data/aeat_export_mod123_data.xml
@@ -366,7 +366,7 @@
             <field name="sequence">9</field>
             <field name="export_config_id" ref="aeat_mod123_main_export_config"/>
             <field name="name">Versión del programa</field>
-            <field name="fixed_value">8.0</field>
+            <field name="fixed_value">odoo</field>
             <field name="export_type">string</field>
             <field name="size">4</field>
             <field name="alignment">left</field>
@@ -386,7 +386,7 @@
             <field name="sequence">11</field>
             <field name="export_config_id" ref="aeat_mod123_main_export_config"/>
             <field name="name">NIF Empresa Desarrollo</field>
-            <field name="fixed_value">Odoo</field>
+            <field name="fixed_value">G87846952</field>
             <field name="export_type">string</field>
             <field name="size">9</field>
             <field name="alignment">left</field>

--- a/l10n_es_aeat_mod303/data/aeat_export_mod303_2018_data.xml
+++ b/l10n_es_aeat_mod303/data/aeat_export_mod303_2018_data.xml
@@ -2743,7 +2743,7 @@
             <field name="sequence">9</field>
             <field name="export_config_id" ref="aeat_mod303_2018_main_export_config"/>
             <field name="name">Versión del Programa: </field>
-            <field name="fixed_value">8.0</field>
+            <field name="fixed_value">odoo</field>
             <field name="export_type">string</field>
             <field name="size">4</field>
             <field name="alignment">left</field>
@@ -2763,7 +2763,7 @@
             <field name="sequence">11</field>
             <field name="export_config_id" ref="aeat_mod303_2018_main_export_config"/>
             <field name="name">NIF Empresa Desarrollo</field>
-            <field name="fixed_value">Odoo</field>
+            <field name="fixed_value">G87846952</field>
             <field name="export_type">string</field>
             <field name="size">9</field>
             <field name="alignment">left</field>


### PR DESCRIPTION
Buenas @pedrobaeza @rlizana 

Este es el PR para aplicar los cambios realizados en la v12 para corregir el error de "NIF de empresa de desarrollo" en la presentación de las declaraciones desde fichero a la agenciatributaria.es en la V8. Este PR asigna como NIF el de la Asociación Española de Odoo como solución.

Un saludo

