### PR TITLE
[FIX] delivery_gls_asm: escaped int

### DIFF
--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -106,7 +106,7 @@ class DeliveryCarrier(models.Model):
             "destinatario_direccion": escape(picking.partner_id.street or ""),
             "destinatario_poblacion": escape(picking.partner_id.city or ""),
             "destinatario_provincia": escape(picking.partner_id.state_id.name or ""),
-            "destinatario_pais": escape(picking.partner_id.country_id.phone_code or ""),
+            "destinatario_pais": picking.partner_id.country_id.phone_code or "",
             "destinatario_cp": picking.partner_id.zip,
             "destinatario_telefono": picking.partner_id.phone or "",
             "destinatario_movil": picking.partner_id.mobile or "",


### PR DESCRIPTION
`res_country.phone_code` is an Integer field, thus it should not be
scaped.

cc @Tecnativa TT33879

ping @hildickethan @pedrobaeza 