### PR TITLE
[12.0][IMP] payment_redsys: Confirmar pedido de venta inmediatamente al recibir la contestación de Redsys si es OK.

### DIFF
--- a/payment_redsys/models/redsys.py
+++ b/payment_redsys/models/redsys.py
@@ -339,6 +339,7 @@ class TxRedsys(models.Model):
         if state == 'done':
             vals['state_message'] = _('Ok: %s') % params.get('Ds_Response')
             self._set_transaction_done()
+            self._confirm_sale_order()
         elif state == 'pending':  # 'Payment error: code: %s.'
             state_message = _('Error: %s (%s)')
             self._set_transaction_pending()
@@ -405,3 +406,10 @@ class TxRedsys(models.Model):
                 'Fail to confirm the order or send the confirmation email%s',
                 tx and ' for the transaction %s' % tx.reference or '')
         return res
+
+    def _confirm_sale_order(self):
+        sales_orders = self.mapped('sale_order_ids').filtered(
+            lambda so: so.state == 'draft')
+        sales_orders.force_quotation_send()
+        for payment_transaction in self:
+            payment_transaction._check_amount_and_confirm_order()

--- a/payment_redsys/tests/test_redsys.py
+++ b/payment_redsys/tests/test_redsys.py
@@ -350,7 +350,7 @@ class RedsysCase(HttpCase):
         self.data_post_redsys(
             url='/payment/redsys/return', data=redsys_post_data)
         mock_confirm.assert_called_once_with()
-        mock_quo_send.assert_not_called()
+        mock_quo_send.assert_called_once_with()
         with self.cursor() as cr:
             env = self.env(cr)
             tx = self.tx.with_env(env)


### PR DESCRIPTION
Con este PR evitamos que si un usuario no regresa a la tienda desde el formulario de Redsys haya un retardo de 10 minutos hasta que se confirma el  pedido por el cron de Odoo.

cc @Tecnativa TT26473
ping @chienandalu @carlosdauden 