### PR TITLE
[FIX] l10n_es_irnr:fix tax groups

### DIFF
--- a/l10n_es_irnr/__manifest__.py
+++ b/l10n_es_irnr/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Retenciones IRNR (No residentes)",
-    "version": "13.0.1.0.0",
+    "version": "13.0.1.0.1",
     "category": "Localization",
     "depends": ["l10n_es"],
     "data": [
@@ -14,7 +14,7 @@
         "data/fiscal_positions_irnr.xml",
         "data/fiscal_position_taxes_irnr.xml",
     ],
-    "author": "Tecnativa, " "Odoo Community Association (OCA)",
+    "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "license": "AGPL-3",
     "installable": True,

--- a/l10n_es_irnr/data/account_data.xml
+++ b/l10n_es_irnr/data/account_data.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <data>
-        <record id="tax_group_retenciones_24" model="account.tax.group">
-            <field name="name">Retenciones 24% IRNR</field>
+        <record id="tax_group_irnr_no_ue" model="account.tax.group">
+            <field name="name">Retenciones no residentes no-UE</field>
         </record>
-        <record id="tax_group_retenciones_19_irnr" model="account.tax.group">
-            <field name="name">Retenciones 19% IRNR</field>
+        <record id="tax_group_irnr_ue" model="account.tax.group">
+            <field name="name">Retenciones no residentes UE</field>
         </record>
     </data>
 </odoo>

--- a/l10n_es_irnr/data/taxes_irnr.xml
+++ b/l10n_es_irnr/data/taxes_irnr.xml
@@ -11,7 +11,7 @@
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common" />
         <field name="amount" eval="-24" />
         <field name="amount_type">percent</field>
-        <field name="tax_group_id" ref="tax_group_retenciones_24" />
+        <field name="tax_group_id" ref="tax_group_irnr_no_ue" />
         <field
             name="invoice_repartition_line_ids"
             eval="[(5, 0, 0),
@@ -51,7 +51,7 @@
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common" />
         <field name="amount" eval="-24" />
         <field name="amount_type">percent</field>
-        <field name="tax_group_id" ref="tax_group_retenciones_24" />
+        <field name="tax_group_id" ref="tax_group_irnr_no_ue" />
         <field
             name="invoice_repartition_line_ids"
             eval="[(5, 0, 0),
@@ -92,7 +92,7 @@
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common" />
         <field name="amount" eval="-19" />
         <field name="amount_type">percent</field>
-        <field name="tax_group_id" ref="tax_group_retenciones_19_irnr" />
+        <field name="tax_group_id" ref="tax_group_irnr_ue" />
         <field
             name="invoice_repartition_line_ids"
             eval="[(5, 0, 0),
@@ -132,7 +132,7 @@
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common" />
         <field name="amount" eval="-19" />
         <field name="amount_type">percent</field>
-        <field name="tax_group_id" ref="tax_group_retenciones_19_irnr" />
+        <field name="tax_group_id" ref="tax_group_irnr_ue" />
         <field
             name="invoice_repartition_line_ids"
             eval="[(5, 0, 0),

--- a/l10n_es_irnr/i18n/l10n_es_irnr.pot
+++ b/l10n_es_irnr/i18n/l10n_es_irnr.pot
@@ -14,11 +14,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_es_irnr
-#: model:account.tax.group,name:l10n_es_irnr.tax_group_retenciones_19_irnr
+#: model:account.tax.group,name:l10n_es_irnr.tax_group_irnr_ue
 msgid "Retenciones 19% IRNR"
 msgstr ""
 
 #. module: l10n_es_irnr
-#: model:account.tax.group,name:l10n_es_irnr.tax_group_retenciones_24
+#: model:account.tax.group,name:l10n_es_irnr.tax_group_irnr_no_ue
 msgid "Retenciones 24% IRNR"
 msgstr ""

--- a/l10n_es_irnr/migrations/13.0.1.0.1/pre-migration.py
+++ b/l10n_es_irnr/migrations/13.0.1.0.1/pre-migration.py
@@ -1,0 +1,13 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+xmlid_renames = [
+    ("l10n_es_irnr.tax_group_retenciones_24", "l10n_es_irnr.tax_group_irnr_no_ue"),
+    ("l10n_es_irnr.tax_group_retenciones_19_irnr", "l10n_es_irnr.tax_group_irnr_ue",),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_xmlids(env.cr, xmlid_renames)


### PR DESCRIPTION
Este PR añade un script de migración para adecuar los nombres de los tax groups entre la versión 12 y 13. Tal y como se ha hablado en el PR #1713 