### PR TITLE
[12.0][IMP] l10n_es_aeat: Definir chart_template_id a compañía en base test

### DIFF
--- a/l10n_es_aeat/tests/test_l10n_es_aeat_mod_base.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_mod_base.py
@@ -38,7 +38,7 @@ class TestL10nEsAeatModBase(common.TransactionCase):
     def _chart_of_accounts_create(self):
         _logger.debug('Creating chart of account')
         self.company = self.env['res.company'].create({
-            'name': 'Spanish test company',
+            'name': 'Spanish test company'
         })
         self.chart = self.env.ref('l10n_es.account_chart_template_pymes')
         self.env.ref('base.group_multi_company').write({
@@ -53,6 +53,7 @@ class TestL10nEsAeatModBase(common.TransactionCase):
         self.with_context(
             company_id=self.company.id, force_company=self.company.id,
         )
+        self.company.write({'chart_template_id': chart.id})
         return True
 
     def _accounts_search(self):


### PR DESCRIPTION
Si se tienen instalados: `l10n_es_aeat_mod111` + `l10n_it_account` al correr los test sucede un error puesto que se aplican constraint relativos a `l10n_it_account`.
Para poder tener ambos y que todo funcione, se ha optado por un pequeño truco https://github.com/OCA/l10n-italy/pull/1980 que a su vez hace necesario definir un `chart_template_id` que se usará para otros addons.
Este pequeño truco ayudará a optimizar otros posibles errores respecto a incompatibilidades al tener varias localizaciones instaladas y que los addons SOLO apliquen la funcionalidad en cuestión sobre los registros de la compañía que tiene el plan contable instalado.

@Tecnativa TT26985