### PR TITLE
[14.0][IMP] l10n_es_intrastat_report: Update intrastat transaction data according to documentation.

### DIFF
--- a/l10n_es_intrastat_report/README.rst
+++ b/l10n_es_intrastat_report/README.rst
@@ -49,9 +49,9 @@ If any other installation method is used, you can go to
 *Settings > Technical > Actions > Configuration Wizards* on developer mode,
 and launch there the wizard called "Import Spanish Product HS Codes"
 
-The included codes are for 2020. Please check possible updates for this codes in:
+The included codes are for 2021. Please check possible updates for this codes in:
 
-https://www.agenciatributaria.es/AEAT.internet/Inicio/La_Agencia_Tributaria/Memorias_y_estadisticas_tributarias/Estadisticas/_Comercio_exterior_/Documentacion/Tablas_de_codigos/Tablas_de_codigos.shtml
+https://www.cbs.nl/en-gb/participants-survey/overzicht/businesses/onderzoek/international-trade-in-goods/idep-code-lists
 
 This wizard also sets a sane default Intrastat transaction type for each kind
 of invoice at company level, but it can be changed later.
@@ -157,6 +157,7 @@ Contributors
   * Manuel Calero
   * Pedro M. Baeza
   * João Marques
+  * Víctor Martínez
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_intrastat_report/data/intrastat_transaction.xml
+++ b/l10n_es_intrastat_report/data/intrastat_transaction.xml
@@ -21,6 +21,7 @@
                 name="description"
             >Transacciones que supongan un traspaso de propiedad real o previsto de residentes a no residentes a cambio de una compensación financiera o de otro tipo: Trueque (compensación en especie).</field>
             <field name="company_id" eval="False" />
+            <field name="active" eval="False" />
         </record>
         <record id="intrastat_transaction_14" model="intrastat.transaction">
             <field name="code">14</field>
@@ -28,6 +29,7 @@
                 name="description"
             >Transacciones que supongan un traspaso de propiedad real o previsto de residentes a no residentes a cambio de una compensación financiera o de otro tipo: Arrendamiento financiero (alquiler - compra).</field>
             <field name="company_id" eval="False" />
+            <field name="active" eval="False" />
         </record>
         <record id="intrastat_transaction_19" model="intrastat.transaction">
             <field name="code">19</field>
@@ -35,6 +37,7 @@
                 name="description"
             >Transacciones que supongan un traspaso de propiedad real o previsto de residentes a no residentes a cambio de una compensación financiera o de otro tipo: Otras.</field>
             <field name="company_id" eval="False" />
+            <field name="active" eval="False" />
         </record>
         <record id="intrastat_transaction_21" model="intrastat.transaction">
             <field name="code">21</field>
@@ -63,6 +66,7 @@
                 name="description"
             >Devolución y sustitución gratuita de mercancías después del registro de la transacción original: Otras.</field>
             <field name="company_id" eval="False" />
+            <field name="active" eval="False" />
         </record>
         <record id="intrastat_transaction_31" model="intrastat.transaction">
             <field name="code">31</field>
@@ -85,6 +89,13 @@
             >Transacciones que supongan un traspaso de propiedad sin compensación financiera o en especie: Otras ayudas (particulares, organizaciones no gubernamentales).</field>
             <field name="company_id" eval="False" />
         </record>
+        <record id="intrastat_transaction_34" model="intrastat.transaction">
+            <field name="code">34</field>
+            <field
+                name="description"
+            >Transacciones que implican transferencia de propiedad sin compensación económica. Transacciones que implican el cambio previsto de propiedad o cambio de propiedad sin compensación financiera.</field>
+            <field name="company_id" eval="False" />
+        </record>
         <record id="intrastat_transaction_41" model="intrastat.transaction">
             <field name="code">41</field>
             <field
@@ -105,6 +116,7 @@
                 name="description"
             >Operaciones con vistas a un perfeccionamiento bajo contrato (no se traspasa la propiedad al contratista): Reparación o mantenimiento a título gratuito.</field>
             <field name="company_id" eval="False" />
+            <field name="active" eval="False" />
         </record>
         <record id="intrastat_transaction_45" model="intrastat.transaction">
             <field name="code">45</field>
@@ -112,6 +124,7 @@
                 name="description"
             >Operaciones con vistas a un perfeccionamiento bajo contrato (no se traspasa la propiedad al contratista): Reparación o mantenimiento a título oneroso.</field>
             <field name="company_id" eval="False" />
+            <field name="active" eval="False" />
         </record>
         <record id="intrastat_transaction_51" model="intrastat.transaction">
             <field name="code">51</field>
@@ -133,6 +146,7 @@
                 name="description"
             >Operaciones posteriores al perfeccionamiento bajo contrato (no se traspasa la propiedad al contratista): Reparación o mantenimiento a título gratuito.</field>
             <field name="company_id" eval="False" />
+            <field name="active" eval="False" />
         </record>
         <record id="intrastat_transaction_55" model="intrastat.transaction">
             <field name="code">55</field>
@@ -140,12 +154,35 @@
                 name="description"
             >Operaciones posteriores al perfeccionamiento bajo contrato (no se traspasa la propiedad al contratista): Reparación o mantenimiento a título oneroso.</field>
             <field name="company_id" eval="False" />
+            <field name="active" eval="False" />
+        </record>
+        <record id="intrastat_transaction_60" model="intrastat.transaction">
+            <field name="code">60</field>
+            <field
+                name="description"
+            >Transacciones particulares registradas para fines nacionales, como reparaciones.</field>
+            <field name="company_id" eval="False" />
         </record>
         <record id="intrastat_transaction_70" model="intrastat.transaction">
             <field name="code">70</field>
             <field
                 name="description"
             >Operaciones en el marco de programas comunes de defensa u otros programas intergubernamentales de producción conjunta.</field>
