### PR TITLE
[13.0][FIX] delivery_seur: avoid error due to non existent field

### DIFF
--- a/delivery_seur/models/delivery_carrier.py
+++ b/delivery_seur/models/delivery_carrier.py
@@ -322,8 +322,6 @@ class DeliveryCarrier(models.Model):
                 {
                     "name": "SEUR %s" % picking.carrier_tracking_ref,
                     "datas": label_content,
-                    "datas_fname": "seur_%s.%s"
-                    % (picking.carrier_tracking_ref, self.seur_label_format),
                     "res_model": "stock.picking",
                     "res_id": picking.id,
                     "mimetype": "application/%s" % self.seur_label_format,


### PR DESCRIPTION
Por si acaso, a mi me da error porque el campo `datas_fname` no existe en `ir.attachment`.