### PR TITLE
[13.0][IMP] delivery_dhl_parcel: Producto DHL (B2B/B2C/R2C)

### DIFF
--- a/delivery_dhl_parcel/i18n/delivery_dhl_parcel.pot
+++ b/delivery_dhl_parcel/i18n/delivery_dhl_parcel.pot
@@ -6,12 +6,24 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-11-02 07:36+0000\n"
+"PO-Revision-Date: 2021-11-02 07:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_product__b2b
+msgid "B2B Product"
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_product__b2c
+msgid "B2C Product"
+msgstr ""
 
 #. module: delivery_dhl_parcel
 #: model_terms:ir.ui.view,arch_db:delivery_dhl_parcel.delivery_endday_wizard_form
@@ -131,6 +143,11 @@ msgid "DHL Parcel shipment on hold"
 msgstr ""
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_product
+msgid "DHL Product"
+msgstr ""
+
+#. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__display_name
 msgid "Display Name"
 msgstr ""
@@ -168,6 +185,11 @@ msgid ""
 "If doing multiple, input them separated by commas without spaces.\n"
 "i.e. '001-000001,002-000002'\n"
 "You can also use 'ALL' to end all of them"
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_product
+msgid "If the product is not specified, it is considered B2B"
 msgstr ""
 
 #. module: delivery_dhl_parcel

--- a/delivery_dhl_parcel/i18n/es.po
+++ b/delivery_dhl_parcel/i18n/es.po
@@ -4,17 +4,28 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0+e\n"
+"Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-12 13:38+0000\n"
-"PO-Revision-Date: 2021-05-12 13:38+0000\n"
+"POT-Creation-Date: 2021-11-02 07:36+0000\n"
+"PO-Revision-Date: 2021-11-02 08:37+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 2.3\n"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_product__b2b
+msgid "B2B Product"
+msgstr "Producto B2B"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_product__b2c
+msgid "B2C Product"
+msgstr "Producto B2C"
 
 #. module: delivery_dhl_parcel
 #: model_terms:ir.ui.view,arch_db:delivery_dhl_parcel.delivery_endday_wizard_form
@@ -120,7 +131,6 @@ msgstr "Código de cliente DHL Parcel"
 
 #. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_incoterm
-#, fuzzy
 msgid "DHL Parcel incoterms"
 msgstr "Servicio DHL Parcel"
 
@@ -141,9 +151,12 @@ msgid "DHL Parcel shipment on hold"
 msgstr "Envío DHL Parcel retenido"
 
 #. module: delivery_dhl_parcel
-#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__display_name
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_product
+msgid "DHL Product"
+msgstr "Producto DHL"
+
+#. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__display_name
-#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_stock_picking__display_name
 msgid "Display Name"
 msgstr "Nombre mostrado"
 
@@ -170,9 +183,7 @@ msgid "Hold DHL Parcel shipment"
 msgstr "Retener envío DHL Parcel"
 
 #. module: delivery_dhl_parcel
-#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__id
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__id
-#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_stock_picking__id
 msgid "ID"
 msgstr "ID"
 
@@ -188,6 +199,11 @@ msgstr ""
 "También se puede usar 'ALL' para cerrarlos todos"
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_product
+msgid "If the product is not specified, it is considered B2B"
+msgstr "Si no se especifica el producto, se considera producto B2B"
+
+#. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_last_request
 msgid "Last DHL Parcel API request"
 msgstr "Último pedido a la API DHL Parcel"
@@ -198,9 +214,7 @@ msgid "Last DHL Parcel API response"
 msgstr "Última respuesta a la API DHL Parcel"
 
 #. module: delivery_dhl_parcel
-#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier____last_update
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard____last_update
-#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_stock_picking____last_update
 msgid "Last Modified on"
 msgstr "Última modificación el"
 
@@ -283,6 +297,3 @@ msgstr "Tipo de respuesta no soportado, por favor solo usa 'GET' o 'POST'"
 #: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_last_response
 msgid "Used for debugging"
 msgstr "Usado para debug"
-
-#~ msgid "DHL Parcel Tracking reference"
-#~ msgstr "Referencia de seguimiento DHL Parcel"

--- a/delivery_dhl_parcel/models/delivery_carrier.py
+++ b/delivery_dhl_parcel/models/delivery_carrier.py
@@ -15,9 +15,21 @@ class DeliveryCarrier(models.Model):
     _inherit = "delivery.carrier"
 
     delivery_type = fields.Selection(selection_add=[("dhl_parcel", "DHL Parcel")],)
+
+    def _compute_can_generate_return(self):
+        super()._compute_can_generate_return()
+        for carrier in self:
+            if carrier.delivery_type == "dhl_parcel":
+                carrier.can_generate_return = True
+
     dhl_parcel_customer_code = fields.Char(string="DHL Parcel customer code")
     dhl_parcel_incoterm = fields.Selection(
         string="DHL Parcel incoterms", selection=DHL_PARCEL_INCOTERMS_STATIC
+    )
+    dhl_parcel_product = fields.Selection(
+        string="DHL Product",
+        selection=[("B2B", "B2B Product"), ("B2C", "B2C Product")],
+        help="If the product is not specified, it is considered B2B",
     )
     dhl_parcel_uid = fields.Char(string="DHL Parcel UID")
     dhl_parcel_password = fields.Char(string="DHL Parcel Password")
@@ -69,6 +81,12 @@ class DeliveryCarrier(models.Model):
             "Email": partner.email or "",
         }
 
+    def _get_dhl_parcel_product(self, picking):
+        product = self.dhl_parcel_product
+        if product == "B2C" and picking.is_return_picking:
+            product = "R2C"
+        return product or "B2B"
+
     def _prepare_dhl_parcel_shipping(self, picking):
         """Convert picking values for dhl parcel api
         :param picking record with picking to send
@@ -94,6 +112,7 @@ class DeliveryCarrier(models.Model):
             "Remarks1": "",  # [optional]
             "Remarks2": "",  # [optional]
             "Incoterms": self.dhl_parcel_incoterm,  # CPT paid, EXW owed
+            "Product": self._get_dhl_parcel_product(picking),
             "ContactName": "",  # [optional]
             "GoodsDescription": "",  # [optional]
             "CustomsValue": "",  # [optional]

--- a/delivery_dhl_parcel/views/delivery_carrier_view.xml
+++ b/delivery_dhl_parcel/views/delivery_carrier_view.xml
@@ -29,6 +29,10 @@
                                 attrs="{'required': [('delivery_type', '=', 'dhl_parcel')]}"
                             />
                             <field
+                                name="dhl_parcel_product"
+                                attrs="{'required': [('delivery_type', '=', 'dhl_parcel')]}"
+                            />
+                            <field
                                 name="dhl_parcel_last_end_day_report"
                                 filename="dhl_parcel_last_end_day_report_name"
                             />


### PR DESCRIPTION
FWP de 14.0: https://github.com/OCA/l10n-spain/pull/1880

Permitir seleccionar el producto DHL vinculado al método de envío, ya que en caso de no especificarlo, se considera siempre B2B y según el producto, se genera un tipo de envío u otro.

Por favor, @pedrobaeza y @chienandalu podéis revisarlo?

@Tecnativa