### PR TITLE
[FIX] l10n_es_aeat_sii: add missing tax mapping

### DIFF
--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -49,6 +49,7 @@
             <field name="code">SFESS</field>
             <field name="taxes" eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_s_iva21s'),
+                ref('l10n_es.account_tax_template_s_iva21isp'),
                 ref('l10n_es.account_tax_template_s_iva10s'),
                 ref('l10n_es.account_tax_template_s_iva4s'),
             ])]"/>


### PR DESCRIPTION
Soluciona https://github.com/OCA/l10n-spain/issues/1664