### PR TITLE
[8.0] l10n_es_aeat_sii 2021

### DIFF
--- a/l10n_es_aeat_sii/README.rst
+++ b/l10n_es_aeat_sii/README.rst
@@ -108,7 +108,7 @@ Contributors
 * Jordi Tolsà <jordi@studio73.es>
 * Ismael Calvo <ismael.calvo@factorlibre.es>
 * Omar Castiñeira - Comunitea S.L. <omar@comunitea.com>
-* Juanjo Algaz <jalgaz@gmail.com>
+* Juanjo Algaz <jalgaz@gmail.com>, Planeta Huerto <juanjoalgaz@planetahuerto.es>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Santiago Argüeso - Comunitea S.L. <santi@comunitea.com>
 

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -160,7 +160,7 @@
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFact Recargo Equivalencia</field>
         </record>
-        
+
         <record id="aeat_sii_map_line_SFRND" model="aeat.sii.map.lines">
             <field name="code">SFRND</field>
             <field name="taxes" eval="[(6, 0, [
@@ -169,5 +169,43 @@
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas No Deducible</field>
         </record>
-    </data>
+
+        <record id="aeat_sii_map_line_NotIncludedInTotal" model="aeat.sii.map.lines">
+            <field name="code">NotIncludedInTotal</field>
+            <field name="taxes" eval="[(6, 0, [
+              ref('l10n_es.account_tax_template_s_irpf1'),
+              ref('l10n_es.account_tax_template_p_irpf1'),
+              ref('l10n_es.account_tax_template_s_irpf2'),
+              ref('l10n_es.account_tax_template_p_irpf2'),
+              ref('l10n_es.account_tax_template_s_irpf7'),
+              ref('l10n_es.account_tax_template_p_irpf7'),
+              ref('l10n_es.account_tax_template_s_irpf9'),
+              ref('l10n_es.account_tax_template_p_irpf9'),
+              ref('l10n_es.account_tax_template_s_irpf15'),
+              ref('l10n_es.account_tax_template_p_irpf15'),
+              ref('l10n_es.account_tax_template_s_irpf18'),
+              ref('l10n_es.account_tax_template_p_irpf18'),
+              ref('l10n_es.account_tax_template_s_irpf19'),
+              ref('l10n_es.account_tax_template_s_irpf19a'),
+              ref('l10n_es.account_tax_template_s_irpf195a'),
+              ref('l10n_es.account_tax_template_p_irpf19'),
+              ref('l10n_es.account_tax_template_p_irpf19a'),
+              ref('l10n_es.account_tax_template_p_irpf195a'),
+              ref('l10n_es.account_tax_template_s_irpf20'),
+              ref('l10n_es.account_tax_template_s_irpf20a'),
+              ref('l10n_es.account_tax_template_p_irpf20'),
+              ref('l10n_es.account_tax_template_p_irpf20a'),
+              ref('l10n_es.account_tax_template_s_irpf21'),
+              ref('l10n_es.account_tax_template_s_irpf21a'),
+              ref('l10n_es.account_tax_template_p_irpf21a'),
+              ref('l10n_es.account_tax_template_p_irpf21p'),
+              ref('l10n_es.account_tax_template_p_irpf21t'),
+              ref('l10n_es.account_tax_template_p_irpf21td'),
+              ref('l10n_es.account_tax_template_p_irpf21te'),
+            ])]"/>
+            <field name="sii_map_id" ref="aeat_sii_map"/>
+            <field name="name">Impuestos no incluidos en ImporteTotal</field>
+        </record>
+
+ </data>
 </openerp>

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -786,7 +786,13 @@ class AccountInvoice(models.Model):
                         inv_line._get_sii_line_price_unit(), inv_line.quantity,
                         inv_line.product_id, self.partner_id,
                     )
-                    amount_total += sum([t['amount'] for t in taxes['taxes']])
+                    if taxes['total'] >= 0:
+                        amount_total += sum([t['amount'] for t in
+                                             taxes['taxes'] if
+                                             t['amount'] >= 0])
+                    else:
+                        amount_total += sum([t['amount'] for t in
+                                            taxes['taxes'] if t['amount'] < 0])
 
         amount_total_company_signed = amount_total
         if (self.currency_id and self.company_id and
@@ -928,7 +934,6 @@ class AccountInvoice(models.Model):
             )
         else:
             # Check if refund type is 'By differences'. Negative amounts!
-            sign = self._get_sii_sign()
             inv_dict["FacturaRecibida"] = {
                 # TODO: Incluir los 5 tipos de facturas rectificativas
                 "TipoFactura": (

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -803,8 +803,7 @@ class AccountInvoice(models.Model):
                 self.company_id.currency_id,
                 self.company_id,
                 self.date_invoice or fields.Date.today())
-        return round(float_round(abs(amount_total_company_signed) * sign, 2),
-                     2)
+        return round(float_round(amount_total_company_signed * sign, 2), 2)
 
     @api.multi
     def _get_sii_invoice_dict_out(self, cancel=False):

--- a/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii/tests/test_l10n_es_aeat_sii.py
@@ -290,6 +290,7 @@ class TestL10nEsAeatSii(common.TransactionCase):
         # 2/ obtener con get_dict_in los valores a enviar al sii
         # 3/ comprobar el valor de ImporteTotal es igual al estimado
         # 1
+        self._open_invoice()
         amount_base = 100
         amount_tax = 10
         amount_to_communicate_sii = amount_base + amount_tax
@@ -299,6 +300,7 @@ class TestL10nEsAeatSii(common.TransactionCase):
             'period_id': self.period.id,
             'type': 'in_invoice',
             'reference': 'PH-2020-0031',
+            'supplier_invoice_number': 'PH-2020-0031',
             'account_id': self.partner.property_account_payable.id,
             'invoice_line': [
                 (0, 0, {


### PR DESCRIPTION
Hola, 

Se adaptan los cambios añadidos en 12.0 para adaptar el SII a los nuevos requisitos del 1/1/21.

https://github.com/OCA/l10n-spain/pull/1414 (Backport)
https://github.com/OCA/l10n-spain/pull/1546 (Adaptado a la estructura del módulo en la 8.0)