### PR TITLE
[FIX][12.0] delivery_seur: weight data and error catching

### DIFF
--- a/delivery_seur/README.rst
+++ b/delivery_seur/README.rst
@@ -71,6 +71,11 @@ Contributors
 * `FactorLibre <https://www.factorlibre.com>`_:
     * Zahra Velasco <zahra.velasco@factorlibre.com>
 
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+    * Pedro M. Baeza
+    * David Vidal
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/delivery_seur/__manifest__.py
+++ b/delivery_seur/__manifest__.py
@@ -22,5 +22,6 @@
     },
     'data': [
         'views/delivery_carrier_views.xml',
+        'views/stock_picking_views.xml',
     ],
 }

--- a/delivery_seur/models/__init__.py
+++ b/delivery_seur/models/__init__.py
@@ -2,3 +2,4 @@
 # Copyright 2020 FactorLibre
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import delivery_carrier
+from . import stock_picking

--- a/delivery_seur/models/delivery_carrier.py
+++ b/delivery_seur/models/delivery_carrier.py
@@ -211,9 +211,9 @@ class DeliveryCarrier(models.Model):
             'cod_centro': '',
             'total_bultos': picking.number_of_packages or 1,
             'total_kilos': picking.shipping_weight or 1,
-            # According API documentation, it's the total weight, not the
-            # package one
-            'pesoBulto': picking.shipping_weight or 1,
+            'pesoBulto': ((
+                picking.shipping_weight / picking.number_of_packages or 1)
+                or 1),
             'observaciones': picking.note,
             'referencia_expedicion': picking.name,
             'ref_bulto': '',

--- a/delivery_seur/models/stock_picking.py
+++ b/delivery_seur/models/stock_picking.py
@@ -1,0 +1,21 @@
+
+# Copyright 2020 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    seur_last_request = fields.Text(
+        string="Last SEUR xml request",
+        help="Used for issues debugging",
+        copy=False,
+        readonly=True,
+    )
+    seur_last_response = fields.Text(
+        string="Last SEUR xml response",
+        help="Used for issues debugging",
+        copy=False,
+        readonly=True,
+    )

--- a/delivery_seur/readme/CONTRIBUTORS.rst
+++ b/delivery_seur/readme/CONTRIBUTORS.rst
@@ -3,3 +3,8 @@
 
 * `FactorLibre <https://www.factorlibre.com>`_:
     * Zahra Velasco <zahra.velasco@factorlibre.com>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+    * Pedro M. Baeza
+    * David Vidal

--- a/delivery_seur/static/description/index.html
+++ b/delivery_seur/static/description/index.html
@@ -412,10 +412,10 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </div>
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#id5">Contributors</a></h2>
-<ul class="simple">
+<ul>
 <li><dl class="first docutils">
 <dt><a class="reference external" href="https://www.trey.es">Trey</a>:</dt>
-<dd><ul class="first last">
+<dd><ul class="first last simple">
 <li>Roberto Lizana &lt;<a class="reference external" href="mailto:roberto&#64;trey.es">roberto&#64;trey.es</a>&gt;</li>
 </ul>
 </dd>
@@ -423,11 +423,19 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </li>
 <li><dl class="first docutils">
 <dt><a class="reference external" href="https://www.factorlibre.com">FactorLibre</a>:</dt>
-<dd><ul class="first last">
+<dd><ul class="first last simple">
 <li>Zahra Velasco &lt;<a class="reference external" href="mailto:zahra.velasco&#64;factorlibre.com">zahra.velasco&#64;factorlibre.com</a>&gt;</li>
 </ul>
 </dd>
 </dl>
+</li>
+<li><p class="first"><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:</p>
+<blockquote>
+<ul class="simple">
+<li>Pedro M. Baeza</li>
+<li>David Vidal</li>
+</ul>
+</blockquote>
 </li>
 </ul>
 </div>

--- a/delivery_seur/views/stock_picking_views.xml
+++ b/delivery_seur/views/stock_picking_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<!-- Copyright 2020 Tecnativa - David Vidal
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).-->
+    <record id="view_picking_withcarrier_out_form" model="ir.ui.view">
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="delivery.view_picking_withcarrier_out_form"/>
+        <field name="groups_id" eval="[(4, ref('base.group_no_one'))]"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='extra']" position="inside">
+                <group string="SEUR Technical"
+                       attrs="{'invisible': ['|', ('delivery_type', '!=', 'seur'), '&amp;', ('seur_last_request', '=', False), ('seur_last_response', '=', False)]}">
+                    <field name="seur_last_request" />
+                    <field name="seur_last_response" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- De acuerdo con SEUR, el valor esperado en `pesoBulto` es el peso de cada bulto, luego debemos dividir el total por el número de bultos.
- En algunos errores (por ejemplo, una dirección que el API no acepta) SEUR devuelve un error en un formato distinto al esperado, por lo que obtenemos un error de clave.
- Además añadimos una mejora para poder trazar las últimas comunicaciones entrantes y salientes de forma que sea mucho más directo resolver incidencias.

cc @Tecnativa TT25530 TT25328 TT25535

Resuelve: https://github.com/OCA/l10n-spain/issues/1450