### PR TITLE
[FIX] l10n_es_ticketbai_api - use commercial_partner_id

### DIFF
--- a/l10n_es_ticketbai_api/models/res_partner.py
+++ b/l10n_es_ticketbai_api/models/res_partner.py
@@ -62,10 +62,11 @@ class ResPartner(models.Model):
             <maxLength value="120"/>
         :return: Name and surname, or business name
         """
-        if 120 < len(self.name.strip()):
+        name = self.commercial_partner_id.name
+        if 120 < len(name.strip()):
             raise exceptions.ValidationError(_(
-                "Name %s too long. Should be 120 characters max.!") % self.name)
-        return self.name.strip()  # Remove leading and trailing whitespace
+                "Name %s too long. Should be 120 characters max.!") % name)
+        return name.strip()  # Remove leading and trailing whitespace
 
     def tbai_get_value_nif(self):
         """ V 1.2

--- a/l10n_es_ticketbai_api/models/res_partner.py
+++ b/l10n_es_ticketbai_api/models/res_partner.py
@@ -63,10 +63,7 @@ class ResPartner(models.Model):
         :return: Name and surname, or business name
         """
         name = self.commercial_partner_id.name
-        if 120 < len(name.strip()):
-            raise exceptions.ValidationError(_(
-                "Name %s too long. Should be 120 characters max.!") % name)
-        return name.strip()  # Remove leading and trailing whitespace
+        return name.strip()[:120]  # Remove leading and trailing whitespace
 
     def tbai_get_value_nif(self):
         """ V 1.2


### PR DESCRIPTION
Usar `commercial_partner_id` al coger razón social o nombre y apellidos de empresa. 
De lo contrario, en entornos con distintas direcciones de facturación, lo que se traslada a hacienda es el nombre de la dirección.