### PR TITLE
[11.0][FIX] l10n_es_aeat_mod349: Refund record totals + details

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -12,6 +12,7 @@
 import math
 import re
 from odoo import models, fields, api, exceptions, _
+from odoo.fields import first
 from odoo.tools import float_is_zero
 
 
@@ -183,11 +184,18 @@ class Mod349(models.Model):
         # This is for avoiding to find same lines several times
         visited_details = self.env['l10n.es.aeat.mod349.partner_record_detail']
         visited_move_lines = self.env['account.move.line']
+        groups = {}
         for refund_detail in self.partner_refund_detail_ids:
+            move_line = refund_detail.refund_line_id
+            origin_invoice = move_line.invoice_id.refund_invoice_id
+            groups.setdefault(origin_invoice, refund_detail_obj)
+            groups[origin_invoice] += refund_detail
+        for origin_invoice in groups:
+            refund_details = groups[origin_invoice]
+            refund_detail = first(refund_details)
             move_line = refund_detail.refund_line_id
             partner = move_line.partner_id
             op_key = move_line.l10n_es_aeat_349_operation_key
-            origin_invoice = move_line.invoice_id.refund_invoice_id
             if not origin_invoice:
                 # TODO: Instead continuing, generate an empty record and a msg
                 continue
@@ -240,7 +248,7 @@ class Mod349(models.Model):
                 'refund_details': refund_detail_obj,
             })
             key_vals['original_amount'] += origin_amount
-            key_vals['refund_details'] += refund_detail
+            key_vals['refund_details'] += refund_details
         for key, key_vals in data.items():
             partner, op_key, period_type, year = key
             partner_refund = obj.create({

--- a/l10n_es_aeat_mod349/tests/test_l10n_es_aeat_mod349.py
+++ b/l10n_es_aeat_mod349/tests/test_l10n_es_aeat_mod349.py
@@ -19,7 +19,8 @@ class TestL10nEsAeatMod349Base(TestL10nEsAeatModBase):
     }
     taxes_purchase = {
         # tax code: (base, tax_amount)
-        'P_IVA21_IC_BC': (300, 0),
+        'P_IVA21_IC_BC': (150, 0),
+        'P_IVA21_IC_BC//2': (150, 0),
     }
 
     def test_model_349(self):
@@ -68,7 +69,7 @@ class TestL10nEsAeatMod349Base(TestL10nEsAeatModBase):
         a_record = model349.partner_record_ids.filtered(
             lambda x: x.operation_key == 'A')
         self.assertEqual(len(a_record), 1)
-        self.assertEqual(len(a_record.record_detail_ids), 3)
+        self.assertEqual(len(a_record.record_detail_ids), 6)
         self.assertEqual(a_record.partner_vat,  self.supplier.vat)
         self.assertEqual(a_record.country_id, self.supplier.country_id)
         # p1 + p2 - p3 = 300 + 300 - 300
@@ -177,6 +178,7 @@ class TestL10nEsAeatMod349Base(TestL10nEsAeatModBase):
         a_refund = model349_2t.partner_refund_ids.filtered(
             lambda x: x.operation_key == 'A')
         self.assertEqual(len(a_refund), 1)
+        self.assertEqual(len(a_refund.refund_detail_ids), 2)
         self.assertEqual(a_refund.total_origin_amount, 300)
         self.assertEqual(a_refund.total_operation_amount, 0)
         self.assertEqual(a_refund.period_type, model349_s.period_type)


### PR DESCRIPTION
**Steps to reproduce**

- Create an intra-community invoice with several lines in May.
- Create a 349 AEAT report for May and calculate it.
- Refund the invoice in June.
- Create a 349 report for June and calculate it.

**Current behavior**

You get double origin amount in the refund record.

**Expected behavior**

Get proper origin amount.

**Solution**

We have to pre-group refund details by origin invoice, and then process them in batch for getting the total amount.

It includes regression test.

cc @Tecnativa