### PR TITLE
[14.0][FIX]l10n_es_aeat_sii_oca: Fix field name on default type function.

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -90,7 +90,7 @@ class AccountMove(models.Model):
 
     def _get_default_type(self):
         context = self.env.context
-        return context.get("move_type", context.get("default_type"))
+        return context.get("move_type", context.get("default_move_type"))
 
     def _default_sii_refund_type(self):
         inv_type = self._get_default_type()


### PR DESCRIPTION
Pequeño error en el nombre del campo, hacía que fallaran los defaults de sii_registration_key y sii_refund_type