### PR TITLE
[14.0][IMP] delivery_dhl_parcel: Remove dhl_parcel_last_request + dhl_parcel_last_response fields.

### DIFF
--- a/delivery_dhl_parcel/README.rst
+++ b/delivery_dhl_parcel/README.rst
@@ -123,10 +123,6 @@ Depuración de errores
 
   #. Es importante tener en cuenta que solo funcionará con códigos postales de
      España (por lo menos para el consignatario).
-  #. En cada servicio DHL Parcel dispone de una pestaña llamada "Técnico" en la
-     que puede consultar la última petición y respuesta a la API de DHL Parcel.
-     Esto le servirá como ayuda a la hora de depurar posibles errores de
-     comunicación.
   #. También puede activar Odoo con `--log-level=debug` para registrar las
      peticiones y las respuestas en el log.
 

--- a/delivery_dhl_parcel/models/delivery_carrier.py
+++ b/delivery_dhl_parcel/models/delivery_carrier.py
@@ -35,12 +35,6 @@ class DeliveryCarrier(models.Model):
     )
     dhl_parcel_uid = fields.Char(string="DHL Parcel UID")
     dhl_parcel_password = fields.Char(string="DHL Parcel Password")
-    dhl_parcel_last_request = fields.Text(
-        string="Last DHL Parcel API request", help="Used for debugging", readonly=True
-    )
-    dhl_parcel_last_response = fields.Text(
-        string="Last DHL Parcel API response", help="Used for debugging", readonly=True
-    )
     dhl_parcel_last_end_day_report = fields.Binary(
         string="DHL Parcel last manual end day report"
     )

--- a/delivery_dhl_parcel/models/dhl_parcel_request.py
+++ b/delivery_dhl_parcel/models/dhl_parcel_request.py
@@ -41,24 +41,19 @@ class DhlParcelRequest(object):
             if not skip_auth:
                 auth = {"Authorization": "Bearer {}".format(self.token)}
             if request_type == "GET":
-                res = requests.get(url=url, headers=auth)
+                res = requests.get(url=url, headers=auth, timeout=60)
             elif request_type == "POST":
-                res = requests.post(url=url, json=data, headers=auth)
+                res = requests.post(url=url, json=data, headers=auth, timeout=60)
             else:
                 raise UserError(
                     _("Unsupported request type, please only use 'GET' or 'POST'")
                 )
             res.raise_for_status()
-            self.carrier_id.write(
-                {
-                    "dhl_parcel_last_request": (
-                        ("Request type: {}\nURL: {}\nData: {}").format(
-                            request_type, url, data
-                        )
-                    ),
-                    "dhl_parcel_last_response": res.text or "",
-                }
+            dhl_parcel_last_request = ("Request type: {}\nURL: {}\nData: {}").format(
+                request_type, url, data
             )
+            self.log_xml(dhl_parcel_last_request, "dhl_parcel_last_request")
+            self.log_xml(res.text or "", "dhl_parcel_last_response")
         except requests.exceptions.Timeout:
             raise UserError(_("Timeout: the server did not reply within 60s"))
         except (ValueError, requests.exceptions.ConnectionError):

--- a/delivery_dhl_parcel/readme/USAGE.rst
+++ b/delivery_dhl_parcel/readme/USAGE.rst
@@ -50,9 +50,5 @@ Depuración de errores
 
   #. Es importante tener en cuenta que solo funcionará con códigos postales de
      España (por lo menos para el consignatario).
-  #. En cada servicio DHL Parcel dispone de una pestaña llamada "Técnico" en la
-     que puede consultar la última petición y respuesta a la API de DHL Parcel.
-     Esto le servirá como ayuda a la hora de depurar posibles errores de
-     comunicación.
   #. También puede activar Odoo con `--log-level=debug` para registrar las
      peticiones y las respuestas en el log.

--- a/delivery_dhl_parcel/static/description/index.html
+++ b/delivery_dhl_parcel/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Delivery DHL Parcel</title>
 <style type="text/css">
 
@@ -492,10 +492,6 @@ cerrar el día manualmente.</li>
 <ol class="arabic simple">
 <li>Es importante tener en cuenta que solo funcionará con códigos postales de
 España (por lo menos para el consignatario).</li>
-<li>En cada servicio DHL Parcel dispone de una pestaña llamada “Técnico” en la
-que puede consultar la última petición y respuesta a la API de DHL Parcel.
-Esto le servirá como ayuda a la hora de depurar posibles errores de
-comunicación.</li>
 <li>También puede activar Odoo con <cite>–log-level=debug</cite> para registrar las
 peticiones y las respuestas en el log.</li>
 </ol>

--- a/delivery_dhl_parcel/views/delivery_carrier_view.xml
+++ b/delivery_dhl_parcel/views/delivery_carrier_view.xml
@@ -44,19 +44,6 @@
                     </group>
                 </page>
             </xpath>
-            <xpath expr="//notebook" position='inside'>
-                <page
-                    string="Technical"
-                    attrs="{'invisible': [('delivery_type', '!=', 'dhl_parcel')]}"
-                >
-                    <group>
-                        <group>
-                            <field name="dhl_parcel_last_request" />
-                            <field name="dhl_parcel_last_response" />
-                        </group>
-                    </group>
-                </page>
-            </xpath>
             <xpath expr="//button[@name='toggle_prod_environment']" position="before">
                 <button
                     name="action_open_end_day"


### PR DESCRIPTION
FWP de 13.0: https://github.com/OCA/l10n-spain/pull/1900

Se eliminan los campos `dhl_parcel_last_request` y `dhl_parcel_last_response` para tratar de estandarizar los transportistas de acuerdo a https://github.com/OCA/delivery-carrier/pull/430.

Por favor, @chienandalu y @pedrobaeza podéis revisarlo?

@Tecnativa