### PR TITLE
[IMP] l10n_es_facturae: Use queue

### DIFF
--- a/l10n_es_facturae/components/account_move_l10n_es_facturae_listener.py
+++ b/l10n_es_facturae/components/account_move_l10n_es_facturae_listener.py
@@ -35,8 +35,7 @@ class AccountMoveL10nEsFacturaeListener(Component):
             exchange_record = backend.create_record(
                 exchange_type, self._get_exchange_record_vals(record)
             )
-            backend.exchange_generate(exchange_record)
-            backend.exchange_send(exchange_record)
+            backend._delay_action(exchange_record).exchange_generate(exchange_record)
 
     def on_generate_account_edi(self, records):
         return self.on_post_account_move(records)


### PR DESCRIPTION
Ya que tenemos queue, podemos usarlo, ya que sino se puede enlentecer la validación de factura