### PR TITLE
[12.0][l10n_es_vat_book] Avoid considering tax fee as base, for taxes with subsequent taxes base checked

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -215,7 +215,8 @@ class L10nEsVatBook(models.Model):
         if vat_book_line['line_type'] in [
                 'received', 'rectification_received']:
             balance = -balance
-        base_amount_untaxed = balance if move_line.tax_ids else 0.0
+        base_amount_untaxed = balance if move_line.tax_ids and not \
+            move_line.tax_line_id else 0.0
         fee_amount_untaxed = balance if move_line.tax_line_id else 0.0
         return {
             'tax_id': move_line.tax_line_id.id,


### PR DESCRIPTION
Hola,

La base informada en el libro de IVA no es correcta cuando existen documentos con la posición fiscal "REAGYP - Agricultura", aplicando los impuestos "12% IVA Soportado régimen agricultura" y "Retenciones IRPF 2%". Dado que el impuesto "12% IVA Soportado régimen agricultura" es "Base imponible de subsiguientes" lo que sucede es que incluye la "Cuota IVA" calculada como "Base imponible" de IVA, cuando debería considerarla únicamente como "Base imponible" para el cálculo del IRPF.
El mismo error sucede con la posición fiscal "REAGYP - Ganadería y pesca" en la que se aplican los impuestos "10,5% IVA Soportado régimen ganadero o pesca" y "Retenciones IRPF 2%".

**Por ejemplo**

* Factura:

![c1pr](https://user-images.githubusercontent.com/18459755/82655444-7b51c900-9c22-11ea-9182-533202b1605c.png)

* Libro IVA antes del PR

![c2pr](https://user-images.githubusercontent.com/18459755/82655564-a5a38680-9c22-11ea-9c82-e8866ca096f5.png)

* Libro IVA despues del PR

![image](https://user-images.githubusercontent.com/18459755/82655715-e9968b80-9c22-11ea-8788-751aacc14d90.png)
