### PR TITLE
[11.0][FIX] DUA ImporteTotal no notificar al SII

### DIFF
--- a/l10n_es_dua_sii/models/account_invoice.py
+++ b/l10n_es_dua_sii/models/account_invoice.py
@@ -74,4 +74,5 @@ class AccountInvoice(models.Model):
             res['FacturaRecibida']['Contraparte']['NIF'] = nif
             res['FacturaRecibida']['Contraparte']['NombreRazon'] = \
                 self.company_id.name
+            res["FacturaRecibida"].pop("ImporteTotal", False)
         return res


### PR DESCRIPTION
Se quita ImporteTotal en las notificaciones que se realizan en facturas DUA, para evitar problemas de nuevas validaciones incorporadas en el SII para 2021.