### PR TITLE
[12.0][FIX] l10n_es_vat_book: Error el cálculo de la cuota del recargo de equivalencia 

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -292,7 +292,8 @@ class L10nEsVatBook(models.Model):
 
     def _get_account_move_lines(self, taxes):
         return self.env['account.move.line'].search(
-            self._account_move_line_domain(taxes))
+            self._account_move_line_domain(taxes),
+            order="move_id ASC, tax_line_id ASC")
 
     @ormcache('self.id')
     def get_pos_partner_ids(self):


### PR DESCRIPTION
El orden en el que se cargan los apuntes influye a la hora de meter el importe de la cuota de los impuesto especiales ya que si no se ha procesado antes el apunte del recargo no puede actualizar el importe de impuesto especial en la linea de libro de iva cuando procesa el apunte con la base.
Esto provoca un efecto en el que algunas veces este importe de la cuota está correcto y otras está a 0