### PR TITLE
[12.0][FIX] l10n_es_aeat_mod390: Ajuste de impuestos

### DIFF
--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub06_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub06_data.xml
@@ -411,7 +411,7 @@
         <field name="sequence">35</field>
         <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
         <field name="name">10. Volumen de operaciones - Operaciones no sujetas por reglas de localización (excepto las incluidas en la casilla 126) [110]</field>
-        <field name="fixed_value">0</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 110).amount}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True"/>
         <field name="size">17</field>
@@ -454,7 +454,7 @@
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
     </record>
-    
+
     <record id="aeat_mod390_2021_sub06_export_line_39" model="aeat.model.export.config.line">
         <field name="sequence">39</field>
         <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>

--- a/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
+++ b/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
@@ -874,7 +874,7 @@
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="False"/>
-        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_s_iva0_e'), ref('l10n_es.account_tax_template_s_iva_e')])]"/>
+        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_s_iva0_e')])]"/>
     </record>
 
     <record id="aeat_mod390_map_line_105" model="l10n.es.aeat.map.tax.line">
@@ -886,6 +886,17 @@
         <field name="sum_type">both</field>
         <field name="inverse" eval="False"/>
         <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_s_iva0'), ref('l10n_es.account_tax_template_s_iva0_ns')])]"/>
+    </record>
+
+    <record id="aeat_mod390_map_line_110" model="l10n.es.aeat.map.tax.line">
+        <field name="map_parent_id" ref="aeat_mod390_map"/>
+        <field name="field_number">110</field>
+        <field name="name">Operaciones no sujetas por regla de localización (excepto las incluidas en la casilla 126)</field>
+        <field name="move_type">all</field>
+        <field name="field_type">base</field>
+        <field name="sum_type">both</field>
+        <field name="inverse" eval="False"/>
+        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_s_iva_e')])]"/>
     </record>
 
     <record id="aeat_mod390_map_line_102" model="l10n.es.aeat.map.tax.line">

--- a/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
+++ b/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
@@ -892,7 +892,7 @@
         <field name="map_parent_id" ref="aeat_mod390_map"/>
         <field name="field_number">102</field>
         <field name="name">Operaciones realizadas por sujetos pasivos acogidos al régimen especial del recargo de equivalencia</field>
-        <field name="move_type">regular</field>
+        <field name="move_type">all</field>
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="True"/>
@@ -903,7 +903,7 @@
         <field name="map_parent_id" ref="aeat_mod390_map"/>
         <field name="field_number">230</field>
         <field name="name">Adquisiciones interiores exentas</field>
-        <field name="move_type">regular</field>
+        <field name="move_type">all</field>
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="True"/>
@@ -914,7 +914,7 @@
         <field name="map_parent_id" ref="aeat_mod390_map"/>
         <field name="field_number">109</field>
         <field name="name">Adquisiciones intracomunitarias exentas</field>
-        <field name="move_type">regular</field>
+        <field name="move_type">all</field>
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="True"/>
@@ -925,7 +925,7 @@
         <field name="map_parent_id" ref="aeat_mod390_map"/>
         <field name="field_number">231</field>
         <field name="name">Importaciones exentas</field>
-        <field name="move_type">regular</field>
+        <field name="move_type">all</field>
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="False"/>
@@ -936,7 +936,7 @@
         <field name="map_parent_id" ref="aeat_mod390_map"/>
         <field name="field_number">232</field>
         <field name="name">Bases imponibles del IVA soportado no deducible</field>
-        <field name="move_type">regular</field>
+        <field name="move_type">all</field>
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="True"/>

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -121,11 +121,13 @@ class TestL10nEsAeatMod390Base(TestL10nEsAeatModBase):
         # Entregas intracomunitarias exentas
         ('103', 9800.0),
         # Exportaciones y otras operaciones exentas con derecho a deducción
-        ('104', 8200.0),
+        ('104', 4000.0),
         # Operaciones exentas sin derecho a deducción
         ('105', 5200),
         # Adquisiciones intracomunitarias exentas
         ('109', 0.0),
+        # Exportaciones y otras operaciones exentas con derecho a deducción
+        ('110', 4200.0),
         # IVA deducible en oper. corrientes de bienes y servicios - Base 4%
         ('190', 2100.0),
         # IVA deducible en oper. corrientes de bienes y servicios - Cuota 4%

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -141,11 +141,11 @@ class TestL10nEsAeatMod390Base(TestL10nEsAeatModBase):
         # IVA deducible en adquisiciones intracomu. bienes corrientes -Cuota 4%
         ('215', 12.0),
         # Adquisiciones interiores exentas
-        ('230', 1200),
+        ('230', 800),
         # Importaciones exentas
         ('231', 0.0),
         # Bases imponibles del IVA soportado no deducible
-        ('232', 1260),
+        ('232', 840),
         # Adquisiciones intracomunitarias de servicios - Base 4%
         ('545', 1200.0),
         # Adquisiciones intracomunitarias de servicios - Cuota 4%


### PR DESCRIPTION
Dos parches:

- *[FIX] l10n_es_aeat_mod390: Consider all moves (regular + refund) on certain fields*

  There are certain fields that doesn't split refunds and regular amounts, so we need to cover it in the same field, having refunds that decrease the amount on the field. The only currently applicable one is the field 230, as it's the only with mapped taxes, but this commit changes preventively other fields with currently no taxes to the same type in case anytime are populated.

-  *[FIX] l10n_es_aeat_mod390: Add field 110*

  The tax "Extracomunitario (servicios)" should go into this field instead of in field 104, as these are the cases for the 104 field:

  ```
- La suma total de las contraprestaciones correspondientes a exportaciones y operaciones asimiladas a la exportación o, en su defecto, los valores en el interior de las operaciones reseñadas (artículos 21 y 22 de la Ley del IVA.).
- El importe de las bases imponibles correspondientes a las devoluciones efectuadas durante el año como consecuencia de las exportaciones realizadas en régimen de viajeros.
- El importe de las operaciones exentas del Impuesto en virtud de lo dispuesto en los artículos 23 y 24 de la Ley del IVA.
- El importe de las prestaciones de servicios relacionadas con la importación y cuya contraprestación esté incluida en la base imponible de las importaciones.
- El importe de las prestaciones de servicios exentas realizadas en aplicación del régimen especial de las agencias de viajes (artículo 143 de la Ley del IVA).
  ```

  which neither of them fits with this case.

  On contrary, field 110 serves for this purpose:

  ```
  Se hará constar el importe de las entregas de bienes y prestaciones de servicios no sujetas por aplicación de las reglas de localización...
  ```

@Tecnativa TT34123 TT34160