### PR TITLE
[11.0][FIX] Check 'Incorrect' state of LROE not to retry sending

### DIFF
--- a/l10n_es_ticketbai_api_batuz/models/lroe_operation_response.py
+++ b/l10n_es_ticketbai_api_batuz/models/lroe_operation_response.py
@@ -268,7 +268,7 @@ class LROEOperationResponse(models.Model):
                 tbai_response_dict = {
                     'tbai_invoice_id': lroe_operation.tbai_invoice_ids[0].id,
                     'state': LROEOperationResponse.get_tbai_state(
-                        LROEOperationResponseState.REQUEST_ERROR.value)
+                        lroe_srv_response_type)
                 }
                 for key in kwargs:
                     tbai_response_dict[key] = kwargs[key]


### PR DESCRIPTION
Check 'Incorrect' status of LROE so as not to try to send the invoice to the tax agency again and mark it as an error.