### PR TITLE
[14.0][IMP] l10n_es_vat_book: Mejora de rendimiento

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -415,12 +415,12 @@ class L10nEsVatBook(models.Model):
                 # Filters in all possible data using, sets for improving performance
                 if account:
                     lines = moves.filtered(
-                        lambda x: x.tax_ids & taxes
-                        or (x.tax_line_id in taxes and x.account_id == account)
+                        lambda line: line.tax_ids & taxes
+                        or (line.tax_line_id in taxes and line.account_id == account)
                     )
                 else:
                     lines = moves.filtered(
-                        lambda x: x.tax_ids & taxes or x.tax_line_id in taxes
+                        lambda line: (line.tax_ids | line.tax_line_id) & taxes
                     )
                 rec.create_vat_book_lines(lines, map_line.book_type, taxes)
             # Issued

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -296,28 +296,35 @@ class L10nEsVatBook(models.Model):
         self.summary_ids.unlink()
         self.tax_summary_ids.unlink()
 
-    def _account_move_line_domain(self, taxes, account=None):
-        # search move lines that contain these tax codes
+    # Not filters by taxes in tax_ids by default for avoiding a poor
+    # performance in psql
+    def _account_move_line_domain(self, taxes=None, account=None):
         domain = [
             ("date", ">=", self.date_start),
             ("date", "<=", self.date_end),
             ("parent_state", "=", "posted"),
-            "|",
-            ("tax_ids", "in", taxes.ids),
         ]
-        if account:
-            domain += [
-                "&",
-                ("tax_line_id", "in", taxes.ids),
-                ("account_id", "=", account.id),
-            ]
+        if taxes:
+            domain.append(("tax_ids", "in", taxes.ids))
+            if account:
+                domain += [
+                    "&",
+                    ("tax_line_id", "in", taxes.ids),
+                    ("account_id", "=", account.id),
+                ]
+            else:
+                domain.append(("tax_line_id", "in", taxes.ids))
         else:
-            domain.append(("tax_line_id", "in", taxes.ids))
+            domain += [
+                "|",
+                ("tax_ids", "!=", []),
+                ("tax_line_id", "!=", False),
+            ]
         return domain
 
-    def _get_account_move_lines(self, taxes, account=None):
+    def _get_account_move_lines(self, taxes=None, account=None):
         return self.env["account.move.line"].search(
-            self._account_move_line_domain(taxes, account=account)
+            self._account_move_line_domain(taxes=taxes, account=account)
         )
 
     @ormcache("self.id")
@@ -400,10 +407,21 @@ class L10nEsVatBook(models.Model):
                 raise UserError(_("This company doesn't have VAT"))
             rec._clear_old_data()
             map_lines = self.env["aeat.vat.book.map.line"].search([])
+            # Searches for all possible usable lines to report
+            moves = self._get_account_move_lines()
             for map_line in map_lines:
                 taxes = map_line.get_taxes(rec)
                 account = rec.get_account_from_template(map_line.tax_account_id)
-                lines = rec._get_account_move_lines(taxes, account=account)
+                # Filters in all possible data using, sets for improving performance
+                if account:
+                    lines = moves.filtered(
+                        lambda x: x.tax_ids & taxes
+                        or (x.tax_line_id in taxes and x.account_id == account)
+                    )
+                else:
+                    lines = moves.filtered(
+                        lambda x: x.tax_ids & taxes or x.tax_line_id in taxes
+                    )
                 rec.create_vat_book_lines(lines, map_line.book_type, taxes)
             # Issued
             book_type = "issued"

--- a/l10n_es_vat_book/readme/CONTRIBUTORS.rst
+++ b/l10n_es_vat_book/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
   * Pedro M. Baeza
   * Carlos Dauden
   * Ernesto Tejeda
+* Omar Castiñeira <omar@comunitea.com>


### PR DESCRIPTION
Hola,

