### PR TITLE
[11.0][FIX] Sing tax l10n es aeat sii

### DIFF
--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -206,6 +206,21 @@
               ref('l10n_es.account_tax_template_p_irpf21t'),
               ref('l10n_es.account_tax_template_p_irpf21td'),
               ref('l10n_es.account_tax_template_p_irpf21te'),
+              ref('l10n_es.account_tax_template_p_iva21_isp_2'),
+              ref('l10n_es.account_tax_template_p_iva10_isp_2'),
+              ref('l10n_es.account_tax_template_p_iva4_isp_2'),
+              ref('l10n_es.account_tax_template_p_iva21_sp_ex_1'),
+              ref('l10n_es.account_tax_template_p_iva10_sp_ex_1'),
+              ref('l10n_es.account_tax_template_p_iva4_sp_ex_1'),
+              ref('l10n_es.account_tax_template_p_iva4_sp_in_1'),
+              ref('l10n_es.account_tax_template_p_iva10_sp_in_1'),
+              ref('l10n_es.account_tax_template_p_iva21_sp_in_1'),
+              ref('l10n_es.account_tax_template_p_iva4_ic_bc_2'),
+              ref('l10n_es.account_tax_template_p_iva10_ic_bc_2'),
+              ref('l10n_es.account_tax_template_p_iva21_ic_bc_2'),
+              ref('l10n_es.account_tax_template_p_iva4_ic_bi_2'),
+              ref('l10n_es.account_tax_template_p_iva10_ic_bi_2'),
+              ref('l10n_es.account_tax_template_p_iva21_ic_bi_2'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">Impuestos no incluidos en ImporteTotal</field>

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -88,9 +88,9 @@
                 ref('l10n_es.account_tax_template_p_iva4_bi'),
                 ref('l10n_es.account_tax_template_p_iva10_bi'),
                 ref('l10n_es.account_tax_template_p_iva21_bi'),
-                ref('l10n_es.account_tax_template_p_iva4_sp_in_1'),
-                ref('l10n_es.account_tax_template_p_iva10_sp_in_1'),
-                ref('l10n_es.account_tax_template_p_iva21_sp_in_1'),
+                ref('l10n_es.account_tax_template_p_iva4_sp_in_2'),
+                ref('l10n_es.account_tax_template_p_iva10_sp_in_2'),
+                ref('l10n_es.account_tax_template_p_iva21_sp_in_2'),
                 ref('l10n_es.account_tax_template_p_iva4_ic_bc_1'),
                 ref('l10n_es.account_tax_template_p_iva10_ic_bc_1'),
                 ref('l10n_es.account_tax_template_p_iva21_ic_bc_1'),
@@ -120,9 +120,9 @@
                 ref('l10n_es.account_tax_template_p_iva21_isp_1'),
                 ref('l10n_es.account_tax_template_p_iva10_isp_1'),
                 ref('l10n_es.account_tax_template_p_iva4_isp_1'),
-                ref('l10n_es.account_tax_template_p_iva21_sp_ex_1'),
-                ref('l10n_es.account_tax_template_p_iva10_sp_ex_1'),
-                ref('l10n_es.account_tax_template_p_iva4_sp_ex_1'),
+                ref('l10n_es.account_tax_template_p_iva21_sp_ex_2'),
+                ref('l10n_es.account_tax_template_p_iva10_sp_ex_2'),
+                ref('l10n_es.account_tax_template_p_iva4_sp_ex_2'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas ISP</field>

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -425,13 +425,13 @@ class AccountInvoice(models.Model):
             tax_type = abs(tax.amount)
         tax_dict = {
             'TipoImpositivo': str(tax_type),
-            'BaseImponible': sign * abs(tax_line.base_company),
+            'BaseImponible': sign * tax_line.base_company,
         }
         if self.type in ['out_invoice', 'out_refund']:
             key = 'CuotaRepercutida'
         else:
             key = 'CuotaSoportada'
-        tax_dict[key] = sign * abs(tax_line.amount_company)
+        tax_dict[key] = sign * tax_line.amount_company
         # Recargo de equivalencia
         re_tax_line = self._get_sii_tax_line_req(tax)
         if re_tax_line:
@@ -439,7 +439,7 @@ class AccountInvoice(models.Model):
                 abs(re_tax_line.tax_id.amount)
             )
             tax_dict['CuotaRecargoEquivalencia'] = (
-                sign * abs(re_tax_line.amount_company)
+                sign * re_tax_line.amount_company
             )
         return tax_dict
 
@@ -640,7 +640,7 @@ class AccountInvoice(models.Model):
                 continue
             tax_dict = self._get_sii_tax_dict(tax_line, sign)
             if tax in taxes_sfrisp + taxes_sfrs:
-                tax_amount += abs(tax_line.amount_company)
+                tax_amount += tax_line.amount_company
             if tax in taxes_sfrns:
                 tax_dict.pop("TipoImpositivo")
                 tax_dict.pop("CuotaSoportada")


### PR DESCRIPTION
Buenas, 

He creado la siguiente PR para solucionar un problema de signos que puede darse en según que facturas al ser notificads al SII.
Actualmente sin importar el signo de cada linea de factura, este dato pasa por una transformación en absoluto perdiendo su signo, y asignándole un signo según el tipo de factura, esto puede ser incorrecto cuando se nos presentan facturas con lineas positivas y negativas con distintas cuotas de IVA, como se muestra en el siguiente ejemplo de una factura rectificativa de proveedor:

![Selección_104](https://user-images.githubusercontent.com/6359121/94255222-328b8300-ff28-11ea-9ab9-46a886a89096.png)

Si comprobamos como ha llegado la información al SII vemos que el importe de las "CuotasSoportadas" pasan a negativo y dando un Total de "CuotaDeducible" de -3.96 y un importe total de -22.06, lo cual no concuerda con el detalle de las líneas.

![Selección_107](https://user-images.githubusercontent.com/6359121/94256771-92832900-ff2a-11ea-8b46-de433609f696.png)

Cuando lo correcto seria mantener el signo de cada una de las lineas para que tanto el desglose de las cuotas y los valores totalizados concuerden.

"TipoImpositivo": "21.0",
"BaseImponible": 6.11,
"CuotaSoportada": 1.28

"TipoImpositivo": "10.0",
"BaseImponible": -26.77,
"CuotaSoportada": -2.68

"CuotaDeducible": -1.4 (-2.68+1.28)

Un saludo

CC: @soniaviciana