### PR TITLE
[FIX] l10n_es_aeat_partner_check: Add missing return values

### DIFF
--- a/l10n_es_aeat_partner_check/README.rst
+++ b/l10n_es_aeat_partner_check/README.rst
@@ -72,6 +72,7 @@ Contributors
 
 * Ignacio Ibeas - Acysos S.L. <ignacio@acysos.com>
 * Ethan Hildick - Studio73 <ethan@studio73.es>
+* Aritz Olea - Landoo Sistemas de Información S.L. <ao@landoo.es>
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_aeat_partner_check/models/res_partner.py
+++ b/l10n_es_aeat_partner_check/models/res_partner.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Acysos S.L.
+# Copyright 2021 Landoo Sistemas de Informacion SL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import requests
@@ -10,6 +11,8 @@ RESULTS = [
     ("IDENTIFICADO", _("Identificado")),
     ("NO PROCESADO", _("No procesado")),
     ("NO IDENTIFICABLE", _("No identificable")),
+    ("IDENTIFICADO-BAJA", _("Identificado, baja")),
+    ("IDENTIFICADO-REVOCADO", _("Identificado, revocado")),
 ]
 TYPES = [
     ("sales_equalization", _("Régimen de recargo de equivalencia")),

--- a/l10n_es_aeat_partner_check/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_partner_check/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Ignacio Ibeas - Acysos S.L. <ignacio@acysos.com>
 * Ethan Hildick - Studio73 <ethan@studio73.es>
+* Aritz Olea - Landoo Sistemas de Información S.L. <ao@landoo.es>


### PR DESCRIPTION
Se agregan dos valores de respuesta del servicio que no estaban contemplados, si no aparecía un traceback.

Viene del Issue #1916 