### PR TITLE
[11.0][FIX] l10n_es_aeat_mod303: Se añade el iva exento repercutido

### DIFF
--- a/l10n_es_aeat_mod303/data/tax_code_map_mod303_data.xml
+++ b/l10n_es_aeat_mod303/data/tax_code_map_mod303_data.xml
@@ -560,7 +560,7 @@
     <field name="inverse" eval="False"/>
     <!-- Base facturas de venta (haber) - Base facturas rectificativas de venta (debe):
          S_IVA0_E -->
-    <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_s_iva0_e')])]"/>
+    <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_s_iva0_e'), ref('l10n_es.account_tax_template_s_iva0')])]"/>
 </record>
 <record id="aeat_mod303_map_line_61" model="l10n.es.aeat.map.tax.line">
     <field name="map_parent_id" ref="aeat_mod303_map"/>

--- a/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
+++ b/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
@@ -34,6 +34,7 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
         'S_IVA0_ISP': (2300, 0),
         'S_IVA0_IC': (2400, 0),
         'S_IVA0_SP_I': (2500, 0),
+        'S_IVA0': (2600, 0),
     }
     taxes_purchase = {
         # tax code: (base, tax_amount)
@@ -232,7 +233,7 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
         # Entregas intra. de bienes y servicios - Base ventas
         '59': (2 * 2400) + (2 * 2500),  # S_IVA0_IC, S_IVA0_SP_I
         # Exportaciones y operaciones asimiladas - Base ventas
-        '60': (2 * 2000),  # S_IVA0_E
+        '60': (2 * 2000) + (2 * 2600),  # S_IVA0_E + S_IVA0
         # Op. no sujetas o con inv. del sujeto pasivo - Base ventas
         '61': ((2 * 2100) + (2 * 2200) +   # S_IVA_SP_E, S_IVA_NS
                (2 * 2300)),                # S_IVA0_ISP
@@ -399,7 +400,7 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
             ).amount, 14280.0,
         )
         self.assertAlmostEqual(
-            self.model303_4t.casilla_88, 38280.0,
+            self.model303_4t.casilla_88, 30480.0,
         )
         # Check change of period type
         self.model303_4t.period_type = '1T'


### PR DESCRIPTION
Hola,

Corrección a lo hablado en https://github.com/OCA/l10n-spain/issues/1300