### PR TITLE
[IMP] delivery_gls_asm: warn about reference limit

### DIFF
--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import _, fields, models
+from odoo.exceptions import UserError
 from xml.sax.saxutils import escape
 from .gls_asm_request import GlsAsmRequest
 from .gls_asm_request import (
@@ -144,6 +145,15 @@ class DeliveryCarrier(models.Model):
         gls_request = GlsAsmRequest(self._gls_asm_uid())
         result = []
         for picking in pickings:
+            if len(picking.name) > 15:
+                raise UserError(_(
+                    "GLS-ASM API doesn't admit a reference number higher than "
+                    "15 characters. In order to handle it, they trim the"
+                    "reference and as the reference is unique to every "
+                    "customer we soon would have duplicated reference "
+                    "collisions. To prevent this, you should edit your picking "
+                    "sequence to a max of 15 characters."
+                ))
             vals = self._prepare_gls_asm_shipping(picking)
             vals.update({"tracking_number": False, "exact_price": 0})
             response = gls_request._send_shipping(vals)


### PR DESCRIPTION
GLS ASM API has a limit of 15 characters for its reference so we should
avoid sequences longer than that if we want to avoid collisions.

cc @Tecnativa TT33272

ping @pedrobaeza @victoralmau 