### PR TITLE
11.0 [FIX] l10n_es_aeat_sii: Allow to merge tax dictionaries w/o TipoImpositivo key

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -599,7 +599,8 @@ class AccountInvoice(models.Model):
     def _merge_tax_dict(self, vat_list, tax_dict, comp_key, merge_keys):
         """Helper method for merging values in an existing tax dictionary."""
         for existing_dict in vat_list:
-            if existing_dict[comp_key] == tax_dict[comp_key]:
+            if (existing_dict.get(comp_key, "-99") ==
+                    tax_dict.get(comp_key, "-99")):
                 for key in merge_keys:
                     existing_dict[key] += tax_dict[key]
                 return True


### PR DESCRIPTION
For "IVA no sujeto", there's no key "TipoImpositivo" in the dictionary, and the helper
method will fail on that case, so we provide a sane default value for avoiding the crash.

Buenas @pedrobaeza,

Hoy nos hemos topado con una factura en un cliente con el mismo problema, íbamos a presentar una solución tanto para la v11.0 como v12.0 pero comprobando el código antes en la v12.0 vi que lo resolviste. He realizado cherry-pic de tu commit https://github.com/OCA/l10n-spain/commit/f50b63c934d253a0507b1bf7678d41b679ae4cfe para la v11.0 que resuelve el problema perfectamente.

Un saludo