### PR TITLE
[13.0][FIX] l10n_es_intrastat_report: Add _description to models

### DIFF
--- a/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
+++ b/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
@@ -182,6 +182,7 @@ class L10nEsIntrastatProductDeclaration(models.Model):
 
 class L10nEsIntrastatProductComputationLine(models.Model):
     _name = "l10n.es.intrastat.product.computation.line"
+    _description = "Intrastat Product Computation Line"
     _inherit = "intrastat.product.computation.line"
 
     parent_id = fields.Many2one(
@@ -202,6 +203,7 @@ class L10nEsIntrastatProductComputationLine(models.Model):
 
 class L10nEsIntrastatProductDeclarationLine(models.Model):
     _name = "l10n.es.intrastat.product.declaration.line"
+    _description = "Intrastat Product Declaration Line"
     _inherit = "intrastat.product.declaration.line"
 
     parent_id = fields.Many2one(

--- a/l10n_es_intrastat_report/wizards/l10n_es_intrastat_code_import.py
+++ b/l10n_es_intrastat_report/wizards/l10n_es_intrastat_code_import.py
@@ -23,6 +23,7 @@ UOM_MAPPING = {
 
 class L10nEsPartnerImportWizard(models.TransientModel):
     _name = "l10n.es.intrastat.code.import"
+    _description = "Intrastat Code Import"
     _inherit = "res.config.installer"
 
     @tools.ormcache("name")


### PR DESCRIPTION
Se añade `_description` a los modelos que no lo tienen para evitar el warning en el log al instalarlo.

Por favor @CarlosRoca13 y @joao-p-marques ¿podéis revisarlo?

@Tecnativa TT26919