### PR TITLE
[13.0][FIX] l10n_es_vat_book: avoids adding not posted invoices to vat book

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -300,6 +300,7 @@ class L10nEsVatBook(models.Model):
         return [
             ("date", ">=", self.date_start),
             ("date", "<=", self.date_end),
+            ("parent_state", "=", "posted"),
             "|",
             ("tax_ids", "in", taxes.ids),
             ("tax_line_id", "in", taxes.ids),


### PR DESCRIPTION
fixes #1618