### PR TITLE
[IMP] delivery_dhl_parcel: Producto DHL (B2B/B2C/R2C)

### DIFF
--- a/delivery_dhl_parcel/i18n/es.po
+++ b/delivery_dhl_parcel/i18n/es.po
@@ -4,17 +4,26 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0+e\n"
+"Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-12 13:38+0000\n"
-"PO-Revision-Date: 2021-05-12 13:38+0000\n"
+"POT-Creation-Date: 2021-10-30 10:29+0000\n"
+"PO-Revision-Date: 2021-10-30 10:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_product__b2b
+msgid "B2B Product"
+msgstr "Producto B2B"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_product__b2c
+msgid "B2C Product"
+msgstr "Producto B2C"
 
 #. module: delivery_dhl_parcel
 #: model_terms:ir.ui.view,arch_db:delivery_dhl_parcel.delivery_endday_wizard_form
@@ -43,17 +52,15 @@ msgstr "DHL Parcel"
 
 #. module: delivery_dhl_parcel
 #: code:addons/delivery_dhl_parcel/models/delivery_carrier.py:0
+#: code:addons/delivery_dhl_parcel/models/delivery_carrier.py:0
 #, python-format
 msgid ""
 "DHL Parcel API doesn't provide methods to compute delivery rates, so\n"
-"                you should rely on another price method instead or override "
-"this\n"
+"                you should rely on another price method instead or override this\n"
 "                one in your custom code."
 msgstr ""
-"DHL Parcel API no provee ninguna forma de calcular las tarifas de envío, "
-"por\n"
-"                lo tanto se deberia usar otro método o sobreescribir este en "
-"una herencia"
+"DHL Parcel API no provee ninguna forma de calcular las tarifas de envío, por\n"
+"                lo tanto se deberia usar otro método o sobreescribir este en una herencia"
 
 #. module: delivery_dhl_parcel
 #: code:addons/delivery_dhl_parcel/models/delivery_carrier.py:0
@@ -120,7 +127,6 @@ msgstr "Código de cliente DHL Parcel"
 
 #. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_incoterm
-#, fuzzy
 msgid "DHL Parcel incoterms"
 msgstr "Servicio DHL Parcel"
 
@@ -139,6 +145,11 @@ msgstr "Último informe DHL Parcel de cierro de día"
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_stock_picking__dhl_parcel_shipment_held
 msgid "DHL Parcel shipment on hold"
 msgstr "Envío DHL Parcel retenido"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_product
+msgid "DHL Product"
+msgstr "Producto DHL"
 
 #. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__display_name
@@ -186,6 +197,11 @@ msgstr ""
 "Si se están cerrando vários, introducelos separados por comas sin espacios\n"
 "i.e. '001-000001,002-000002'\n"
 "También se puede usar 'ALL' para cerrarlos todos"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_product
+msgid "If the product is not specified, it is considered B2B"
+msgstr "Si no se especifica el producto, se considera producto B2B"
 
 #. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_last_request
@@ -283,6 +299,3 @@ msgstr "Tipo de respuesta no soportado, por favor solo usa 'GET' o 'POST'"
 #: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_last_response
 msgid "Used for debugging"
 msgstr "Usado para debug"
-
-#~ msgid "DHL Parcel Tracking reference"
-#~ msgstr "Referencia de seguimiento DHL Parcel"

--- a/delivery_dhl_parcel/views/delivery_carrier_view.xml
+++ b/delivery_dhl_parcel/views/delivery_carrier_view.xml
@@ -29,6 +29,10 @@
                                 attrs="{'required': [('delivery_type', '=', 'dhl_parcel')]}"
                             />
                             <field
+                                name="dhl_parcel_product"
+                                attrs="{'required': [('delivery_type', '=', 'dhl_parcel')]}"
+                            />
+                            <field
                                 name="dhl_parcel_last_end_day_report"
                                 filename="dhl_parcel_last_end_day_report_name"
                             />


### PR DESCRIPTION
- Permitir seleccionar el producto DHL vinculado al método de envío, ya que en caso de no especificarlo, se considera siempre B2B y según el producto, se genera un tipo de envío u otro

**Productos disponibles según DHL**:
![delivery_dhl_parcel_product](https://user-images.githubusercontent.com/29223264/139452499-c085b54c-1e5f-41ac-aeb8-d8e4a369e7d5.png)

