### PR TITLE
[FIX] l10n_es_aeat_mod349: origin amount incorrect

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -215,11 +215,43 @@ class Mod349(models.Model):
             if original_details:
                 # There's at least one previous 349 declaration report
                 report = original_details.mapped('report_id')[:1]
-                original_details = original_details.filtered(
-                    lambda d: d.report_id == report)
-                origin_amount = sum(original_details.mapped('amount_untaxed'))
+                partner_id = original_details.mapped('partner_id')[:1]
                 period_type = report.period_type
                 year = str(report.year)
+
+                key_vals = data.get((partner, op_key, period_type, year))
+                if key_vals:
+                    key_vals['refund_details'] += refund_details
+                    continue
+
+                # Sum all details period origin
+                all_details_period = detail_obj.search([
+                    ('partner_id', '=', partner_id.id),
+                    ('partner_record_id.operation_key', '=', op_key),
+                    ('report_id', '=', report.id),
+                ], order='report_id desc')
+                origin_amount = sum(
+                    all_details_period.mapped('amount_untaxed'))
+
+                # If there are intermediate periods between the original
+                # period and the period where the rectification is taking
+                # place, it's necessary to check if there is any rectification
+                # of the original period in between these periods. This
+                # happens in this way because the right original_amount
+                # will be the value of the total_operation_amount
+                # corresponding to the last period found in between the periods
+                other_invoice_period = all_details_period.mapped(
+                    'invoice_id') - origin_invoice
+                if other_invoice_period.mapped('refund_invoice_ids'):
+                    last_refund_detail = refund_detail_obj.search([
+                        ('report_id.date_start', '>', report.date_end),
+                        ('report_id.date_end', '<', self.date_start),
+                        ('invoice_id', 'in', other_invoice_period.mapped(
+                            'refund_invoice_ids').ids)
+                    ], order='date desc', limit=1)
+                    if last_refund_detail:
+                        origin_amount = last_refund_detail.refund_id.\
+                            total_operation_amount
             else:
                 # There's no previous 349 declaration report in Odoo
                 original_amls = move_line_obj.search([


### PR DESCRIPTION
Buenas, nos hemos encontrado un mal funcionamiento con el cálculo del importe total en el detalle de rectificativas del modelo 349.
Datos para la explicación:

- Enero.

> Cliente 1 - Registro de empresa, Importe total de la operación 100€:
> Factura 11: Importe 40
> Factura 12: Importe 40
> Factura 13: Importe 20

- Febrero.

> Cliente 1
> Rectificativa de la Factura 11 de 10€

- Marzo.

> Cliente 1
> Rectificativa de la Factura 11 de 10€

- Abril.

> Cliente 1
> Rectificativa de la Factura 11 de 10€
> Rectificativa de la Factura 13 de 10€

**Antecedentes.**

Si desde el modelo 349 lo ejecutamos para los meses de Febrero, Marzo, Abril, en el apartado de Rectificaciones de otros periodos veremos lo siguiente.

- Febrero

> Cliente1
> Importe total tras la rectificación 30€ (40 - 10)

- Marzo

> Cliente1
> Importe total tras la rectificación 30€ (40 - 10)

- Abril

> Cliente1
> Importe total tras la rectificación 30€ (40 - 10)

Esto es así ya que actualmente el código solo tiene en cuenta el total de la factura que está rectificando, cuando lo correcto sería informar del total que se informó de ese cliente en el periodo menos la cantidad a rectificar, además hay que tener en cuenta que si entre periodo hay rectificaciones el periodo el importe original será el del último periodo ya rectificado.

- Febrero

> Cliente1
> Importe total tras la rectificación 90€ (100 - 10)

- Marzo

> Cliente1
> Importe total tras la rectificación 80€ (90 - 10)

- Abril

> Cliente1
> Importe total tras la rectificación 60€ (80 - 10 - 10)

Un saludo