### PR TITLE
[12.0][IMP] l10n_es_ticketbai: operation description value can be configured

### DIFF
--- a/l10n_es_ticketbai/README.rst
+++ b/l10n_es_ticketbai/README.rst
@@ -9,7 +9,7 @@ TicketBAI - Haciendas Forales Vascas
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-OCA%2Fl10n--spain-lightgray.png?logo=github
-    :target: https://github.com/OCA/l10n-spain/tree/11.0/l10n_es_ticketbai
+    :target: https://github.com/OCA/l10n-spain/tree/12.0/l10n_es_ticketbai
     :alt: OCA/l10n-spain
 
 |badge1| |badge2| |badge3|
@@ -85,7 +85,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/l10n-spain/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
-`feedback <https://github.com/OCA/l10n-spain/issues/new?body=module:%20l10n_es_ticketbai%0Aversion:%2011.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/OCA/l10n-spain/issues/new?body=module:%20l10n_es_ticketbai%0Aversion:%2012.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -116,6 +116,6 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-This module is part of the `OCA/l10n-spain <https://github.com/OCA/l10n-spain/tree/11.0/l10n_es_ticketbai>`_ project on GitHub.
+This module is part of the `OCA/l10n-spain <https://github.com/OCA/l10n-spain/tree/12.0/l10n_es_ticketbai>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/l10n_es_ticketbai/i18n/es.po
+++ b/l10n_es_ticketbai/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-17 07:48+0000\n"
-"PO-Revision-Date: 2021-09-17 09:49+0200\n"
+"POT-Creation-Date: 2021-10-07 09:26+0000\n"
+"PO-Revision-Date: 2021-10-07 11:26+0200\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -54,6 +54,11 @@ msgid "Art. 80.4"
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: selection:res.company,tbai_description_method:0
+msgid "Automatic"
+msgstr "Automático"
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,help:l10n_es_ticketbai.field_account_invoice__tbai_refund_key
 msgid ""
 "BOE-A-1992-28740. Ley 37/1992, de 28 de diciembre, del Impuesto sobre el "
@@ -71,7 +76,7 @@ msgid "Cancel and recreate"
 msgstr "Cancelar y recrear"
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:246
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:248
 #, python-format
 msgid "Cancellation"
 msgstr "Anulación factura"
@@ -166,6 +171,12 @@ msgid "Display Name"
 msgstr "Nombre mostrado"
 
 #. module: l10n_es_ticketbai
+#: sql_constraint:account.fp.tbai.tax:0
+#: sql_constraint:account.fp.tbai.tax_template:0
+msgid "El impuesto debe ser único por posición fiscal."
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_import_journal_creation__tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_enabled
@@ -198,6 +209,11 @@ msgstr "Posición fiscal"
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_account_fiscal_position_template_view_tree
 msgid "Fiscal Position Template"
 msgstr "Plantilla de posición fiscal"
+
+#. module: l10n_es_ticketbai
+#: selection:res.company,tbai_description_method:0
+msgid "Fixed"
+msgstr "Predefinido"
 
 #. module: l10n_es_ticketbai
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_finance_ticketbai_general_info
@@ -282,9 +298,32 @@ msgid "Link between a validated Customer Invoice and its substitute."
 msgstr "Enlace entre la factura del cliente y su sustituta."
 
 #. module: l10n_es_ticketbai
+#: selection:res.company,tbai_description_method:0
+msgid "Manual"
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.invoice_form_inherit
 msgid "Messages"
 msgstr "Mensajes"
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_res_company__tbai_description_method
+msgid ""
+"Method for the TicketBAI invoices description, can be one of these:\n"
+"- Automatic: the description will be the join of the invoice   lines "
+"description\n"
+"- Fixed: the description write on the below field 'TBAI   Description'\n"
+"- Manual (by default): It will be necessary to manually enter   the "
+"description on each invoice"
+msgstr ""
+"Método para la descripción de facturas TicketBAI, puede ser uno de éstos:\n"
+"- Automático: la descripción será la unión de las descripciones de las "
+"lineas de la factura\n"
+"- Predefinido: la descripción escrita en el campo de abajo 'Descripción "
+"TBAI'\n"
+"- Manual (por defecto): Es necesario insertar la descripción de la factura "
+"manualmente en cada factura"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_tax_map__name
@@ -314,7 +353,7 @@ msgid "Refund"
 msgstr "Rectificativa"
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:269
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:271
 #, python-format
 msgid ""
 "Refund invoices must be cancelled in order to cancel the original invoice."
@@ -351,8 +390,6 @@ msgid "Tax"
 msgstr "Impuesto"
 
 #. module: l10n_es_ticketbai
-#: sql_constraint:account.fp.tbai.tax:0
-#: sql_constraint:account.fp.tbai.tax_template:0
 #: code:addons/l10n_es_ticketbai/models/account_fiscal_position.py:35
 #: code:addons/l10n_es_ticketbai/models/chart_template.py:37
 #, python-format
@@ -407,6 +444,15 @@ msgid "Template for Fiscal Position"
 msgstr "Plantilla de posición fiscal"
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_res_company__tbai_description
+msgid ""
+"The description for invoices. Only used when the field TicketBAI Description "
+"Method is 'Fixed'."
+msgstr ""
+"Descripción de las facturas. Utilizado cuando el campo Método de descripción "
+"TicketBAI es 'Predefinido'."
+
+#. module: l10n_es_ticketbai
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_finance_ticketbai
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_l10n_es_tbai_config
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.invoice_form_inherit
@@ -444,6 +490,16 @@ msgstr "TicketBAI anulación"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_cancellation_ids
 msgid "TicketBAI Cancellations"
 msgstr "TicketBAI anulaciones"
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_res_company__tbai_description
+msgid "TicketBAI Description"
+msgstr "Descripción TBAI"
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_res_company__tbai_description_method
+msgid "TicketBAI Description Method"
+msgstr "Método descripción TBAI"
 
 #. module: l10n_es_ticketbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_account_fiscal_position_template_view_search
@@ -607,13 +663,13 @@ msgid "Wizard to Load AEAT Certificate"
 msgstr "Asistente para cargar el certificado AEAT"
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:68
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:70
 #, python-format
 msgid "You cannot change to draft a TicketBAI invoice!"
 msgstr "No es posible cambiar el estado a borrador de una factura TicketBAI."
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:286
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:288
 #, python-format
 msgid "You cannot validate a refund invoice without the origin invoice!"
 msgstr "No es posible validar la factura rectificativa sin factura origen."

--- a/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
+++ b/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 12.0\n"
+"Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-10-07 09:26+0000\n"
+"PO-Revision-Date: 2021-10-07 09:26+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -50,6 +52,11 @@ msgid "Art. 80.4"
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: selection:res.company,tbai_description_method:0
+msgid "Automatic"
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,help:l10n_es_ticketbai.field_account_invoice__tbai_refund_key
 msgid "BOE-A-1992-28740. Ley 37/1992, de 28 de diciembre, del Impuesto sobre el Valor Añadido. Artículo 80. Modificación de la base imponible."
 msgstr ""
@@ -65,7 +72,7 @@ msgid "Cancel and recreate"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:246
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:248
 #, python-format
 msgid "Cancellation"
 msgstr ""
@@ -160,6 +167,12 @@ msgid "Display Name"
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: sql_constraint:account.fp.tbai.tax:0
+#: sql_constraint:account.fp.tbai.tax_template:0
+msgid "El impuesto debe ser único por posición fiscal."
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_import_journal_creation__tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_enabled
@@ -191,6 +204,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_account_fiscal_position_template_view_search
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_account_fiscal_position_template_view_tree
 msgid "Fiscal Position Template"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: selection:res.company,tbai_description_method:0
+msgid "Fixed"
 msgstr ""
 
 #. module: l10n_es_ticketbai
@@ -276,8 +294,21 @@ msgid "Link between a validated Customer Invoice and its substitute."
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: selection:res.company,tbai_description_method:0
+msgid "Manual"
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.invoice_form_inherit
 msgid "Messages"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_res_company__tbai_description_method
+msgid "Method for the TicketBAI invoices description, can be one of these:\n"
+"- Automatic: the description will be the join of the invoice   lines description\n"
+"- Fixed: the description write on the below field 'TBAI   Description'\n"
+"- Manual (by default): It will be necessary to manually enter   the description on each invoice"
 msgstr ""
 
 #. module: l10n_es_ticketbai
@@ -308,7 +339,7 @@ msgid "Refund"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:269
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:271
 #, python-format
 msgid "Refund invoices must be cancelled in order to cancel the original invoice."
 msgstr ""
@@ -342,8 +373,6 @@ msgid "Tax"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: sql_constraint:account.fp.tbai.tax:0
-#: sql_constraint:account.fp.tbai.tax_template:0
 #: code:addons/l10n_es_ticketbai/models/account_fiscal_position.py:35
 #: code:addons/l10n_es_ticketbai/models/chart_template.py:37
 #, python-format
@@ -398,6 +427,11 @@ msgid "Template for Fiscal Position"
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_res_company__tbai_description
+msgid "The description for invoices. Only used when the field TicketBAI Description Method is 'Fixed'."
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_finance_ticketbai
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_l10n_es_tbai_config
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.invoice_form_inherit
@@ -434,6 +468,16 @@ msgstr ""
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_cancellation_ids
 msgid "TicketBAI Cancellations"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_res_company__tbai_description
+msgid "TicketBAI Description"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_res_company__tbai_description_method
+msgid "TicketBAI Description Method"
 msgstr ""
 
 #. module: l10n_es_ticketbai
@@ -587,13 +631,13 @@ msgid "Wizard to Load AEAT Certificate"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:68
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:70
 #, python-format
 msgid "You cannot change to draft a TicketBAI invoice!"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:286
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:288
 #, python-format
 msgid "You cannot validate a refund invoice without the origin invoice!"
 msgstr ""

--- a/l10n_es_ticketbai/models/res_company.py
+++ b/l10n_es_ticketbai/models/res_company.py
@@ -12,6 +12,28 @@ class ResCompany(models.Model):
         comodel_name='l10n.es.aeat.certificate', string='AEAT Certificate',
         domain="[('state', '=', 'active'), ('company_id', '=', id)]", copy=False)
 
+    tbai_description_method = fields.Selection(
+        string='TicketBAI Description Method',
+        selection=[("auto", "Automatic"), ("fixed", "Fixed"),
+                   ("manual", "Manual")],
+        default="manual",
+        required=True,
+        help="Method for the TicketBAI invoices description, can be one of these:\n"
+             "- Automatic: the description will be the join of the invoice "
+             "  lines description\n"
+             "- Fixed: the description write on the below field 'TBAI "
+             "  Description'\n"
+             "- Manual (by default): It will be necessary to manually enter "
+             "  the description on each invoice",
+    )
+
+    tbai_description = fields.Char(
+        string="TicketBAI Description",
+        size=250,
+        help="The description for invoices. Only used when the field TicketBAI "
+        "Description Method is 'Fixed'.",
+    )
+
     @api.onchange('tbai_enabled')
     def onchange_tbai_enabled_unset_tbai_aeat_certificate_id(self):
         if not self.tbai_enabled:

--- a/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
+++ b/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
@@ -28,6 +28,26 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
         res = XMLSchema.xml_is_valid(self.test_xml_invoice_schema_doc, root)
         self.assertTrue(res)
 
+    def test_invoice_operation_desc(self):
+        self.main_company.tbai_description_method = 'manual'
+        invoice = self.create_draft_invoice(
+            self.account_billing.id, self.fiscal_position_national)
+        invoice.onchange_fiscal_position_id_tbai_vat_regime_key()
+        invoice.compute_taxes()
+        self.assertEqual(invoice.tbai_description_operation, '/')
+        self.main_company.tbai_description_method = 'fixed'
+        description = 'description test'
+        self.main_company.tbai_description = description
+        invoice._compute_tbai_description()
+        self.assertEqual(invoice.tbai_description_operation, description)
+        self.main_company.tbai_description_method = 'auto'
+        description = ''
+        for line in invoice.invoice_line_ids:
+            description += (line.name or line.ref) + ' - '
+        description = description[:-3]
+        invoice._compute_tbai_description()
+        self.assertEqual(invoice.tbai_description_operation, description)
+
     def test_cancel_and_recreate(self):
         # Build three invoices and check the chaining.
         invoice = self.create_draft_invoice(

--- a/l10n_es_ticketbai/views/res_company_views.xml
+++ b/l10n_es_ticketbai/views/res_company_views.xml
@@ -16,6 +16,18 @@
                     <field name="tbai_aeat_certificate_id" attrs="{'required': [('tbai_enabled', '=', True)]}"
                            options="{'no_open':True,'no_create':True}"/>
                 </field>
+                <xpath expr="//group[@name='ticketbai_company_config']" position="after">
+                    <group name="ticketbai_operation_desc_config" attrs="{'invisible': [('tbai_enabled', '=', False)]}">
+                        <field name="tbai_description_method" />
+                        <field
+                            name="tbai_description"
+                            attrs="{
+                                'invisible': [('tbai_description_method', '!=', 'fixed')],
+                                'required': [('tbai_description_method', '=', 'fixed')],
+                            }"
+                        />
+                    </group>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
Se puede configurar en la compañía como se rellena el campo de descripción de operación, manual, fijo o automático. Igual que en el SII.