### PR TITLE
[IMP] l10n_es_aeat_sii_oca: Mejorar deteccion de VAT

### DIFF
--- a/l10n_es_aeat/tests/test_l10n_es_aeat.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat.py
@@ -1,6 +1,7 @@
 # Copyright 2016-2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import ValidationError
 from odoo.tests.common import SavepointCase
 
 
@@ -33,6 +34,25 @@ class TestL10nEsAeat(SavepointCase):
         self.assertEqual(country_code, "ES")
         self.assertEqual(identifier_type, "")
         self.assertEqual(vat_number, "12345678Z")
+
+    def test_parse_vat_info_es_passport_exception(self):
+        with self.assertRaises(ValidationError):
+            self.partner.write(
+                {"vat": "ZZ_MY_PASSPORT", "country_id": self.env.ref("base.es").id}
+            )
+
+    def test_parse_vat_info_es_passport(self):
+        self.partner.write(
+            {
+                "aeat_identification": "ZZ_MY_PASSPORT",
+                "aeat_identification_type": "05",
+                "country_id": self.env.ref("base.es").id,
+            }
+        )
+        country_code, identifier_type, identifier = self.partner._parse_aeat_vat_info()
+        self.assertEqual(country_code, "ES")
+        self.assertEqual(identifier_type, "05")
+        self.assertEqual(identifier, "ZZ_MY_PASSPORT")
 
     def test_parse_vat_info_fr_wo_prefix(self):
         self.partner.write(

--- a/l10n_es_aeat/views/res_partner_view.xml
+++ b/l10n_es_aeat/views/res_partner_view.xml
@@ -4,11 +4,17 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="account.view_partner_property_form" />
         <field name="arch" type="xml">
-            <group name="fiscal_information" position="inside">
-                <field name="aeat_anonymous_cash_customer" />
-            </group>
             <notebook position="inside">
-                <page string="AEAT" id="aeat" />
+                <page string="AEAT" id="aeat">
+                    <group>
+                        <field name="aeat_anonymous_cash_customer" />
+                        <field name="aeat_identification_type" />
+                        <field
+                            name="aeat_identification"
+                            attrs="{'required': [('aeat_identification_type', '!=', False)], 'invisible': [('aeat_identification_type', '=', False)]}"
+                        />
+                    </group>
+                </page>
             </notebook>
         </field>
     </record>

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -52,12 +52,6 @@ SII_STATES = [
     ("cancelled_modified", "Cancelled in SII but last modifications not sent"),
 ]
 SII_VERSION = "1.1"
-SII_COUNTRY_CODE_MAPPING = {
-    "RE": "FR",
-    "GP": "FR",
-    "MQ": "FR",
-    "GF": "FR",
-}
 SII_MACRODATA_LIMIT = 100000000.0
 SII_VALID_INVOICE_STATES = ["posted"]
 
@@ -1330,42 +1324,48 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
         gen_type = self._get_sii_gen_type()
+        (
+            country_code,
+            identifier_type,
+            identifier,
+        ) = self.commercial_partner_id._parse_aeat_vat_info()
         # Limpiar alfanum
-        if self.partner_id.vat:
-            vat = "".join(e for e in self.partner_id.vat if e.isalnum()).upper()
+        if identifier:
+            identifier = "".join(e for e in identifier if e.isalnum()).upper()
         else:
-            vat = "NO_DISPONIBLE"
-        country_code = self._get_sii_country_code()
+            identifier = "NO_DISPONIBLE"
+            identifier_type = "06"
         if gen_type == 1:
             if "1117" in (self.sii_send_error or ""):
                 return {
                     "IDOtro": {
                         "CodigoPais": country_code,
                         "IDType": "07",
-                        "ID": vat[2:],
+                        "ID": identifier,
                     }
                 }
             else:
-                if country_code != "ES":
-                    id_type = "06" if vat == "NO_DISPONIBLE" else "04"
-                    return {
-                        "IDOtro": {
-                            "CodigoPais": country_code,
-                            "IDType": id_type,
-                            "ID": vat,
-                        },
-                    }
-                else:
-                    return {"NIF": vat[2:]}
+                if identifier_type == "":
+                    return {"NIF": identifier}
+                return {
+                    "IDOtro": {
+                        "CodigoPais": country_code,
+                        "IDType": identifier_type,
+                        "ID": identifier,
+                    },
+                }
         elif gen_type == 2:
-            return {"IDOtro": {"IDType": "02", "ID": vat}}
-        elif gen_type == 3 and country_code != "ES":
-            id_type = "06" if vat == "NO_DISPONIBLE" else "04"
+            return {"IDOtro": {"IDType": "02", "ID": identifier}}
+        elif gen_type == 3 and identifier_type:
             return {
-                "IDOtro": {"CodigoPais": country_code, "IDType": id_type, "ID": vat},
+                "IDOtro": {
+                    "CodigoPais": country_code,
+                    "IDType": identifier_type,
+                    "ID": identifier,
+                },
             }
         elif gen_type == 3:
-            return {"NIF": vat[2:]}
+            return {"NIF": identifier[2:]}
 
     def _get_sii_exempt_cause(self, applied_taxes):
         """Código de la causa de exención según 3.6 y 3.7 de la FAQ del SII.
@@ -1421,11 +1421,7 @@ class AccountMove(models.Model):
 
     def _get_sii_country_code(self):
         self.ensure_one()
-        country_code = (
-            self.partner_id.commercial_partner_id.country_id.code
-            or (self.partner_id.vat or "")[:2]
-        ).upper()
-        return SII_COUNTRY_CODE_MAPPING.get(country_code, country_code)
+        return self.commercial_partner_id._parse_aeat_vat_info()[0]
 
     @api.depends(
         "invoice_line_ids", "invoice_line_ids.name", "company_id",

--- a/l10n_es_aeat_sii_oca/models/res_partner.py
+++ b/l10n_es_aeat_sii_oca/models/res_partner.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -14,7 +14,10 @@ class ResPartner(models.Model):
         "sent to SII as simplified invoices.",
     )
 
+    @api.depends("company_id")
     def _compute_sii_enabled(self):
-        sii_enabled = self.env.user.company_id.sii_enabled
+        sii_enabled = any(self.env.companies.mapped("sii_enabled"))
         for partner in self:
-            partner.sii_enabled = sii_enabled
+            partner.sii_enabled = (
+                partner.company_id.sii_enabled if partner.company_id else sii_enabled
+            )

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -192,6 +192,13 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
     def test_job_creation(self):
         self.assertTrue(self.invoice.invoice_jobs_ids)
 
+    def test_partner_sii_enabled(self):
+        company_02 = self.env["res.company"].create({"name": "Company 02"})
+        self.env.user.company_ids += company_02
+        self.assertTrue(self.partner.sii_enabled)
+        self.partner.company_id = company_02
+        self.assertFalse(self.partner.sii_enabled)
+
     def test_get_invoice_data(self):
         mapping = [
             ("out_invoice", [(100, ["s_iva10b"]), (200, ["s_iva21s"])], {}),

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -321,6 +321,12 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
             invoice_temp.sii_description, "Test customer header | Test line",
         )
 
+    def test_vat_number_check(self):
+        self.partner.write(
+            {"vat": "F35999705", "country_id": self.env.ref("base.es").id}
+        )
+        self.test_get_invoice_data()
+
     def _activate_certificate(self, passwd=None):
         """  Obtain Keys from .pfx and activate the cetificate """
         if passwd:


### PR DESCRIPTION
Aprovechamos la misma lógica que hay en `l10n_es_aeat`. Añado un test para que se vea.