### PR TITLE
[FIX] l10n_es_intrastat_report: additional check if company's country…

### DIFF
--- a/l10n_es_intrastat_report/wizards/l10n_es_intrastat_code_import.py
+++ b/l10n_es_intrastat_report/wizards/l10n_es_intrastat_code_import.py
@@ -91,7 +91,7 @@ class L10nEsPartnerImportWizard(models.TransientModel):
 
     def execute(self):
         company = self.env.company
-        if company.country_id.code.lower() != "es":
+        if (company.country_id.code or "").lower() != "es":
             raise exceptions.UserError(
                 _("Current company is not Spanish, so it can't be configured.")
             )


### PR DESCRIPTION
… is set

If user installed l10n_es_intrastat_report and forgot to set company's country, he will receive an exception when python trying to call .lower() method on boolean type in this [line](https://github.com/dosipchuk/l10n-spain/blob/14.0/l10n_es_intrastat_report/wizards/l10n_es_intrastat_code_import.py#L94)

Added an additional check for the presence of a country for the company.