### PR TITLE
[13.0][FIX] l10n_es_vat_book: Restrict tax move lines to certain accounts

### DIFF
--- a/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
+++ b/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
@@ -31,6 +31,7 @@
         <field name="special_tax_group" eval="False" />
         <field name="fee_type_xlsx_column">O</field>
         <field name="fee_amount_xlsx_column">P</field>
+        <field name="tax_account_id" ref="l10n_es.account_common_472" />
         <field
             name="tax_tmpl_ids"
             eval="[

--- a/l10n_es_vat_book/models/aeat_vat_book_map_line.py
+++ b/l10n_es_vat_book/models/aeat_vat_book_map_line.py
@@ -27,3 +27,6 @@ class AeatVatBookMapLines(models.Model):
     tax_tmpl_ids = fields.Many2many(
         comodel_name="account.tax.template", string="Taxes",
     )
+    tax_account_id = fields.Many2one(
+        comodel_name="account.account.template", string="Tax Account Restriction",
+    )

--- a/l10n_es_vat_book/views/aeat_vat_book_map_view.xml
+++ b/l10n_es_vat_book/views/aeat_vat_book_map_view.xml
@@ -22,6 +22,7 @@
                 <field name="fee_type_xlsx_column" />
                 <field name="fee_amount_xlsx_column" />
                 <field name="tax_tmpl_ids" widget="many2many_tags" />
+                <field name="tax_account_id" />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
On intra-community operations and other 2-sided received taxes, we have these move lines:

| Account  | Tax                            | Debit   | Credit  |
|----------|:-------------------------------|:--------|:--------|
| 47200000 | IVA 21% Adquisición de serv... | 16,63 € | 0,00 €  |
| 47700000 | IVA 21% Adquisición de serv... | 0,00 €  | 16,63 € |

so both lines were nullified when computing tax amount.

We need to restrict the search of this kind of lines to one side, and the best way to do it is through linked account, in a similar way as it's done on AEAT reports.

@Tecnativa TT29073