### PR TITLE
[12.0][FIX] Correct production URLs and removed label repeating warning

### DIFF
--- a/l10n_es_ticketbai_api/data/tax_agency_data.xml
+++ b/l10n_es_ticketbai_api/data/tax_agency_data.xml
@@ -12,9 +12,9 @@
             <field name="version">1.2</field>
             <field name="qr_base_url">https://tbai.egoitza.gipuzkoa.eus/qr/</field>
             <field name="test_qr_base_url">https://tbai.prep.gipuzkoa.eus/qr/</field>
-            <field name="rest_url_invoice">https://tbai.egoitza.gipuzkoa.eus/WAS/HACI/HTBRecepcionFacturasWEB/rest/recepcionFacturas/alta</field>
+            <field name="rest_url_invoice">https://tbai-z.egoitza.gipuzkoa.eus/sarrerak/alta</field>
             <field name="test_rest_url_invoice">https://tbai-prep.egoitza.gipuzkoa.eus/WAS/HACI/HTBRecepcionFacturasWEB/rest/recepcionFacturas/alta</field>
-            <field name="rest_url_cancellation">https://tbai.egoitza.gipuzkoa.eus/WAS/HACI/HTBRecepcionFacturasWEB/rest/recepcionFacturas/anulacion</field>
+            <field name="rest_url_cancellation">https://tbai-z.egoitza.gipuzkoa.eus/sarrerak/baja</field>
             <field name="test_rest_url_cancellation">https://tbai-prep.egoitza.gipuzkoa.eus/WAS/HACI/HTBRecepcionFacturasWEB/rest/recepcionFacturas/anulacion</field>
         </record>
     </data>

--- a/l10n_es_ticketbai_api/i18n/es.po
+++ b/l10n_es_ticketbai_api/i18n/es.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-17 09:33+0000\n"
-"PO-Revision-Date: 2021-06-17 09:33+0000\n"
+"POT-Creation-Date: 2021-09-16 08:39+0000\n"
+"PO-Revision-Date: 2021-09-16 10:42+0200\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 3.0\n"
 
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,help:l10n_es_ticketbai_api.field_tbai_invoice__schema
@@ -347,7 +348,6 @@ msgstr "Entidad desarrolladora"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_installation.py:21
-#: sql_constraint:tbai.installation:0
 #, python-format
 msgid "Developer must be unique!"
 msgstr "¡La entidad desarrolladora debe ser única!"
@@ -575,7 +575,6 @@ msgstr "Licencia TBAI"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_installation.py:22
-#: sql_constraint:tbai.installation:0
 #, python-format
 msgid "License Key must be unique!"
 msgstr "¡La licencia TicketBAI debe ser única!"
@@ -704,10 +703,9 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_tax_agency__qr_base_url
-#: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_tax_agency__test_qr_base_url
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_tax_agency_version__qr_base_url
 msgid "QR Base URL"
-msgstr ""
+msgstr "URL base del QR"
 
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_line__quantity
@@ -853,7 +851,6 @@ msgstr "Nombre del software"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_installation.py:20
-#: sql_constraint:tbai.installation:0
 #, python-format
 msgid "Software Name must be unique!"
 msgstr "¡El nombre de Software TicketBAI debe ser único!"
@@ -943,11 +940,6 @@ msgid "TIN"
 msgstr "NIF"
 
 #. module: l10n_es_ticketbai_api
-#: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_res_company__tbai_tax_agency_id
-msgid "Tax Agency"
-msgstr "Hacienda"
-
-#. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_tax_agency__tax_agency_version_ids
 msgid "Tax Agency Version"
 msgstr "Hacienda - versión"
@@ -997,7 +989,7 @@ msgstr "Hacienda TicketBAI"
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_tax_agency_version__test_qr_base_url
 msgid "Test - QR Base URL"
-msgstr ""
+msgstr "Test - URL base del QR"
 
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_tax_agency__test_rest_url_cancellation
@@ -1010,6 +1002,11 @@ msgstr "Entorno de pruebas - REST API URL para la anulación de facturas"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_tax_agency_version__test_rest_url_invoice
 msgid "Test - REST API URL for Invoices"
 msgstr "Entorno de pruebas - REST API URL para facturas"
+
+#. module: l10n_es_ticketbai_api
+#: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_tax_agency__test_qr_base_url
+msgid "Test QR Base URL"
+msgstr "URL base del QR test"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:628
@@ -1652,6 +1649,7 @@ msgstr "TicketBAI Facturas rectificadas"
 
 #. module: l10n_es_ticketbai_api
 #: model:ir.model,name:l10n_es_ticketbai_api.model_tbai_tax_agency
+#: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_res_company__tbai_tax_agency_id
 msgid "TicketBAI Tax Agency"
 msgstr "TicketBAI Hacienda"
 
@@ -1749,3 +1747,18 @@ msgstr "XML Respuesta"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_customer__zip
 msgid "ZIP Code"
 msgstr "Código postal"
+
+#. module: l10n_es_ticketbai_api
+#: sql_constraint:tbai.installation:0
+msgid "¡El nombre de Software TicketBAI debe ser único!"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: sql_constraint:tbai.installation:0
+msgid "¡La entidad desarrolladora debe ser única!"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: sql_constraint:tbai.installation:0
+msgid "¡La licencia TicketBAI debe ser única!"
+msgstr ""

--- a/l10n_es_ticketbai_api/models/res_company.py
+++ b/l10n_es_ticketbai_api/models/res_company.py
@@ -25,7 +25,7 @@ class ResCompany(models.Model):
     tbai_device_serial_number = fields.Char(
         'Device Serial Number', default='', copy=False)
     tbai_tax_agency_id = fields.Many2one(
-        comodel_name='tbai.tax.agency', string='Tax Agency', copy=False)
+        comodel_name='tbai.tax.agency', string='TicketBAI Tax Agency', copy=False)
     tbai_vat_regime_simplified = fields.Boolean('Regime Simplified', copy=False)
     tbai_last_invoice_id = fields.Many2one(
         string='Last TicketBAI Invoice sent', comodel_name='tbai.invoice', copy=False)

--- a/l10n_es_ticketbai_api/models/ticketbai_tax_agency.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_tax_agency.py
@@ -14,7 +14,7 @@ class TicketBAITaxAgency(models.Model):
     qr_base_url = fields.Char(
         string='QR Base URL', compute='_compute_ticketbai_version', store=True)
     test_qr_base_url = fields.Char(
-        string='QR Base URL', compute='_compute_ticketbai_version', store=True)
+        string='Test QR Base URL', compute='_compute_ticketbai_version', store=True)
     tax_agency_version_ids = fields.One2many(
         comodel_name='tbai.tax.agency.version', inverse_name='tbai_tax_agency_id')
     rest_url_invoice = fields.Char(


### PR DESCRIPTION
Se establece el URL correcto de producción y se elimina el warning 
`WARNING: Two fields (tax_agency_id, tbai_tax_agency_id) of res.company() have the same label: Tax Agency.`

ping @Bilbonet se elimina el warning que me mencionaste en el otro PR para configurar la descripción de operación #1803 