### PR TITLE
[FIX] delivery_seur: Cash on Delivery value

### DIFF
--- a/delivery_seur/models/delivery_carrier.py
+++ b/delivery_seur/models/delivery_carrier.py
@@ -220,7 +220,7 @@ class DeliveryCarrier(models.Model):
             'clavePortes': 'F',
             'clavePod': '',
             'claveReembolso': 'F',
-            'valorReembolso': 1,
+            'valorReembolso': '',
             'libroControl': '',
             'nombre_consignatario': partner.name,
             'direccion_consignatario': ' '.join([


### PR DESCRIPTION
- Currently there's no support for Cash on Delivery expeditions. We
shouldn't give any value to the Cash on Delivery field as it's recorded
in the expedition and can lead to errors.

cc @Tecnativa TT25379