### PR TITLE
[11.0][FIX] l10n_es_ticketbai - añadidos impuestos al mapeo no sujeto repercutido servicios

### DIFF
--- a/l10n_es_ticketbai/data/tax_map_data.xml
+++ b/l10n_es_ticketbai/data/tax_map_data.xml
@@ -23,6 +23,8 @@
         <record id="tbai_tax_map_SNS" model="tbai.tax.map">
             <field name="code">SNS</field>
             <field name="tax_template_ids" eval="[(6, 0, [
+                ref('l10n_es.account_tax_template_s_iva_e'),
+                ref('l10n_es.account_tax_template_s_iva0_sp_i'),
                 ref('l10n_es.account_tax_template_s_iva_ns'),
             ])]"/>
             <field name="name">No sujeto Repercutido (Servicios)</field>


### PR DESCRIPTION
Se añaden al mapeo de impuestos `tbai.tax.map` _No sujeto Repercutido (Servicios)_ los impuestos:
- _IVA 0% Prestación de servicios extracomunitaria_
- _IVA 0% Prestación de servicios intracomunitario_  

Para que se informe el `DetalleNoSujeta` y la pertinente `Causa` e `Importe`