### PR TITLE
[14.0][FIX] l10n_es_dua_sii: Rectificativas de DUA

### DIFF
--- a/l10n_es_dua_sii/models/account_move.py
+++ b/l10n_es_dua_sii/models/account_move.py
@@ -65,7 +65,8 @@ class AccountMove(models.Model):
         """
         res = super()._get_sii_invoice_dict_in(cancel=cancel)
         if res.get("FacturaRecibida") and self.sii_dua_invoice:
-            res["FacturaRecibida"]["TipoFactura"] = "F5"
+            if self.move_type == "in_invoice":
+                res["FacturaRecibida"]["TipoFactura"] = "F5"
             res["FacturaRecibida"].pop("FechaOperacion", None)
             nif = self.company_id.partner_id._parse_aeat_vat_info()[2]
             res["FacturaRecibida"]["IDEmisorFactura"] = {"NIF": nif}


### PR DESCRIPTION
Hola,

Se nos ha dado un caso de que un cliente ha recibido una rectificativa de un DUA y no se comprueba el tipo de factura recibida que sea crea para cambiar la clave y la rectificativa no se puede enviar como factura de DUA (F5), evitando ese cambio de clave y manteniendo lo demás he logrado enviar la factura.
 
De todas formas, he hecho una consulta a la AEAT sobre esto, esperamos a lo que respondan para el merge si lo veis correcto.

Un saludo