### PR TITLE
[10.0][fix] Corregido error en asientos sin partner del TPV al generar el libro de IVA

### DIFF
--- a/l10n_es_vat_book/__manifest__.py
+++ b/l10n_es_vat_book/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Libro de IVA",
-    "version": "10.0.4.0.0",
+    "version": "10.0.4.0.1",
     "author": "PRAXYA, "
               "Eficent, "
               "Tecnativa, "

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -331,12 +331,15 @@ class L10nEsVatBook(models.Model):
             line_vals['line_type'] = 'rectification_{}'.format(line_type)
 
     def _check_exceptions(self, line_vals):
-        partner = self.env["res.partner"].browse(line_vals['partner_id'])
-        if (partner._parse_aeat_vat_info()[0] in
-            partner._get_aeat_europe_codes() and
-            (not line_vals['vat_number'] and line_vals['partner_id'] not in
-             self.get_pos_partner_ids())):
-            line_vals['exception_text'] = _("Without VAT")
+        partner = False
+        if 'partner_id' in line_vals.keys() and line_vals['partner_id']:
+            partner = self.env["res.partner"].browse(line_vals['partner_id'])
+
+        if (not line_vals['vat_number'] and line_vals['partner_id'] not
+            in self.get_pos_partner_ids()):
+            if (not partner or partner._parse_aeat_vat_info()[0] in
+                partner._get_aeat_europe_codes()):
+                line_vals['exception_text'] = _("Without VAT")
 
     def create_vat_book_lines(self, move_lines, line_type, taxes):
         VatBookLine = self.env['l10n.es.vat.book.line']


### PR DESCRIPTION
Este problema comienza a aparecer tras el commit:
https://github.com/OCA/l10n-spain/commit/55bfd3866fe10d04fcf4758babf148800b9d291f

solo en el caso de que existan asientos sin clientes, normalmente procedentes del TPV.