### PR TITLE
[FIX] l10n_es_intrastat_report: Update multi-company rules

### DIFF
--- a/l10n_es_intrastat_report/migrations/13.0.1.0.0/noupdate_changes.xml
+++ b/l10n_es_intrastat_report/migrations/13.0.1.0.0/noupdate_changes.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+    <record id="l10n_es_intrastat_company_rule" model="ir.rule">
+        <field
+            name="domain_force"
+        >['|',('company_id','=',False),('company_id','in',company_ids)]</field>
+    </record>
+</odoo>

--- a/l10n_es_intrastat_report/migrations/13.0.1.0.0/post-migration.py
+++ b/l10n_es_intrastat_report/migrations/13.0.1.0.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2021 Tecnativa - João Marques
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "l10n_es_intrastat_report", "migrations/13.0.1.0.0/noupdate_changes.xml"
+    )

--- a/l10n_es_intrastat_report/security/l10n_es_intrastat_report_security.xml
+++ b/l10n_es_intrastat_report/security/l10n_es_intrastat_report_security.xml
@@ -6,6 +6,6 @@
         <field name="global" eval="True" />
         <field
             name="domain_force"
-        >[('company_id', 'child_of', user.company_id.ids)]</field>
+        >['|',('company_id','=',False),('company_id','in',company_ids)]</field>
     </record>
 </data>


### PR DESCRIPTION
Missed step from the migration to v13
Update multi-company security domains and provide migration scripts

As discussed in https://github.com/OCA/l10n-spain/pull/1610#discussion_r578971904

@Tecnativa
TT27865

ping @pedrobaeza @victoralmau 