### PR TITLE
[FIX] No actualizar productos dua

### DIFF
--- a/l10n_es_dua/data/products_dua.xml
+++ b/l10n_es_dua/data/products_dua.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo>
+<odoo noupdate="1">
     <record id="producto_dua_valoracion_21" model="product.product">
         <field name="uom_id" ref="uom.product_uom_unit" />
         <field name="uom_po_id" ref="uom.product_uom_unit" />


### PR DESCRIPTION
Esto soluciona un error encontrado que actualizamos los productos DUA y se borran los impuestos o cambia otros datos que se han establecido.