+            <field name="company_id" eval="False" />
+            <field name="active" eval="False" />
+        </record>
+        <record id="intrastat_transaction_71" model="intrastat.transaction">
+            <field name="code">71</field>
+            <field
+                name="description"
+            >Despacho de mercancías a libre práctica en un Estado miembro con una exportación posterior a otro Estado miembro. Transacciones con miras al despacho de aduanas (que no implica cambio de titularidad, relacionados con mercancías en cuasi-importación o exportación).</field>
+            <field name="company_id" eval="False" />
+        </record>
+        <record id="intrastat_transaction_72" model="intrastat.transaction">
+            <field name="code">72</field>
+            <field
+                name="description"
+            >Transporte de mercancías de un miembr Estado a otro Estado miembro para colocar el mercancías en régimen de exportación. Transacciones con miras al despacho de aduanas (que no implica cambio de titularidad, relacionados con mercancías en cuasi-importación o exportación).</field>
             <field name="company_id" eval="False" />
         </record>
         <record id="intrastat_transaction_80" model="intrastat.transaction">
@@ -164,7 +201,9 @@
         </record>
         <record id="intrastat_transaction_99" model="intrastat.transaction">
             <field name="code">99</field>
-            <field name="description">Otras transacciones: Otras.</field>
+            <field
+                name="description"
+            >Otras transacciones que no se pueden clasificar bajo otros códigos. Otras.</field>
             <field name="company_id" eval="False" />
         </record>
     </data>

--- a/l10n_es_intrastat_report/readme/CONTRIBUTORS.rst
+++ b/l10n_es_intrastat_report/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
   * Manuel Calero
   * Pedro M. Baeza
   * João Marques
+  * Víctor Martínez

--- a/l10n_es_intrastat_report/readme/INSTALL.rst
+++ b/l10n_es_intrastat_report/readme/INSTALL.rst
@@ -9,9 +9,9 @@ If any other installation method is used, you can go to
 *Settings > Technical > Actions > Configuration Wizards* on developer mode,
 and launch there the wizard called "Import Spanish Product HS Codes"
 
-The included codes are for 2020. Please check possible updates for this codes in:
+The included codes are for 2021. Please check possible updates for this codes in:
 
-https://www.agenciatributaria.es/AEAT.internet/Inicio/La_Agencia_Tributaria/Memorias_y_estadisticas_tributarias/Estadisticas/_Comercio_exterior_/Documentacion/Tablas_de_codigos/Tablas_de_codigos.shtml
+https://www.cbs.nl/en-gb/participants-survey/overzicht/businesses/onderzoek/international-trade-in-goods/idep-code-lists
 
 This wizard also sets a sane default Intrastat transaction type for each kind
 of invoice at company level, but it can be changed later.

--- a/l10n_es_intrastat_report/static/description/index.html
+++ b/l10n_es_intrastat_report/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Intrastat Product Declaration for Spain</title>
 <style type="text/css">
 
@@ -397,8 +397,8 @@ wizard. It’s automatically launched if installing the module from the UI.</p>
 <p>If any other installation method is used, you can go to
 <em>Settings &gt; Technical &gt; Actions &gt; Configuration Wizards</em> on developer mode,
 and launch there the wizard called “Import Spanish Product HS Codes”</p>
-<p>The included codes are for 2020. Please check possible updates for this codes in:</p>
-<p><a class="reference external" href="https://www.agenciatributaria.es/AEAT.internet/Inicio/La_Agencia_Tributaria/Memorias_y_estadisticas_tributarias/Estadisticas/_Comercio_exterior_/Documentacion/Tablas_de_codigos/Tablas_de_codigos.shtml">https://www.agenciatributaria.es/AEAT.internet/Inicio/La_Agencia_Tributaria/Memorias_y_estadisticas_tributarias/Estadisticas/_Comercio_exterior_/Documentacion/Tablas_de_codigos/Tablas_de_codigos.shtml</a></p>
+<p>The included codes are for 2021. Please check possible updates for this codes in:</p>
+<p><a class="reference external" href="https://www.cbs.nl/en-gb/participants-survey/overzicht/businesses/onderzoek/international-trade-in-goods/idep-code-lists">https://www.cbs.nl/en-gb/participants-survey/overzicht/businesses/onderzoek/international-trade-in-goods/idep-code-lists</a></p>
 <p>This wizard also sets a sane default Intrastat transaction type for each kind
 of invoice at company level, but it can be changed later.</p>
 </div>
@@ -510,6 +510,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Manuel Calero</li>
 <li>Pedro M. Baeza</li>
 <li>João Marques</li>
+<li>Víctor Martínez</li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
FWP de 13.0: https://github.com/OCA/l10n-spain/pull/1839

De acuerdo al documento "**Code list 13 Transaction new code list 2 digits 2021**" de la documentation (https://www.cbs.nl/en-gb/participants-survey/overzicht/businesses/onderzoek/international-trade-in-goods/idep-code-lists) se realizan los siguientes cambios:
- Se desactivan los siguientes códigos de transacciónes: 13, 14, 19, 29, 44, 45, 54, 55, 70
- Se añaden los siguientes códigos de transacciones: 34, 60, 71, 72
- Se modifica la descripción del código de transacción 99
- Añadir el link a la documentación del listado de códigos.

Bloqueado por:
- [x] https://github.com/OCA/intrastat-extrastat/pull/146

Por favor @joao-p-marques y  @pedrobaeza ¿podéis revisarlo?

@Tecnativa TT30682