### PR TITLE
[14.0][FIX]l10n_es_aeat_mod_347: correccion readme

### DIFF
--- a/l10n_es_aeat_mod347/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod347/readme/CONTRIBUTORS.rst
@@ -6,10 +6,11 @@
 * Angel Moya <angel.moya@pesol.es>
 * Albert Cabedo <albert@gafic.com>
 * `Tecnativa <https://www.tecnativa.com>`_:
-* `Sygel <https://www.sygel.es>`_:
 
   * Antonio Espinosa
   * Pedro M. Baeza
   * Cristina Martín
   * Carlos Dauden
+* `Sygel <https://www.sygel.es>`_:
+
   * Manuel Regidor


### PR DESCRIPTION
Había un problema con la definición de los contribudores.