### PR TITLE
[14.0][FIX] l10n_es_aeat_sii_oca: Only assign sii_registration_key if is set in fiscal position

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -296,7 +296,9 @@ class AccountMove(models.Model):
                 key = invoice.fiscal_position_id.sii_registration_key_sale
             else:
                 key = invoice.fiscal_position_id.sii_registration_key_purchase
-            invoice.sii_registration_key = key
+            # Only assign sii_registration_key if is set in fiscal position
+            if key:
+                invoice.sii_registration_key = key
 
     @api.onchange("partner_id", "company_id")
     def _onchange_partner_id(self):


### PR DESCRIPTION
FWP de 13.0: https://github.com/OCA/l10n-spain/pull/1840

Solo asignaremos la clave `sii_registration_key` al definir una posición fiscal si alguna clave definida.

Por favor, @pedrobaeza and @joao-p-marques ¿podéis revisarlo?

@Tecnativa TT31877



