### PR TITLE
[FIX] delivery_gls_manifest: manifest destination name

### DIFF
--- a/delivery_gls_asm/views/gls_asm_manifest_template.xml
+++ b/delivery_gls_asm/views/gls_asm_manifest_template.xml
@@ -90,7 +90,7 @@
                                     <span t-esc="delivery.get('codexp')" />
                                 </td>
                                 <td class="text-left">
-                                    <span t-esc="delivery.get('cliente')" />
+                                    <span t-esc="delivery.get('nombre_dst')" />
                                 </td>
                                 <td class="text-center">
                                     <span t-esc="delivery.get('cp_dst')" />


### PR DESCRIPTION
The `cliente` key corresponds to the company not to the customer, wich
is `nombre_dst`

cc @Tecnativa TT26242