### PR TITLE
[14.0][FIX] l10n_es_pos: Incorrect label texts and translations

### DIFF
--- a/l10n_es_pos/i18n/ca.po
+++ b/l10n_es_pos/i18n/ca.po
@@ -141,16 +141,12 @@ msgid "Simplified Invoice prefix"
 msgstr "Prefix de Factura Simplificada"
 
 #. module: l10n_es_pos
-#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_order__is_l10n_es_simplified_invoice
-msgid "Simplified invoice"
-msgstr "Factura simplificada"
-
-#. module: l10n_es_pos
 #. openerp-web
 #: code:addons/l10n_es_pos/static/src/xml/pos.xml:0
+#: model:ir.model.fields,field_description:l10n_es_pos.field_pos_order__is_l10n_es_simplified_invoice
 #, python-format
-msgid "Simplified invoice>"
-msgstr "Factura simplificada>"
+msgid "Simplified invoice"
+msgstr "Factura simplificada"
 
 #. module: l10n_es_pos
 #: model_terms:ir.ui.view,arch_db:l10n_es_pos.view_pos_order_filter_simplified_invoice

--- a/l10n_es_pos/i18n/l10n_es_pos.pot
+++ b/l10n_es_pos/i18n/l10n_es_pos.pot
@@ -145,7 +145,7 @@ msgstr ""
 #. openerp-web
 #: code:addons/l10n_es_pos/static/src/xml/pos.xml:0
 #, python-format
-msgid "Simplified invoice>"
+msgid "Simplified invoice"
 msgstr ""
 
 #. module: l10n_es_pos

--- a/l10n_es_pos/static/src/xml/pos.xml
+++ b/l10n_es_pos/static/src/xml/pos.xml
@@ -11,7 +11,7 @@
                 t-if="env.pos.config.iface_l10n_es_simplified_invoice and !receipt.is_to_invoice"
             >
                 <div><t t-esc='receipt.date.localestring' /></div>
-                <div>Simplified invoice></div>
+                <div>Simplified invoice</div>
                 <div><t t-esc="receipt.simplified_invoice" /></div><br />
                 <t t-log="receipt" />
             </t>


### PR DESCRIPTION
Este cambio resuelve los siguientes errores:
- Si no es una factura simplificada es una factura normal la condicion if estaba mal 
- El texto Simplified invoice> del div estaba mal escrito y esto genera mal las traducciones de esta linea.