### PR TITLE
[12.0] [FIX] payment_redsys process order call form_feedback

### DIFF
--- a/payment_redsys/__manifest__.py
+++ b/payment_redsys/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Pasarela de pago Redsys',
     'category': 'Payment Acquirer',
     'summary': 'Payment Acquirer: Redsys Implementation',
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.1.1',
     'author': "Tecnativa,"
               "Odoo Community Association (OCA)",
     'depends': [

--- a/payment_redsys/controllers/main.py
+++ b/payment_redsys/controllers/main.py
@@ -40,4 +40,5 @@ class RedsysController(http.Controller):
         ['/payment/redsys/result/<page>'], type='http', auth='public',
         methods=['GET'], website=True)
     def redsys_result(self, page, **vals):
+        request.env['payment.transaction'].sudo().form_feedback(vals, 'redsys')
         return werkzeug.utils.redirect('/payment/process')


### PR DESCRIPTION
Este PR soluciona el problema que se queda el Pedido de venta sin procesar (no se valida ni se confirma el resto del flujo) cuando Redsys devuelve la respuesta del OK de la transacción
(El método actual redirecciona a /payment/process que esta correcto, pero no se hace nada con la respuesta de Redsys, en este caso el encargado sería form_feedback, por si os ayuda un poco el por que se ha hecho esta modificación. )
