### PR TITLE
[IMP] l10n_es_aeat_sii: Refund type

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1410,8 +1410,6 @@ class AccountInvoice(models.Model):
             res['sii_refund_type'] = sii_refund_type
         if supplier_invoice_number_refund:
             res['reference'] = supplier_invoice_number_refund
-        if res['type'] == 'out_refund':
-            res['sii_refund_specific_invoice_type'] = 'R1'
 
         return res
 

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -269,7 +269,7 @@ class AccountInvoice(models.Model):
                               "already registered at the SII. You must cancel "
                               "the invoice and create a new one with the "
                               "correct supplier")
-                            )
+                        )
                 elif 'supplier_invoice_number' in vals:
                     raise exceptions.Warning(
                         _("You cannot change the supplier invoice number of "
@@ -738,7 +738,7 @@ class AccountInvoice(models.Model):
                 if self.sii_refund_specific_invoice_type:
                     tipo_factura = self.sii_refund_specific_invoice_type
                 else:
-                    tipo_factura = 'R5' if simplied else 'R4'
+                    tipo_factura = 'R5' if simplied else 'R1'
             else:
                 tipo_factura = 'F2' if simplied else 'F1'
             inv_dict["FacturaExpedida"] = {
@@ -828,7 +828,7 @@ class AccountInvoice(models.Model):
             inv_dict['IDFactura']['IDEmisorFactura'].update(
                 {'NombreRazon': (
                     self.partner_id.commercial_partner_id.name[0:120]
-                    )}
+                )}
             )
         else:
             # Check if refund type is 'By differences'. Negative amounts!

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -134,7 +134,7 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         expedida_recibida = 'FacturaExpedida'
         if self.invoice.type in ['in_invoice', 'in_refund']:
             expedida_recibida = 'FacturaRecibida'
-        sign = -1.0 if invoice_type == 'R4' else 1.0
+        sign = -1.0 if invoice_type in ('R1', 'R4') else 1.0
         res = {
             'IDFactura': {
                 'FechaExpedicionFacturaEmisor': '01-02-2018',
@@ -184,7 +184,7 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
                 },
                 "CuotaDeducible": sign * 10,
             })
-        if invoice_type == 'R4':
+        if invoice_type in ('R1', 'R4'):
             res[expedida_recibida]['TipoRectificativa'] = 'I'
         return res
 
@@ -204,7 +204,7 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.invoice.type = 'out_refund'
         self.invoice.sii_refund_type = 'I'
         invoices = self.invoice._get_sii_invoice_dict()
-        test_out_refund = self._get_invoices_test('R4', '01')
+        test_out_refund = self._get_invoices_test('R1', '01')
         for key in list(invoices.keys()):
             self.assertDictEqual(
                 _deep_sort(invoices.get(key)),


### PR DESCRIPTION
Como comenta @SoniaViciana en https://github.com/OCA/l10n-spain/pull/1106#issuecomment-694152806:
> Buenos días @danielduqma @pedrobaeza
> 
> La última mejora está dando error actualmente. **Cuando la factura de venta es F2 (simplificada), la rectificativa siempre debe ser R5** (partner.sii_simplified_invoice). En los casos restantes siempre es R1, dado que los demás tipos de rectificativa en el SII son seleccionables de forma manual en la propia factura:
> 
> * R2 -> Concurso de acreedores
> * R3 -> Deuda incobrable
> * R4 -> Resto
> 
> En v11 esta mejora debería aplicar tal y como se realiza en #1410, y además, revertir lo siguiente:
> 
> https://github.com/OCA/l10n-spain/pull/1106/files#diff-1e50d7d6033ffb0d15c5823d421fc2c2R1379-R1380
> 
> Muchas gracias.
> 
> Saludos,

Se revierte la selección de R1 como `sii_refund_specific_invoice_type` y se aplica el cambio de @JuanjoA-PH en https://github.com/OCA/l10n-spain/pull/1410