### PR TITLE
[13.0][FIX] l10n_es_aeat_sii_oca: Hook on post low level method

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -1106,9 +1106,9 @@ class AccountMove(models.Model):
         content_sent = json.loads(self.sii_content_sent)
         return to_send == content_sent
 
-    def action_post(self):
-        res = super(AccountMove, self).action_post()
-        for invoice in self.filtered("sii_enabled"):
+    def post(self):
+        res = super().post()
+        for invoice in self.filtered(lambda x: x.sii_enabled and x.is_invoice()):
             if (
                 invoice.sii_state in ["sent_modified", "sent"]
                 and self._sii_invoice_dict_not_modified()


### PR DESCRIPTION
We were intercepting the high level method for posting the invoice, but this method calls a low level one that is the one that is always called.

There's a chance of having the high level method to be bypassed and not called, so we need to intercept the low level one.

We also need to filter the non invoices records now at this level.

@Tecnativa TT28698