### PR TITLE
[12.0][FIX] delivery_seur: Remove lines in test to check delivery_price_method addon is installed

### DIFF
--- a/delivery_seur/readme/CONTRIBUTORS.rst
+++ b/delivery_seur/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
 
     * Pedro M. Baeza
     * David Vidal
+    * Víctor Martínez

--- a/delivery_seur/tests/test_delivery_seur.py
+++ b/delivery_seur/tests/test_delivery_seur.py
@@ -40,11 +40,6 @@ class TestDeliverySeur(SavepointCase):
         self.assertTrue(response)
 
     def test_delivery_carrier_seur_price(self):
-        module = self.env['ir.module.module'].search([
-            ('name', '=', 'delivery_price_method')])
-        if module.state != 'installed':
-            self.skipTest(
-                'delivery_price_method not installed, ignore price test')
         product = self.env.ref('product.product_delivery_01')
         partner = self.env.ref('base.res_partner_12')
         pricelist = self.env['product.pricelist'].create({


### PR DESCRIPTION
Remove lines in test to check `delivery_price_method` addon is installed (it's not nececessary because it's a dependency)

Related to https://github.com/OCA/l10n-spain/pull/1619#discussion_r586187663

Por favor @chienandalu y @joao-p-marques ¿podéis revisarlo?

@Tecnativa TT26919