### PR TITLE
[12.0][ADD] Nota de la posición fiscal

### DIFF
--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -398,7 +398,7 @@
                                 <AttachmentData t-esc="attachment['data']"/>
                             </Attachment>
                         </RelatedDocuments>
-                        <InvoiceAdditionalInformation t-length="2500" t-esc="invoice.comment + invoice.fiscal_position_id.note" t-if="invoice.comment"/>
+                        <InvoiceAdditionalInformation t-length="2500" t-esc="invoice.comment or '' + invoice.fiscal_position_id.note" t-if="invoice.comment or invoice.fiscal_position_id.note"/>
                         <Extensions t-if="False"/>
                     </AdditionalData>
                 </Invoice>

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -386,7 +386,7 @@
                     </PaymentDetails>
                     <LegalLiterals t-if="False"/>
                     <t t-set="attachments" t-value="invoice._get_facturae_invoice_attachments()"/>
-                    <AdditionalData t-if="invoice.comment or attachments">
+                    <AdditionalData t-if="invoice.comment or attachments or invoice.fiscal_position_id.note">
                         <RelatedInvoice t-if="False"/>
                         <RelatedDocuments t-if="attachments">
                             <Attachment t-foreach="attachments" t-as="attachment">
@@ -398,7 +398,7 @@
                                 <AttachmentData t-esc="attachment['data']"/>
                             </Attachment>
                         </RelatedDocuments>
-                        <InvoiceAdditionalInformation t-length="2500" t-esc="invoice.comment" t-if="invoice.comment"/>
+                        <InvoiceAdditionalInformation t-length="2500" t-esc="invoice.comment + invoice.fiscal_position_id.note" t-if="invoice.comment"/>
                         <Extensions t-if="False"/>
                     </AdditionalData>
                 </Invoice>


### PR DESCRIPTION
Se incluye en la etiqueta "InvoiceAdditionalInformation" la nota de la posición fiscal, acorde a cómo se hace en la versión impresa.
Se evita así el olvido del administrativo y la demora en el pago por parte de la administración insular, por ejemplo