### PR TITLE
[12.0][IMP] l10n_es_aeat_sii: Choose SII identification type for 03-05

### DIFF
--- a/l10n_es_aeat_sii/i18n/es.po
+++ b/l10n_es_aeat_sii/i18n/es.po
@@ -140,11 +140,6 @@ msgid "At fixed time"
 msgstr "A una hora fija"
 
 #. module: l10n_es_aeat_sii
-#: selection:res.company,send_mode:0
-msgid "At the end of the quarter"
-msgstr ""
-
-#. module: l10n_es_aeat_sii
 #: selection:res.company,sii_description_method:0
 #: selection:res.company,sii_method:0
 msgid "Automatic"
@@ -418,10 +413,10 @@ msgid "ID"
 msgstr "ID"
 
 #. module: l10n_es_aeat_sii
-#: model:ir.model.fields,help:l10n_es_aeat_sii.field_res_company__delay_time
-#: model:ir.model.fields,help:l10n_es_aeat_sii.field_res_company__sent_time
-msgid "In hours"
-msgstr ""
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_res_partner__sii_identification_type
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_res_users__sii_identification_type
+msgid "SII Identification type"
+msgstr "Tipo de identificación SII"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model.fields,help:l10n_es_aeat_sii.field_account_invoice__sii_send_failed
@@ -623,6 +618,11 @@ msgid "Obtain Keys"
 msgstr "Obtener claves"
 
 #. module: l10n_es_aeat_sii
+#: selection:res.partner,sii_identification_type:0
+msgid "Official identification document issues by the country or territory of residence"
+msgstr "Documento oficial de identificación expedido por el país o territorio de residencia"
+
+#. module: l10n_es_aeat_sii
 #: selection:res.company,send_mode:0
 msgid "On validate"
 msgstr "Al validar"
@@ -637,6 +637,11 @@ msgstr "La versión OpenSSL no está soportada. Actualice a 0.15 o superior."
 #: selection:account.fiscal.position,sii_no_taxable_cause:0
 msgid "Operaciones no sujetas en el TAI por reglas de localización"
 msgstr "Operaciones no sujetas en el TAI por reglas de localización"
+
+#. module: l10n_es_aeat_sii
+#: selection:res.partner,sii_identification_type:0
+msgid "Passport"
+msgstr "Pasaporte"
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_l10n_es_aeat_sii_password__password
@@ -687,6 +692,11 @@ msgstr "Registro correcto en SII con modificaciones pendientes de comunicar"
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii.view_queue_job_sii
 msgid "Requeue"
 msgstr "Re-encolar"
+
+#. module: l10n_es_aeat_sii
+#: selection:res.partner,sii_identification_type:0
+msgid "Residential certificate"
+msgstr "Certificado de residencia"
 
 #. module: l10n_es_aeat_sii
 #: selection:account.invoice,sii_refund_specific_invoice_type:0
@@ -1105,6 +1115,19 @@ msgstr "Esta compañía no tiene habilitado el SII."
 #, python-format
 msgid "This invoice is not SII enabled."
 msgstr "Esta factura no está habilitada para el SII."
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,help:l10n_es_aeat_sii.field_res_partner__sii_identification_type
+#: model:ir.model.fields,help:l10n_es_aeat_sii.field_res_users__sii_identification_type
+msgid "Used to specify an identification type to send to SII. Normally for sending national and export invoices to SII "
+"where the customer country is not Spain, it would calculate an identification type of 04 if the VAT field is filled and 06 "
+"if it was not. This field is to specify types of 03 through 05, in the event that the customer doesn't identify with a foreign VAT "
+"and instead with their passport or residential certificate. If there is no value it will work as before."
+msgstr "Usado para especificar un tipo de identificación para enviar al SII. Normalmente para enviar facturas nacionales y de exportación "
+"donde el cliente no es español al SII, se calcularia un tipo de identificación de 04 si tiene el campo NIF lleno y 06 "
+"en caso contrario. Este campo es para especificar tipos de 03 hasta 05, en el evento de que un cliente no se identifica con un NIF extranjero "
+"y en su lugar con su pasaporte o certificado de residencia. Si no se rellena, funcionará igual que antes."
+
 
 #. module: l10n_es_aeat_sii
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_aeat_sii_mapping_registration_keys__type

--- a/l10n_es_aeat_sii/i18n/l10n_es_aeat_sii.pot
+++ b/l10n_es_aeat_sii/i18n/l10n_es_aeat_sii.pot
@@ -128,11 +128,6 @@ msgid "At fixed time"
 msgstr ""
 
 #. module: l10n_es_aeat_sii
-#: selection:res.company,send_mode:0
-msgid "At the end of the quarter"
-msgstr ""
-
-#. module: l10n_es_aeat_sii
 #: selection:res.company,sii_description_method:0
 #: selection:res.company,sii_method:0
 msgid "Automatic"
@@ -384,9 +379,9 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_es_aeat_sii
-#: model:ir.model.fields,help:l10n_es_aeat_sii.field_res_company__delay_time
-#: model:ir.model.fields,help:l10n_es_aeat_sii.field_res_company__sent_time
-msgid "In hours"
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_res_partner__sii_identification_type
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii.field_res_users__sii_identification_type
+msgid "Identification type"
 msgstr ""
 
 #. module: l10n_es_aeat_sii
@@ -563,6 +558,11 @@ msgid "Obtain Keys"
 msgstr ""
 
 #. module: l10n_es_aeat_sii
+#: selection:res.partner,sii_identification_type:0
+msgid "Official identification document issues by the country or territory of residence"
+msgstr ""
+
+#. module: l10n_es_aeat_sii
 #: selection:res.company,send_mode:0
 msgid "On validate"
 msgstr ""
