### PR TITLE
[ADD] Solución modificaciones SII 2021.

### DIFF
--- a/l10n_es_aeat_sii/__manifest__.py
+++ b/l10n_es_aeat_sii/__manifest__.py
@@ -27,7 +27,6 @@
               "Otherway,"
               "Tecnativa,"
               "Javi Melendez,"
-              "Punt Sistemes"
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,

--- a/l10n_es_aeat_sii/__manifest__.py
+++ b/l10n_es_aeat_sii/__manifest__.py
@@ -6,14 +6,16 @@
 # Copyright 2017 Studio73 - Jordi Tolsà <jordi@studio73.es>
 # Copyright 2017 Factor Libre - Ismael Calvo
 # Copyright 2017 Otherway - Pedro Rodríguez Gil
-# Copyright 2017 Tecnativa - Pedro M. Baeza
+# Copyright 2017-2021 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Javi Melendez <javimelex@gmail.com>
 # Copyright 2018 Angel Moya <angel.moya@pesol.es>
+# Copyright 2021 Punt Sistemes - Juanvi Pascual <jvpascual@puntsistemes.es>
+# Copyright 2021 Punt Sistemes - Pedro Ortega <portega@puntsistemes.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": u"Suministro Inmediato de Información en el IVA",
-    "version": "10.0.3.4.1",
+    "version": "10.0.4.0.1",
     "category": "Accounting & Finance",
     "website": "https://odoospain.odoo.com",
     "author": "Acysos S.L.,"
@@ -25,6 +27,7 @@
               "Otherway,"
               "Tecnativa,"
               "Javi Melendez,"
+              "Punt Sistemes"
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -230,8 +230,10 @@
         <record id="aeat_sii_map_line_base_not_included_in_total" model="aeat.sii.map.lines">
             <field name="code">BaseNotIncludedInTotal</field>
             <field name="taxes" eval="[(6, 0, [
-              ref('l10n_es.account_tax_template_s_iva0_ns'),
+              ref('l10n_es.account_tax_template_s_iva_ns'),
+              ref('l10n_es.account_tax_template_p_iva0_ns'),
             ])]"/>
+
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">Bases no incluidas en ImporteTotal</field>
         </record>

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -87,9 +87,9 @@
                 ref('l10n_es.account_tax_template_p_iva4_bi'),
                 ref('l10n_es.account_tax_template_p_iva10_bi'),
                 ref('l10n_es.account_tax_template_p_iva21_bi'),
-                ref('l10n_es.account_tax_template_p_iva4_sp_in_1'),
-                ref('l10n_es.account_tax_template_p_iva10_sp_in_1'),
-                ref('l10n_es.account_tax_template_p_iva21_sp_in_1'),
+                ref('l10n_es.account_tax_template_p_iva4_sp_in_2'),
+                ref('l10n_es.account_tax_template_p_iva10_sp_in_2'),
+                ref('l10n_es.account_tax_template_p_iva21_sp_in_2'),
                 ref('l10n_es.account_tax_template_p_iva4_ic_bc_1'),
                 ref('l10n_es.account_tax_template_p_iva10_ic_bc_1'),
                 ref('l10n_es.account_tax_template_p_iva21_ic_bc_1'),
@@ -119,9 +119,9 @@
                 ref('l10n_es.account_tax_template_p_iva21_isp_1'),
                 ref('l10n_es.account_tax_template_p_iva10_isp_1'),
                 ref('l10n_es.account_tax_template_p_iva4_isp_1'),
-                ref('l10n_es.account_tax_template_p_iva21_sp_ex_1'),
-                ref('l10n_es.account_tax_template_p_iva10_sp_ex_1'),
-                ref('l10n_es.account_tax_template_p_iva4_sp_ex_1'),
+                ref('l10n_es.account_tax_template_p_iva21_sp_ex_2'),
+                ref('l10n_es.account_tax_template_p_iva10_sp_ex_2'),
+                ref('l10n_es.account_tax_template_p_iva4_sp_ex_2'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas ISP</field>

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -224,4 +224,13 @@
             <field name="name">Impuestos no incluidos en ImporteTotal</field>
         </record>
 
+        <record id="aeat_sii_map_line_base_not_included_in_total" model="aeat.sii.map.lines">
+            <field name="code">BaseNotIncludedInTotal</field>
+            <field name="taxes" eval="[(6, 0, [
+              ref('l10n_es.account_tax_template_s_iva0_ns'),
+            ])]"/>
+            <field name="sii_map_id" ref="aeat_sii_map"/>
+            <field name="name">Bases no incluidas en ImporteTotal</field>
+        </record>
+
 </odoo>

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -99,6 +99,9 @@
                 ref('l10n_es.account_tax_template_p_iva4_ibc'),
                 ref('l10n_es.account_tax_template_p_iva10_ibc'),
                 ref('l10n_es.account_tax_template_p_iva21_ibc'),
+                ref('l10n_es.account_tax_template_p_iva4_ibi'),
+                ref('l10n_es.account_tax_template_p_iva10_ibi'),
+                ref('l10n_es.account_tax_template_p_iva21_ibi'),
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas Sujetas</field>

--- a/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii/data/aeat_sii_map_data.xml
@@ -160,7 +160,7 @@
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFact Recargo Equivalencia</field>
         </record>
