### PR TITLE
[12.0][FIX] l10n_es_ticketbai

### DIFF
--- a/l10n_es_ticketbai/__manifest__.py
+++ b/l10n_es_ticketbai/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "TicketBAI - "
             "declaración de todas las operaciones de venta realizadas por las personas "
             "y entidades que desarrollan actividades económicas",
-    "version": "12.0.0.1.1",
+    "version": "12.0.1.0.0",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/l10n-spain",
     "author": "Binovo,"

--- a/l10n_es_ticketbai/hooks.py
+++ b/l10n_es_ticketbai/hooks.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Binovo IT Human Project SL
 # Copyright 2021 Landoo Sistemas de Informacion SL
+# Copyright 2021 Digital5, S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, SUPERUSER_ID
 
@@ -29,8 +30,7 @@ def post_init_hook(cr, registry):
             if 0 < len(fiscal_position_template.tbai_vat_exemption_ids):
                 tbai_vat_exemptions = []
                 for exemption in fiscal_position_template.tbai_vat_exemption_ids:
-                    tax = env['account.tax'].search(
-                        [('description', '=', exemption.tax_id.description)])
+                    tax = position.company_id.get_taxes_from_templates(exemption.tax_id)
                     if 1 == len(tax):
                         tbai_vat_exemptions.append((0, 0, {
                             'tax_id': tax.id,

--- a/l10n_es_ticketbai/models/account_tax.py
+++ b/l10n_es_ticketbai/models/account_tax.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Binovo IT Human Project SL
+# Copyright 2021 Digital5, S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
 
@@ -7,13 +8,13 @@ class AccountTax(models.Model):
     _inherit = 'account.tax'
 
     def tbai_is_subject_to_tax(self):
-        s_iva_ns_descriptions = \
-            self.env.ref('l10n_es_ticketbai.tbai_tax_map_SNS').tax_template_ids.mapped(
-                'description')
-        s_iva_ns_b_descriptions = \
-            self.env.ref('l10n_es_ticketbai.tbai_tax_map_BNS').tax_template_ids.mapped(
-                'description')
-        return self.description not in s_iva_ns_descriptions + s_iva_ns_b_descriptions
+        s_iva_ns_tbai_maps = self.env["tbai.tax.map"].search(
+            [('code', 'in', ("SNS", "BNS"))]
+        )
+        s_iva_ns_taxes = self.company_id.get_taxes_from_templates(
+            s_iva_ns_tbai_maps.mapped("tax_template_ids")
+        )
+        return self not in s_iva_ns_taxes
 
     def tbai_is_tax_exempted(self):
         return self.tax_group_id.id == self.env.ref('l10n_es.tax_group_iva_0').id

--- a/l10n_es_ticketbai/models/chart_template.py
+++ b/l10n_es_ticketbai/models/chart_template.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Binovo IT Human Project SL
+# Copyright 2021 Digital5, S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models, fields, api, _
 
@@ -57,8 +58,7 @@ class AccountChartTemplate(models.Model):
             fiscal_position = self.env['account.fiscal.position'].browse(res_id)
             tbai_vat_exemptions = []
             for exemption in template.tbai_vat_exemption_ids:
-                tax = self.env['account.tax'].search(
-                    [('description', '=', exemption.tax_id.description)])
+                tax = company.get_taxes_from_templates(exemption.tax_id)
                 if 1 == len(tax):
                     tbai_vat_exemptions.append((0, 0, {
                         'tax_id': tax.id,

--- a/l10n_es_ticketbai/wizard/ticketbai_info.py
+++ b/l10n_es_ticketbai/wizard/ticketbai_info.py
@@ -38,12 +38,12 @@ class TicketBaiGeneralInfo(models.TransientModel):
                 ('name', '=', name)]).latest_version
             software_version_api = self.sudo().env['ir.module.module'].search([
                 ('name', '=', name_api)]).latest_version
-            record.software = "(%s %s, %s %s) %s" % (
+            record.software = "%s (%s %s, %s %s)" % (
+                record.company_id.tbai_software_name,
                 name_api,
                 software_version_api,
                 name,
-                software_version,
-                record.company_id.tbai_software_name)
+                software_version)
 
     @api.multi
     @api.depends('company_id')


### PR DESCRIPTION
Existen impuestos sin `description` (https://github.com/OCA/OCB/commit/0d22f568b541a4aa63ebb051acce1f15ef30f74b), por tanto la comparación es necesario realizarla a través del `name`.

Aunque podríamos debatir aquí si trasladar esta funcionalidad a como se hace en el SII, tirando del método `get_taxes_from_templates()` del `l10n_es_aeat`, es decir, tirar de los external reference.
De esta manera no dependemos de la posibilidad de modificar el nombre de los impuestos, que aunque no es habitual, puede suceder. Y para impuestos nuevos (impuestos incluidos, por ejemplo), se pueden crear en un módulo custom para el cliente en cuestión.

Nosotros en el desarrollo de batuz estamos tirando del método de `l10n_es_aeat`, FYI.

¿Qué opináis? @pedrobaeza @acysos @ljsalvatierra-binovo @ao-landoo 
Perdón por el "spam", pero me parece algo a tener en cuenta.