### PR TITLE
[12.0][ADD] l10n_es_aeat_partner_check: Comprobación recargo equiv.

### DIFF
--- a/l10n_es_aeat_partner_check/i18n/es.po
+++ b/l10n_es_aeat_partner_check/i18n/es.po
@@ -1,30 +1,26 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* l10n_es_aeat_partner_check
+#	* l10n_es_aeat_partner_check
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-01-20 18:33+0000\n"
-"PO-Revision-Date: 2020-03-08 14:13+0000\n"
-"Last-Translator: Antonio Pérez Ruth <antonio.perez@makrin.es>\n"
+"PO-Revision-Date: 2021-05-07 07:04+0000\n"
+"Last-Translator: Ethan Hildick <ethan@studio73.es>\n"
 "Language-Team: \n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.10\n"
 
+
 #. module: l10n_es_aeat_partner_check
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_partner_check.res_config_settings_aeat_partner_check_view_form
-msgid ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" groups=\"base.group_multi_company\"/>"
-msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Los valores establecidos "
-"aquí, son específicos de la compañia.\" groups=\"base.group_multi_company\"/>"
+msgid "<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\" groups=\"base.group_multi_company\"/>"
+msgstr "<span class=\"fa fa-lg fa-building-o\" title=\"Los valores establecidos aquí, son específicos de la compañia.\" groups=\"base.group_multi_company\"/>"
 
 #. module: l10n_es_aeat_partner_check
 #: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_partner__aeat_partner_name
@@ -70,7 +66,7 @@ msgid "Data different"
 msgstr "Datos diferentes"
 
 #. module: l10n_es_aeat_partner_check
-#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:8
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:10
 #: selection:res.partner,aeat_partner_check_result:0
 #, python-format
 msgid "Identificado"
@@ -83,38 +79,36 @@ msgstr "Identificado"
 
 #. module: l10n_es_aeat_partner_check
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_partner_check.company_form_vat
-msgid ""
-"If this checkbox is ticked, you will check the partner information in AEAT "
-"in create and write partner"
-msgstr ""
-"Si esta activado, se comprobará la información de la empresa en la AEAT al "
-"crear o modificar la empresa"
+msgid "If this checkbox is ticked, you will check the partner information in AEAT in create and write partner"
+msgstr "Si esta activado, se comprobará la información de la empresa en la AEAT al crear o modificar la empresa"
 
 #. module: l10n_es_aeat_partner_check
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_partner_check.res_config_settings_aeat_partner_check_view_form
-msgid ""
-"If this checkbox is ticked, you will check the partner information in AEAT "
-"in create and write partner."
-msgstr ""
-"Si esta activado, se comprobará la información de la empresa en la AEAT al "
-"crear o modificar la empresa."
+msgid "If this checkbox is ticked, you will check the partner information in AEAT in create and write partner."
+msgstr "Si esta activado, se comprobará la información de la empresa en la AEAT al crear o modificar la empresa."
 
 #. module: l10n_es_aeat_partner_check
-#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:10
+#: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_partner__aeat_last_checked
+#: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_users__aeat_last_checked
+msgid "Latest AEAT check"
+msgstr "Última petición"
+
+#. module: l10n_es_aeat_partner_check
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:12
 #: selection:res.partner,aeat_partner_check_result:0
 #, python-format
 msgid "No identificable"
 msgstr "No identificable"
 
 #. module: l10n_es_aeat_partner_check
-#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:7
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:9
 #: selection:res.partner,aeat_partner_check_result:0
 #, python-format
 msgid "No identificado"
 msgstr "No identificado"
 
 #. module: l10n_es_aeat_partner_check
-#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:9
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:11
 #: selection:res.partner,aeat_partner_check_result:0
 #, python-format
 msgid "No procesado"
@@ -141,10 +135,40 @@ msgid "Partner Data Quality"
 msgstr "Calidad de datos de la empresa"
 
 #. module: l10n_es_aeat_partner_check
+#: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_partner__aeat_partner_type
+#: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_users__aeat_partner_type
+msgid "Partner type"
+msgstr "Tipo asociado"
+
+#. module: l10n_es_aeat_partner_check
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:15
+#: selection:res.partner,aeat_partner_type:0
+#, python-format
+msgid "Régimen de recargo de equivalencia"
+msgstr "Régimen de recargo de equivalencia"
+
+#. module: l10n_es_aeat_partner_check
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:16
+#: selection:res.partner,aeat_partner_type:0
+#, python-format
+msgid "Régimen estándar"
+msgstr "Régimen estándar"
+
+#. module: l10n_es_aeat_partner_check
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_partner_check.view_res_partner_aeat_filter
+msgid "Sales Equiv. regimen"
+msgstr "Régimen de recargo de equivalencia"
+
+#. module: l10n_es_aeat_partner_check
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_partner_check.view_res_partner_aeat_filter
+msgid "Standard regimen"
+msgstr "Régimen estándar"
+
+#. module: l10n_es_aeat_partner_check
 #: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_partner__aeat_partner_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_users__aeat_partner_vat
 msgid "VAT"
-msgstr "IVA"
+msgstr "NIF"
 
 #. module: l10n_es_aeat_partner_check
 #: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_company__vat_check_aeat

