### PR TITLE
[FIX] facturae: Change of function mame on `edi`

### DIFF
--- a/l10n_es_facturae/components/account_move_l10n_es_facturae_listener.py
+++ b/l10n_es_facturae/components/account_move_l10n_es_facturae_listener.py
@@ -35,7 +35,7 @@ class AccountMoveL10nEsFacturaeListener(Component):
             exchange_record = backend.create_record(
                 exchange_type, self._get_exchange_record_vals(record)
             )
-            backend.generate_output(exchange_record)
+            backend.exchange_generate(exchange_record)
             backend.exchange_send(exchange_record)
 
     def on_generate_account_edi(self, records):


### PR DESCRIPTION
This is making #1590 fail.

@pedrobaeza 

@simahawk We should avoid changing function names on existent modules, as it might happen something like this :sob: The best option would be to add a deprecated on the old name and delete it on the next migration