### PR TITLE
[13.0][FIX] payment_redsys: Proper controller visibility

### DIFF
--- a/payment_redsys/controllers/main.py
+++ b/payment_redsys/controllers/main.py
@@ -27,7 +27,7 @@ class RedsysController(http.Controller):
             "/payment/redsys/reject",
         ],
         type="http",
-        auth="none",
+        auth="public",
         csrf=False,
     )
     def redsys_return(self, **post):


### PR DESCRIPTION
this change fixes the issue that appears when redsys responds to odoo 
default_followers = self.env['mail.followers']._add_default_followers(self._name, [], self.env.user.partner_id.ids, customer_ids=[])[0][0]
KeyError: 0 - - -