### PR TITLE
[12.0][IMP] Crea método para obtener si una factura se enviará como simplificada o completa

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -619,6 +619,14 @@ class AccountInvoice(models.Model):
         return taxes_dict, tax_amount
 
     @api.multi
+    def _is_sii_simplified_invoice(self):
+        """Inheritable method to allow control when an
+        invoice are simplified or normal"""
+        partner = self.partner_id.commercial_partner_id
+        is_simplified = partner.sii_simplified_invoice
+        return is_simplified
+
+    @api.multi
     def _sii_check_exceptions(self):
         """Inheritable method for exceptions control when sending SII invoices.
         """
@@ -626,12 +634,14 @@ class AccountInvoice(models.Model):
         gen_type = self._get_sii_gen_type()
         partner = self.partner_id.commercial_partner_id
         country_code = self._get_sii_country_code()
-        if partner.sii_simplified_invoice and self.type[:2] == 'in':
+        is_simplified_invoice = self._is_sii_simplified_invoice()
+
+        if is_simplified_invoice and self.type[:2] == 'in':
             raise exceptions.Warning(
                 _("You can't make a supplier simplified invoice.")
             )
         if ((gen_type != 3 or country_code == 'ES') and
-                not partner.vat and not partner.sii_simplified_invoice):
+                not partner.vat and not is_simplified_invoice):
             raise exceptions.Warning(
                 _("The partner has not a VAT configured.")
             )
@@ -679,6 +689,7 @@ class AccountInvoice(models.Model):
         company = self.company_id
         ejercicio = fields.Date.to_date(self.date).year
         periodo = '%02d' % fields.Date.to_date(self.date).month
+        is_simplified_invoice = self._is_sii_simplified_invoice()
         inv_dict = {
             "IDFactura": {
                 "IDEmisorFactura": {
@@ -698,14 +709,13 @@ class AccountInvoice(models.Model):
         if not cancel:
             # Check if refund type is 'By differences'. Negative amounts!
             sign = self._get_sii_sign()
-            simplied = partner.sii_simplified_invoice
             if self.type == 'out_refund':
                 if self.sii_refund_specific_invoice_type:
                     tipo_factura = self.sii_refund_specific_invoice_type
                 else:
-                    tipo_factura = 'R5' if simplied else 'R1'
+                    tipo_factura = 'R5' if is_simplified_invoice else 'R1'
             else:
-                tipo_factura = 'F2' if simplied else 'F1'
+                tipo_factura = 'F2' if is_simplified_invoice else 'F1'
             inv_dict["FacturaExpedida"] = {
                 "TipoFactura": tipo_factura,
                 "ClaveRegimenEspecialOTrascendencia": (
@@ -736,7 +746,7 @@ class AccountInvoice(models.Model):
                     }
                 }
             exp_dict = inv_dict['FacturaExpedida']
-            if not partner.sii_simplified_invoice:
+            if not is_simplified_invoice:
                 # Simplified invoices don't have counterpart
                 exp_dict["Contraparte"] = {
                     "NombreRazon": partner.name[0:120],

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -357,3 +357,19 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.assertFalse(invoice.sii_refund_type)
         invoice.type = 'out_refund'
         self.assertEqual(invoice.sii_refund_type, 'I')
+
+    def test_is_sii_simplified_invoice(self):
+        self.assertFalse(self.invoice._is_sii_simplified_invoice())
+        self.partner.sii_simplified_invoice = True
+        self.assertTrue(self.invoice._is_sii_simplified_invoice())
+
+    def test_sii_check_exceptions_case_supplier_simplified(self):
+        self.partner.is_simplified_invoice = True
+        invoice = self.env['account.invoice'].create({
+            'partner_id': self.partner.id,
+            'date_invoice': '2018-02-01',
+            'type': 'in_invoice',
+            'account_id': self.partner.property_account_payable_id.id,
+        })
+        with self.assertRaises(exceptions.Warning):
+            invoice._sii_check_exceptions()


### PR DESCRIPTION
Al hilo de: [#1171](https://github.com/OCA/l10n-spain/issues/1171#issuecomment-651198092)
La idea de este PR es facilitar la modificación de la forma en que se obtiene si una factura es simplificada o no.
Se veis el link anterior, hay casos en los que es mejor controlar a nivel de factura si cuando se envía al SII se hace como simplificada o no, y no a nivel de partner.
Este cambio permitiría heredar el método y cambiar la lógica para decidir si una factura es simplificada o no, permitiendo heredarlo y no tener que modificar sustancialmente los métodos en los que se comprueba el _partner.sii_simplified_invoice_

Entiendo que esto no afecta a la operativa actual, pero si mejora la integración con otras casuísticas.

A ver qué os parece.

Un saludo.
