### PR TITLE
[12.0][FIX] AEAT Validations fixes

### DIFF
--- a/l10n_es_aeat_mod190/data/aeat_export_mod190_data.xml
+++ b/l10n_es_aeat_mod190/data/aeat_export_mod190_data.xml
@@ -4,7 +4,7 @@
 
     <!--  MAIN-190
         A. TIPO DE REGISTRO 1: REGISTRO DE DECLARANTE -->
-    
+
     <record id="aeat_mod190_main_export_config" model="aeat.model.export.config">
         <field name="name">Exportación modelo 190 - Tipo de Registro 1 – Registro de declarante</field>
         <field name="date_start">2017-01-01</field>
@@ -158,22 +158,32 @@
         <field name="alignment">right</field>
     </record>
 
-    <!-- IMPORTE TOTAL DE LAS PERCEPCIONES (16) -->
+    <!-- SIGNO TOTAL DE LAS PERCEPCIONES (1) -->
     <record id="aeat_mod190_main_export_line_14" model="aeat.model.export.config.line">
         <field name="sequence">14</field>
+        <field name="export_config_id" ref="aeat_mod190_main_export_config"/>
+        <field name="name">Signo Rendimientos del trabajo y en especie - Importe de las percepciones [02]</field>
+        <field name="expression">${' ' if object.casilla_02 >= 0 else 'N'}</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+    </record>
+
+    <!-- IMPORTE TOTAL DE LAS PERCEPCIONES (16) -->
+    <record id="aeat_mod190_main_export_line_15" model="aeat.model.export.config.line">
+        <field name="sequence">15</field>
         <field name="export_config_id" ref="aeat_mod190_main_export_config"/>
         <field name="name">Rendimientos del trabajo y en especie - Importe de las percepciones [02]</field>
         <field name="expression">${object.casilla_02}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True"/>
-        <field name="size">16</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">15</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
     </record>
 
     <!-- IMPORTE TOTAL DE LAS RETENCIONES E INGRESOS A CUENTA (15) -->
-    <record id="aeat_mod190_main_export_line_15" model="aeat.model.export.config.line">
-        <field name="sequence">15</field>
+    <record id="aeat_mod190_main_export_line_16" model="aeat.model.export.config.line">
+        <field name="sequence">16</field>
         <field name="export_config_id" ref="aeat_mod190_main_export_config"/>
         <field name="name">Rendimientos del trabajo y en especie - Importe de las retenciones [03]</field>
         <field name="expression">${object.casilla_03}</field>
@@ -185,8 +195,8 @@
     </record>
 
     <!-- CORREO ELECTRONICO DE LA PERSONA CON QUIEN RELACIONARSE (55) -->
-    <record id="aeat_mod190_main_export_line_16" model="aeat.model.export.config.line">
-        <field name="sequence">16</field>
+    <record id="aeat_mod190_main_export_line_17" model="aeat.model.export.config.line">
+        <field name="sequence">17</field>
         <field name="export_config_id" ref="aeat_mod190_main_export_config"/>
         <field name="name">Correo electrónico</field>
         <field name="expression">${object.contact_email}</field>
@@ -196,8 +206,8 @@
     </record>
 
     <!-- BLANCOS (260) -->
-    <record id="aeat_mod190_main_export_line_17" model="aeat.model.export.config.line">
-        <field name="sequence">17</field>
+    <record id="aeat_mod190_main_export_line_18" model="aeat.model.export.config.line">
+        <field name="sequence">18</field>
         <field name="export_config_id" ref="aeat_mod190_main_export_config"/>
         <field name="name">Reservado para la Administración. Rellenar con blancos</field>
         <field name="fixed_value"/>
@@ -206,19 +216,19 @@
         <field name="alignment">left</field>
     </record>
 
-    <!-- SELLO ELECTRONICO (13) -->
-    <record id="aeat_mod190_main_export_line_18" model="aeat.model.export.config.line">
-        <field name="sequence">18</field>
+    <!-- SELLO ELECTRONICO (16) -->
+    <record id="aeat_mod190_main_export_line_19" model="aeat.model.export.config.line">
+        <field name="sequence">19</field>
         <field name="export_config_id" ref="aeat_mod190_main_export_config"/>
-        <field name="name">Reservado para el sello electrónico de la AEAT (13)</field>
+        <field name="name">Reservado para el sello electrónico de la AEAT (14)</field>
         <field name="fixed_value"/>
         <field name="export_type">string</field>
-        <field name="size">13</field>
+        <field name="size">16</field>
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod190_main_export_line_19" model="aeat.model.export.config.line">
-        <field name="sequence">19</field>
+    <record id="aeat_mod190_main_export_line_20" model="aeat.model.export.config.line">
+        <field name="sequence">20</field>
         <field name="export_config_id" ref="aeat_mod190_main_export_config"/>
         <field name="name">Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
         <field name="expression">${"\r\n".encode("ascii")}</field>
@@ -230,7 +240,7 @@
     <!--  B. TIPO DE REGISTRO 2: REGISTRO DE PERCEPTOR -->
 
     <record id="aeat_mod190_main_export_line_20" model="aeat.model.export.config.line">
-        <field name="sequence">20</field>
+        <field name="sequence">21</field>
         <field name="export_config_id" ref="aeat_mod190_main_export_config"/>
         <field name="name">Exportación modelo 190 - Tipo de Registro 2 – Registro de cliente</field>
         <field name="subconfig_id" ref="aeat_mod190_partner_export_config"/>

--- a/l10n_es_aeat_mod190/data/aeat_export_mod190_partner_data.xml
+++ b/l10n_es_aeat_mod190/data/aeat_export_mod190_partner_data.xml
@@ -114,7 +114,7 @@
         <field name="sequence">10</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config"/>
         <field name="name">Subclave</field>
