### PR TITLE
[12.0][IMP] l10n_es_ticketbai: journals are able not to send invoices to tax agency

### DIFF
--- a/l10n_es_ticketbai/README.rst
+++ b/l10n_es_ticketbai/README.rst
@@ -79,6 +79,10 @@ Usage
   * Por limitaciones de TicketBAI, se eliminan los sufijos de las secuencias de los diarios de ventas.
   * Por legalidad, se obliga a especificar una secuencia dedicada para las facturas rectificativas.
 
+* Habilitar/deshabilitar envio de facturas TicketBAI por diarios de ventas
+
+  * En caso de que se tengan varias series de facturación, si una de ellas se envía a TicketBAI a través de otro software, en el diario de ventas en el cual se contabilizan estas facturas en Odoo deberá estar desactivado el envío de facturas TicketBAI para evitar duplicar la información en hacienda.
+
 Bug Tracker
 ===========
 

--- a/l10n_es_ticketbai/i18n/es.po
+++ b/l10n_es_ticketbai/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-07 09:26+0000\n"
-"PO-Revision-Date: 2021-10-07 11:26+0200\n"
+"POT-Creation-Date: 2021-11-11 11:38+0000\n"
+"PO-Revision-Date: 2021-11-11 12:43+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -76,7 +76,7 @@ msgid "Cancel and recreate"
 msgstr "Cancelar y recrear"
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:248
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:249
 #, python-format
 msgid "Cancellation"
 msgstr "Anulación factura"
@@ -347,7 +347,7 @@ msgid "Refund"
 msgstr "Rectificativa"
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:271
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:272
 #, python-format
 msgid ""
 "Refund invoices must be cancelled in order to cancel the original invoice."
@@ -360,6 +360,13 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.invoice_form_inherit
 msgid "Responses"
 msgstr "Respuestas"
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_import_journal_creation__tbai_send_invoice
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_send_invoice
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_send_invoice
+msgid "Send TicketBAI invoices to tax agency"
+msgstr "Enviar facturas a hacienda TicketBAI"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_ir_sequence
@@ -659,13 +666,23 @@ msgid "Wizard to Load AEAT Certificate"
 msgstr "Asistente para cargar el certificado AEAT"
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:70
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:71
 #, python-format
 msgid "You cannot change to draft a TicketBAI invoice!"
 msgstr "No es posible cambiar el estado a borrador de una factura TicketBAI."
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:288
+#: code:addons/l10n_es_ticketbai/models/account_journal.py:34
+#, python-format
+msgid ""
+"You cannot stop sending invoices from this journal, an invoice has already "
+"been sent."
+msgstr ""
+"No puedes dejar de enviar facturas de este diario, al menos una factura ya a "
+"sido enviada."
+
+#. module: l10n_es_ticketbai
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:289
 #, python-format
 msgid "You cannot validate a refund invoice without the origin invoice!"
 msgstr "No es posible validar la factura rectificativa sin factura origen."

--- a/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
+++ b/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 12.0\n"
+"Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-11 11:38+0000\n"
+"PO-Revision-Date: 2021-11-11 11:38+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -70,7 +72,7 @@ msgid "Cancel and recreate"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:248
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:249
 #, python-format
 msgid "Cancellation"
 msgstr ""
@@ -331,7 +333,7 @@ msgid "Refund"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:271
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:272
 #, python-format
 msgid "Refund invoices must be cancelled in order to cancel the original invoice."
 msgstr ""
@@ -340,6 +342,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_response_ids
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.invoice_form_inherit
 msgid "Responses"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_import_journal_creation__tbai_send_invoice
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_send_invoice
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_send_invoice
+msgid "Send TicketBAI invoices to tax agency"
 msgstr ""
 
 #. module: l10n_es_ticketbai
@@ -625,13 +634,19 @@ msgid "Wizard to Load AEAT Certificate"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:70
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:71
 #, python-format
 msgid "You cannot change to draft a TicketBAI invoice!"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/account_invoice.py:288
+#: code:addons/l10n_es_ticketbai/models/account_journal.py:34
+#, python-format
+msgid "You cannot stop sending invoices from this journal, an invoice has already been sent."
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:289
 #, python-format
 msgid "You cannot validate a refund invoice without the origin invoice!"
 msgstr ""

--- a/l10n_es_ticketbai/models/account_invoice.py
+++ b/l10n_es_ticketbai/models/account_invoice.py
@@ -14,6 +14,7 @@ class AccountInvoice(models.Model):
 
     tbai_enabled = fields.Boolean(
         related='company_id.tbai_enabled', readonly=True)
+    tbai_send_invoice = fields.Boolean(related='journal_id.tbai_send_invoice')
     tbai_substitution_invoice_id = fields.Many2one(
         comodel_name='account.invoice', copy=False,
         help="Link between a validated Customer Invoice and its substitute.")
@@ -308,7 +309,7 @@ class AccountInvoice(models.Model):
                         x.refund_invoice_id.tbai_invoice_id and not
                         x.refund_invoice_id.tbai_cancellation_id
                     )
-                )
+                ) and x.tbai_send_invoice
             )
             tbai_invoices._tbai_build_invoice()
         return res

