### PR TITLE
[12.0][FIX] l10n_es_aeat_sii: Change key when invoicing purchase order

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -231,6 +231,21 @@ class AccountInvoice(models.Model):
                 }
             }
 
+    @api.onchange('partner_id', 'company_id')
+    def _onchange_partner_id(self):
+        """Trigger fiscal position onchange for assigning SII key when creating
+        bills from purchase module with the button from PO, due to the special
+        way this is triggered through chained onchanges.
+        """
+        trigger_fp = (
+            self.partner_id.property_account_position_id !=
+            self.fiscal_position_id
+        )
+        res = super()._onchange_partner_id()
+        if trigger_fp:
+            self.onchange_fiscal_position_id_l10n_es_aeat_sii()
+        return res
+
     @api.onchange('fiscal_position_id')
     def onchange_fiscal_position_id_l10n_es_aeat_sii(self):
         for invoice in self.filtered('fiscal_position_id'):


### PR DESCRIPTION
Steps to reproduce:

1. Create vendor with fiscal position "Régimen intracomunitario".
2. Assign in the fiscal position the SII registration key for purchases "[09]".
3. Create a purchase order for that vendor and confirm it.
4. Press on "Create Bill" button.

Current behavior:

The vendor bill is created with SII registration key "[01]".

Expected behavior:

The vendor bill is created with SII registration key "[09]".

This is provoked by the sequence Odoo follows for creating the vendor bill, using a combination of default values + the triggering of onchanges. The problem is that the onchange of the fiscal position is triggered once at the beginning (when no partner nor fiscal position is set), and not triggered again when this happens.

The solution is to catch on the partner onchange also the possible condition for changing the SII registration key, and trigger it
manually.

Unfortunately, a regression test can't be added, as this module doesn't depend on purchase for recreating the steps above.

@Tecnativa TT26658