### PR TITLE
[FIX] l10n_es_aeat_mod347: Error when adding a partner in the real estate registry

### DIFF
--- a/l10n_es_aeat_mod347/i18n/bg.po
+++ b/l10n_es_aeat_mod347/i18n/bg.po
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/ca.po
+++ b/l10n_es_aeat_mod347/i18n/ca.po
@@ -1464,7 +1464,7 @@ msgstr "Estat"
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr "Codi de província"
 

--- a/l10n_es_aeat_mod347/i18n/cs.po
+++ b/l10n_es_aeat_mod347/i18n/cs.po
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/es.po
+++ b/l10n_es_aeat_mod347/i18n/es.po
@@ -1363,7 +1363,7 @@ msgstr "Estado"
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr "Código de provincia"
 

--- a/l10n_es_aeat_mod347/i18n/es_CO.po
+++ b/l10n_es_aeat_mod347/i18n/es_CO.po
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/es_CR.po
+++ b/l10n_es_aeat_mod347/i18n/es_CR.po
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/eu.po
+++ b/l10n_es_aeat_mod347/i18n/eu.po
@@ -1323,7 +1323,7 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/fr.po
+++ b/l10n_es_aeat_mod347/i18n/fr.po
@@ -1335,7 +1335,7 @@ msgstr "État"
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/gl.po
+++ b/l10n_es_aeat_mod347/i18n/gl.po
@@ -1384,7 +1384,7 @@ msgstr "Provincia"
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr "Código de provincia"
 

--- a/l10n_es_aeat_mod347/i18n/hr.po
+++ b/l10n_es_aeat_mod347/i18n/hr.po
@@ -1327,7 +1327,7 @@ msgstr "Status"
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/l10n_es_aeat_mod347.pot
+++ b/l10n_es_aeat_mod347/i18n/l10n_es_aeat_mod347.pot
@@ -1274,7 +1274,7 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/nl.po
+++ b/l10n_es_aeat_mod347/i18n/nl.po
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/pl.po
+++ b/l10n_es_aeat_mod347/i18n/pl.po
@@ -1325,7 +1325,7 @@ msgstr "Stan"
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/pt.po
+++ b/l10n_es_aeat_mod347/i18n/pt.po
@@ -1324,7 +1324,7 @@ msgstr "Estado"
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/pt_BR.po
+++ b/l10n_es_aeat_mod347/i18n/pt_BR.po
@@ -1326,7 +1326,7 @@ msgstr "Estado"
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/ru.po
+++ b/l10n_es_aeat_mod347/i18n/ru.po
@@ -1327,7 +1327,7 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/sl.po
+++ b/l10n_es_aeat_mod347/i18n/sl.po
@@ -1330,7 +1330,7 @@ msgstr "Stanje"
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/sv.po
+++ b/l10n_es_aeat_mod347/i18n/sv.po
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/tr.po
+++ b/l10n_es_aeat_mod347/i18n/tr.po
@@ -1325,7 +1325,7 @@ msgstr "Durum"
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/i18n/vi.po
+++ b/l10n_es_aeat_mod347/i18n/vi.po
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #. module: l10n_es_aeat_mod347
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_partner_record__partner_state_code
-#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__state_code
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod347.field_l10n_es_aeat_mod347_real_estate_record__partner_state_code
 msgid "State Code"
 msgstr ""
 

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -679,17 +679,18 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
     city = fields.Char(string='City', size=30)
     township = fields.Char(string='Township', size=30)
     township_code = fields.Char(string='Township Code', size=5)
-    state_code = fields.Char(string='State Code', size=2)
+    partner_state_code = fields.Char(
+        string='State Code', oldname='state_code', size=2)
     postal_code = fields.Char(string='Postal code', size=5)
     check_ok = fields.Boolean(
         compute="_compute_check_ok", string='Record is OK',
         store=True, help='Checked if this record is OK',
     )
 
-    @api.depends('state_code')
+    @api.depends('partner_state_code')
     def _compute_check_ok(self):
         for record in self:
-            record.check_ok = bool(record.state_code)
+            record.check_ok = bool(record.partner_state_code)
 
     @api.onchange('partner_id')
     def _onchange_partner_id(self):

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -246,7 +246,7 @@
                     </group>
                         <group>
                             <field name="city"/>
-                            <field name="state_code"/>
+                            <field name="partner_state_code"/>
 
                         </group>
                         <group>


### PR DESCRIPTION
In model 347, in the real estate registration tab, when adding a new registration and trying to assign a partner, an error appears that the "partner_state_code" field does not exist