--- a/l10n_es_aeat_partner_check/i18n/l10n_es_aeat_partner_check.pot
+++ b/l10n_es_aeat_partner_check/i18n/l10n_es_aeat_partner_check.pot
@@ -62,7 +62,7 @@ msgid "Data different"
 msgstr ""
 
 #. module: l10n_es_aeat_partner_check
-#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:8
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:10
 #: selection:res.partner,aeat_partner_check_result:0
 #, python-format
 msgid "Identificado"
@@ -84,21 +84,27 @@ msgid "If this checkbox is ticked, you will check the partner information in AEA
 msgstr ""
 
 #. module: l10n_es_aeat_partner_check
-#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:10
+#: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_partner__aeat_last_checked
+#: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_users__aeat_last_checked
+msgid "Latest AEAT check"
+msgstr ""
+
+#. module: l10n_es_aeat_partner_check
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:12
 #: selection:res.partner,aeat_partner_check_result:0
 #, python-format
 msgid "No identificable"
 msgstr ""
 
 #. module: l10n_es_aeat_partner_check
-#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:7
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:9
 #: selection:res.partner,aeat_partner_check_result:0
 #, python-format
 msgid "No identificado"
 msgstr ""
 
 #. module: l10n_es_aeat_partner_check
-#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:9
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:11
 #: selection:res.partner,aeat_partner_check_result:0
 #, python-format
 msgid "No procesado"
@@ -122,6 +128,36 @@ msgstr ""
 #. module: l10n_es_aeat_partner_check
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_partner_check.view_partner_aeat_form
 msgid "Partner Data Quality"
+msgstr ""
+
+#. module: l10n_es_aeat_partner_check
+#: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_partner__aeat_partner_type
+#: model:ir.model.fields,field_description:l10n_es_aeat_partner_check.field_res_users__aeat_partner_type
+msgid "Partner type"
+msgstr ""
+
+#. module: l10n_es_aeat_partner_check
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:15
+#: selection:res.partner,aeat_partner_type:0
+#, python-format
+msgid "Régimen de recargo de equivalencia"
+msgstr ""
+
+#. module: l10n_es_aeat_partner_check
+#: code:addons/l10n_es_aeat_partner_check/models/res_partner.py:16
+#: selection:res.partner,aeat_partner_type:0
+#, python-format
+msgid "Régimen estándar"
+msgstr ""
+
+#. module: l10n_es_aeat_partner_check
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_partner_check.view_res_partner_aeat_filter
+msgid "Sales Equiv. regimen"
+msgstr ""
+
+#. module: l10n_es_aeat_partner_check
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_partner_check.view_res_partner_aeat_filter
+msgid "Standard regimen"
 msgstr ""
 
 #. module: l10n_es_aeat_partner_check

--- a/l10n_es_aeat_partner_check/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_partner_check/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Ignacio Ibeas - Acysos S.L. <ignacio@acysos.com>
+* Ethan Hildick - Studio73 <ethan@studio73.es>

--- a/l10n_es_aeat_partner_check/readme/DESCRIPTION.rst
+++ b/l10n_es_aeat_partner_check/readme/DESCRIPTION.rst
@@ -1,2 +1,2 @@
-Comprueba los datos de la empresa en el censo de la AEAT
+Comprueba los datos de la empresa en el censo de la AEAT y en el recargo de equivalencia
 https://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Declaraciones/Modelos_01_al_99/030_036_037/WS_Masivo/Manual_Tecnico_WS_Masivo_Calidad_Datos_Identificativos.pdf

--- a/l10n_es_aeat_partner_check/views/res_partner_view.xml
+++ b/l10n_es_aeat_partner_check/views/res_partner_view.xml
@@ -16,6 +16,8 @@
 						<field name="aeat_partner_vat" />
 						<field name="aeat_partner_check_result"/>
 						<field name="aeat_data_diff"/>
+						<field name="aeat_last_checked" />
+						<field name="aeat_partner_type" />
 					</group>
 				</page>
 			</field>
@@ -33,6 +35,8 @@
 					<filter string="Not Processed" name="not_processed" domain="[('aeat_partner_check_result','=','NO PROCESADO')]"/>
 					<filter string="Not Identifiable" name="not_identifiable" domain="[('aeat_partner_check_result','=','NO IDENTIFICABLE')]"/>
 					<filter string="Data Diff" name="data_diff" domain="[('aeat_partner_check_result','!=','NO IDENTIFICABLE'), ('aeat_data_diff', '=', True)]"/>
+					<filter string="Sales Equiv. regimen" name="se_type" domain="[('aeat_partner_type','=','sales_equalization')]"/>
+					<filter string="Standard regimen" name="standard_type" domain="[('aeat_partner_type','=','standard')]"/>
 				</filter>
 			</field>
 		</record>


### PR DESCRIPTION
Se propone estos cambios para poder comprobar contra la AEAT si la empresa está sometido al recargo de equivalencia e indica la última fecha de comprobación.

Este proceso se hace junto con la petición del resto de la información, pero no se puede utilizar la funcionalidad de `l10n_es_aeat` de `soap` ya que no hay WebService de la información que queremos, estamos haciendo una petición directa al formulario y "parseando" el HTML devuelto para ver el estado de la empresa.

Puse la actualización de fecha en las 2 peticiones por si solo se quiere hacer la petición de recargo (mi caso de uso personal), que se actualize