Migramos recientemente un Odoo bastante grande a 14.0, al mes tienen una media de 34000 apuntes de asientos de factura y el cálculo del libro de iva era mucho más lento que antes, sólo del mes de noviembre se iba a más de 15 minutos, cuando no se bloqueaba. Le he dado una vuelta y el problema principal venía con la búsqueda sobre "tax_ids" que al ser un many2many hacía una subquery del tipo "("account_move_line"."id" in (SELECT "account_move_line_id" FROM "account_move_line_account_tax_rel" WHERE "account_tax_id" IN (231, 232, 269, 270, 271, 283, 285, 286, 288, 289, 309, 310, 334, 2006, 2007))" por cada mapeo y que con tantos apuntes no es viable.

Lo he cambiado a obtener todos los apuntes que pueden estar sujetos a aparecer en el libro de iva primero y luego por cada mapeo buscar sobre estos los apropiados para ese mapeo, así la base de datos tiene menos uso y se vuelca el cálculo en Python, la diferencia es muy grande, pego las estadísticas de profile.

**Antes:**

```
1         0         0.02          @profile
                                  def _calculate_vat_book(self):
                                      """
                                      This function calculate all the taxes, from issued invoices,
                                      received invoices and rectification invoices
                                      """
3         0         0.06              for rec in self:
1         11        43.44                 if not rec.company_id.partner_id.vat:
                                              raise UserError(_("This company doesn't have VAT"))
1         58        579.59                rec._clear_old_data()
1         3         2.68                  map_lines = self.env["aeat.vat.book.map.line"].search([])
9         0         0.17                  for map_line in map_lines:
7         199       339.61                    taxes = map_line.get_taxes(rec)
7         5         8.39                      account = rec.get_account_from_template(map_line.tax_account_id)
7         12        2154371.93                lines = rec._get_account_move_lines(taxes, account=account)
7         6280      32430.91                  rec.create_vat_book_lines(lines, map_line.book_type, taxes)
                                          # Issued
1         0         0.01                  book_type = "issued"
1         1         149.74                issued_tax_lines = rec.issued_line_ids.mapped("tax_line_ids")
1         1         24.25                 rectification_issued_tax_lines = rec.rectification_issued_line_ids.mapped(
1         0         0.85                      "tax_line_ids"
                                          )
1         0         0.01                  tax_summary_data_recs = rec._prepare_vat_book_tax_summary(
1         0         449.26                    issued_tax_lines + rectification_issued_tax_lines, book_type
                                          )
1         11        18.06                 rec._create_vat_book_tax_summary(tax_summary_data_recs)
1         6         13.41                 rec._create_vat_book_summary(rec.issued_tax_summary_ids, book_type)
                              
                                          # Received
1         0         0.01                  book_type = "received"
1         1         31.0                  received_tax_lines = rec.received_line_ids.mapped("tax_line_ids")
                                          # flake8: noqa
                                          rectification_received_tax_lines = (
1         1         16.88                     rec.rectification_received_line_ids.mapped("tax_line_ids")
                                          )
1         0         0.01                  tax_summary_data_recs = rec._prepare_vat_book_tax_summary(
1         0         52.4                      received_tax_lines + rectification_received_tax_lines, book_type
                                          )
1         13        22.11                 rec._create_vat_book_tax_summary(tax_summary_data_recs)
1         3         10.13                 rec._create_vat_book_summary(rec.received_tax_summary_ids, book_type)
                              
                                          # If we require to auto-renumber invoices received
1         0         0.03                  if rec.auto_renumber:
                                              rec_invs = self.env["l10n.es.vat.book.line"].search(
                                                  [("vat_book_id", "=", rec.id), ("line_type", "=", "received")],
                                                  order="invoice_date asc, ref asc",
                                              )
                                              i = 1
                                              for rec_inv in rec_invs:
                                                  rec_inv.entry_number = i
                                                  i += 1
                                              rec_invs = self.env["l10n.es.vat.book.line"].search(
                                                  [
                                                      ("vat_book_id", "=", rec.id),
                                                      ("line_type", "=", "rectification_received"),
                                                  ],
                                                  order="invoice_date asc, ref asc",
                                              )
                                              i = 1
                                              for rec_inv in rec_invs:
                                                  rec_inv.entry_number = i
                                                  i += 1
                                              # Write state and date in the report
1         0         0.01                  rec.write(
1         0         1.3                       {"state": "calculated", "calculation_date": fields.Datetime.now()}
                                          )

Total:
1         6605      **2188566.23**
```


