### PR TITLE
Haciendo campo 06 del Modelo 130 editable

### DIFF
--- a/l10n_es_aeat_mod130/views/mod130_view.xml
+++ b/l10n_es_aeat_mod130/views/mod130_view.xml
@@ -55,7 +55,6 @@
                                 />
                                 <field name="casilla_06"
                                     string="[06] A deducir - Retenciones e ingr. a cuenta"
-                                    attrs="{'readonly': [('state', '!=', 'draft')]}"
                                 />
                                 <field name="casilla_07"
                                     string="[07] Pago fraccionado previo del trimestre"


### PR DESCRIPTION
Además de hacer editable el campo 06 del Modelo 130, también calculo su valor inicial utilizando las retenciones aplicadas a las facturas emitidas (código like 473%). Ignoro y hasta dudo que con ello se cubra toda casuística del cómputo agregado de retenciones, pero en mi caso de autónomo con emisión de facturas con retención me vale.