### PR TITLE
[12.0][IMP] l10n_es_aeat_mod349: Don't mangle VAT number

### DIFF
--- a/l10n_es_aeat_mod349/views/mod349_view.xml
+++ b/l10n_es_aeat_mod349/views/mod349_view.xml
@@ -68,7 +68,7 @@
                                 <field name="operation_key"/>
                                 <field name="partner_id"/>
                                 <field name="country_id"/>
-                                <field name="partner_vat" on_change="onchange_format_partner_vat(partner_vat,country_id)"/>
+                                <field name="partner_vat"/>
                                 <field name="total_operation_amount"/>
                             </group>
                         </page>


### PR DESCRIPTION
There's a VAT formatting method that adds country code if not present in the partner vat. This method is not useful at all, as all European VAT numbers should have country prefix for being validated in invoices, so there's not too much sense to try to reformat it. There are also cases where a big company has one country VAT number, but has fiscal address in other country, resulting in an incorrect reformating.

Not even that, there are old style onchanges that are not ever triggered, as the XML declaration disappeared or is not effective as the view is readonly, becoming dead code.

This commit removes all this stuff, with no expected side effects.

@Tecnativa TT31460