### PR TITLE
[11.0][IMP] l10n_es_ticketbai: Remove l10n_es_account_invoice_sequence module dependency

### DIFF
--- a/l10n_es_ticketbai/README.rst
+++ b/l10n_es_ticketbai/README.rst
@@ -28,7 +28,7 @@ Installation
 
 Para instalar este módulo se necesita:
 
-#. Los módulos `l10n_es_ticketbai_api`, `l10n_es_aeat`, `l10n_es_aeat_certificate`, `l10n_es_account_invoice_sequence`, `account_cancel`
+#. Los módulos `l10n_es_ticketbai_api`, `l10n_es_aeat`, `l10n_es_aeat_certificate`, `account_cancel`
 
 y el módulo `account_invoice_tax_required` que se encuentra en:
 
@@ -102,6 +102,7 @@ Contributors
 
 * Victor Laskurain <blaskurain@binovo.es>
 * Luis J. Salvatierra <ljsalvatierra@binovo.es>
+* Aritz Olea <ao@landoo.es>
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_ticketbai/__manifest__.py
+++ b/l10n_es_ticketbai/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Binovo IT Human Project SL
+# Copyright 2021 Landoo Sistemas de Informacion SL
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "TicketBAI - "
@@ -24,7 +25,6 @@
         "l10n_es_aeat_certificate",
         "l10n_es_ticketbai_api",
         "account_invoice_tax_required",
