### PR TITLE
[11.0][FIX] l10n_es_aeat_mod349: fix 'Original amount' calculation on credit notes

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -207,6 +207,7 @@ class Mod349(models.Model):
                 origin_amount = sum(original_details.mapped('amount_untaxed'))
                 period_type = report.period_type
                 year = str(report.year)
+                visited_move_lines |= original_details.mapped('move_line_id')
             else:
                 # There's no previous 349 declaration report in Odoo
                 original_amls = move_line_obj.search([
@@ -527,9 +528,9 @@ class Mod349PartnerRefund(models.Model):
             rectified_amount = sum(
                 record.mapped('refund_detail_ids.amount_untaxed')
             )
-            record.total_operation_amount = (
+            record.total_operation_amount = float('{:f}'.format(
                 record.total_origin_amount - rectified_amount
-            )
+            ))
 
     @api.multi
     def onchange_format_partner_vat(self, partner_vat, country_id):


### PR DESCRIPTION
Este PR soluciona dos problemas:

1 - Corrige el calculo del campo "Importe original" de la pestaña "Rectificaciones de otros periodos" del modelo 349 para facturas rectificativas con más de una línea y en diferentes periodos respecto a la factura que se rectifica. El error exacto es que el importe se multiplica por dos, puesto que se tienen en cuenta los apuntes relacionados dos veces.
2 - Corrige los ceros negativos (-0.00) que se generan al hacer el calculo de la columna "Importe total tras rectificación" una vez corregido el fallo anterior.

Para reproducción el error del punto uno basta con generar una factura con más de una línea en un periodo determinado y crear su rectificativa en otro periodo diferente. Una vez realizado el calculo del 349 sin este PR quedaría algo así:

![Error 349](https://user-images.githubusercontent.com/17765523/87650434-f1ba0580-c751-11ea-9c24-9d0d8e41c049.png)
