### PR TITLE
[IMP] l10n_es_facturae: Add disable_edi_auto configuration

### DIFF
--- a/l10n_es_facturae/__manifest__.py
+++ b/l10n_es_facturae/__manifest__.py
@@ -28,6 +28,7 @@
         "report_qweb_parameter",
     ],
     "data": [
+        "security/ir.model.access.csv",
         "data/account_tax_template.xml",
         "views/res_partner_view.xml",
         "views/res_company.xml",

--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -101,6 +101,9 @@ class AccountMove(models.Model):
         copy=False,
         help="Número de la factura emitida por un tercero.",
     )
+    l10n_es_facturae_attachment_ids = fields.One2many(
+        "l10n.es.facturae.attachment", inverse_name="move_id", copy=False,
+    )
 
     @api.depends("journal_id")
     def _compute_thirdparty_invoice(self):
@@ -210,6 +213,17 @@ class AccountMove(models.Model):
                     "content_type": content_type,
                     "encoding": "BASE64",
                     "description": _("Invoice %s") % self.name,
+                    "compression": False,
+                }
+            )
+        for attachment in self.l10n_es_facturae_attachment_ids:
+            description, content_type = attachment.filename.rsplit(".", 1)
+            result.append(
+                {
+                    "data": attachment.file,
+                    "content_type": content_type,
+                    "encoding": "BASE64",
+                    "description": description,
                     "compression": False,
                 }
             )
@@ -544,3 +558,11 @@ class AccountMoveLine(models.Model):
             "res_id": self.id,
             "context": self.env.context,
         }
+
+
+class L10nEsFacturaeAttachment(models.Model):
+    _name = "l10n.es.facturae.attachment"
+
+    move_id = fields.Many2one("account.move", required=True, ondelete="cascade")
+    file = fields.Binary(required=True)
+    filename = fields.Char()

--- a/l10n_es_facturae/security/ir.model.access.csv
+++ b/l10n_es_facturae/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_l10n_es_facturae_attachment,access_l10n_es_facturae_attachment,model_l10n_es_facturae_attachment,base.group_user,1,0,0,0
+manage_l10n_es_facturae_attachment,manage_l10n_es_facturae_attachment,model_l10n_es_facturae_attachment,account.group_account_invoice,1,1,1,1

--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -291,6 +291,44 @@ class CommonTest(common.TransactionCase):
             ),
         )
 
+    def test_facturae_with_extra_attachments(self):
+        self.move.action_post()
+        self.move.name = "2999/99999"
+        self.partner.attach_invoice_as_annex = False
+        self.move.write(
+            {
+                "l10n_es_facturae_attachment_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "filename": "new_file.pdf",
+                            "file": base64.b64encode(b"DEMO FILE"),
+                        },
+                    )
+                ]
+            }
+        )
+        self.wizard.with_context(
+            force_report_rendering=True,
+            active_ids=self.move.ids,
+            active_model="account.move",
+        ).create_facturae_file()
+        generated_facturae = etree.fromstring(base64.b64decode(self.wizard.facturae))
+        self.assertTrue(
+            generated_facturae.xpath(
+                "/fe:Facturae/Invoices/Invoice/AdditionalData/" "RelatedDocuments",
+                namespaces={"fe": self.fe},
+            ),
+        )
+        self.assertTrue(
+            generated_facturae.xpath(
+                "/fe:Facturae/Invoices/Invoice/AdditionalData/"
+                "RelatedDocuments/Attachment",
+                namespaces={"fe": self.fe},
+            ),
+        )
+
     def test_bank(self):
         self.bank.bank_id.bic = "CAIXESBB"
         with self.assertRaises(exceptions.ValidationError):

--- a/l10n_es_facturae/views/account_move_view.xml
+++ b/l10n_es_facturae/views/account_move_view.xml
@@ -32,6 +32,27 @@
                             <field name="facturae_end_date" />
                         </group>
                     </group>
+                    <group
+                        name="facturae_attachment"
+                        string="Facturae Attachment"
+                        attrs="{'invisible': [('facturae', '=', False)]}"
+                    >
+                    <field name="l10n_es_facturae_attachment_ids" nolabel="1">
+                        <tree>
+                            <field name="move_id" invisible="1" />
+                            <field name="filename" />
+                            <field name="file" filename="filename" />
+                        </tree>
+                        <form>
+                            <sheet>
+                                <group>
+                                    <field name="file" filename="filename" />
+                                    <field name="filename" invisible="1" />
+                                </group>
+                            </sheet>
+                        </form>
+                    </field>
+                </group>
                 </page>
             </notebook>
         </field>

--- a/l10n_es_facturae_face/__manifest__.py
+++ b/l10n_es_facturae_face/__manifest__.py
@@ -17,6 +17,7 @@
         "views/account_move.xml",
         "views/res_company_view.xml",
         "views/edi_exchange_record.xml",
+        "views/res_partner.xml",
     ],
     "external_dependencies": {"python": ["OpenSSL", "zeep", "xmlsec"]},
     "installable": True,

--- a/l10n_es_facturae_face/components/account_move_l10n_es_facturae_listener.py
+++ b/l10n_es_facturae_face/components/account_move_l10n_es_facturae_listener.py
@@ -21,6 +21,8 @@ class AccountMoveL10nEsFacturaeListener(Component):
 
     def on_post_account_move(self, records):
         for record in records:
+            if record.disable_edi_auto:
+                continue
             partner = record.partner_id
             if record.type not in ["out_invoice", "out_refund"]:
                 continue


### PR DESCRIPTION
Depende de https://github.com/OCA/edi/pull/455
Es útil cuando se tiene que emitir una factura que no queremos integrar por alguna razón.
En nuestro caso, a veces el cliente cancela directamente la factura y no quiere recibir el abono.