### PR TITLE
[14.0][IMP] l10n_es_aeat_sii_oca + l10n_es_facturae: Add thirdparty fields to allow inheritance in other addons.

### DIFF
--- a/l10n_es_aeat_sii_oca/__manifest__.py
+++ b/l10n_es_aeat_sii_oca/__manifest__.py
@@ -14,7 +14,7 @@
 
 {
     "name": "Suministro Inmediato de Información en el IVA",
-    "version": "14.0.1.8.3",
+    "version": "14.0.1.9.0",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/l10n-spain",
     "author": "Acysos S.L.,"

--- a/l10n_es_aeat_sii_oca/migrations/14.0.1.9.0/pre-migration.py
+++ b/l10n_es_aeat_sii_oca/migrations/14.0.1.9.0/pre-migration.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+from odoo.tools.sql import column_exists
+
+_column_renames = {
+    "account_move": [
+        ("sii_thirdparty_invoice", "thirdparty_invoice"),
+        ("sii_thirdparty_number", "thirdparty_number"),
+    ]
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if column_exists(env.cr, "account_move", "sii_thirdparty_invoice"):
+        openupgrade.rename_columns(env.cr, _column_renames)

--- a/l10n_es_aeat_sii_oca/models/__init__.py
+++ b/l10n_es_aeat_sii_oca/models/__init__.py
@@ -9,5 +9,6 @@ from . import aeat_sii_map
 from . import product_product
 from . import queue_job
 from . import account_fiscal_position
+from . import account_journal
 from . import account_move
 from . import res_partner

--- a/l10n_es_aeat_sii_oca/models/account_journal.py
+++ b/l10n_es_aeat_sii_oca/models/account_journal.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from lxml import etree
+
+from odoo import api, fields, models
+
+
+class AccountFiscalPosition(models.Model):
+    _inherit = "account.journal"
+
+    thirdparty_invoice = fields.Boolean(string="Third-party invoice", copy=False)
+
+    @api.model
+    def fields_view_get(
+        self, view_id=None, view_type="form", toolbar=False, submenu=False
+    ):
+        """Thirdparty fields are added to the form view only if they don't exist
+        previously (l10n_es_facturae addon also has the same field names).
+        """
+        res = super().fields_view_get(
+            view_id=view_id,
+            view_type=view_type,
+            toolbar=toolbar,
+            submenu=submenu,
+        )
+        if view_type == "form":
+            doc = etree.XML(res["arch"])
+            node = doc.xpath("//field[@name='thirdparty_invoice']")
+            if node:
+                return res
+            for node in doc.xpath("//field[@name='type']"):
+                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                node.addnext(elem)
+            res["arch"] = etree.tostring(doc)
+            xarch, xfields = self.env["ir.ui.view"].postprocess_and_fields(
+                self._name, etree.fromstring(res["arch"]), view_id
+            )
+            res["arch"] = xarch
+            res["fields"] = xfields
+        return res

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -7,6 +7,8 @@
 
 import json
 
+from lxml import etree
+
 from odoo import exceptions
 from odoo.modules.module import get_resource_path
 
@@ -388,3 +390,12 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.invoice.sii_state = "sent"
         with self.assertRaises(exceptions.UserError):
             self.invoice.unlink()
+
+    def test_account_move_thirdparty_fields(self):
+        view = self.env["account.move"].fields_view_get(
+            view_id=self.env.ref("account.view_move_form").id,
+            view_type="form",
+        )
+        doc = etree.XML(view["arch"])
+        self.assertTrue(doc.xpath("//field[@name='thirdparty_number']"))
+        self.assertTrue(doc.xpath("//field[@name='thirdparty_invoice']"))

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -42,11 +42,6 @@
                             name="sii_description"
                             attrs="{'required': [('sii_enabled', '=', True)]}"
                         />
-                        <field name="sii_thirdparty_invoice" />
-                        <field
-                            name="sii_thirdparty_number"
-                            attrs="{'required': [('sii_thirdparty_invoice', '=', True)]}"
-                        />
                         <field
                             name="sii_refund_type"
                             attrs="{'required': [('sii_enabled', '=', True),('move_type', 'in', ('out_refund','in_refund'))], 'invisible': [('move_type', 'not in', ('out_refund','in_refund'))]}"

--- a/l10n_es_facturae/models/__init__.py
+++ b/l10n_es_facturae/models/__init__.py
@@ -6,5 +6,6 @@ from . import res_partner
 from . import account_tax_template
 from . import account_tax
 from . import res_currency
+from . import account_journal
 from . import account_move
 from . import edi_exchange_record

--- a/l10n_es_facturae/models/account_journal.py
+++ b/l10n_es_facturae/models/account_journal.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Tecnativa- Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from lxml import etree
+
+from odoo import api, fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    thirdparty_invoice = fields.Boolean(string="Third-party invoice", copy=False)
+
+    @api.model
+    def fields_view_get(
+        self, view_id=None, view_type="form", toolbar=False, submenu=False
+    ):
+        """Thirdparty fields are added to the form view only if they don't exist
+        previously (l10n_es_aeat_sii_oca addon also has the same field names).
+        """
+        res = super().fields_view_get(
+            view_id=view_id,
+            view_type=view_type,
+            toolbar=toolbar,
+            submenu=submenu,
+        )
+        if view_type == "form":
+            doc = etree.XML(res["arch"])
+            node = doc.xpath("//field[@name='thirdparty_invoice']")
+            if node:
+                return res
+            for node in doc.xpath("//field[@name='type']"):
+                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                node.addnext(elem)
+            res["arch"] = etree.tostring(doc)
+            xarch, xfields = self.env["ir.ui.view"].postprocess_and_fields(
+                self._name, etree.fromstring(res["arch"]), view_id
+            )
+            res["arch"] = xarch
+            res["fields"] = xfields
+        return res

--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -4,8 +4,15 @@
 import base64
 from collections import defaultdict
 
+from lxml import etree
+
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
+
+from odoo.addons.base.models.ir_ui_view import (
+    transfer_modifiers_to_node,
+    transfer_node_to_modifiers,
+)
 
 
 class AccountMove(models.Model):
@@ -82,6 +89,26 @@ class AccountMove(models.Model):
         inverse_name="move_id",
         copy=False,
     )
+    thirdparty_invoice = fields.Boolean(
+        string="Third-party invoice",
+        copy=False,
+        compute="_compute_thirdparty_invoice",
+        store=True,
+        readonly=False,
+    )
+    thirdparty_number = fields.Char(
+        string="Third-party number",
+        index=True,
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        copy=False,
+        help="Número de la factura emitida por un tercero.",
+    )
+
+    @api.depends("journal_id")
+    def _compute_thirdparty_invoice(self):
+        for item in self:
+            item.thirdparty_invoice = item.journal_id.thirdparty_invoice
 
     def _get_edi_missing_records(self):
         result = super()._get_edi_missing_records()
@@ -279,6 +306,44 @@ class AccountMove(models.Model):
                 withheld_taxes[tax]["base"] * tax.amount / 100
             )
         return output_taxes, withheld_taxes
