### PR TITLE
[14.0][FIX] l10n_es_aeat_sii_oca: SII Refund Type not required

### DIFF
--- a/l10n_es_aeat_sii_oca/wizards/account_move_reversal.py
+++ b/l10n_es_aeat_sii_oca/wizards/account_move_reversal.py
@@ -12,7 +12,14 @@ class AccountMoveReversal(models.TransientModel):
         invoices = self.env["account.move"].browse(
             self.env.context.get("active_ids"),
         )
-        return any(invoices.mapped("company_id.sii_enabled"))
+        # If any of the invoices part of the active_ids match the criteria,
+        # show the field
+        return bool(
+            invoices.filtered(
+                lambda i: i.move_type in ("in_invoice", "out_invoice")
+                and i.company_id.sii_enabled
+            )
+        )
 
     def _default_supplier_invoice_number_refund_required(self):
         invoices = (


### PR DESCRIPTION
FWP of https://github.com/OCA/l10n-spain/pull/1722

Make the SII Refund Type not required nor available for account.move records that are not "in_invoices" or "out_invoices"

@Tecnativa
TT30339

ping @pedrobaeza 