### PR TITLE
[12.0][IMP] l10n_es_aeat_vat_prorrate: Add expression to 2021-07 303 format

### DIFF
--- a/l10n_es_aeat_vat_prorrate/data/aeat_export_mod303_data.xml
+++ b/l10n_es_aeat_vat_prorrate/data/aeat_export_mod303_data.xml
@@ -6,6 +6,10 @@
             <field name="fixed_value"/>
             <field name="expression">${object.casilla_44}</field>
         </record>
+        <record id="l10n_es_aeat_mod303.aeat_mod303_2021_sub01_export_line_68" model="aeat.model.export.config.line">
+            <field name="fixed_value"/>
+            <field name="expression">${object.casilla_44}</field>
+        </record>
 
     </data>
 </openerp>


### PR DESCRIPTION
De acuerdo al comentario https://github.com/OCA/l10n-spain/pull/1852#discussion_r721475789

Añadir compatibilidad con el formato 2021-07 del modelo 303.

Por favor, @pedrobaeza y @joao-p-marques, ¿podéis revisarlo?

@Tecnativa TT32128