### PR TITLE
[13.0][FIX]l10n_es_vat_book: error in the partner origin when the account.move is not an invoice

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -203,7 +203,8 @@ class L10nEsVatBook(models.Model):
         invoice = move_line.move_id
         partner = move_line.partner_id
         if invoice:
-            partner = invoice.commercial_partner_id
+            if invoice.is_invoice():
+                partner = invoice.commercial_partner_id
             ref = invoice.name
             ext_ref = invoice.ref
         return {


### PR DESCRIPTION
Create a new account.move with 2 accounts.move.line and select the partner in these moving lines.
Generate a new VAT book or recalculate another in the same period, the line related to the 'account.move.line' created earlier will have an empty customer.