### PR TITLE
[IMP] l10n_es_aeat: Remove pyOpenSSL dependancy

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -20,7 +20,7 @@
     "website": "https://github.com/OCA/l10n-spain",
     "category": "Accounting & Finance",
     "depends": ["l10n_es", "account_tax_balance"],
-    "external_dependencies": {"python": ["unidecode", "pyOpenSSL"]},
+    "external_dependencies": {"python": ["unidecode", "cryptography"]},
     "data": [
         "security/aeat_security.xml",
         "security/ir.model.access.csv",

--- a/l10n_es_aeat_sii_oca/__manifest__.py
+++ b/l10n_es_aeat_sii_oca/__manifest__.py
@@ -32,7 +32,7 @@
     "installable": True,
     "development_status": "Production/Stable",
     "maintainers": ["pedrobaeza"],
-    "external_dependencies": {"python": ["zeep", "requests", "pyOpenSSL"]},
+    "external_dependencies": {"python": ["zeep", "requests", "cryptography"]},
     "depends": ["account_invoice_refund_link", "l10n_es", "l10n_es_aeat", "queue_job"],
     "data": [
         "data/aeat_sii_queue_job.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # generated from manifests external_dependencies
 chardet
+cryptography
 pycrypto
 pyOpenSSL
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 chardet
 cryptography
 pycrypto
-pyOpenSSL
 requests
 unidecode
 zeep


### PR DESCRIPTION
Pues eso, eliminamos la dependencia de pyOpenSSL según lo hablado en los OCA Days

@pedrobaeza 