### PR TITLE
[13.0][FIX] delivery_dhl_parcel: Fix log_xml

### DIFF
--- a/delivery_dhl_parcel/models/dhl_parcel_request.py
+++ b/delivery_dhl_parcel/models/dhl_parcel_request.py
@@ -52,8 +52,8 @@ class DhlParcelRequest(object):
             dhl_parcel_last_request = ("Request type: {}\nURL: {}\nData: {}").format(
                 request_type, url, data
             )
-            self.log_xml(dhl_parcel_last_request, "dhl_parcel_last_request")
-            self.log_xml(res.text or "", "dhl_parcel_last_response")
+            self.carrier_id.log_xml(dhl_parcel_last_request, "dhl_parcel_last_request")
+            self.carrier_id.log_xml(res.text or "", "dhl_parcel_last_response")
         except requests.exceptions.Timeout:
             raise UserError(_("Timeout: the server did not reply within 60s"))
         except (ValueError, requests.exceptions.ConnectionError):


### PR DESCRIPTION
Bugfix
- `log_xml` is a carrier function, `self` in this context is the DhlParcelRequest class

Cherry-pick of:
- https://github.com/OCA/l10n-spain/pull/1913