### PR TITLE
[FIX] delivery_gls_asm: escaping shipping vals for xml

### DIFF
--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import _, fields, models
+from xml.sax.saxutils import escape
 from .gls_asm_request import GlsAsmRequest
 from .gls_asm_request import (
     GLS_ASM_SERVICES, GLS_SHIPPING_TIMES, GLS_POSTAGE_TYPE,
@@ -85,8 +86,8 @@ class DeliveryCarrier(models.Model):
             "pod": "N",  # [optional]
             "podobligatorio": "N",  # [deprecated]
             "remite_plaza": "",  # [optional] Origin agency
-            "remite_nombre": sender_partner.name,
-            "remite_direccion": sender_partner.street or "",
+            "remite_nombre": escape(sender_partner.name),
+            "remite_direccion": escape(sender_partner.street) or "",
             "remite_poblacion": sender_partner.city or "",
             "remite_provincia": sender_partner.state_id.name or "",
             "remite_pais": "34",  # [mandatory] always 34=Spain
@@ -100,8 +101,9 @@ class DeliveryCarrier(models.Model):
             "destinatario_codigo": "",
             "destinatario_plaza": "",
             "destinatario_nombre": (
-                picking.partner_id.name or
-                picking.partner_id.commercial_partner_id.name),
+                escape(picking.partner_id.name)
+                or escape(picking.partner_id.commercial_partner_id.name)
+            ),
             "destinatario_direccion": picking.partner_id.street or "",
             "destinatario_poblacion": picking.partner_id.city or "",
             "destinatario_provincia": picking.partner_id.state_id.name or "",
@@ -115,7 +117,7 @@ class DeliveryCarrier(models.Model):
             "destinatario_att": "",
             "destinatario_departamento": "",
             "destinatario_nif": "",
-            "referencia_c": picking.name,  # Our unique reference
+            "referencia_c": escape(picking.name),  # Our unique reference
             "referencia_0": "",  # Not used if the above is set
             "importes_debido": "0",  # The customer pays the shipping
             "importes_reembolso": "",  # TODO: Support Cash On Delivery

--- a/delivery_gls_asm/tests/test_delivery_gls_asm.py
+++ b/delivery_gls_asm/tests/test_delivery_gls_asm.py
@@ -31,7 +31,7 @@ class TestDeliveryGlsAsm(common.SavepointCase):
             'name': 'Test product',
         })
         cls.partner = cls.env['res.partner'].create({
-            'name': 'Mr. Odoo',
+            'name': 'Mr. Odoo & Co.',
             'city': 'Odoo Ville',
             'zip': '28001',
             'street': 'Calle de La Rua, 3',
@@ -103,3 +103,9 @@ class TestDeliveryGlsAsm(common.SavepointCase):
         ):
             report = wizard.get_manifest()
             self.assertEqual(report["data"]["deliveries"], mocked_response)
+
+    def test_03_gls_escaping(self):
+        """We must ensure that the values we'll be putting into the XML are
+        properly escaped"""
+        vals = self.carrier_gls_asm._prepare_gls_asm_shipping(self.picking)
+        self.assertEqual(vals.get("destinatario_nombre"), "Mr. Odoo &amp; Co.")


### PR DESCRIPTION
Ensure that the values sent to the xml soap request are properly
escaped. A partner name like "Johnson & Johnson" would fail otherwise.

cc @Tecnativa TT28662

ping @victoralmau @pedrobaeza 