### PR TITLE
[13.0][OU-IMP] l10n_es_facturae: Migration script, set column as nullable

### DIFF
--- a/l10n_es_facturae/migrations/13.0.1.0.0/post-migration.py
+++ b/l10n_es_facturae/migrations/13.0.1.0.0/post-migration.py
@@ -49,5 +49,21 @@ def migrate(env, version):
             facturae_end_date = ail.facturae_end_date,
             facturae_transaction_date = ail.facturae_transaction_date
         FROM account_invoice_line ail
-        WHERE ail.id = aml.old_invoice_line_id""",
+        WHERE ail.id = aml.old_invoice_line_id
+            AND (
+                ail.facturae_receiver_contract_reference is not NULL
+                OR ail.facturae_receiver_contract_date is not NULL
+                OR ail.facturae_receiver_transaction_reference is not NULL
+                OR ail.facturae_receiver_transaction_date is not NULL
+                OR ail.facturae_issuer_contract_reference is not NULL
+                OR ail.facturae_issuer_contract_date is not NULL
+                OR ail.facturae_issuer_transaction_reference is not NULL
+                OR ail.facturae_issuer_transaction_date is not NULL
+                OR ail.facturae_file_reference is not NULL
+                OR ail.facturae_file_date is not NULL
+                OR ail.facturae_start_date is not NULL
+                OR ail.facturae_end_date is not NULL
+                OR ail.facturae_transaction_date is not NULL
+            )
+        """,
     )

--- a/l10n_es_facturae/migrations/13.0.1.0.1/pre-migration.py
+++ b/l10n_es_facturae/migrations/13.0.1.0.1/pre-migration.py
@@ -32,3 +32,11 @@ def migrate(env, version):
                 'account.move.integration.method'
             )""",
     )
+    openupgrade.remove_tables_fks(
+        env.cr,
+        [
+            "account_move_integration_method",
+            "account_move_integration_log",
+            "account_move_integration",
+        ],
+    )


### PR DESCRIPTION
Al actualizar, da un error al intentar eliminar los registros que ya no se usan.

Pasa cuando una vez actualizado con OpenUpgrade se actualiza todo con odoo