### PR TITLE
[11.0][FIX] l10n_es_ticketbai_api: Call make_image function correctly

### DIFF
--- a/l10n_es_ticketbai_api/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice.py
@@ -421,7 +421,7 @@ class TicketBAIInvoice(models.Model):
                     border=0, error_correction=qrcode.constants.ERROR_CORRECT_M)
                 qr.add_data(record.qr_url)
                 qr.make()
-                img = qr.make_image(fill_color="white", back_color="black")
+                img = qr.make_image()
                 with io.BytesIO() as temp:
                     img.save(temp, format="PNG")
                     record.qr = base64.b64encode(temp.getvalue())


### PR DESCRIPTION
Se llama a la función make_image sin enviar ningún argumento para evitar errores según la versión de Python utilizada.