### PR TITLE
[12.0][FIX] Envío al SII ImporteTotal sin IRPF en facturas de proveedor

### DIFF
--- a/l10n_es_aeat_sii/README.rst
+++ b/l10n_es_aeat_sii/README.rst
@@ -144,7 +144,7 @@ Contributors
 * Jordi Tolsà <jordi@studio73.es>
 * Ismael Calvo <ismael.calvo@factorlibre.es>
 * Omar Castiñeira - Comunitea S.L. <omar@comunitea.com>
-* Juanjo Algaz <jalgaz@gmail.com>
+* Juanjo Algaz <jalgaz@gmail.com>, Planeta Huerto <juanjoalgaz@planetahuerto.es>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Javi Melendez <javimelex@gmail.com>
 * Santi Argüeso - Comunitea S.L. <santi@comunitea.com>

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -174,4 +174,41 @@
             <field name="name">SuministroFactRecibidas No Deducible</field>
         </record>
 
+        <record id="aeat_sii_map_line_NotIncludedInTotal" model="aeat.sii.map.lines">
+            <field name="code">NotIncludedInTotal</field>
+            <field name="taxes" eval="[(6, 0, [
+              ref('l10n_es.account_tax_template_s_irpf1'),
+              ref('l10n_es.account_tax_template_p_irpf1'),
+              ref('l10n_es.account_tax_template_s_irpf2'),
+              ref('l10n_es.account_tax_template_p_irpf2'),
+              ref('l10n_es.account_tax_template_s_irpf7'),
+              ref('l10n_es.account_tax_template_p_irpf7'),
+              ref('l10n_es.account_tax_template_s_irpf9'),
+              ref('l10n_es.account_tax_template_p_irpf9'),
+              ref('l10n_es.account_tax_template_s_irpf15'),
+              ref('l10n_es.account_tax_template_p_irpf15'),
+              ref('l10n_es.account_tax_template_s_irpf18'),
+              ref('l10n_es.account_tax_template_p_irpf18'),
+              ref('l10n_es.account_tax_template_s_irpf19'),
+              ref('l10n_es.account_tax_template_s_irpf19a'),
+              ref('l10n_es.account_tax_template_s_irpf195a'),
+              ref('l10n_es.account_tax_template_p_irpf19'),
+              ref('l10n_es.account_tax_template_p_irpf19a'),
+              ref('l10n_es.account_tax_template_p_irpf195a'),
+              ref('l10n_es.account_tax_template_s_irpf20'),
+              ref('l10n_es.account_tax_template_s_irpf20a'),
+              ref('l10n_es.account_tax_template_p_irpf20'),
+              ref('l10n_es.account_tax_template_p_irpf20a'),
+              ref('l10n_es.account_tax_template_s_irpf21'),
+              ref('l10n_es.account_tax_template_s_irpf21a'),
+              ref('l10n_es.account_tax_template_p_irpf21a'),
+              ref('l10n_es.account_tax_template_p_irpf21p'),
+              ref('l10n_es.account_tax_template_p_irpf21t'),
+              ref('l10n_es.account_tax_template_p_irpf21td'),
+              ref('l10n_es.account_tax_template_p_irpf21te'),
+            ])]"/>
+            <field name="sii_map_id" ref="aeat_sii_map"/>
+            <field name="name">Impuestos no incluidos en ImporteTotal</field>
+        </record>
+
 </odoo>

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -454,14 +454,18 @@ class AccountInvoice(models.Model):
         taxes_sfess = self._get_sii_taxes_map(['SFESS'])
         taxes_sfesse = self._get_sii_taxes_map(['SFESSE'])
         taxes_sfesns = self._get_sii_taxes_map(['SFESNS'])
+        taxes_not_in_total = self._get_sii_taxes_map(['NotIncludedInTotal'])
         # Check if refund type is 'By differences'. Negative amounts!
         sign = self._get_sii_sign()
