### PR TITLE
[8.0][FIX] l10n_es_aeat_sii: Add l10n_es dependency to prevent error to install

### DIFF
--- a/l10n_es_aeat_sii/__openerp__.py
+++ b/l10n_es_aeat_sii/__openerp__.py
@@ -36,6 +36,7 @@
     "depends": [
         "account_refund_original",
         "l10n_es_aeat",
+        "l10n_es",
         "connector",
         "account_invoice_currency",
     ],


### PR DESCRIPTION
Es necesario añadir la dependencia l10n_es para poder instalar el addon.

@pedrobaeza y @joao-p-marques ¿podéis revisarlo?

@Tecnativa TT28516