+
+    @api.model
+    def fields_view_get(
+        self, view_id=None, view_type="form", toolbar=False, submenu=False
+    ):
+        """Thirdparty fields are added to the form view only if they don't exist
+        previously (l10n_es_aeat_sii_oca addon also has the same field names).
+        """
+        res = super().fields_view_get(
+            view_id=view_id,
+            view_type=view_type,
+            toolbar=toolbar,
+            submenu=submenu,
+        )
+        if view_type == "form":
+            doc = etree.XML(res["arch"])
+            node = doc.xpath("//field[@name='thirdparty_invoice']")
+            if node:
+                return res
+            for node in doc.xpath("//field[@name='ref']"):
+                attrs = {
+                    "required": [("thirdparty_invoice", "=", True)],
+                    "invisible": [("thirdparty_invoice", "=", False)],
+                }
+                elem = etree.Element(
+                    "field",
+                    {"name": "thirdparty_number", "attrs": str(attrs)},
+                )
+                modifiers = {}
+                transfer_node_to_modifiers(elem, modifiers)
+                transfer_modifiers_to_node(modifiers, elem)
+                node.addnext(elem)
+                res["fields"].update(self.fields_get(["thirdparty_number"]))
+                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                node.addnext(elem)
+                res["fields"].update(self.fields_get(["thirdparty_invoice"]))
+            res["arch"] = etree.tostring(doc)
+        return res
 
 
 class AccountMoveLine(models.Model):