@@ -576,6 +576,11 @@ msgstr ""
 #. module: l10n_es_aeat_sii
 #: selection:account.fiscal.position,sii_no_taxable_cause:0
 msgid "Operaciones no sujetas en el TAI por reglas de localización"
+msgstr ""
+
+#. module: l10n_es_aeat_sii
+#: selection:res.partner,sii_identification_type:0
+msgid "Passport"
 msgstr ""
 
 #. module: l10n_es_aeat_sii
@@ -626,6 +631,11 @@ msgstr ""
 #. module: l10n_es_aeat_sii
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii.view_queue_job_sii
 msgid "Requeue"
+msgstr ""
+
+#. module: l10n_es_aeat_sii
+#: selection:res.partner,sii_identification_type:0
+msgid "Residential certificate"
 msgstr ""
 
 #. module: l10n_es_aeat_sii
@@ -1040,6 +1050,15 @@ msgstr ""
 #: code:addons/l10n_es_aeat_sii/models/account_invoice.py:707
 #, python-format
 msgid "This invoice is not SII enabled."
+msgstr ""
+
+#. module: l10n_es_aeat_sii
+#: model:ir.model.fields,help:l10n_es_aeat_sii.field_res_partner__sii_identification_type
+#: model:ir.model.fields,help:l10n_es_aeat_sii.field_res_users__sii_identification_type
+msgid "Used to specify an identification type to send to SII. Normally for sending national and export invoices to SII "
+"where the customer country is not Spain, it would calculate an identification type of 04 if the VAT field is filled and 06 "
+"if it was not. This field is to specify types of 03 through 05, in the event that the customer doesn't identify with a foreign VAT "
+"and instead with their passport or residential certificate. If there is no value it will work as before."
 msgstr ""
 
 #. module: l10n_es_aeat_sii

--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -1293,11 +1293,10 @@ class AccountInvoice(models.Model):
                 }
             else:
                 if country_code != 'ES':
-                    id_type = '06' if vat == 'NO_DISPONIBLE' else '04'
                     return {
                         "IDOtro": {
                             "CodigoPais": country_code,
-                            "IDType": id_type,
+                            "IDType": self._get_sii_id_type(vat),
                             "ID": vat,
                         },
                     }
@@ -1311,16 +1310,23 @@ class AccountInvoice(models.Model):
                 }
             }
         elif gen_type == 3 and country_code != 'ES':
-            id_type = '06' if vat == 'NO_DISPONIBLE' else '04'
             return {
                 "IDOtro": {
                     "CodigoPais": country_code,
-                    "IDType": id_type,
+                    "IDType": self._get_sii_id_type(vat),
                     "ID": vat,
                 },
             }
         elif gen_type == 3:
             return {"NIF": vat[2:]}
+
+    def _get_sii_id_type(self, vat):
+        id_type = "04"
+        if self.partner_id.sii_identification_type:
+            id_type = self.partner_id.sii_identification_type
+        elif vat == "NO_DISPONIBLE":
+            id_type = "06"
+        return id_type
 
     @api.multi
     def _get_sii_exempt_cause(self, applied_taxes):

--- a/l10n_es_aeat_sii/models/res_partner.py
+++ b/l10n_es_aeat_sii/models/res_partner.py
@@ -5,15 +5,34 @@ from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
-    _inherit = 'res.partner'
+    _inherit = "res.partner"
 
-    sii_enabled = fields.Boolean(
-        compute="_compute_sii_enabled",
-    )
+    sii_enabled = fields.Boolean(compute="_compute_sii_enabled")
     sii_simplified_invoice = fields.Boolean(
         string="Simplified invoices in SII?",
         help="Checking this mark, invoices done to this partner will be "
-             "sent to SII as simplified invoices."
+        "sent to SII as simplified invoices.",
+    )
+    sii_identification_type = fields.Selection(
+        string="SII Identification type",
+        help=(
+            "Used to specify an identification type to send to SII. Normally for "
+            "sending national and export invoices to SII where the customer country "
+            "is not Spain, it would calculate an identification type of 04 if the VAT "
+            "field is filled and 06 if it was not. This field is to specify "
+            "types of 03 through 05, in the event that the customer doesn't identify "
+            "with a foreign VAT and instead with their passport "
+            "or residential certificate. If there is no value it will work as before."
+        ),
+        selection=[
+            ("03", "Passport"),
+            (
+                "04",
+                "Official identification document issues by the country or "
+                "territory of residence",
+            ),
+            ("05", "Residential certificate"),
+        ],
     )
 
     @api.multi
@@ -21,3 +40,13 @@ class ResPartner(models.Model):
         sii_enabled = self.env.user.company_id.sii_enabled
         for partner in self:
             partner.sii_enabled = sii_enabled
+
+    @api.constrains("vat", "country_id", "sii_identification_type")
+    def check_vat(self):
+        for partner in self:
+            if (
+                partner.sii_identification_type
+                or partner.parent_id.sii_identification_type
+            ):
+                return True
+            super(ResPartner, partner).check_vat()

--- a/l10n_es_aeat_sii/views/res_partner_views.xml
+++ b/l10n_es_aeat_sii/views/res_partner_views.xml
@@ -11,6 +11,9 @@
                 <field name="sii_simplified_invoice"
                        attrs="{'invisible': [('sii_enabled', '=', False)]}"
                 />
+                <field name="sii_identification_type"
+                    attrs="{'invisible': [('sii_enabled', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Add a field to partners to choose additional identification types, notably 3, 4 and 5 as currently it assumes 4 or 6.
There are customers that might want to use their passport (3) or residential certificate (5) as identification.

If nothing is chosen in this field, it works as it does currently

- Also removes the `check_vat` check when this field is in use, as the value input in the VAT field most likely won't fit the usual vat format