**Tras el cambio:**

```
1         0         0.02          @profile
                                  def _calculate_vat_book(self):
                                      """
                                      This function calculate all the taxes, from issued invoices,
                                      received invoices and rectification invoices
                                      """
3         0         0.06              for rec in self:
1         11        41.58                 if not rec.company_id.partner_id.vat:
                                              raise UserError(_("This company doesn't have VAT"))
1         58        605.59                rec._clear_old_data()
1         3         2.91                  map_lines = self.env["aeat.vat.book.map.line"].search([])
1         7         253.11                moves = self._get_account_move_lines()
9         0         0.21                  for map_line in map_lines:
7         198       378.81                    taxes = map_line.get_taxes(rec)
7         5         9.25                      account = rec.get_account_from_template(map_line.tax_account_id)
7         0         0.07                      if account:
1         0         2908.27                       lines = moves.filtered(lambda x: x.tax_ids & taxes or (x.tax_line_id in taxes and x.account_id == account))
                                              else:
6         70        27205.52                      lines = moves.filtered(lambda x: x.tax_ids & taxes or x.tax_line_id in taxes)
7         6214      29544.23                  rec.create_vat_book_lines(lines, map_line.book_type, taxes)
                                          # Issued
1         0         0.01                  book_type = "issued"
1         1         158.95                issued_tax_lines = rec.issued_line_ids.mapped("tax_line_ids")
1         1         28.47                 rectification_issued_tax_lines = rec.rectification_issued_line_ids.mapped(
1         0         1.07                      "tax_line_ids"
                                          )
1         0         0.02                  tax_summary_data_recs = rec._prepare_vat_book_tax_summary(
1         0         483.65                    issued_tax_lines + rectification_issued_tax_lines, book_type
                                          )
1         11        20.05                 rec._create_vat_book_tax_summary(tax_summary_data_recs)
1         6         14.21                 rec._create_vat_book_summary(rec.issued_tax_summary_ids, book_type)
                              
                                          # Received
1         0         0.01                  book_type = "received"
1         1         34.05                 received_tax_lines = rec.received_line_ids.mapped("tax_line_ids")
                                          # flake8: noqa
                                          rectification_received_tax_lines = (
1         1         20.37                     rec.rectification_received_line_ids.mapped("tax_line_ids")
                                          )
1         0         0.01                  tax_summary_data_recs = rec._prepare_vat_book_tax_summary(
1         0         56.04                     received_tax_lines + rectification_received_tax_lines, book_type
                                          )
1         13        27.72                 rec._create_vat_book_tax_summary(tax_summary_data_recs)
1         3         11.0                  rec._create_vat_book_summary(rec.received_tax_summary_ids, book_type)
                              
                                          # If we require to auto-renumber invoices received
1         0         0.04                  if rec.auto_renumber:
                                              rec_invs = self.env["l10n.es.vat.book.line"].search(
                                                  [("vat_book_id", "=", rec.id), ("line_type", "=", "received")],
                                                  order="invoice_date asc, ref asc",
                                              )
                                              i = 1
                                              for rec_inv in rec_invs:
                                                  rec_inv.entry_number = i
                                                  i += 1
                                              rec_invs = self.env["l10n.es.vat.book.line"].search(
                                                  [
                                                      ("vat_book_id", "=", rec.id),
                                                      ("line_type", "=", "rectification_received"),
                                                  ],
                                                  order="invoice_date asc, ref asc",
                                              )
                                              i = 1
                                              for rec_inv in rec_invs:
                                                  rec_inv.entry_number = i
                                                  i += 1
                                              # Write state and date in the report
1         0         0.01                  rec.write(
1         0         1.5                       {"state": "calculated", "calculation_date": fields.Datetime.now()}
                                          )

Total:
1         6603      **61806.79**
```

Un saludo y felices fiestas