### PR TITLE
[11.0] [FIX] l10n_es_aeat_sii: not type _onchange_partner_id

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -237,7 +237,7 @@ class AccountInvoice(models.Model):
             self.fiscal_position_id
         )
         res = super()._onchange_partner_id()
-        if trigger_fp:
+        if trigger_fp and self.type:
             self.onchange_fiscal_position_id_l10n_es_aeat_sii()
         return res
 


### PR DESCRIPTION
Este fix corrige el error de asignar la variable sii_registration_key si no tenemos type definido.

Este error se ha encontrado junto con el modulo account_banking_mandate del repositorio bank-payment, en el método create
que instancia una nueva factura con unos valores que no tiene type definido, provocando que al ejecutar el _onchange_partner_id
provoca que en el sii al pasar por _onchange_partner_id la varialbe trigger_fp puede ser positivo y ejecutara la función
onchange_fiscal_position_id_l10n_es_aeat_sii pero al no tener type definido se provoca el error en la comprobación del if.