### PR TITLE
[12.0][FIX] facturae: keys were not loaded properly

### DIFF
--- a/l10n_es_facturae_efact/models/account_invoice_integration_log.py
+++ b/l10n_es_facturae_efact/models/account_invoice_integration_log.py
@@ -27,7 +27,8 @@ class AccountInvoiceIntegration(models.Model):
         connection.load_system_host_keys()
         connection.connect(
             ICP.get_param("account.invoice.efact.server", default=None),
-            port=ICP.get_param("account.invoice.efact.port", default=None),
+            port=int(ICP.get_param(
+                "account.invoice.efact.port", default=None)),
             username=ICP.get_param(
                 "account.invoice.efact.user", default=None),
             password=ICP.get_param(

--- a/l10n_es_facturae_efact/tests/test_efact.py
+++ b/l10n_es_facturae_efact/tests/test_efact.py
@@ -22,6 +22,8 @@ class TestConnection:
     def __init__(self, data, filename=''):
         self.data = data
         self.filename = filename
+        self._host_keys = {}
+        self._system_host_keys = {}
 
     def connect(self, hostname, port, username, password):
         return


### PR DESCRIPTION
Depende de que versión de paramiko se usa, requiere que el puerto sea un entero.