### PR TITLE
[FIX] l10n_es_ticketbai_api

### DIFF
--- a/l10n_es_ticketbai_api/__manifest__.py
+++ b/l10n_es_ticketbai_api/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "TicketBAI - API",
-    "version": "11.0.0.1.0",
+    "version": "11.0.0.3.0",
     "category": "Accounting & Finance",
     "website": "http://www.binovo.es",
     "author": "Binovo,"

--- a/l10n_es_ticketbai_api/data/tax_agency_data.xml
+++ b/l10n_es_ticketbai_api/data/tax_agency_data.xml
@@ -12,9 +12,9 @@
             <field name="version">1.2</field>
             <field name="qr_base_url">https://tbai.egoitza.gipuzkoa.eus/qr/</field>
             <field name="test_qr_base_url">https://tbai.prep.gipuzkoa.eus/qr/</field>
-            <field name="rest_url_invoice">https://tbai.egoitza.gipuzkoa.eus/WAS/HACI/HTBRecepcionFacturasWEB/rest/recepcionFacturas/alta</field>
+            <field name="rest_url_invoice">https://tbai-z.egoitza.gipuzkoa.eus/sarrerak/alta</field>
             <field name="test_rest_url_invoice">https://tbai-prep.egoitza.gipuzkoa.eus/WAS/HACI/HTBRecepcionFacturasWEB/rest/recepcionFacturas/alta</field>
-            <field name="rest_url_cancellation">https://tbai.egoitza.gipuzkoa.eus/WAS/HACI/HTBRecepcionFacturasWEB/rest/recepcionFacturas/anulacion</field>
+            <field name="rest_url_cancellation">https://tbai-z.egoitza.gipuzkoa.eus/sarrerak/baja</field>
             <field name="test_rest_url_cancellation">https://tbai-prep.egoitza.gipuzkoa.eus/WAS/HACI/HTBRecepcionFacturasWEB/rest/recepcionFacturas/anulacion</field>
         </record>
     </data>

--- a/l10n_es_ticketbai_api/ticketbai/xml_schema.py
+++ b/l10n_es_ticketbai_api/ticketbai/xml_schema.py
@@ -17,6 +17,11 @@ except(ImportError, IOError) as err:
     _logger.error(err)
 
 
+SP_FILENAME = 'https://www.batuz.eus/fitxategiak/batuz/ticketbai/' \
+              'sinadura_elektronikoaren_zehaztapenak_especificaciones_' \
+              'de_la_firma_electronica_v1_0.pdf'
+
+
 class XMLSchemaException(Exception):
     def __init__(self, name, value=None):
         if type(self) == XMLSchemaException:
@@ -137,7 +142,8 @@ class XMLSchema:
             signature, xmlsig.constants.TransformSha256, uri='#' + kinfo_id
         )
         xmlsig.template.add_reference(
-            signature, xmlsig.constants.TransformSha256, uri="#" + sp_id
+            signature, xmlsig.constants.TransformSha256, uri="#" + sp_id,
+            uri_type='http://uri.etsi.org/01903#SignedProperties'
         )
         ki = xmlsig.template.ensure_key_info(signature, name=kinfo_id)
         data = xmlsig.template.add_x509_data(ki)
@@ -157,19 +163,19 @@ class XMLSchema:
                       ('etsi:Cert', (),
                        ('etsi:CertDigest', (),
                         ('ds:DigestMethod',
-                         ('Algorithm', 'http://www.w3.org/2000/09/xmldsig#sha256')),
+                         ('Algorithm', 'http://www.w3.org/2001/04/xmlenc#sha256')),
                         ('ds:DigestValue', (),
                          b64encode(ctx.x509.fingerprint(hashes.SHA256())).decode())))),
                      ('etsi:SignaturePolicyIdentifier', (),
                       ('etsi:SignaturePolicyId', (),
                        ('etsi:SigPolicyId', (),
-                        ('etsi:Identifier', (), 'http://ticketbai.eus/politicafirma'),
-                        ('etsi:Description', (), 'Política de Firma TicketBAI 1.0')),
+                        ('etsi:Identifier', (), SP_FILENAME),
+                        ('etsi:Description', (), )),
                        ('etsi:SigPolicyHash', (),
                         ('ds:DigestMethod',
-                         ('Algorithm', 'http://www.w3.org/2000/09/xmldsig#sha256')),
+                         ('Algorithm', 'http://www.w3.org/2001/04/xmlenc#sha256')),
                         ('ds:DigestValue', (),
-                         'lX1xDvBVAsPXkkJ7R07WCVbAm9e0H33I1sCpDtQNkbc='))))))))
+                         'Quzn98x3PMbSHwbUzaj5f5KOpiH0u8bvmwbbbNkO9Es='))))))))
         root.append(signature)
         create_node_tree(signature, [dslist])
         ctx.sign(signature)


### PR DESCRIPTION
      Actualizar atributos de la política de firmas en el fichero XML firmado, acorde a validaciones XAdES-EPES y diputación de Bizkaia. Validado también para Gipuzkoa.

      Actualizar URLS de producción de Gipuzkoa.