### PR TITLE
[14.0][FIX]l10n_es_aeat_mod347: not_in_mod347 checkbox display in invoice

### DIFF
--- a/l10n_es_aeat_mod347/views/account_move_view.xml
+++ b/l10n_es_aeat_mod347/views/account_move_view.xml
@@ -5,9 +5,9 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-            <field name="currency_id" position="after">
+            <xpath expr="//div[@name='journal_div']" position="after">
                 <field name="not_in_mod347" />
-            </field>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Show field not_in_mod347 in invoices correctly.

Antes:
![347_antes](https://user-images.githubusercontent.com/62256279/146329990-cc7a889b-45d5-425f-81d5-f24eb80310bd.png)

Después:
![347_despues](https://user-images.githubusercontent.com/62256279/146330030-2705cb27-7f67-4a51-91b4-24b3965cf565.png)