### PR TITLE
[13.0][FIX]l10n_es_dua_sii changed SII filters to exclude DUA invoices

### DIFF
--- a/l10n_es_dua_sii/__manifest__.py
+++ b/l10n_es_dua_sii/__manifest__.py
@@ -12,7 +12,7 @@
     "author": "Studio73, " "Comunitea, " "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["l10n_es_aeat_sii_oca", "l10n_es_dua"],
-    "data": ["data/tax_code_map_dua_sii_data.xml"],
+    "data": ["data/tax_code_map_dua_sii_data.xml", "views/account_move_views.xml"],
     "application": False,
     "installable": True,
     "auto_install": True,

--- a/l10n_es_dua_sii/models/account_move.py
+++ b/l10n_es_dua_sii/models/account_move.py
@@ -11,7 +11,9 @@ from odoo import api, fields, models, tools
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    sii_dua_invoice = fields.Boolean("SII DUA Invoice", compute="_compute_dua_invoice")
+    sii_dua_invoice = fields.Boolean(
+        "SII DUA Invoice", compute="_compute_dua_invoice", store=True
+    )
 
     @api.model
     @tools.ormcache("company")

--- a/l10n_es_dua_sii/views/account_move_views.xml
+++ b/l10n_es_dua_sii/views/account_move_views.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_account_invoice_sii_filter_dua" model="ir.ui.view">
+        <field name="name">view.account.invoice.sii.filter.dua</field>
+        <field name="model">account.move</field>
+        <field
+            name="inherit_id"
+            ref="l10n_es_aeat_sii_oca.view_account_invoice_sii_filter"
+        />
+        <field name="arch" type="xml">
+            <xpath expr='//filter[@name="sii_not_sent"]' position='attributes'>
+                <attribute
+                    name="domain"
+                >[('sii_state', '=', 'not_sent'), ('date', '>=', '2017-01-01'), ('sii_dua_invoice', '=', False)]</attribute>
+            </xpath>
+            <xpath expr='//filter[@name="sii_pending"]' position='attributes'>
+                <attribute
+                    name="domain"
+                >[('sii_state', 'in', ['sent_modified','cancelled_modified']), ('sii_dua_invoice', '=', False)]</attribute>
+            </xpath>
+            <xpath expr='//filter[@name="sii_sent"]' position='attributes'>
+                <attribute
+                    name="domain"
+                >[('sii_state', 'not in', ['not_sent']), ('sii_dua_invoice', '=', False)]</attribute>
+            </xpath>
+            <xpath expr='//filter[@name="sii_send_failed"]' position='attributes'>
+                <attribute
+                    name="domain"
+                >[('sii_send_failed', '=', True), ('sii_dua_invoice', '=', False)]</attribute>
+            </xpath>
+            <xpath expr='//filter[@name="sii_cancelled"]' position='attributes'>
+                <attribute
+                    name="domain"
+                >[('sii_state', 'in', ['cancelled','cancelled_modified']), ('sii_dua_invoice', '=', False)]</attribute>
+            </xpath>
+            <xpath expr='//filter[@name="sii_error"]' position='attributes'>
+                <attribute
+                    name="domain"
+                >[('sii_send_failed', '=', True), ('sii_dua_invoice', '=', False)]</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Se han cambiado los filtros del SII para excluir las facturas DUA ya que estas facturas nunca se envían.

@pedrobaeza Lo hemos intentado primero del siguiente modo:

```
            <xpath expr='//filter[@name="sii_not_sent"]' position='attributes'>
                <attribute name="domain" add="('sii_dua_invoice', '=', False)" separator=", "/>
            </xpath>
```

El problema es que creemos que la nueva condición del dominio se añadía detrás de los corchetes en lugar de dentro. Es por eso que hemos optado por reescribir el dominio. ¿Se te ocurre alguna manera mejor de hacerlo? Gracias.