### PR TITLE
[11.0][FIX] l10n_es_vat_book: Recargo de equivalencia en Excel

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -370,10 +370,12 @@ class L10nEsVatBook(models.Model):
             # clean the old records
             rec._clear_old_data()
 
-            map_lines = self.env["aeat.vat.book.map.line"].search([])
-
-            for map_line in map_lines:
-                taxes = map_line.get_taxes(rec)
+            for book_type in ["issued", "received"]:
+                map_lines = self.env["aeat.vat.book.map.line"].search(
+                    [("book_type", "=", book_type)])
+                taxes = self.env["account.tax"]
+                for map_line in map_lines:
+                    taxes |= map_line.get_taxes(rec)
                 lines = rec._get_account_move_lines(taxes)
                 rec.create_vat_book_lines(lines, map_line.book_type, taxes)
 


### PR DESCRIPTION
Hola,

Desde que se ha subido la modificación en el libro de iva para el desarrollo del libro de iva de OSS, los recargos de equivalencia aparecen en un registro completo nuevo en los pdf y pantalla y no aparecen en la exportación a Excel, se recupera la visualización anterior, para la que está preparado el código, respetando el cambio necesario para el OSS.  Habría que meterlo para todas las versiones para las que se ha includo el l10n_es_vat_book_oss.
El commit concreto desde el que falla es: https://github.com/OCA/l10n-spain/commit/f781d7a2a76c7ae550434750063c7c5092f61024
Un saludo