### PR TITLE
[13.0][FIX] l10n_es_aeat_mod347: Don't include cancel and draft moves

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -164,6 +164,7 @@ class L10nEsAeatMod347Report(models.Model):
             "|",
             ("tax_ids", "in", taxes.ids),
             ("tax_line_id", "in", taxes.ids),
+            ("parent_state", "=", "posted"),
         ]
 
     @api.model

--- a/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
+++ b/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
@@ -55,6 +55,9 @@ class TestL10nEsAeatMod347(TestL10nEsAeatModBase):
             "S_IVA10B": (2000, 200),
         }
         cls.invoice_1 = cls._invoice_sale_create("2019-01-01")
+        # Cancelled invoice - Shouldn't count for partner `customer`
+        cls.invoice_cancel = cls._invoice_sale_create("2019-01-01")
+        cls.invoice_cancel.button_cancel()
         # Invoice higher than limit with IRPF
         cls.taxes_sale = {
             "S_IVA10S,S_IRPF20": (4000, 400),


### PR DESCRIPTION
Previously, if there are cancel or draft moves with the corresponding taxes, they were included in the report.

We should filter them out.

TT33910