### PR TITLE
[13.0][IMP]l10n_es_vat_book: refactorización para mejorar herencias

### DIFF
--- a/l10n_es_vat_book/models/aeat_vat_book_map_line.py
+++ b/l10n_es_vat_book/models/aeat_vat_book_map_line.py
@@ -30,3 +30,7 @@ class AeatVatBookMapLines(models.Model):
     tax_account_id = fields.Many2one(
         comodel_name="account.account.template", string="Tax Account Restriction",
     )
+
+    def get_taxes(self, report):
+        self.ensure_one()
+        return report.get_taxes_from_templates(self.tax_tmpl_ids)

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -336,7 +336,7 @@ class L10nEsVatBook(models.Model):
         )
         special_dic = {}
         for map_line in map_lines:
-            for tax in self.get_taxes_from_templates(map_line.tax_tmpl_ids):
+            for tax in map_line.get_taxes(self):
                 special_dic[tax.id] = {
                     "name": map_line.name,
                     "book_type": map_line.book_type,
@@ -401,7 +401,7 @@ class L10nEsVatBook(models.Model):
             rec._clear_old_data()
             map_lines = self.env["aeat.vat.book.map.line"].search([])
             for map_line in map_lines:
-                taxes = rec.get_taxes_from_templates(map_line.tax_tmpl_ids)
+                taxes = map_line.get_taxes(rec)
                 account = rec.get_account_from_template(map_line.tax_account_id)
                 lines = rec._get_account_move_lines(taxes, account=account)
                 rec.create_vat_book_lines(lines, map_line.book_type, taxes)

--- a/l10n_es_vat_book/readme/CONTRIBUTORS.rst
+++ b/l10n_es_vat_book/readme/CONTRIBUTORS.rst
@@ -1,6 +1,7 @@
 * Daniel Rodriguez <drl.9319@gmail.com>
 * Jordi Ballester (ForgeFlow) <jordi.ballester@forgeflow.com>
 * Luis M. Ontalba <luismaront@gmail.com>
+* Manuel Regidor <manuel.regidor@sygel.es>
 * `Tecnativa <https://www.tecnativa.com/>`_:
 
   * Pedro M. Baeza


### PR DESCRIPTION
Parte de la función _calculate_vat_book se ha separado en una nueva función, con lo que se permite añadir impuestos a los que se tienen en cuenta a la hora de calcular el libro de IVA, independientemente de los que se están mapeando.