### PR TITLE
[12.0][IMP] l10n_es_ticketbai simplify document schema validation.

### DIFF
--- a/l10n_es_ticketbai_api/ticketbai/xml_schema.py
+++ b/l10n_es_ticketbai_api/ticketbai/xml_schema.py
@@ -76,13 +76,7 @@ class XMLSchema:
         :return: bool
         """
         schema = etree.XMLSchema(test_xmlschema_doc)
-        try:
-            schema.assertValid(root)
-            valid = True
-        except etree.DocumentInvalid as error:
-            _logger.exception(error)
-            valid = False
-        return valid
+        return schema(root)
 
     @staticmethod
     def sign(root, certificate, tax_agency):


### PR DESCRIPTION
Instead of raise + except just ask the schema whether a document is
valid: much simpler and cleaner. Also, keeps travis happy by not
logging assertion errors.

Cherry-pick del commit 4893de6eb0418475898ee9446359103649657a4b del PR #1886 