### PR TITLE
[14.0][FIX] l10n_es_aeat_sii_oca: type in domain to move_type

### DIFF
--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -75,11 +75,11 @@
                                 'invisible': [
                                     '|',
                                     ('sii_registration_key_code', 'not in', ['12', '13']),
-                                    ('type', 'not in', ['out_invoice', 'out_refund']),
+                                    ('move_type', 'not in', ['out_invoice', 'out_refund']),
                                 ],
                                 'required': [
                                     ('sii_registration_key_code', 'in', ['12', '13']),
-                                    ('type', 'in', ['out_invoice', 'out_refund']),
+                                    ('move_type', 'in', ['out_invoice', 'out_refund']),
                                 ],
                             }"
                         />
@@ -89,12 +89,12 @@
                                 'invisible': [
                                     '|',
                                     ('sii_registration_key_code', 'not in', ['12', '13']),
-                                    ('type', 'not in', ['out_invoice', 'out_refund']),
+                                    ('move_type', 'not in', ['out_invoice', 'out_refund']),
                                 ],
                                 'required': [
                                     ('sii_registration_key_code', 'in', ['12', '13']),
                                     ('sii_property_location', 'in', ['1', '2']),
-                                    ('type', 'in', ['out_invoice', 'out_refund']),
+                                    ('move_type', 'in', ['out_invoice', 'out_refund']),
                                 ],
                             }"
                         />


### PR DESCRIPTION
Fixes domain added last night https://github.com/OCA/l10n-spain/commit/ee17a5dcd91b944593d49cbfe9b70b365cb5762c, this field is called `move_type` in 14.0+

This module isn't installable in its current state (causing tests to fail)