### PR TITLE
[12.0] [FIX] modelo 190 float_compare

### DIFF
--- a/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
+++ b/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
@@ -1,5 +1,6 @@
 
 from odoo import api, fields, models, exceptions, _
+from odoo.tools import float_compare
 
 
 class L10nEsAeatMod190Report(models.Model):
@@ -52,10 +53,10 @@ class L10nEsAeatMod190Report(models.Model):
                     line.retenciones_dinerarias + \
                     line.retenciones_dinerarias_incap
 
-            if self.casilla_02 != percepciones:
+            if float_compare(self.casilla_02, percepciones, 2) != 0:
                 valid = False
 
-            if self.casilla_03 != retenciones:
+            if float_compare(self.casilla_03, retenciones, 2) != 0:
                 valid = False
 
             if not valid:


### PR DESCRIPTION
Despues de calcular, al darle a confirmar no valida porque la comparación de dos float no coincide porque no está redondeado... haciendo debug he está comparando:

```
(Pdb) self.casilla_02 
XXX.03
(Pdb) percepciones
XXX.0299999999
```

esto se soluciona con float_compare