-        
+
         <record id="aeat_sii_map_line_SFRND" model="aeat.sii.map.lines">
             <field name="code">SFRND</field>
             <field name="taxes" eval="[(6, 0, [
@@ -170,6 +170,58 @@
             ])]"/>
             <field name="sii_map_id" ref="aeat_sii_map"/>
             <field name="name">SuministroFactRecibidas No Deducible</field>
+        </record>
+
+        <record id="aeat_sii_map_line_NotIncludedInTotal" model="aeat.sii.map.lines">
+            <field name="code">NotIncludedInTotal</field>
+            <field name="taxes" eval="[(6, 0, [
+              ref('l10n_es.account_tax_template_s_irpf1'),
+              ref('l10n_es.account_tax_template_p_irpf1'),
+              ref('l10n_es.account_tax_template_s_irpf2'),
+              ref('l10n_es.account_tax_template_p_irpf2'),
+              ref('l10n_es.account_tax_template_s_irpf7'),
+              ref('l10n_es.account_tax_template_p_irpf7'),
+              ref('l10n_es.account_tax_template_s_irpf9'),
+              ref('l10n_es.account_tax_template_p_irpf9'),
+              ref('l10n_es.account_tax_template_s_irpf15'),
+              ref('l10n_es.account_tax_template_p_irpf15'),
+              ref('l10n_es.account_tax_template_s_irpf18'),
+              ref('l10n_es.account_tax_template_p_irpf18'),
+              ref('l10n_es.account_tax_template_s_irpf19'),
+              ref('l10n_es.account_tax_template_s_irpf19a'),
+              ref('l10n_es.account_tax_template_s_irpf195a'),
+              ref('l10n_es.account_tax_template_p_irpf19'),
+              ref('l10n_es.account_tax_template_p_irpf19a'),
+              ref('l10n_es.account_tax_template_p_irpf195a'),
+              ref('l10n_es.account_tax_template_s_irpf20'),
+              ref('l10n_es.account_tax_template_s_irpf20a'),
+              ref('l10n_es.account_tax_template_p_irpf20'),
+              ref('l10n_es.account_tax_template_p_irpf20a'),
+              ref('l10n_es.account_tax_template_s_irpf21'),
+              ref('l10n_es.account_tax_template_s_irpf21a'),
+              ref('l10n_es.account_tax_template_p_irpf21a'),
+              ref('l10n_es.account_tax_template_p_irpf21p'),
+              ref('l10n_es.account_tax_template_p_irpf21t'),
+              ref('l10n_es.account_tax_template_p_irpf21td'),
+              ref('l10n_es.account_tax_template_p_irpf21te'),
+              ref('l10n_es.account_tax_template_p_iva21_isp_2'),
+              ref('l10n_es.account_tax_template_p_iva10_isp_2'),
+              ref('l10n_es.account_tax_template_p_iva4_isp_2'),
+              ref('l10n_es.account_tax_template_p_iva21_sp_ex_1'),
+              ref('l10n_es.account_tax_template_p_iva10_sp_ex_1'),
+              ref('l10n_es.account_tax_template_p_iva4_sp_ex_1'),
+              ref('l10n_es.account_tax_template_p_iva4_sp_in_1'),
+              ref('l10n_es.account_tax_template_p_iva10_sp_in_1'),
+              ref('l10n_es.account_tax_template_p_iva21_sp_in_1'),
+              ref('l10n_es.account_tax_template_p_iva4_ic_bc_2'),
+              ref('l10n_es.account_tax_template_p_iva10_ic_bc_2'),
+              ref('l10n_es.account_tax_template_p_iva21_ic_bc_2'),
+              ref('l10n_es.account_tax_template_p_iva4_ic_bi_2'),
+              ref('l10n_es.account_tax_template_p_iva10_ic_bi_2'),
+              ref('l10n_es.account_tax_template_p_iva21_ic_bi_2'),
+            ])]"/>
+            <field name="sii_map_id" ref="aeat_sii_map"/>
+            <field name="name">Impuestos no incluidos en ImporteTotal</field>
         </record>
 
 </odoo>

--- a/l10n_es_aeat_sii/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_sii/readme/CONTRIBUTORS.rst
@@ -11,3 +11,5 @@
 * Santi Argüeso - Comunitea S.L. <santi@comunitea.com>
 * Angel Moya - PESOL <angel.moya@pesol.es>
 * Nacho Muñoz <nacmuro@gmail.com>
+* Juanvi Pascual <jvpascual@puntsistemes.es>
+* Pedro Ortega <portega@puntsistemes.es>


### PR DESCRIPTION
Modificaciones SII 2021

Se corrige:

- Cuando la CuotaRecargoEquivalencia este cumplimentada, la CuotaDeducible tiene que ser cero.

- El campo CuotaDeducible ha de ser cero cuando el valor de ClaveRegimenEspecialOTrascendencia o alguna ClaveRegimenEspecialOTrascendenciaAdicional sea 13.

- El valor de ImporteTotal no coincide con el sumatorio de BaseImponible, CuotaSoportada, CuotaRecargoEquivalencia e ImporteCompensacionREAGYP en todas las lineas de detalle.