### PR TITLE
[15.0][FIX] l10n_es_aeat: Fix development_status

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -19,6 +19,7 @@
     "license": "AGPL-3",
     "website": "https://github.com/OCA/l10n-spain",
     "category": "Accounting & Finance",
+    "development_status": "Mature",
     "depends": ["l10n_es", "account_tax_balance"],
     # odoo_test_helper is needed for the tests
     "external_dependencies": {"python": ["unidecode", "cryptography"]},


### PR DESCRIPTION
Se añade el estado de desarrollo para las dependencias.
Depende de:
- [X] https://github.com/OCA/account-financial-reporting/pull/842
- [X] https://github.com/OCA/account-invoicing/pull/1068