### PR TITLE
[13.0][FIX] l10n_es_vat_book: Prevent duplicate reports (html + pdf) and remove html reports only in print menu

### DIFF
--- a/l10n_es_account_asset/tests/test_l10n_es_account_asset.py
+++ b/l10n_es_account_asset/tests/test_l10n_es_account_asset.py
@@ -114,7 +114,12 @@ class TestL10nEsAccountAsset(common.SavepointCase):
     def test_assign_profile(self):
         # direct profile assignation
         asset = self.asset.copy(
-            {"name": "Test Asset 2", "method_time": "year", "method_percentage": 0}
+            {
+                "name": "Test Asset 2",
+                "method_time": "year",
+                "method_percentage": 0,
+                "method_number": self.asset.profile_id.method_number,
+            }
         )
         profile = self.profile.copy(
             {

--- a/l10n_es_vat_book/report/report_views.xml
+++ b/l10n_es_vat_book/report/report_views.xml
@@ -8,6 +8,7 @@
         name="l10n_es_vat_book.report_vat_book_invoices_issued_html"
         file="l10n_es_vat_book.report_vat_book_invoices_issued"
         attachment_use="False"
+        menu="False"
     />
     <report
         id="act_report_vat_book_invoices_received_html"
@@ -17,12 +18,12 @@
         name="l10n_es_vat_book.report_vat_book_invoices_received_html"
         file="l10n_es_vat_book.report_vat_book_invoices_received"
         attachment_use="False"
+        menu="False"
     />
     <report
         id="act_report_vat_book_invoices_issued_pdf"
         model="l10n.es.vat.book"
         string="Vat book invoices issued"
-        report_type="qweb-pdf"
         name="l10n_es_vat_book.report_vat_book_invoices_issued_pdf"
         file="l10n_es_vat_book.report_vat_book_invoices_issued"
         attachment_use="False"
@@ -31,7 +32,6 @@
         id="act_report_vat_book_invoices_received_pdf"
         model="l10n.es.vat.book"
         string="Vat book invoices received"
-        report_type="qweb-pdf"
         name="l10n_es_vat_book.report_vat_book_invoices_received_pdf"
         file="l10n_es_vat_book.report_vat_book_invoices_received"
         attachment_use="False"


### PR DESCRIPTION
Prevent duplicate reports (html + pdf) and remove html reports only in print menu. (It's need to fix too in 14.0)

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT29305