-        <field name="expression">${object.aeat_perception_subkey_id.name}</field>
+        <field name="expression">${object.aeat_perception_subkey_id.name if object.aeat_perception_subkey_id.name else '00'}</field>
         <field name="export_type">string</field>
         <field name="size">2</field>
         <field name="alignment">left</field>
@@ -208,7 +208,8 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config"/>
         <field name="name">Ejercicio devengo</field>
         <field name="expression">${object.ejercicio_devengo}</field>
-        <field name="export_type">string</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
         <field name="size">4</field>
         <field name="alignment">right</field>
     </record>
@@ -233,7 +234,7 @@
         <field name="sequence">20</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config"/>
         <field name="name">Datos adicionales: Año de nacimiento</field>
-        <field name="expression">${object.a_nacimiento}</field>
+        <field name="expression">${object.a_nacimiento if object.a_nacimiento else '0000'}</field>
         <field name="export_type">string</field>
         <field name="size">4</field>
         <field name="alignment">left</field>
@@ -244,7 +245,7 @@
         <field name="sequence">21</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config"/>
         <field name="name">Datos adicionales: Situación familiar</field>
-        <field name="expression">${object.situacion_familiar}</field>
+        <field name="expression">${object.situacion_familiar if object.situacion_familiar else '0'}</field>
         <field name="export_type">string</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
@@ -266,7 +267,7 @@
         <field name="sequence">23</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config"/>
         <field name="name">Datos adicionales: Discapacidad</field>
-        <field name="expression">${object.discapacidad}</field>
+        <field name="expression">${object.discapacidad if object.discapacidad else '0'}</field>
         <field name="export_type">string</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
@@ -277,7 +278,7 @@
         <field name="sequence">24</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config"/>
         <field name="name">Datos adicionales: Contrato o relación</field>
-        <field name="expression">${object.contrato_o_relacion}</field>
+        <field name="expression">${object.contrato_o_relacion if object.contrato_o_relacion else '0'}</field>
         <field name="export_type">string</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
@@ -299,7 +300,7 @@
         <field name="sequence">26</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config"/>
         <field name="name">Datos adicionales: Movilidad geográfica</field>
-        <field name="expression">${object.movilidad_geografica}</field>
+        <field name="expression">${object.movilidad_geografica if object.movilidad_geografica else '0'}</field>
         <field name="export_type">string</field>
         <field name="size">1</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
+++ b/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
@@ -141,12 +141,24 @@ class L10nEsAeatMod190Report(models.Model):
                             tax_line.res_id == report.id
                         ):
                             rde += line.credit - line.debit
+                        gd = 0.0
+                        if (
+                            tax_line.field_number == 11 and
+                            tax_line.res_id == report.id
+                        ):
+                            account_gd = self.env.ref('l10n_es.{}_account_common_476'.
+                                                      format(self.env.user.company_id.id))
+                            line_gd = line.mapped('move_id.line_ids').\
+                                filtered(lambda l: l.partner_id == rp and l.account_id == account_gd)
+                            gd += line_gd.credit - line_gd.debit
+
                         if not rp.discapacidad or rp.discapacidad == '0':
                             values['percepciones_dinerarias'] += pd
                             values['retenciones_dinerarias'] += rd
                             values['percepciones_en_especie'] += pde - rde
                             values['ingresos_a_cuenta_efectuados'] += pde
                             values['ingresos_a_cuenta_repercutidos'] += rde
+                            values['gastos_deducibles'] += gd
                         else:
                             values['percepciones_dinerarias_incap'] += pd
                             values['retenciones_dinerarias_incap'] += rd
@@ -155,6 +167,7 @@ class L10nEsAeatMod190Report(models.Model):
                             values['ingresos_a_cuenta_efectuados_incap'] += pde
                             values[
                                 'ingresos_a_cuenta_repercutidos_incap'] += rde
+                            values['gastos_deducibles'] += gd
 
             line_obj = self.env['l10n.es.aeat.mod190.report.line']
             registros = 0
@@ -230,6 +243,7 @@ class L10nEsAeatMod190Report(models.Model):
             'percepciones_en_especie_incap': 0,
             'ingresos_a_cuenta_efectuados_incap': 0,
             'ingresos_a_cuenta_repercutidos_incap': 0,
+            'gastos_deducibles': 0,
         }
         if key_id.ad_required + subkey_id.ad_required >= 2:
             vals.update({

--- a/l10n_es_aeat_mod190/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod190/readme/CONTRIBUTORS.rst
@@ -2,3 +2,6 @@
 * Juan Vicente Pascual (http://www.puntsistemes.com)
 * Pedro Ortega (http://www.puntsistemes.com)
 * Enric Tobella <etobella@creublanca.es>
+* `Guadaltech <https://www.guadaltech.es>`__:
+
+  * Fernando La Chica <fernandolachica@gmail.com>


### PR DESCRIPTION
Según se comenta en la [norma](https://www.agenciatributaria.es/static_files/Sede/Disenyo_registro/ant_100_199/archivos/Dr_190_2020.pdf) que define el diseño de los registros y las pruebas que he realizado en mis clientes:

- La longitud total de los registros es de 500
- Aunque la norma diga que los números deben ser completados con ceros a la izquierda no pasa así con el signo. Necesita que sea un espacio.
- Si la subclave no se especifica se ha de informar con 00
- El ejercicio de devengo si es actual se debe informar con 0000
- El año de nacimiento es obligatorio "Solo para percepciones correspondientes a las claves A, B.01, B.03 y C.". Si declaro un/a perceptor/a con la clave F falla al importar indicando E020180 Caracteres no válidos 'Año de nacimiento'
- Errores similares para los campos situación familiar, dicapacidad, contrato, Movilidad geográfica