### PR TITLE
[13.0][IMP] delivery_gls_asm: Remove gls_last_request + gls_last_response fields.

### DIFF
--- a/delivery_gls_asm/README.rst
+++ b/delivery_gls_asm/README.rst
@@ -122,10 +122,6 @@ Depuración de errores
 
   #. Es importante tener en cuenta que solo funcionará con códigos postales de
      España.
-  #. En cada servicio GLS-ASM dispone de una pestaña llamada "Técnico" en la
-     que puede consultar la última petición y respuesta a la API de GLS-ASM.
-     Esto le servirá como ayuda a la hora de depurar posibles errores de
-     comunicación.
   #. También puede activar Odoo con `--log-level=debug` para registrar las
      peticiones y las respuestas en el log.
 

--- a/delivery_gls_asm/readme/USAGE.rst
+++ b/delivery_gls_asm/readme/USAGE.rst
@@ -56,9 +56,5 @@ Depuración de errores
 
   #. Es importante tener en cuenta que solo funcionará con códigos postales de
      España.
-  #. En cada servicio GLS-ASM dispone de una pestaña llamada "Técnico" en la
-     que puede consultar la última petición y respuesta a la API de GLS-ASM.
-     Esto le servirá como ayuda a la hora de depurar posibles errores de
-     comunicación.
   #. También puede activar Odoo con `--log-level=debug` para registrar las
      peticiones y las respuestas en el log.

--- a/delivery_gls_asm/static/description/index.html
+++ b/delivery_gls_asm/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Delivery GLS-ASM</title>
 <style type="text/css">
 
@@ -493,10 +493,6 @@ envíos del servicio seleccionado.</li>
 <ol class="arabic simple">
 <li>Es importante tener en cuenta que solo funcionará con códigos postales de
 España.</li>
-<li>En cada servicio GLS-ASM dispone de una pestaña llamada “Técnico” en la
-que puede consultar la última petición y respuesta a la API de GLS-ASM.
-Esto le servirá como ayuda a la hora de depurar posibles errores de
-comunicación.</li>
 <li>También puede activar Odoo con <cite>–log-level=debug</cite> para registrar las
 peticiones y las respuestas en el log.</li>
 </ol>

--- a/delivery_gls_asm/views/delivery_asm_view.xml
+++ b/delivery_gls_asm/views/delivery_asm_view.xml
@@ -33,19 +33,6 @@
                     </group>
                 </page>
             </xpath>
-            <xpath expr="//notebook" position='inside'>
-                <page
-                    string="Technical"
-                    attrs="{'invisible': [('delivery_type', '!=', 'gls_asm')]}"
-                >
-                    <group>
-                        <group>
-                            <field name="gls_last_request" />
-                            <field name="gls_last_response" />
-                        </group>
-                    </group>
-                </page>
-            </xpath>
             <xpath expr="//button[@name='toggle_prod_environment']" position="before">
                 <button
                     name="action_get_manifest"


### PR DESCRIPTION
Se eliminan los campos `gls_last_request` y `gls_last_response` para tratar de estandarizar los transportistas de acuerdo a https://github.com/OCA/delivery-carrier/pull/430.

Por favor, @chienandalu y @pedrobaeza podéis revisarlo?

@Tecnativa