### PR TITLE
[13.0][FIX] account_promissory_note_caixabank: Add _description to report model

### DIFF
--- a/account_promissory_note_caixabank/report/check_print.py
+++ b/account_promissory_note_caixabank/report/check_print.py
@@ -6,3 +6,4 @@ class ReportPromissoryNotePrintCB(models.AbstractModel):
     # account_check_printing_report_base for the report to work.
     _name = "report.account_promissory_note_caixabank.promissory_footer_cb"
     _inherit = "report.account_check_printing_report_base.promissory_footer_a4"
+    _description = "Promissory Note CaixaBank"


### PR DESCRIPTION
Se añade `_description` al modelo de reporte para evitar el warning en el log al instalarlo.

Por favor @CarlosRoca13 y @joao-p-marques ¿podéis revisarlo?

@Tecnativa TT26919