+        not_in_amount_total = 0
         exempt_cause = self._get_sii_exempt_cause(taxes_sfesbe + taxes_sfesse)
         for tax_line in self.tax_line_ids:
             tax = tax_line.tax_id
             breakdown_taxes = (
                 taxes_sfesb + taxes_sfesisp + taxes_sfens + taxes_sfesbe
             )
+            if tax in taxes_not_in_total:
+                not_in_amount_total += tax_line.amount_total
             if tax in breakdown_taxes:
                 tax_breakdown = taxes_dict.setdefault(
                     'DesgloseFactura', {},
@@ -558,7 +562,7 @@ class AccountInvoice(models.Model):
             taxes_dict['DesgloseTipoOperacion']['Entrega'] = \
                 taxes_dict['DesgloseFactura']
             del taxes_dict['DesgloseFactura']
-        return taxes_dict
+        return taxes_dict, not_in_amount_total
 
     @api.model
     def _merge_tax_dict(self, vat_list, tax_dict, comp_key, merge_keys):
@@ -583,11 +587,15 @@ class AccountInvoice(models.Model):
         taxes_sfrisp = self._get_sii_taxes_map(['SFRISP'])
         taxes_sfrns = self._get_sii_taxes_map(['SFRNS'])
         taxes_sfrnd = self._get_sii_taxes_map(['SFRND'])
+        taxes_not_in_total = self._get_sii_taxes_map(['NotIncludedInTotal'])
         tax_amount = 0.0
+        not_in_amount_total = 0.0
         # Check if refund type is 'By differences'. Negative amounts!
         sign = self._get_sii_sign()
         for tax_line in self.tax_line_ids:
             tax = tax_line.tax_id
+            if tax in taxes_not_in_total:
+                not_in_amount_total += tax_line.amount_total
             if tax in taxes_sfrisp:
                 base_dict = taxes_dict.setdefault(
                     'InversionSujetoPasivo', {'DetalleIVA': []},
@@ -619,7 +627,7 @@ class AccountInvoice(models.Model):
                     ["BaseImponible", "CuotaSoportada"]
                 ):
                     base_dict['DetalleIVA'].append(tax_dict)
-        return taxes_dict, tax_amount
+        return taxes_dict, tax_amount, not_in_amount_total
 
     @api.multi
     def _is_sii_simplified_invoice(self):
@@ -678,38 +686,6 @@ class AccountInvoice(models.Model):
         return self.sii_account_registration_date or fields.Date.today()
 
     @api.multi
-    def _get_importe_total(self):
-        """Get ImporteTotal value.
-        Avoid to send IRPF data to SII systems,
-        but only check supplier invoices
-        """
-        taxes_notincludedintotal = self._get_sii_taxes_map(
-            ['NotIncludedInTotal'])
-        # Check if refund type is 'By differences'. Negative amounts!
-        sign = self._get_sii_sign()
-
-        # supplier invoice, check lines & irpf
-        round_curr = self.currency_id.round
-        # sumo/resto impuestos a menos que estén incluidos
-        # en el aeat.sii.map.lines NotIncludedInTotal
-        lines = [
-            line for line in self.tax_line_ids
-            if line.tax_id not in taxes_notincludedintotal]
-        amount_tax_no_irpf = sum(round_curr(
-            line.amount_total) for line in lines)
-        amount_total = self.amount_untaxed + amount_tax_no_irpf
-        amount_total_company_signed = amount_total
-        if (self.currency_id and self.company_id and
-                self.currency_id != self.company_id.currency_id):
-            currency_id = self.currency_id
-            amount_total_company_signed = currency_id._convert(
-                amount_total,
-                self.company_id.currency_id,
-                self.company_id,
-                self.date_invoice or fields.Date.today())
-        return abs(amount_total_company_signed) * sign
-
-    @api.multi
     def _get_sii_invoice_dict_out(self, cancel=False):
         """Build dict with data to send to AEAT WS for invoice types:
         out_invoice and out_refund.
@@ -742,6 +718,12 @@ class AccountInvoice(models.Model):
             },
         }
         if not cancel:
+            # Check if refund type is 'By differences'. Negative amounts!
+            sign = self._get_sii_sign()
+            tipo_desglose, not_in_amount_total = self._get_sii_out_taxes()
+            amount_total = (
+                abs(self.amount_total_company_signed) - not_in_amount_total
+            ) * sign
             if self.type == 'out_refund':
                 if self.sii_refund_specific_invoice_type:
                     tipo_factura = self.sii_refund_specific_invoice_type
@@ -755,8 +737,8 @@ class AccountInvoice(models.Model):
                     self.sii_registration_key.code
                 ),
                 "DescripcionOperacion": self.sii_description,
-                "TipoDesglose": self._get_sii_out_taxes(),
-                "ImporteTotal": self._get_importe_total(),
+                "TipoDesglose": tipo_desglose,
+                "ImporteTotal": amount_total,
             }
             if self.sii_macrodata:
                 inv_dict["FacturaExpedida"].update(Macrodato="S")
@@ -814,7 +796,8 @@ class AccountInvoice(models.Model):
             self._get_account_registration_date())
         ejercicio = fields.Date.to_date(self.date).year
         periodo = '%02d' % fields.Date.to_date(self.date).month
-        desglose_factura, tax_amount = self._get_sii_in_taxes()
+        desglose_factura, tax_amount, not_in_amount_total = (
+            self._get_sii_in_taxes())
         inv_dict = {
             "IDFactura": {
                 "IDEmisorFactura": {},
@@ -839,6 +822,9 @@ class AccountInvoice(models.Model):
         else:
             # Check if refund type is 'By differences'. Negative amounts!
             sign = self._get_sii_sign()
+            amount_total = (
+                abs(self.amount_total_company_signed) - not_in_amount_total
+            ) * sign
             inv_dict["FacturaRecibida"] = {
                 # TODO: Incluir los 5 tipos de facturas rectificativas
                 "TipoFactura": (
@@ -855,7 +841,7 @@ class AccountInvoice(models.Model):
                     )
                 },
                 "FechaRegContable": reg_date,
-                "ImporteTotal": self._get_importe_total(),
+                "ImporteTotal": amount_total,
                 "CuotaDeducible": tax_amount * sign,
             }
             if self.sii_macrodata:

--- a/l10n_es_aeat_sii/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_sii/readme/CONTRIBUTORS.rst
@@ -5,7 +5,7 @@
 * Jordi Tolsà <jordi@studio73.es>
 * Ismael Calvo <ismael.calvo@factorlibre.es>
 * Omar Castiñeira - Comunitea S.L. <omar@comunitea.com>
-* Juanjo Algaz <jalgaz@gmail.com>
+* Juanjo Algaz <jalgaz@gmail.com>, Planeta Huerto <juanjoalgaz@planetahuerto.es>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Javi Melendez <javimelex@gmail.com>
 * Santi Argüeso - Comunitea S.L. <santi@comunitea.com>

--- a/l10n_es_aeat_sii/static/description/index.html
+++ b/l10n_es_aeat_sii/static/description/index.html
@@ -492,7 +492,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Jordi Tolsà &lt;<a class="reference external" href="mailto:jordi&#64;studio73.es">jordi&#64;studio73.es</a>&gt;</li>
 <li>Ismael Calvo &lt;<a class="reference external" href="mailto:ismael.calvo&#64;factorlibre.es">ismael.calvo&#64;factorlibre.es</a>&gt;</li>
 <li>Omar Castiñeira - Comunitea S.L. &lt;<a class="reference external" href="mailto:omar&#64;comunitea.com">omar&#64;comunitea.com</a>&gt;</li>
-<li>Juanjo Algaz &lt;<a class="reference external" href="mailto:jalgaz&#64;gmail.com">jalgaz&#64;gmail.com</a>&gt;</li>
+<li>Juanjo Algaz &lt;<a class="reference external" href="mailto:jalgaz&#64;gmail.com">jalgaz&#64;gmail.com</a>&gt;, Planeta Huerto &lt;<a class="reference external" href="mailto:juanjoalgaz&#64;planetahuerto.es">juanjoalgaz&#64;planetahuerto.es</a>&gt;</li>
 <li>Pedro M. Baeza &lt;<a class="reference external" href="mailto:pedro.baeza&#64;tecnativa.com">pedro.baeza&#64;tecnativa.com</a>&gt;</li>
 <li>Javi Melendez &lt;<a class="reference external" href="mailto:javimelex&#64;gmail.com">javimelex&#64;gmail.com</a>&gt;</li>
 <li>Santi Argüeso - Comunitea S.L. &lt;<a class="reference external" href="mailto:santi&#64;comunitea.com">santi&#64;comunitea.com</a>&gt;</li>

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -11,7 +11,7 @@ from odoo.modules.module import get_resource_path
 
 try:
     from zeep.client import ServiceProxy
-except (ImportError, IOError) as err:
+except (ImportError, IOError):
     ServiceProxy = object
 
 CERTIFICATE_PATH = get_resource_path(
@@ -83,6 +83,9 @@ class TestL10nEsAeatSiiBase(common.SavepointCase):
                 'model': cls.tax._name,
                 'res_id': cls.tax.id,
             })
+        irpf_xml_id = '%s_account_tax_template_p_irpf19' % cls.company.id
+        cls.tax = cls.env.ref('l10n_es.' + xml_id, raise_if_not_found=False)
+        cls.tax_irpf19 = cls.env.ref('l10n_es.' + irpf_xml_id)
         cls.env.user.company_id.sii_description_method = 'manual'
         cls.invoice = cls.env['account.invoice'].create({
             'partner_id': cls.partner.id,
@@ -373,3 +376,42 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         })
         with self.assertRaises(exceptions.Warning):
             invoice._sii_check_exceptions()
+
+    def test_importe_total_when_supplier_invoice_with_irpf(self):
+        # 1/ tener una factura con líneas con retención e iva
+        # 2/ obtener con get_dict_in los valores a enviar al sii
+        # 3/ comprobar el valor de ImporteTotal es igual al estimado
+        # 1
+        amount_base = 100
+        amount_tax = 10
+        amount_to_communicate_sii = amount_base + amount_tax
+        invoice = self.env['account.invoice'].create({
+            'partner_id': self.partner.id,
+            'date_invoice': '2018-02-01',
+            'date': '2018-02-01',
+            'type': 'in_invoice',
+            'reference': 'PH-2020-0031',
+            'account_id': self.partner.property_account_payable_id.id,
+            'invoice_line_ids': [
+                (0, 0, {
+                    'product_id': self.product.id,
+                    'account_id': self.account_expense.id,
+                    'account_analytic_id': self.analytic_account.id,
+                    'name': 'Test line with irpf and iva',
+                    'price_unit': amount_base,
+                    'quantity': 1,
+                    'invoice_line_tax_ids': [
+                        (6, 0, self.tax.ids + self.tax_irpf19.ids)],
+                })],
+            'sii_manual_description': '/',
+        })
+        # 2
+        invoices = invoice._get_sii_invoice_dict()
+        importe_total = invoices['FacturaRecibida']['ImporteTotal']
+        # 3
+        self.assertEqual(amount_to_communicate_sii, importe_total)
+
+    def test_unlink_invoice_when_sent_to_sii(self):
+        self.invoice.sii_state = 'sent'
+        with self.assertRaises(exceptions.Warning):
+            self.invoice.unlink()


### PR DESCRIPTION
Al hilo de:  https://github.com/OCA/l10n-spain/issues/1281
He estado trabajando en esto y he modificado el módulo para sacar el irpf del ImporteTotal que se envía al SII, añadiento también un test.
Antes de hacer PR no estaría mal si alguien lo puede probar, por ejemplo con facturas en otra divisa, o se anima a meterle un test para esto.

Añado:
  - Uno de los problemas era como detectar que el impuesto en uso es un IRPF. Esto lo he 'arreglado' buscando en el modelo del impuesto que el campo description contenga la cadena 'irpf'. Aquí no valía buscar por ejemplo  un impuesto negativo. Si veis otra forma más formal, me decís y lo cambio.