### PR TITLE
[FIX] l10n_es_irnr: fix tax groups

### DIFF
--- a/l10n_es_irnr/data/taxes_irnr.xml
+++ b/l10n_es_irnr/data/taxes_irnr.xml
@@ -6,7 +6,7 @@
 
 <!-- Retenciones IRPF No residentes no-UE 24% -->
 
-    <record id="tax_group_irnr_no_ue" model="account.tax.group">
+    <record id="tax_group_retenciones_24" model="account.tax.group">
         <field name="name">Retenciones no residentes no-UE</field>
     </record>
 
@@ -18,7 +18,7 @@
     <field name="refund_account_id" ref="l10n_es.account_common_473"/>
     <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
     <field name="amount" eval="-24"/>
-    <field name="tax_group_id" ref="tax_group_irnr_no_ue"/>
+    <field name="tax_group_id" ref="tax_group_retenciones_24"/>
     <field name="amount_type">percent</field>
 </record>
 
@@ -31,13 +31,13 @@
     <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
     <field name="amount" eval="-24"/>
     <field name="amount_type">percent</field>
-    <field name="tax_group_id" ref="tax_group_irnr_no_ue"/>
+    <field name="tax_group_id" ref="tax_group_retenciones_24"/>
 </record>
 
 <!-- Retenciones IRPF No residentes UE 19% -->
 
 
-    <record id="tax_group_irnr_ue" model="account.tax.group">
+    <record id="tax_group_retenciones_19_irnr" model="account.tax.group">
         <field name="name">Retenciones no residentes UE</field>
     </record>
 
@@ -49,7 +49,7 @@
     <field name="refund_account_id" ref="l10n_es.account_common_473"/>
     <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
     <field name="amount" eval="-19"/>
-    <field name="tax_group_id" ref="tax_group_irnr_ue"/>
+    <field name="tax_group_id" ref="tax_group_retenciones_19_irnr"/>
     <field name="amount_type">percent</field>
 </record>
 
@@ -61,7 +61,7 @@
     <field name="refund_account_id" ref="l10n_es.account_common_4751"/>
     <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
     <field name="amount" eval="-19"/>
-    <field name="tax_group_id" ref="tax_group_irnr_ue"/>
+    <field name="tax_group_id" ref="tax_group_retenciones_19_irnr"/>
     <field name="amount_type">percent</field>
 </record>
 

--- a/l10n_es_irnr/migrations/12.0.2.2.0/pre-migration.py
+++ b/l10n_es_irnr/migrations/12.0.2.2.0/pre-migration.py
@@ -1,0 +1,12 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+xmlid_renames = [
+    ('l10_es_irnr.tax_group_irnr_no_ue', 'l10_es_irnr.tax_group_retenciones_24'),
+    ('l10_es_irnr.tax_group_irnr_ue', 'l10_es_irnr.tax_group_retenciones_19_irnr'),
+]
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_xmlids(env.cr, xmlid_renames)


### PR DESCRIPTION
Este PR añade un script de migración de la versión 12.0.2.1.0 a la 12.0.2.2.0 para resolver un problema con los ID de tax groups. El problema es que en la versón12.0 son tax_group_irnr_no_ue y tax_group_irnr_ue y en la versión 13.0 tax_group_retenciones_24 y tax_group_retenciones_19_irnr. De esta manera se podrá pasar de la version 12 a la 13 sin problemas.
@etobella @pedrobaeza 