### PR TITLE
[l10n_es_pos] rename category of l10n_es_pos, as 'Point of Sale' is not valid in 13.0

### DIFF
--- a/l10n_es_pos/__manifest__.py
+++ b/l10n_es_pos/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "Punto de venta adaptado a la legislación española",
-    "category": "Point Of Sale",
+    "category": "Sales/Point Of Sale",
     "author": "Tecnativa, "
     "Aselcis Consulting, "
     "Acysos S.L., "


### PR DESCRIPTION
Otherwise migration from v12 fails