### PR TITLE
[14.0][IMP] l10n_es_aeat_sii_oca: Allow send invoices with LC type (create get_sii_invoice_type() function to set 'TipoFactura'

### DIFF
--- a/l10n_es_aeat_sii_oca/i18n/es.po
+++ b/l10n_es_aeat_sii_oca/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-23 18:31+0000\n"
-"PO-Revision-Date: 2020-10-23 20:32+0200\n"
+"POT-Creation-Date: 2021-07-22 14:39+0000\n"
+"PO-Revision-Date: 2021-07-22 16:40+0200\n"
 "Last-Translator: Josep M <jmyepes@mac.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -194,6 +194,17 @@ msgstr ""
 "cuando se valida"
 
 #. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_move__sii_lc_operation
+msgid ""
+"Check this mark if this invoice represents a complementary settlement for "
+"customs.\n"
+"The invoice number should start with LC, QZC, QRC, A01 or A02."
+msgstr ""
+"Marque esta casilla si esta factura representa una liquidación "
+"complementaria para la aduana.\n"
+"El número de factura debe comenzar con LC, QZC, QRC, A01 o A02."
+
+#. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_move__sii_macrodata
 msgid ""
 "Check to confirm that the invoice has an absolute amount greater o equal to "
@@ -270,6 +281,11 @@ msgstr "Creado en"
 #, python-format
 msgid "Currently there's no support for multiple exempt causes."
 msgstr "Actualmente no hay soporte para múltiples causas de exención."
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_lc_operation
+msgid "Customs - Complementary settlement"
+msgstr "Aduanas - Liquidación complementaria"
 
 #. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_aeat_sii_map__date_from
@@ -752,6 +768,11 @@ msgstr "Cabecera de proveedor para SII"
 #: model:ir.ui.menu,name:l10n_es_aeat_sii_oca.aeat_sii_tax_agency_menu
 msgid "SII Tax Agencies"
 msgstr "Agencias tributarias SII"
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_res_company__sii_tax_agency_id
+msgid "SII Tax Agency"
+msgstr "Agencia Tributaria SII"
 
 #. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_account_registration_date

--- a/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
+++ b/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-22 14:39+0000\n"
+"PO-Revision-Date: 2021-07-22 14:39+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -161,7 +163,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_es_aeat_sii_oca
-#: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_bank_statement_line__sii_macrodata
+#: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_move__sii_lc_operation
+msgid ""
+"Check this mark if this invoice represents a complementary settlement for customs.\n"
+"The invoice number should start with LC, QZC, QRC, A01 or A02."
+msgstr ""
+
+#. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_move__sii_macrodata
 #: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_payment__sii_macrodata
 msgid ""
@@ -226,6 +234,11 @@ msgstr ""
 #: code:addons/l10n_es_aeat_sii_oca/models/account_move.py:0
 #, python-format
 msgid "Currently there's no support for multiple exempt causes."
+msgstr ""
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_lc_operation
+msgid "Customs - Complementary settlement"
 msgstr ""
 
 #. module: l10n_es_aeat_sii_oca

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -69,6 +69,7 @@
                         />
                         <field name="sii_registration_key_code" invisible="1" />
                         <field name="sii_enabled" invisible="1" />
+                        <field name="sii_lc_operation" />
                         <field
                             name="sii_property_location"
                             attrs="{


### PR DESCRIPTION
FWP de 13.0: https://github.com/OCA/l10n-spain/pull/1779

Se añade el campo "_Operación LC_" en las facturas (al hacerlo, se enviarán la factura con TipoFactura=LC).
Se crea la función `get_sii_invoice_type()` que define el campo **TIpoFactura** que se enviará.

Por favor @pedrobaeza y @chienandalu ¿podéis revisar esto?

El tipo LC es obligatorio especificarlo cuando se debe identificar rectificaciones de la declaración en aduanas 
(https://www.agenciatributaria.es/AEAT.internet/Inicio/Ayuda/Modelos__Procedimientos_y_Servicios/Ayuda_P_G417____IVA__Llevanza_de_libros_registro__SII_/Informacion_general/Preguntas_frecuentes/4__Libro_registro_de_facturas_recibidas/4_24___En_que_casos_debe_utilizarse_la_clave__LC___Aduanas_Liquidacion_.shtml)

@Tecnativa TT30680