### PR TITLE
[12.0][FIX] Changing the name of some variables

### DIFF
--- a/l10n_es_aeat_mod347/data/mail_template_data.xml
+++ b/l10n_es_aeat_mod347/data/mail_template_data.xml
@@ -48,10 +48,10 @@
   % if object.real_estate_transmissions_amount:
   <p>
   <strong>Importe de transmisión de inmueble:</strong> ${object.real_estate_transmissions_amount}<br/>
-  <strong>Inmuebles primer trimestre:</strong> ${object.first_quarter_real_estate_transmission_amount}<br/>
-  <strong>Inmuebles segundo trimestre:</strong> ${object.second_quarter_real_estate_transmission_amount}<br/>
-  <strong>Inmuebles tercer trimestre:</strong> ${object.third_quarter_real_estate_transmission_amount}<br/>
-  <strong>Inmuebles cuarto trimestre:</strong> ${object.fourth_quarter_real_estate_transmission_amount}<br/>
+  <strong>Inmuebles primer trimestre:</strong> ${object.first_quarter_real_estate_transmission}<br/>
+  <strong>Inmuebles segundo trimestre:</strong> ${object.second_quarter_real_estate_transmission}<br/>
+  <strong>Inmuebles tercer trimestre:</strong> ${object.third_quarter_real_estate_transmission}<br/>
+  <strong>Inmuebles cuarto trimestre:</strong> ${object.fourth_quarter_real_estate_transmission}<br/>
   </p>
   % endif
   <p>En el documento adjunto se incluyen las facturas en base a las cuales se obtienen los importes anteriores.</p>

--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -116,19 +116,19 @@
               </div>
               <div class="col-xs-2">
                 <strong  class="text-right">Amount 1Q:</strong>
-                <p class="text-right" t-field="o.first_quarter_real_estate_transmissions_amount"/>
+                <p class="text-right" t-field="o.first_quarter_real_estate_transmission"/>
               </div>
               <div class="col-xs-2">
                 <strong  class="text-right">Amount 2Q:</strong>
-                <p class="text-right" t-field="o.second_quarter_real_estate_transmissions_amount"/>
+                <p class="text-right" t-field="o.second_quarter_real_estate_transmission"/>
               </div>
               <div class="col-xs-2">
                 <strong  class="text-right">Amount 3Q:</strong>
-                <p class="text-right" t-field="o.third_quarter_real_estate_transmissions_amount"/>
+                <p class="text-right" t-field="o.third_quarter_real_estate_transmission"/>
               </div>
               <div class="col-xs-2">
                 <strong  class="text-right">Amount 4Q:</strong>
-                <p class="text-right" t-field="o.fourth_quarter_real_estate_transmissions_amount"/>
+                <p class="text-right" t-field="o.fourth_quarter_real_estate_transmission"/>
               </div>
             </div>
           </t>


### PR DESCRIPTION
The fields "X_quarter_real_estate_transmissions_amount" (X=first, second, third, fourth) had the old names so the template was failing. The new names for those fields are "X_quarter_real_estate_transmission".
It was failing in the mail_template as well