### PR TITLE
[14.0][FIX] l10n_es_vat_book: Prevent duplicate reports (html + pdf) and remove html reports only in print menu

### DIFF
--- a/l10n_es_vat_book/report/report_views.xml
+++ b/l10n_es_vat_book/report/report_views.xml
@@ -10,7 +10,6 @@
         <field
             name="report_file"
         >l10n_es_vat_book.report_vat_book_invoices_issued</field>
-        <field name="binding_model_id" ref="model_l10n_es_vat_book" />
         <field name="binding_type">report</field>
     </record>
     <record id="act_report_vat_book_invoices_received_html" model="ir.actions.report">
@@ -23,13 +22,11 @@
         <field
             name="report_file"
         >l10n_es_vat_book.report_vat_book_invoices_received</field>
-        <field name="binding_model_id" ref="model_l10n_es_vat_book" />
         <field name="binding_type">report</field>
     </record>
     <record id="act_report_vat_book_invoices_issued_pdf" model="ir.actions.report">
         <field name="name">Vat book invoices issued</field>
         <field name="model">l10n.es.vat.book</field>
-        <field name="report_type">qweb-pdf</field>
         <field
             name="report_name"
         >l10n_es_vat_book.report_vat_book_invoices_issued_pdf</field>
@@ -42,7 +39,6 @@
     <record id="act_report_vat_book_invoices_received_pdf" model="ir.actions.report">
         <field name="name">Vat book invoices received</field>
         <field name="model">l10n.es.vat.book</field>
-        <field name="report_type">qweb-pdf</field>
         <field
             name="report_name"
         >l10n_es_vat_book.report_vat_book_invoices_received_pdf</field>


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/l10n-spain/pull/1680

Prevent duplicate reports (html + pdf) and remove html reports only in print menu.

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT29305