### PR TITLE
[IMP] l10n_es_aeat_mod349: add missing tax

### DIFF
--- a/l10n_es_aeat_mod349/data/aeat_349_map_data.xml
+++ b/l10n_es_aeat_mod349/data/aeat_349_map_data.xml
@@ -51,6 +51,8 @@
             <field name="operation_key">I</field>
             <field name="tax_tmpl_ids" eval="[
                 (4, ref('l10n_es.account_tax_template_p_iva21_sp_in')),
+                (4, ref('l10n_es.account_tax_template_p_iva10_sp_in')),
+                (4, ref('l10n_es.account_tax_template_p_iva4_sp_in')),
             ]"/>
         </record>
 


### PR DESCRIPTION
@pedrobaeza @AlbertCabedo 

Según un asesor falta este impuesto en el 349.

Puede ser?