### PR TITLE
[11.0][FIX] l10n_es_vat_book: Error on special line

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -262,10 +262,10 @@ class L10nEsVatBook(models.Model):
                 tax_lines[key]['special_tax_group'] = tax_group
         if vat_book_line['special_tax_group']:
             base_line = next(filter(
-                lambda l: not l['special_tax_group'], implied_lines))
+                lambda l: not l['special_tax_group'], implied_lines), None)
             special_line = next(filter(
                 lambda l: l['special_tax_group'], implied_lines), None)
-            if special_line:
+            if base_line and special_line:
                 base_line.update({
                     'special_tax_id': special_line['tax_id'],
                     'special_tax_amount': special_line['tax_amount'],


### PR DESCRIPTION
Buenas,

Nos hemos encontrado en los asientos contables que tienen recargo de equivalencia, el fallo en la linea que corresponde al recargo de equivalencia.

![Selección_036](https://user-images.githubusercontent.com/6359121/80513456-5ea5d680-897f-11ea-8b71-5a37198b71e6.png)

Cuya linea de impuesto especial no contiene una línea correspondiente de base asociada, por lo cual provoca error al obtener la información de base_line.

Ademas hemos incluido una mejora de rendimiento al obtener todas las lineas de los apuntes contables que son necesarios para calcular el libro de IVA, ya que a partir de un volumen de lineas de apuntes contables, realizar así el search nos provocaba un coste de rendimiento mucho mayor que de la forma que proponemos.

Un saludo

@pedrobaeza @carlosdauden @Tardo Os menciono por vuestros aportes en el ticket #1314 y este pueda ser de vuestro interés
