### PR TITLE
[14.0][FIX] l10n_es_aeat_sii_oca: Error en la obtención del certificado en multicompañía

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -1003,9 +1003,9 @@ class AccountMove(models.Model):
 
     def _connect_sii(self, mapping_key):
         self.ensure_one()
-        public_crt, private_key = self.env[
-            "l10n.es.aeat.certificate"
-        ].get_certificates()
+        public_crt, private_key = self.env["l10n.es.aeat.certificate"].get_certificates(
+            company=self.company_id
+        )
         params = self._connect_params_sii(mapping_key)
         session = Session()
         session.cert = (public_crt, private_key)


### PR DESCRIPTION
Hola,

Se nos ha dado un caso en un entorno multicompañía que fallaba en la obtención del certificado, el problema viene porque el usuario que validó la factura en su ficha tenía la compañía Y pero estaba trabajando en la compañía X y al enviar una factura al SII de X no le encontraba el certificado correcto, iba a buscar el por defecto y fallaba. 
En el método "get_certificate" sino se le pasa como argumento una compañía la coge del usuario con: self.env.user.company_id pero esto no es correcto en versión 13.0 y posteriores al menos, ya que la compañía de la ficha puede no tener nada que ver con la compañía en la que está trabajando en ese momento el usuario o en la que validó la factura en su momento si se envían con retardo.

Un saludo