### PR TITLE
[FIX] l10n_es_account_asset. Percentage dotation number

### DIFF
--- a/l10n_es_account_asset/models/account_asset.py
+++ b/l10n_es_account_asset/models/account_asset.py
@@ -106,9 +106,13 @@ class AccountAssetAsset(models.Model):
             percentage = 100.0
             while percentage > 0:
                 if number == 0 and self.prorata:
-                    total_days = calendar.monthrange(
-                        depreciation_date.year, depreciation_date.month)[1]
-                    days = total_days - float(depreciation_date.day) + 1
+                    if self.method_period == 1:
+                        total_days = calendar.monthrange(
+                            depreciation_date.year, depreciation_date.month)[1]
+                    	days = total_days - float(depreciation_date.day) + 1
+                    else:
+	                    days = (total_days - float(
+                            depreciation_date.strftime('%j'))) + 1 
                     percentage -= self.method_percentage * days / total_days
                 else:
                     percentage -= self.method_percentage


### PR DESCRIPTION
Al calcular el número de elementos del cuadro no considera del número de meses de cada amortización lo que resulta generalmente  en un cuadro incorrecto con una amortización menos de las necesarias.