### PR TITLE
[13.0][IMP] l10n_es_aeat_sii_oca: Add SII third-party

### DIFF
--- a/l10n_es_aeat_sii_oca/i18n/es.po
+++ b/l10n_es_aeat_sii_oca/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-22 14:39+0000\n"
-"PO-Revision-Date: 2021-07-22 16:40+0200\n"
+"POT-Creation-Date: 2021-07-22 14:33+0000\n"
+"PO-Revision-Date: 2021-07-22 16:34+0200\n"
 "Last-Translator: Josep M <jmyepes@mac.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -771,6 +771,7 @@ msgstr "Agencias tributarias SII"
 
 #. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_res_company__sii_tax_agency_id
+#, fuzzy
 msgid "SII Tax Agency"
 msgstr "Agencia Tributaria SII"
 
@@ -848,6 +849,16 @@ msgstr "Estado de envío SII"
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii_oca.view_account_invoice_sii_filter
 msgid "SII sent"
 msgstr "Enviadas SII"
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_thirdparty_invoice
+msgid "SII third-party invoice"
+msgstr "Factura de terceros SII"
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_thirdparty_number
+msgid "SII third-party number"
+msgstr "Número de terceros SII"
 
 #. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields.selection,name:l10n_es_aeat_sii_oca.selection__aeat_sii_mapping_registration_keys__type__sale

--- a/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
+++ b/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-22 14:33+0000\n"
+"PO-Revision-Date: 2021-07-22 14:33+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -805,6 +807,16 @@ msgstr ""
 #. module: l10n_es_aeat_sii_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii_oca.view_account_invoice_sii_filter
 msgid "SII sent"
+msgstr ""
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_thirdparty_invoice
+msgid "SII third-party invoice"
+msgstr ""
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_thirdparty_number
+msgid "SII third-party number"
 msgstr ""
 
 #. module: l10n_es_aeat_sii_oca

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -227,6 +227,17 @@ class AccountMove(models.Model):
         "The invoice number should start with LC, QZC, QRC, A01 or A02.",
         copy=False,
     )
+    sii_thirdparty_invoice = fields.Boolean(
+        string="SII third-party invoice", copy=False
+    )
+    sii_thirdparty_number = fields.Char(
+        string="SII third-party number",
+        help="[RD 1619/2012] Cumplimiento de la obligación de expedir factura "
+        "por el destinatario o por un tercero.\n"
+        "Se permite notificar de Factura emitida por Terceros mediante el campo "
+        "'Factura de terceros SII' y 'Número de terceros SII'.",
+        copy=False,
+    )
     invoice_jobs_ids = fields.Many2many(
         comodel_name="queue.job",
         column1="invoice_id",
@@ -775,11 +786,14 @@ class AccountMove(models.Model):
         ejercicio = fields.Date.to_date(self.date).year
         periodo = "%02d" % fields.Date.to_date(self.date).month
         is_simplified_invoice = self._is_sii_simplified_invoice()
+        serial_number = (self.name or "")[0:60]
+        if self.sii_thirdparty_invoice:
+            serial_number = self.sii_thirdparty_number[0:60]
         inv_dict = {
             "IDFactura": {
                 "IDEmisorFactura": {"NIF": company.vat[2:]},
                 # On cancelled invoices, number is not filled
-                "NumSerieFacturaEmisor": (self.name or "")[0:60],
+                "NumSerieFacturaEmisor": serial_number,
                 "FechaExpedicionFacturaEmisor": invoice_date,
             },
             "PeriodoLiquidacion": {"Ejercicio": ejercicio, "Periodo": periodo},
@@ -794,6 +808,8 @@ class AccountMove(models.Model):
                 "TipoDesglose": tipo_desglose,
                 "ImporteTotal": amount_total,
             }
+            if self.sii_thirdparty_invoice:
+                inv_dict["FacturaExpedida"]["EmitidaPorTercerosODestinatario"] = "S"
             if self.sii_macrodata:
                 inv_dict["FacturaExpedida"].update(Macrodato="S")
             if self.sii_registration_key_additional1:

--- a/l10n_es_aeat_sii_oca/static/description/index.html
+++ b/l10n_es_aeat_sii_oca/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Suministro Inmediato de Información en el IVA</title>
 <style type="text/css">
 

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -41,6 +41,11 @@
                             name="sii_description"
                             attrs="{'required': [('sii_enabled', '=', True)]}"
                         />
+                        <field name="sii_thirdparty_invoice" />
+                        <field
+                            name="sii_thirdparty_number"
+                            attrs="{'required': [('sii_thirdparty_invoice', '=', True)]}"
+                        />
                         <field
                             name="sii_refund_type"
                             attrs="{'required': [('sii_enabled', '=', True),('type', 'in', ('out_refund','in_refund'))], 'invisible': [('type', 'not in', ('out_refund','in_refund'))]}"


### PR DESCRIPTION
Ampliación para la presentación inmediata del IVA para auto facturas generadas por terceros. 

Por favor @pedrobaeza y @chienandalu ¿podéis revisar esto?

https://www.agenciatributaria.es/AEAT.internet/Inicio/Ayuda/Modelos__Procedimientos_y_Servicios/Ayuda_P_G417____IVA__Llevanza_de_libros_registro__SII_/Informacion_general/Preguntas_frecuentes/3__Libro_registro_de_facturas_expedidas/3_3___Que_operaciones_se_registran_en_el_campo__Emitida_por_Terceros_o_Destinatario__del_Libro_registro_Facturas_Expedidas_.shtml

@Tecnativa TT30681