### PR TITLE
[13.0][IMP] l10n_es_aeat_sii_oca: Allow send invoices with LC type (create get_sii_invoice_type() function to set 'TipoFactura'

### DIFF
--- a/l10n_es_aeat_sii_oca/i18n/es.po
+++ b/l10n_es_aeat_sii_oca/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-23 18:31+0000\n"
-"PO-Revision-Date: 2020-10-23 20:32+0200\n"
+"POT-Creation-Date: 2021-07-22 14:39+0000\n"
+"PO-Revision-Date: 2021-07-22 16:40+0200\n"
 "Last-Translator: Josep M <jmyepes@mac.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -194,6 +194,17 @@ msgstr ""
 "cuando se valida"
 
 #. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_move__sii_lc_operation
+msgid ""
+"Check this mark if this invoice represents a complementary settlement for "
+"customs.\n"
+"The invoice number should start with LC, QZC, QRC, A01 or A02."
+msgstr ""
+"Marque esta casilla si esta factura representa una liquidación "
+"complementaria para la aduana.\n"
+"El número de factura debe comenzar con LC, QZC, QRC, A01 o A02."
+
+#. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_move__sii_macrodata
 msgid ""
 "Check to confirm that the invoice has an absolute amount greater o equal to "
@@ -270,6 +281,11 @@ msgstr "Creado en"
 #, python-format
 msgid "Currently there's no support for multiple exempt causes."
 msgstr "Actualmente no hay soporte para múltiples causas de exención."
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_lc_operation
+msgid "Customs - Complementary settlement"
+msgstr "Aduanas - Liquidación complementaria"
 
 #. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_aeat_sii_map__date_from
@@ -756,7 +772,7 @@ msgstr "Agencias tributarias SII"
 #. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_res_company__sii_tax_agency_id
 msgid "SII Tax Agency"
-msgstr ""
+msgstr "Agencia Tributaria SII"
 
 #. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_account_registration_date

--- a/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
+++ b/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-22 14:39+0000\n"
+"PO-Revision-Date: 2021-07-22 14:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -182,6 +184,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_move__sii_lc_operation
+msgid ""
+"Check this mark if this invoice represents a complementary settlement for customs.\n"
+"The invoice number should start with LC, QZC, QRC, A01 or A02."
+msgstr ""
+
+#. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_move__sii_macrodata
 msgid ""
 "Check to confirm that the invoice has an absolute amount greater o equal to "
@@ -253,6 +262,11 @@ msgstr ""
 #: code:addons/l10n_es_aeat_sii_oca/models/account_move.py:0
 #, python-format
 msgid "Currently there's no support for multiple exempt causes."
+msgstr ""
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_lc_operation
+msgid "Customs - Complementary settlement"
 msgstr ""
 
 #. module: l10n_es_aeat_sii_oca

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -220,6 +220,13 @@ class AccountMove(models.Model):
         "greater o equal to 100 000 000,00 euros.",
         compute="_compute_macrodata",
     )
+    sii_lc_operation = fields.Boolean(
+        string="Customs - Complementary settlement",
+        help="Check this mark if this invoice represents a complementary "
+        "settlement for customs.\n"
+        "The invoice number should start with LC, QZC, QRC, A01 or A02.",
+        copy=False,
+    )
     invoice_jobs_ids = fields.Many2many(
         comodel_name="queue.job",
         column1="invoice_id",
@@ -737,6 +744,22 @@ class AccountMove(models.Model):
         self.ensure_one()
         return self.sii_account_registration_date or fields.Date.today()
 
+    def _get_sii_invoice_type(self):
+        tipo_factura = ""
+        if self.sii_lc_operation:
+            return "LC"
+        if self.type in ["in_invoice", "in_refund"]:
+            tipo_factura = "R4" if self.type == "in_refund" else "F1"
+        elif self.type in ["out_invoice", "out_refund"]:
+            is_simplified = self._is_sii_simplified_invoice()
+            tipo_factura = "F2" if is_simplified else "F1"
+            if self.type == "out_refund":
+                if self.sii_refund_specific_invoice_type:
+                    tipo_factura = self.sii_refund_specific_invoice_type
+                else:
+                    tipo_factura = "R5" if is_simplified else "R1"
+        return tipo_factura
+
     def _get_sii_invoice_dict_out(self, cancel=False):
         """Build dict with data to send to AEAT WS for invoice types:
         out_invoice and out_refund.
@@ -764,15 +787,8 @@ class AccountMove(models.Model):
         if not cancel:
             tipo_desglose, not_in_amount_total = self._get_sii_out_taxes()
             amount_total = self.amount_total_signed - not_in_amount_total
-            if self.type == "out_refund":
-                if self.sii_refund_specific_invoice_type:
-                    tipo_factura = self.sii_refund_specific_invoice_type
-                else:
-                    tipo_factura = "R5" if is_simplified_invoice else "R1"
-            else:
-                tipo_factura = "F2" if is_simplified_invoice else "F1"
             inv_dict["FacturaExpedida"] = {
-                "TipoFactura": tipo_factura,
+                "TipoFactura": self._get_sii_invoice_type(),
                 "ClaveRegimenEspecialOTrascendencia": (self.sii_registration_key.code),
                 "DescripcionOperacion": self.sii_description,
                 "TipoDesglose": tipo_desglose,
@@ -858,7 +874,7 @@ class AccountMove(models.Model):
             amount_total = -self.amount_total_signed - not_in_amount_total
             inv_dict["FacturaRecibida"] = {
                 # TODO: Incluir los 5 tipos de facturas rectificativas
-                "TipoFactura": ("R4" if self.type == "in_refund" else "F1"),
+                "TipoFactura": self._get_sii_invoice_type(),
                 "ClaveRegimenEspecialOTrascendencia": self.sii_registration_key.code,
                 "DescripcionOperacion": self.sii_description,
                 "DesgloseFactura": desglose_factura,

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -68,6 +68,7 @@
                         />
                         <field name="sii_registration_key_code" invisible="1" />
                         <field name="sii_enabled" invisible="1" />
+                        <field name="sii_lc_operation" />
                         <field
                             name="sii_property_location"
                             attrs="{


### PR DESCRIPTION
Se añade el campo "_Operación LC_" en las facturas (al hacerlo, se enviarán la factura con TipoFactura=LC).
Se crea la función `get_sii_invoice_type()` que define el campo **TIpoFactura** que se enviará.

Por favor @pedrobaeza y @chienandalu ¿podéis revisar esto?

El tipo LC es obligatorio especificarlo cuando se debe identificar rectificaciones de la declaración en aduanas 
(https://www.agenciatributaria.es/AEAT.internet/Inicio/Ayuda/Modelos__Procedimientos_y_Servicios/Ayuda_P_G417____IVA__Llevanza_de_libros_registro__SII_/Informacion_general/Preguntas_frecuentes/4__Libro_registro_de_facturas_recibidas/4_24___En_que_casos_debe_utilizarse_la_clave__LC___Aduanas_Liquidacion_.shtml)

@Tecnativa TT30680