### PR TITLE
[13.0][FIX] l10n_es_aeat_sii_oca: Prevent duplicate label in some fields

### DIFF
--- a/l10n_es_aeat_sii_oca/models/res_company.py
+++ b/l10n_es_aeat_sii_oca/models/res_company.py
@@ -71,7 +71,7 @@ class ResCompany(models.Model):
     )
     sent_time = fields.Float(string="Sent time")
     delay_time = fields.Float(string="Delay time")
-    sii_tax_agency_id = fields.Many2one("aeat.sii.tax.agency", string="Tax Agency")
+    sii_tax_agency_id = fields.Many2one("aeat.sii.tax.agency", string="SII Tax Agency")
 
     def _get_sii_eta(self):
         if self.send_mode == "fixed":


### PR DESCRIPTION
Resolver el warning relativo a etiquetas duplicadas:

`WARNING openerp_test odoo.addons.base.models.ir_model: Two fields (sii_tax_agency_id, tax_agency_id) of res.company() have the same label: Tax Agency.`

Esto es necesario de aplicarlo a 14.0 también.

Por favor @CarlosRoca13 y @joao-p-marques ¿podéis revisarlo?

@Tecnativa TT26919