### PR TITLE
[FIX] 11.0 l10n_es_aeat_sii: amount total tax line incorrect

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -511,7 +511,16 @@ class AccountInvoice(models.Model):
                 taxes_sfesb + taxes_sfesisp + taxes_sfens + taxes_sfesbe
             )
             if tax in taxes_not_in_total:
-                not_in_amount_total += tax_line.amount_total
+                if self.currency_id != self.company_id.currency_id:
+                    amount = self.currency_id._convert(
+                        tax_line.amount_total,
+                        self.company_id.currency_id,
+                        self.company_id,
+                        self._get_currency_rate_date(),
+                    )
+                else:
+                    amount = tax_line.amount_total
+                not_in_amount_total += amount
             if tax in breakdown_taxes:
                 tax_breakdown = taxes_dict.setdefault(
                     'DesgloseFactura', {},
@@ -642,7 +651,16 @@ class AccountInvoice(models.Model):
         for tax_line in self.tax_line_ids:
             tax = tax_line.tax_id
             if tax in taxes_not_in_total:
-                not_in_amount_total += tax_line.amount_total
+                if self.currency_id != self.company_id.currency_id:
+                    amount = self.currency_id._convert(
+                        tax_line.amount_total,
+                        self.company_id.currency_id,
+                        self.company_id,
+                        self._get_currency_rate_date(),
+                    )
+                else:
+                    amount = tax_line.amount_total
+                not_in_amount_total += amount
             if tax in taxes_sfrisp:
                 base_dict = taxes_dict.setdefault(
                     'InversionSujetoPasivo', {'DetalleIVA': []},

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -512,12 +512,14 @@ class AccountInvoice(models.Model):
             )
             if tax in taxes_not_in_total:
                 if self.currency_id != self.company_id.currency_id:
-                    amount = self.currency_id._convert(
+                    currency = self.currency_id.with_context(
+                        date=self._get_currency_rate_date(),
+                        company_id=self.company_id.id
+                        )
+                    amount = currency.compute(
                         tax_line.amount_total,
-                        self.company_id.currency_id,
-                        self.company_id,
-                        self._get_currency_rate_date(),
-                    )
+                        self.company_id.currency_id
+                        )
                 else:
                     amount = tax_line.amount_total
                 not_in_amount_total += amount
@@ -652,12 +654,14 @@ class AccountInvoice(models.Model):
             tax = tax_line.tax_id
             if tax in taxes_not_in_total:
                 if self.currency_id != self.company_id.currency_id:
-                    amount = self.currency_id._convert(
+                    currency = self.currency_id.with_context(
+                        date=self._get_currency_rate_date(),
+                        company_id=self.company_id.id
+                        )
+                    amount = currency.compute(
                         tax_line.amount_total,
-                        self.company_id.currency_id,
-                        self.company_id,
-                        self._get_currency_rate_date(),
-                    )
+                        self.company_id.currency_id
+                        )
                 else:
                     amount = tax_line.amount_total
                 not_in_amount_total += amount


### PR DESCRIPTION
Este FIX soluciona la información enviada al SII en las facturas que tienen una moneda diferente. Si tienes una factura con:
Base imponible: 605,16£
Cuota de IVA: 127,08£

Nuestra empresa al ser española, tenemos que informar de estos importes en euros:
Base imponible: 0,899030 / 605,16£ = 673,13€.
Cuota de IVA: 0,899030 / 127,08£ = 141,35€.

Sin este FIX estaríamos enviando al SII un importe total de (673,13€ + 127,08£) 800,21€. Esto no es correcto, ya que el importe de 673,13 se informa en euros pero estamos añadiendo el IVA en 127,08£.

Con esta corrección el importe que nos queda por añadir como tasa de IVA es la moneda de la empresa utilizando el campo amount_company dando como resultado (673,13€ + 141,35€) 814,48€ que es correcto.

Un saludo