### PR TITLE
[13.0][IMP] delivery_gls_asm: warn about reference limit

### DIFF
--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -3,6 +3,7 @@
 from xml.sax.saxutils import escape
 
 from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 from .gls_asm_request import (
     GLS_ASM_SERVICES,
@@ -141,6 +142,17 @@ class DeliveryCarrier(models.Model):
         gls_request = GlsAsmRequest(self._gls_asm_uid())
         result = []
         for picking in pickings:
+            if len(picking.name) > 15:
+                raise UserError(
+                    _(
+                        "GLS-ASM API doesn't admit a reference number higher than "
+                        "15 characters. In order to handle it, they trim the"
+                        "reference and as the reference is unique to every "
+                        "customer we soon would have duplicated reference "
+                        "collisions. To prevent this, you should edit your picking "
+                        "sequence to a max of 15 characters."
+                    )
+                )
             vals = self._prepare_gls_asm_shipping(picking)
             vals.update({"tracking_number": False, "exact_price": 0})
             response = gls_request._send_shipping(vals)

--- a/delivery_gls_asm/tests/test_delivery_gls_asm.py
+++ b/delivery_gls_asm/tests/test_delivery_gls_asm.py
@@ -50,6 +50,9 @@ class TestDeliveryGlsAsm(common.SavepointCase):
         # unique key that doesn't collide with any CI around, as every test really
         # records an expedition
         self.picking.name = "ODOO-TEST-{}".format(time.time())
+        with self.assertRaises(UserError):
+            self.picking.button_validate()
+        self.picking.name = "ODOO-{}".format(int(time.time()))
         self.picking.button_validate()
         self.assertTrue(self.picking.carrier_tracking_ref)
         self.assertTrue(self.picking.gls_asm_public_tracking_ref)


### PR DESCRIPTION
FWP from 12.0: https://github.com/OCA/l10n-spain/pull/1934

GLS ASM API has a limit of 15 characters for its reference so we should avoid sequences longer than that if we want to avoid collisions.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT33272