--- a/l10n_es_ticketbai/models/account_journal.py
+++ b/l10n_es_ticketbai/models/account_journal.py
@@ -1,6 +1,7 @@
 #  Copyright 2021 Landoo Sistemas de Informacion SL
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import models, fields, api
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
 
 
 class AccountJournal(models.Model):
@@ -8,6 +9,9 @@ class AccountJournal(models.Model):
 
     tbai_enabled = fields.Boolean(
         related='company_id.tbai_enabled', readonly=True)
+
+    tbai_send_invoice = fields.Boolean(
+        string='Send TicketBAI invoices to tax agency', default=True)
 
     @api.onchange('refund_sequence')
     def onchange_refund_sequence(self):
@@ -18,3 +22,14 @@ class AccountJournal(models.Model):
     def onchange_type(self):
         if self.type == 'sale':
             self.refund_sequence = True
+
+    @api.onchange('tbai_send_invoice')
+    def onchange_tbai_send_invoice(self):
+        if not self.tbai_send_invoice:
+            tbai_invoices = self.env["account.invoice"].search(
+                [('journal_id', '=', self._origin.id),
+                 ('tbai_invoice_id', '!=', False)]
+            )
+            if len(tbai_invoices) > 0:
+                raise UserError(_('You cannot stop sending invoices from this'
+                                  ' journal, an invoice has already been sent.'))

--- a/l10n_es_ticketbai/models/res_company.py
+++ b/l10n_es_ticketbai/models/res_company.py
@@ -93,7 +93,7 @@ class ResCompany(models.Model):
                             if self.env['ir.module.module'].search([
                                 ('name', '=', 'l10n_es_account_invoice_sequence'),
                                 ('state', '=', 'installed')
-                            ]):
+                            ]) and journal.invoice_sequence_id:
                                 journal.invoice_sequence_id.suffix = ''
                             else:
                                 journal.sequence_id.suffix = ''

--- a/l10n_es_ticketbai/tests/common.py
+++ b/l10n_es_ticketbai/tests/common.py
@@ -237,3 +237,9 @@ class TestL10nEsTicketBAI(TestL10nEsTicketBAIAPI):
         })
         self.fiscal_position_ipsi_igic = self.main_company.get_fps_from_templates(
             self.env.ref("l10n_es.fp_not_subject_tai"))
+        self.non_tbai_journal = self.env['account.journal'].create({
+            'name': 'Non-Tbai journal',
+            'type': 'sale',
+            'code': 'NTBAI',
+            'tbai_send_invoice': False,
+        })

--- a/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
+++ b/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
@@ -48,6 +48,16 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
         invoice._compute_tbai_description()
         self.assertEqual(invoice.tbai_description_operation, description)
 
+    def test_invoice_non_tbai_journal(self):
+        invoice = self.create_draft_invoice(
+            self.account_billing.id, self.fiscal_position_national)
+        invoice.journal_id = self.non_tbai_journal
+        invoice.onchange_fiscal_position_id_tbai_vat_regime_key()
+        invoice.compute_taxes()
+        invoice.action_invoice_open()
+        self.assertEqual(invoice.state, 'open')
+        self.assertEqual(0, len(invoice.tbai_invoice_ids))
+
     def test_cancel_and_recreate(self):
         # Build three invoices and check the chaining.
         invoice = self.create_draft_invoice(

--- a/l10n_es_ticketbai/views/account_invoice_views.xml
+++ b/l10n_es_ticketbai/views/account_invoice_views.xml
@@ -14,10 +14,11 @@
                            options="{'no_open':True,'no_create':True}"/>
                 </xpath>
                 <page name="other_info" position="after">
-                    <page name="ticketbai" string="TicketBAI" attrs="{'invisible': ['|', ('tbai_enabled', '=', False), '&amp;', ('type', '=', 'out_refund'), ('refund_invoice_id', '=', False)]}">
+                    <page name="ticketbai" string="TicketBAI" attrs="{'invisible': ['|', ('tbai_enabled', '=', False), '|', ('tbai_send_invoice', '=', False), '&amp;', ('type', '=', 'out_refund'), ('refund_invoice_id', '=', False)]}">
                         <group name="main_grp" col="4">
                             <group name="ticketbai" colspan="2" col="2">
                                 <field name="tbai_enabled" invisible="1"/>
+                                <field name="tbai_send_invoice" invisible="1"/>
                                 <field name="tbai_invoice_id" readonly="1" options="{'no_create':True}"
                                        attrs="{'invisible': [('tbai_invoice_id', '=', False)]}"/>
                                 <field name="tbai_cancellation_id" readonly="1" options="{'no_create':True}"

--- a/l10n_es_ticketbai/views/account_journal_views.xml
+++ b/l10n_es_ticketbai/views/account_journal_views.xml
@@ -10,6 +10,9 @@
                 <xpath expr="//field[@name='refund_sequence']" position="before">
                     <field name="tbai_enabled" invisible="1" />
                 </xpath>
+                <xpath expr="//field[@name='type']" position="after">
+                    <field name="tbai_send_invoice" attrs="{'invisible': ['|', ('type', '!=', 'sale'), ('tbai_enabled', '=', False)]}" />
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
Se agrega un checkbox en los diarios para poder hacer que no se envíen las facturas a hacienda. Si al menos una factura ya ha sido enviada desde ese diario, este checkbox no se puede deshabilitar.