--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -647,3 +647,12 @@ class CommonTest(TestL10nEsAeatCertificateBase):
             }
         )
         self._check_amounts(move, *self.second_check_amount)
+
+    def test_account_move_thirdparty_fields(self):
+        view = self.env["account.move"].fields_view_get(
+            view_id=self.env.ref("account.view_move_form").id,
+            view_type="form",
+        )
+        doc = etree.XML(view["arch"])
+        self.assertTrue(doc.xpath("//field[@name='thirdparty_number']"))
+        self.assertTrue(doc.xpath("//field[@name='thirdparty_invoice']"))

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -164,12 +164,30 @@
                     t-esc="'3.2.1' if version == '3_2_1' else ('3.2.2' if version == '3_2_2' else '3.2')"
                 />
                 <Modality t-esc="'I'" />
-                <InvoiceIssuerType t-esc="'EM'" />
+                <t t-if="not move.thirdparty_number">
+                    <InvoiceIssuerType t-esc="'EM'" />
+                </t>
+                <t t-if="move.thirdparty_number">
+                    <InvoiceIssuerType t-esc="'TE'" />
+                    <ThirdParty>
+                        <t t-call="l10n_es_facturae.entity">
+                            <t t-set="partner" t-value="company_partner" />
+                        </t>
+                    </ThirdParty>
+                </t>
                 <Batch>
-                    <BatchIdentifier
-                        t-length="70"
-                        t-esc="(move.name or '') + (company_partner.vat or '')"
-                    />
+                    <t t-if="not move.thirdparty_number">
+                        <BatchIdentifier
+                            t-length="70"
+                            t-esc="(move.name or '') + (company_partner.vat or '')"
+                        />
+                    </t>
+                    <t t-if="move.thirdparty_number">
+                        <BatchIdentifier
+                            t-length="70"
+                            t-esc="(move.thirdparty_number or '') + (company_partner.vat or '')"
+                        />
+                    </t>
                     <InvoicesCount t-esc="'1'" />
                     <TotalInvoicesAmount>
                         <TotalAmount
@@ -234,7 +252,15 @@
                         </t>
                     </t>
                     <InvoiceHeader>
-                        <InvoiceNumber t-length="20" t-esc="move.name" />
+                        <t t-if="not move.thirdparty_number">
+                            <InvoiceNumber t-length="20" t-esc="move.name" />
+                        </t>
+                        <t t-if="move.thirdparty_number">
+                            <InvoiceNumber
+                                t-length="20"
+                                t-esc="move.thirdparty_number"
+                            />
+                        </t>
                         <InvoiceSeriesCode t-length="20" t-esc="''" />
                         <InvoiceDocumentType t-esc="'FC'" />
                         <InvoiceClass


### PR DESCRIPTION
Se añaden / renombran campos para el uso de facturas de terceros y la compatibilidad en los addons `l10n_es_aeat_sii_oca` +  `l10n_es_facturae` sin necesidad de añadir dependencias entre ellos o módulos extra para unirlos.

FWP de 13.0: https://github.com/OCA/l10n-spain/pull/1906

Por favor @pedrobaeza y @chienandalu podéis revisarlo?

@Tecnativa TT32612