### PR TITLE
[13.0][IMP] l10n_es_aeat_sii_oca + l10n_es_facturae: Hide thirdparty fields in some cases

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_journal.py
+++ b/l10n_es_aeat_sii_oca/models/account_journal.py
@@ -24,7 +24,12 @@ class AccountFiscalPosition(models.Model):
             if node:
                 return res
             for node in doc.xpath("//field[@name='type']"):
-                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                attrs = {
+                    "invisible": [("type", "not in", ("sale", "purchase"))],
+                }
+                elem = etree.Element(
+                    "field", {"name": "thirdparty_invoice", "attrs": str(attrs)}
+                )
                 node.addnext(elem)
             res["arch"] = etree.tostring(doc)
             xarch, xfields = self.env["ir.ui.view"].postprocess_and_fields(

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -1531,7 +1531,20 @@ class AccountMove(models.Model):
                 transfer_modifiers_to_node(modifiers, elem)
                 node.addnext(elem)
                 res["fields"].update(self.fields_get(["thirdparty_number"]))
-                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                attrs = {
+                    "invisible": [
+                        (
+                            "type",
+                            "not in",
+                            ("in_invoice", "out_invoice", "out_refund", "in_refund"),
+                        )
+                    ],
+                }
+                elem = etree.Element(
+                    "field", {"name": "thirdparty_invoice", "attrs": str(attrs)}
+                )
+                transfer_node_to_modifiers(elem, modifiers)
+                transfer_modifiers_to_node(modifiers, elem)
                 node.addnext(elem)
                 res["fields"].update(self.fields_get(["thirdparty_invoice"]))
             res["arch"] = etree.tostring(doc)

--- a/l10n_es_facturae/models/account_journal.py
+++ b/l10n_es_facturae/models/account_journal.py
@@ -24,7 +24,12 @@ class AccountJournal(models.Model):
             if node:
                 return res
             for node in doc.xpath("//field[@name='type']"):
-                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                attrs = {
+                    "invisible": [("type", "not in", ("sale", "purchase"))],
+                }
+                elem = etree.Element(
+                    "field", {"name": "thirdparty_invoice", "attrs": str(attrs)}
+                )
                 node.addnext(elem)
             res["arch"] = etree.tostring(doc)
             xarch, xfields = self.env["ir.ui.view"].postprocess_and_fields(

--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -539,7 +539,20 @@ class AccountMove(models.Model):
                 transfer_modifiers_to_node(modifiers, elem)
                 node.addnext(elem)
                 res["fields"].update(self.fields_get(["thirdparty_number"]))
-                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                attrs = {
+                    "invisible": [
+                        (
+                            "type",
+                            "not in",
+                            ("in_invoice", "out_invoice", "out_refund", "in_refund"),
+                        )
+                    ],
+                }
+                elem = etree.Element(
+                    "field", {"name": "thirdparty_invoice", "attrs": str(attrs)}
+                )
+                transfer_node_to_modifiers(elem, modifiers)
+                transfer_modifiers_to_node(modifiers, elem)
                 node.addnext(elem)
                 res["fields"].update(self.fields_get(["thirdparty_invoice"]))
             res["arch"] = etree.tostring(doc)


### PR DESCRIPTION
Hide thirdparty fields in some cases: 

- Hide thirdparty fields in moves when it is not an invoice.
- Hide thirdparty field in journals when it is not sale/purchase type.

Please @chienandalu and @pedrobaeza can you review it?

@Tecnativa TT32612