### PR TITLE
[12.0][FIX]l10n_es_facturae: check partner lastname empty.

### DIFF
--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -29,7 +29,7 @@
             <CentreCode t-length="10" t-esc="centre_code"/>
             <RoleTypeCode t-esc="role_type_code"/>
             <Name t-length="40" t-esc="partner.firstname if partner._fields.get('firstname') else partner.name" t-if="not partner.is_company"/>
-            <FirstSurname t-length="40" t-esc="partner.lastname if partner._fields.get('lastname') else ''" t-if="not partner.is_company"/>
+            <FirstSurname t-length="40" t-esc="partner.lastname if partner._fields.get('lastname') and partner.lastname else ''" t-if="not partner.is_company"/>
             <SecondSurname t-if="False"/>
             <t t-call="l10n_es_facturae.address_contact">
                 <t t-set="partner" t-value="partner"/>
@@ -79,7 +79,7 @@
         </LegalEntity>
         <Individual t-if="buyer_type == 'F'">
             <Name t-length="40" t-esc="partner.firstname if partner._fields.get('firstname') else partner.name"/>
-            <FirstSurname t-length="40" t-esc="partner.lastname if partner._fields.get('lastname') else ''"/>
+            <FirstSurname t-length="40" t-esc="partner.lastname if partner._fields.get('lastname') and partner.lastname else ''"/>
             <SecondSurname t-length="40" t-esc="''"/>
             <t t-call="l10n_es_facturae.address_contact">
             </t>


### PR DESCRIPTION
Si el cliente no es empresa y no tiene el campo 'lastname' relleno da un error. 
Se debe de comprobar que si el campo existe y que tenga valor.