### PR TITLE
[11.0] Evitar error 500 y confirmación de pedido después de pago OK

### DIFF
--- a/payment_redsys/controllers/main.py
+++ b/payment_redsys/controllers/main.py
@@ -22,7 +22,7 @@ class RedsysController(http.Controller):
         '/payment/redsys/cancel',
         '/payment/redsys/error',
         '/payment/redsys/reject',
-    ], type='http', auth='none', csrf=False)
+    ], type='http', auth='public', csrf=False)
     def redsys_return(self, **post):
         """ Redsys."""
         _logger.info('Redsys: entering form_feedback with post data %s',


### PR DESCRIPTION
Actualización para evitar el error 500 que daba Redsys al volver a la tienda después de la conformación del pago. El pedido no se confirmaba.