### PR TITLE
[FIX] l10n_es_aeat_sii_oca: SII description override

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -5,6 +5,7 @@
 # Copyright 2018 PESOL - Angel Moya <angel.moya@pesol.es>
 # Copyright 2011-2021 Tecnativa - Pedro M. Baeza
 # Copyright 2020 Valentin Vinagre <valent.vinagre@sygel.es>
+# Copyright 2021 Tecnativa - João Marques
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import json
@@ -1400,7 +1401,7 @@ class AccountMove(models.Model):
                         "invoice_line_ids.ref"
                     )
                     description += " - ".join(filter(None, names))
-            invoice.sii_description = description[:500] or "/"
+            invoice.sii_description = (description or "")[:500] or "/"
 
     @api.depends(
         "company_id",

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -302,6 +302,7 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.assertEqual(
             invoice_temp.sii_description, "Test supplier header | Test description",
         )
+        company.sii_description = False
         company.sii_description_method = "manual"
         invoice_temp = self.invoice.copy()
         invoice_temp._compute_sii_description()


### PR DESCRIPTION
If an invoice has the `sii_description` attribute set to "False", this will override the `default_description` computed when creating the invoice. We should check if it is defined or not. 

Even though it has a default value of "/", some old invoices might not have that value defined, or it might not get picked up when creating the invoice. This increases resilience.

@Tecnativa
TT28236

ping @pedrobaeza @victoralmau 