### PR TITLE
Changed X590SerialNumber to string to avoid error with large numbers

### DIFF
--- a/l10n_es_facturae/data/xmldsig-core-schema.xsd
+++ b/l10n_es_facturae/data/xmldsig-core-schema.xsd
@@ -189,7 +189,13 @@
 <complexType name="X509IssuerSerialType"> 
   <sequence> 
     <element name="X509IssuerName" type="string"/> 
-    <element name="X509SerialNumber" type="integer"/> 
+    <element name="X509SerialNumber">
+      <simpleType>
+        <restriction base="string">
+            <pattern value="[0-9]+"></pattern>
+        </restriction>
+      </simpleType>
+    </element>
   </sequence>
 </complexType>
 


### PR DESCRIPTION
Tenemos problemas con facturas con un número en el campo `X509SerialNumber` demasidado grande. He encontrado varios enlaces donde sugieren que la solución puede ser cambiar ese campo a `string` en la definición
* [https://www.w3.org/TR/xmldsig-core2/](https://www.w3.org/TR/xmldsig-core2/) (Final del párrafo `7.4 The X509Data Element`)
* [https://github.com/benoist/xmldsig/issues/31](https://github.com/benoist/xmldsig/issues/31)
A nosotros desde luego nos soluciona el problema y parsea bien la factura.