### PR TITLE
[12.0][FIX] l10n_es_aeat_partner_check: Only set if not submitted

### DIFF
--- a/l10n_es_aeat_partner_check/models/res_partner.py
+++ b/l10n_es_aeat_partner_check/models/res_partner.py
@@ -139,6 +139,6 @@ class ResPartner(models.Model):
             }
             if b"NIF sometido" in res.content:
                 vals.update({"aeat_partner_type": "sales_equalization"})
-            else:
+            elif b"NIF no sometido" in res.content:
                 vals.update({"aeat_partner_type": "standard"})
             partner.write(vals)


### PR DESCRIPTION
Ajustar `else` a `elif` para que solo actualize el valor del campo a "Standard" cuando explícitamente se menciona que el NIF no está sometido, ya por como está hecha la petición, en cualquier momento que la página ponia otra cosa como 404 o 503 etc nos guardaba "Standard".