-        "l10n_es_account_invoice_sequence",
         "account_cancel"
     ],
     "external_dependencies": {
@@ -40,6 +40,7 @@
         "views/account_fiscal_position_template_views.xml",
         "views/account_fiscal_position_views.xml",
         "views/account_invoice_views.xml",
+        "views/ir_sequence_views.xml",
         "views/report_invoice.xml",
         "views/res_company_views.xml",
         "views/res_partner_views.xml",

--- a/l10n_es_ticketbai/hooks.py
+++ b/l10n_es_ticketbai/hooks.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Binovo IT Human Project SL
+# Copyright 2021 Landoo Sistemas de Informacion SL
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, SUPERUSER_ID
 
@@ -40,3 +41,21 @@ def post_init_hook(cr, registry):
                     vals['tbai_vat_exemption_ids'] = tbai_vat_exemptions
             if vals:
                 position.write(vals)
+
+    companies = env['res.company'].search([])
+
+    for company in companies:
+        if company.tbai_enabled:
+            journals = env['account.journal'].search(
+                [('company_id', '=', company.id)]
+            )
+            for journal in journals:
+                if 'sale' == journal.type:
+                    if env['ir.module.module'].search([
+                        ('name', '=', 'l10n_es_account_invoice_sequence'),
+                        ('state', '=', 'installed')
+                    ]):
+                        journal.invoice_sequence_id.suffix = ''
+                    else:
+                        journal.sequence_id.suffix = ''
+                        journal.refund_sequence = True

--- a/l10n_es_ticketbai/models/__init__.py
+++ b/l10n_es_ticketbai/models/__init__.py
@@ -4,6 +4,7 @@ from . import account_invoice_tax
 from . import account_tax
 from . import aeat_certificate
 from . import chart_template
+from . import ir_sequence
 from . import res_company
 from . import ticketbai_invoice
 from . import ticketbai_tax_map

--- a/l10n_es_ticketbai/models/account_invoice.py
+++ b/l10n_es_ticketbai/models/account_invoice.py
@@ -1,11 +1,15 @@
 # Copyright 2021 Binovo IT Human Project SL
+# Copyright 2021 Landoo Sistemas de Informacion SL
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from datetime import datetime
+import re
 from odoo import models, fields, exceptions, _, api
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT
 from odoo.addons.l10n_es_ticketbai_api.models.ticketbai_invoice import RefundCode, \
     RefundType, SiNoType, TicketBaiInvoiceState
 from odoo.addons.l10n_es_ticketbai_api.ticketbai.xml_schema import TicketBaiSchema
+
+INVOICE_NUMBER_RE = re.compile(r'^(.*\D)?(\d*)$')
 
 
 class AccountInvoice(models.Model):
@@ -401,20 +405,15 @@ class AccountInvoice(models.Model):
             res = False
         return res
 
+    def split_invoice_number(self):
+        m = re.match(INVOICE_NUMBER_RE, self.number)
+        return m.group(1), m.group(2)
+
     def tbai_get_value_serie_factura(self):
-        sequence = self.journal_id.invoice_sequence_id
-        date = self.date or self.date_invoice
-        prefix, suffix = sequence.with_context(
-            ir_sequence_date=date, ir_sequence_date_range=date)._get_prefix_suffix()
-        return prefix
+        return self.split_invoice_number()[0]
 
     def tbai_get_value_num_factura(self):
-        invoice_number_prefix = self.tbai_get_value_serie_factura()
-        if invoice_number_prefix and not self.number.startswith(invoice_number_prefix):
-            raise exceptions.ValidationError(_(
-                "Invoice Number Prefix %s is not part of Invoice Number %s!"
-            ) % (invoice_number_prefix, self.number))
-        return self.number[len(invoice_number_prefix):]
+        return self.split_invoice_number()[1]
 
     def tbai_get_value_fecha_expedicion_factura(self):
         invoice_date = self.date or self.date_invoice

--- a/l10n_es_ticketbai/models/ir_sequence.py
+++ b/l10n_es_ticketbai/models/ir_sequence.py
@@ -1,0 +1,10 @@
+#  Copyright 2021 Landoo Sistemas de Informacion SL
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models, fields
+
+
+class IrSequence(models.Model):
+    _inherit = 'ir.sequence'
+
+    tbai_enabled = fields.Boolean(
+        related='company_id.tbai_enabled', readonly=True)

--- a/l10n_es_ticketbai/models/res_company.py
+++ b/l10n_es_ticketbai/models/res_company.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Binovo IT Human Project SL
+# Copyright 2021 Landoo Sistemas de Informacion SL
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models, fields, api
 from odoo.tools import ormcache
@@ -63,3 +64,21 @@ class ResCompany(models.Model):
             if fp_id:
                 fp_ids.append(fp_id)
         return self.env['account.fiscal.position'].browse(fp_ids)
+
+    def write(self, vals):
+        res = super().write(vals)
+        if not vals.get('tbai_enabled', False):
+            return res
+        for record in self:
+            if record.tbai_enabled:
+                journals = self.env['account.journal'].search([('type', '=', 'sale')])
+                for journal in journals:
+                    if self.env['ir.module.module'].search([
+                        ('name', '=', 'l10n_es_account_invoice_sequence'),
+                        ('state', '=', 'installed')
+                    ]) and journal.invoice_sequence_id:
+                        journal.invoice_sequence_id.suffix = ''
+                    else:
+                        journal.sequence_id.suffix = ''
+                        journal.refund_sequence = True
+        return res

--- a/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
+++ b/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
@@ -494,3 +494,15 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
             invoice.sudo().tbai_invoice_ids.get_tbai_xml_signed_and_signature_value()
         res = XMLSchema.xml_is_valid(self.test_xml_invoice_schema_doc, root)
         self.assertTrue(res)
+
+    def test_enable_tbai_no_invoice_sequence(self):
+        self.main_company.tbai_enabled = False
+        account_invoice_sequence = self.env['ir.module.module'].search([
+            ('name', '=', 'l10n_es_account_invoice_sequence')
+        ], limit=1)
+        account_invoice_sequence.state = 'uninstalled'
+        self.main_company.tbai_enabled = True
+        journals = self.env['account.journal'].search([('type', '=', 'sale')])
+        for journal in journals:
+            self.assertEqual(journal.sequence_id.suffix, '')
+            self.assertEqual(journal.refund_sequence, True)

--- a/l10n_es_ticketbai/views/ir_sequence_views.xml
+++ b/l10n_es_ticketbai/views/ir_sequence_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Landoo Sistemas de Informacion SL
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <data>
+        <record id="view_ir_sequence_form_inherit" model="ir.ui.view">
+            <field name="model">ir.sequence</field>
+            <field name="inherit_id" ref="base.sequence_view" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='suffix']" position="replace" >
+                    <field name="tbai_enabled" invisible="1" />
+                    <field name="suffix" attrs="{'readonly': [('tbai_enabled', '=', True)]}"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Este PR elimina la dependencia del módulo `l10n_es_account_invoice_sequence` haciendo que aun así funcione se encuentre o no este módulo instalado.

Este nuevo sistema lee la factura en orden inverso hasta encontrarse un carácter que no sea numérico, para así detectar hasta donde esta el número de la factura. Para evitar errores, no se permite establecer sufijo a las secuencias de los diarios de ventas (se eliminan si ya estaban establecidos).

ping @blaskurain 

