### PR TITLE
[11.0][FIX] l10n_es_aeat_mod390: diseno de registro 2021

### DIFF
--- a/l10n_es_aeat_mod390/__manifest__.py
+++ b/l10n_es_aeat_mod390/__manifest__.py
@@ -45,10 +45,21 @@
         'data/aeat_export_mod390_2019_sub07_data.xml',
         'data/aeat_export_mod390_2019_sub08_data.xml',
         'data/aeat_export_mod390_2019_main_data.xml',
+        # 2021
+        'data/aeat_export_mod390_2021_sub01_data.xml',
+        'data/aeat_export_mod390_2021_sub02_data.xml',
+        'data/aeat_export_mod390_2021_sub03_data.xml',
+        'data/aeat_export_mod390_2021_sub04_data.xml',
+        'data/aeat_export_mod390_2021_sub05_data.xml',
+        'data/aeat_export_mod390_2021_sub06_data.xml',
+        'data/aeat_export_mod390_2021_sub07_data.xml',
+        'data/aeat_export_mod390_2021_sub08_data.xml',
+        'data/aeat_export_mod390_2021_main_data.xml',
         'data/tax_code_map_mod390_data.xml',
         'views/mod390_view.xml',
         'security/ir.model.access.csv',
         'security/l10n_es_aeat_mod390_security.xml',
+
     ],
     'installable': True,
     'maintainers': [

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_main_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_main_data.xml
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2019 Tecnativa - Pedro M. Baeza
+<!-- Copyright 2021 Tecnativa - Pedro M. Baeza
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
 
-    <record id="aeat_mod390_2019_main_export_config" model="aeat.model.export.config">
-        <field name="name">Mod.390 2019-2020</field>
-        <field name="date_start">2019-01-01</field>
-        <field name="date_end">2020-12-31</field>
+    <record id="aeat_mod390_2021_main_export_config" model="aeat.model.export.config">
+        <field name="name">Mod.390 2021-actualidad</field>
+        <field name="date_start">2021-01-01</field>
         <field name="model_number">390</field>
         <field name="model_id" ref="model_l10n_es_aeat_mod390_report"/>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_01" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_01" model="aeat.model.export.config.line">
         <field name="sequence">1</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Constante: &lt;T</field>
         <field name="fixed_value">&lt;T</field>
         <field name="export_type">string</field>
@@ -21,9 +20,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_02" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_02" model="aeat.model.export.config.line">
         <field name="sequence">2</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Constante: 390</field>
         <field name="fixed_value">390</field>
         <field name="export_type">string</field>
@@ -31,9 +30,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_03" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_03" model="aeat.model.export.config.line">
         <field name="sequence">3</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Constante: 0</field>
         <field name="fixed_value">0</field>
         <field name="export_type">string</field>
@@ -41,9 +40,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_04" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_04" model="aeat.model.export.config.line">
         <field name="sequence">4</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Ejercicio devengo</field>
         <field name="expression">${object.year}</field>
         <field name="export_type">string</field>
@@ -51,9 +50,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_05" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_05" model="aeat.model.export.config.line">
         <field name="sequence">5</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Identificación Periodo</field>
         <field name="expression">${object.period_type}</field>
         <field name="export_type">string</field>
@@ -61,9 +60,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_06" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_06" model="aeat.model.export.config.line">
         <field name="sequence">6</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Constante: 0000&gt;</field>
         <field name="fixed_value">0000&gt;</field>
         <field name="export_type">string</field>
@@ -71,9 +70,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_07" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_07" model="aeat.model.export.config.line">
         <field name="sequence">7</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Constante: &lt;AUX&gt;</field>
         <field name="fixed_value">&lt;AUX&gt;</field>
         <field name="export_type">string</field>
@@ -81,9 +80,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_08" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_08" model="aeat.model.export.config.line">
         <field name="sequence">8</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Reservado para la Administración: Rellenar con blancos</field>
         <field name="fixed_value"/>
         <field name="export_type">string</field>
@@ -91,9 +90,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_09" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_09" model="aeat.model.export.config.line">
         <field name="sequence">9</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Versión del programa</field>
         <field name="fixed_value">odoo</field>
         <field name="export_type">string</field>
@@ -101,9 +100,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_10" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_10" model="aeat.model.export.config.line">
         <field name="sequence">10</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Reservado para la Administración. Rellenar con blancos</field>
         <field name="fixed_value"/>
         <field name="export_type">string</field>
@@ -111,9 +110,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_11" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_11" model="aeat.model.export.config.line">
         <field name="sequence">11</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">NIF Empresa Desarrollo</field>
         <field name="fixed_value">G87846952</field>
         <field name="export_type">string</field>
@@ -121,9 +120,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_12" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_12" model="aeat.model.export.config.line">
         <field name="sequence">12</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Reservado para la Administración. Rellenar con blancos</field>
         <field name="fixed_value"/>
         <field name="export_type">string</field>
@@ -131,9 +130,9 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_13" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_13" model="aeat.model.export.config.line">
         <field name="sequence">13</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Constante: &lt;/AUX&gt;</field>
         <field name="fixed_value">&lt;/AUX&gt;</field>
         <field name="export_type">string</field>
@@ -141,81 +140,81 @@
         <field name="alignment">left</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_14" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_14" model="aeat.model.export.config.line">
         <field name="sequence">14</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Contenido del fichero [sub01]</field>
         <field name="conditional_expression">True</field>
-        <field name="subconfig_id" ref="aeat_mod390_2019_sub01_export_config"/>
+        <field name="subconfig_id" ref="aeat_mod390_2021_sub01_export_config"/>
         <field name="export_type">subconfig</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_15" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_15" model="aeat.model.export.config.line">
         <field name="sequence">15</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Contenido del fichero [sub02]</field>
         <field name="conditional_expression">True</field>
-        <field name="subconfig_id" ref="aeat_mod390_2019_sub02_export_config"/>
+        <field name="subconfig_id" ref="aeat_mod390_2021_sub02_export_config"/>
         <field name="export_type">subconfig</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_16" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_16" model="aeat.model.export.config.line">
         <field name="sequence">16</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Contenido del fichero [sub03]</field>
         <field name="conditional_expression">True</field>
-        <field name="subconfig_id" ref="aeat_mod390_2019_sub03_export_config"/>
+        <field name="subconfig_id" ref="aeat_mod390_2021_sub03_export_config"/>
         <field name="export_type">subconfig</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_17" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_17" model="aeat.model.export.config.line">
         <field name="sequence">17</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Contenido del fichero [sub04]</field>
         <field name="conditional_expression">True</field>
-        <field name="subconfig_id" ref="aeat_mod390_2019_sub04_export_config"/>
+        <field name="subconfig_id" ref="aeat_mod390_2021_sub04_export_config"/>
         <field name="export_type">subconfig</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_18" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_18" model="aeat.model.export.config.line">
         <field name="sequence">18</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Contenido del fichero [sub05]</field>
         <field name="conditional_expression">False</field>
-        <field name="subconfig_id" ref="aeat_mod390_2019_sub05_export_config"/>
+        <field name="subconfig_id" ref="aeat_mod390_2021_sub05_export_config"/>
         <field name="export_type">subconfig</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_19" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_19" model="aeat.model.export.config.line">
         <field name="sequence">19</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Contenido del fichero [sub06]</field>
         <field name="conditional_expression">True</field>
-        <field name="subconfig_id" ref="aeat_mod390_2019_sub06_export_config"/>
+        <field name="subconfig_id" ref="aeat_mod390_2021_sub06_export_config"/>
         <field name="export_type">subconfig</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_20" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_20" model="aeat.model.export.config.line">
         <field name="sequence">20</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Contenido del fichero [sub07]</field>
         <field name="conditional_expression">True</field>
-        <field name="subconfig_id" ref="aeat_mod390_2019_sub07_export_config"/>
+        <field name="subconfig_id" ref="aeat_mod390_2021_sub07_export_config"/>
         <field name="export_type">subconfig</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_21" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_21" model="aeat.model.export.config.line">
         <field name="sequence">21</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Contenido del fichero [sub08]</field>
         <field name="conditional_expression">False</field>
-        <field name="subconfig_id" ref="aeat_mod390_2019_sub08_export_config"/>
+        <field name="subconfig_id" ref="aeat_mod390_2021_sub08_export_config"/>
         <field name="export_type">subconfig</field>
     </record>
 
-    <record id="aeat_mod390_2019_main_export_line_22" model="aeat.model.export.config.line">
+    <record id="aeat_mod390_2021_main_export_line_22" model="aeat.model.export.config.line">
         <field name="sequence">22</field>
-        <field name="export_config_id" ref="aeat_mod390_2019_main_export_config"/>
+        <field name="export_config_id" ref="aeat_mod390_2021_main_export_config"/>
         <field name="name">Constante: &lt;/T3900+Ejercicio+periodo+0000&gt;</field>
         <field name="expression">&lt;/T3900${object.year}${object.period_type}0000&gt;</field>
         <field name="export_type">string</field>

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub01_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub01_data.xml
@@ -1,0 +1,756 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="aeat_mod390_2021_sub01_export_config" model="aeat.model.export.config">
+        <field name="name">Mod.390 2021 - Página 1</field>
+        <field name="model_number">390</field>
+        <field name="active" eval="False"/>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_01" model="aeat.model.export.config.line">
+        <field name="sequence">1</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Constante: &lt;T</field>
+        <field name="fixed_value">&lt;T</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_02" model="aeat.model.export.config.line">
+        <field name="sequence">2</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Constante: 390</field>
+        <field name="fixed_value">390</field>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_03" model="aeat.model.export.config.line">
+        <field name="sequence">3</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Página</field>
+        <field name="fixed_value">01</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_04" model="aeat.model.export.config.line">
+        <field name="sequence">4</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Constante: 000&gt;</field>
+        <field name="fixed_value">000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_05" model="aeat.model.export.config.line">
+        <field name="sequence">5</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Indicador de página complementaria: En blanco</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_06" model="aeat.model.export.config.line">
+        <field name="sequence">6</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco)</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_07" model="aeat.model.export.config.line">
+        <field name="sequence">7</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Identificación: NIF</field>
+        <field name="expression">${object.company_vat}</field>
+        <field name="export_type">string</field>
+        <field name="size">9</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_08" model="aeat.model.export.config.line">
+        <field name="sequence">8</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Identificación: Denominación o Apellidos</field>
+        <field name="expression">${object.company_id.name}</field>
+        <field name="export_type">string</field>
+        <field name="size">60</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_09" model="aeat.model.export.config.line">
+        <field name="sequence">9</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Identificación: Nombre</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">20</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_10" model="aeat.model.export.config.line">
+        <field name="sequence">10</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Identificación: Ejercicio</field>
+        <field name="expression">${object.year}</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_11" model="aeat.model.export.config.line">
+        <field name="sequence">11</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco)</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_12" model="aeat.model.export.config.line">
+        <field name="sequence">12</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">1. Sujeto pasivo - Registro de devolución mensual.</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_13" model="aeat.model.export.config.line">
+        <field name="sequence">13</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">1. Sujeto pasivo - Regimen especial del grupo de entidades</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_14" model="aeat.model.export.config.line">
+        <field name="sequence">14</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">1. Sujeto pasivo - Número de grupo</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">7</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_15" model="aeat.model.export.config.line">
+        <field name="sequence">15</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">1. Sujeto pasivo - dominante?</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_16" model="aeat.model.export.config.line">
+        <field name="sequence">16</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">1. Sujeto pasivo - dependiente?</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_17" model="aeat.model.export.config.line">
+        <field name="sequence">17</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">1. Sujeto pasivo - Tipo régimen especial aplicable. Art 163 sexies.cinco. Si o No</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_18" model="aeat.model.export.config.line">
+        <field name="sequence">18</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">1. Sujeto pasivo - NIF entidad dominante</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">9</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_19" model="aeat.model.export.config.line">
+        <field name="sequence">19</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">1. Sujeto pasivo - Concurso acreedores en este ejercicio</field>
+        <field name="fixed_value">2</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_20" model="aeat.model.export.config.line">
+        <field name="sequence">20</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">1. Sujeto pasivo - Regimen especial del criterio de caja</field>
+        <field name="fixed_value">2</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_21" model="aeat.model.export.config.line">
+        <field name="sequence">21</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">1. Sujeto pasivo - Ha sido destinatario del régimen especial del criterio de caja</field>
+        <field name="fixed_value">2</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_22" model="aeat.model.export.config.line">
+        <field name="sequence">22</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">2. Devengo - Sustitutiva?</field>
+        <field name="expression">${object.type == 'S'}</field>
+        <field name="export_type">boolean</field>
+        <field name="size">1</field>
+        <field name="bool_yes">1</field>
+        <field name="bool_no">0</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_23" model="aeat.model.export.config.line">
+        <field name="sequence">23</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">2. Devengo - Sustitutiva por rectificación de cuotas?</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_24" model="aeat.model.export.config.line">
+        <field name="sequence">24</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">2. Devengo - Nº justificante declaración anterior</field>
+        <field name="expression">${object.previous_number if object.type in ('S', 'SF') else ''}</field>
+        <field name="export_type">string</field>
+        <field name="size">13</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_25" model="aeat.model.export.config.line">
+        <field name="sequence">25</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - A - Actividades - Principal</field>
+        <field name="expression">${object.main_activity}</field>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_26" model="aeat.model.export.config.line">
+        <field name="sequence">26</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - B - Clave - Principal</field>
+        <field name="expression">${object.main_activity_code}</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_27" model="aeat.model.export.config.line">
+        <field name="sequence">27</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - C -Epígrafe I.A.E. - Principal</field>
+        <field name="expression">${object.main_activity_iae}</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_28" model="aeat.model.export.config.line">
+        <field name="sequence">28</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - A - Actividades - Otras - 1ª</field>
+        <field name="expression">${object.other_first_activity}</field>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_29" model="aeat.model.export.config.line">
+        <field name="sequence">29</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - B - Clave - Otras 1ª</field>
+        <field name="expression">${object.other_first_activity_code or '0'}</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_30" model="aeat.model.export.config.line">
+        <field name="sequence">30</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - C -Epígrafe I.A.E. - Otras 1º</field>
+        <field name="expression">${object.other_first_activity_iae}</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_31" model="aeat.model.export.config.line">
+        <field name="sequence">31</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - A - Actividades - Otras - 2ª</field>
+        <field name="expression">${object.other_second_activity}</field>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_32" model="aeat.model.export.config.line">
+        <field name="sequence">32</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - B - Clave - Otras 2ª</field>
+        <field name="expression">${object.other_second_activity_code or '0'}</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_33" model="aeat.model.export.config.line">
+        <field name="sequence">33</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - C -Epígrafe I.A.E. - Otras 2º</field>
+        <field name="expression">${object.other_second_activity_iae}</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_34" model="aeat.model.export.config.line">
+        <field name="sequence">34</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - A - Actividades - Otras - 3ª</field>
+        <field name="expression">${object.other_third_activity}</field>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_35" model="aeat.model.export.config.line">
+        <field name="sequence">35</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - B - Clave - Otras 3ª</field>
+        <field name="expression">${object.other_third_activity_code or '0'}</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_36" model="aeat.model.export.config.line">
+        <field name="sequence">36</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - C -Epígrafe I.A.E. - Otras 3º</field>
+        <field name="expression">${object.other_third_activity_iae}</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_37" model="aeat.model.export.config.line">
+        <field name="sequence">37</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - A - Actividades - Otras - 4ª</field>
+        <field name="expression">${object.other_fourth_activity}</field>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_38" model="aeat.model.export.config.line">
+        <field name="sequence">38</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - B - Clave - Otras 4ª</field>
+        <field name="expression">${object.other_fourth_activity_code or '0'}</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_39" model="aeat.model.export.config.line">
+        <field name="sequence">39</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - C -Epígrafe I.A.E. - Otras 4º</field>
+        <field name="expression">${object.other_fourth_activity_iae}</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_40" model="aeat.model.export.config.line">
+        <field name="sequence">40</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - A - Actividades - Otras - 5ª</field>
+        <field name="expression">${object.other_fifth_activity}</field>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_41" model="aeat.model.export.config.line">
+        <field name="sequence">41</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - B - Clave - Otras 5ª</field>
+        <field name="expression">${object.other_fifth_activity_code or '0'}</field>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_42" model="aeat.model.export.config.line">
+        <field name="sequence">42</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - C -Epígrafe I.A.E. - Otras 5º</field>
+        <field name="expression">${object.other_fifth_activity_iae}</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_43" model="aeat.model.export.config.line">
+        <field name="sequence">43</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - D - Declaración anual operac. con terceras personas.</field>
+        <field name="expression">${object.has_347}</field>
+        <field name="export_type">boolean</field>
+        <field name="size">1</field>
+        <field name="bool_yes">1</field>
+        <field name="bool_no">0</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_44" model="aeat.model.export.config.line">
+        <field name="sequence">44</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - Declaración conjunta - NIF.</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">9</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_45" model="aeat.model.export.config.line">
+        <field name="sequence">45</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">3. Datos estadísticos - Declaración conjunta - Razón social</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">37</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_46" model="aeat.model.export.config.line">
+        <field name="sequence">46</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - NIF.</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">9</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_47" model="aeat.model.export.config.line">
+        <field name="sequence">47</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Apellidos y Nombre/Razón social</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">80</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_48" model="aeat.model.export.config.line">
+        <field name="sequence">48</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Calle/Pza./Avda.</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_49" model="aeat.model.export.config.line">
+        <field name="sequence">49</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Nombre de la vía pública</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">17</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_50" model="aeat.model.export.config.line">
+        <field name="sequence">50</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Número</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">5</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_51" model="aeat.model.export.config.line">
+        <field name="sequence">51</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Esc.</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_52" model="aeat.model.export.config.line">
+        <field name="sequence">52</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Piso</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_53" model="aeat.model.export.config.line">
+        <field name="sequence">53</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Prta.</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_54" model="aeat.model.export.config.line">
+        <field name="sequence">54</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Teléfono</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">9</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_55" model="aeat.model.export.config.line">
+        <field name="sequence">55</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Municipio</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">20</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_56" model="aeat.model.export.config.line">
+        <field name="sequence">56</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Provincia</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">15</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_57" model="aeat.model.export.config.line">
+        <field name="sequence">57</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Físicas/Comunid. Bienes - Represent. - Código Postal</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">5</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_58" model="aeat.model.export.config.line">
+        <field name="sequence">58</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 1 - Nombre y Apellidos</field>
+        <field name="expression">${object.first_representative_name}</field>
+        <field name="export_type">string</field>
+        <field name="size">80</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_59" model="aeat.model.export.config.line">
+        <field name="sequence">59</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 1 - NIF</field>
+        <field name="expression">${object.first_representative_vat}</field>
+        <field name="export_type">string</field>
+        <field name="size">9</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_60" model="aeat.model.export.config.line">
+        <field name="sequence">60</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 1 - Fecha Poder (DDMMAAAA)</field>
+        <field name="expression">${object._get_formatted_date(object.first_representative_date) or '00000000'}</field>
+        <field name="export_type">string</field>
+        <field name="size">8</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_61" model="aeat.model.export.config.line">
+        <field name="sequence">61</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 1 - Notaría</field>
+        <field name="expression">${object.first_representative_notary}</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_62" model="aeat.model.export.config.line">
+        <field name="sequence">62</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 2 - Nombre y Apellidos</field>
+        <field name="expression">${object.second_representative_name}</field>
+        <field name="export_type">string</field>
+        <field name="size">80</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_63" model="aeat.model.export.config.line">
+        <field name="sequence">63</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 2 - NIF</field>
+        <field name="expression">${object.second_representative_vat}</field>
+        <field name="export_type">string</field>
+        <field name="size">9</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_64" model="aeat.model.export.config.line">
+        <field name="sequence">64</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 2 - Fecha Poder (DDMMAAAA)</field>
+        <field name="expression">${object._get_formatted_date(object.second_representative_date) or '00000000'}</field>
+        <field name="export_type">string</field>
+        <field name="size">8</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_65" model="aeat.model.export.config.line">
+        <field name="sequence">65</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 2 - Notaría</field>
+        <field name="expression">${object.second_representative_notary}</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_66" model="aeat.model.export.config.line">
+        <field name="sequence">66</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 3 - Nombre y Apellidos</field>
+        <field name="expression">${object.third_representative_name}</field>
+        <field name="export_type">string</field>
+        <field name="size">80</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_67" model="aeat.model.export.config.line">
+        <field name="sequence">67</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 3 - NIF</field>
+        <field name="expression">${object.third_representative_vat}</field>
+        <field name="export_type">string</field>
+        <field name="size">9</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_68" model="aeat.model.export.config.line">
+        <field name="sequence">68</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 3 - Fecha Poder (DDMMAAAA)</field>
+        <field name="expression">${object._get_formatted_date(object.third_representative_date) or '00000000'}</field>
+        <field name="export_type">string</field>
+        <field name="size">8</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_69" model="aeat.model.export.config.line">
+        <field name="sequence">69</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">4. Representante - Personas Jurídicas - Represent. 3 - Notaría</field>
+        <field name="expression">${object.third_representative_notary}</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_70" model="aeat.model.export.config.line">
+        <field name="sequence">70</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco) Incluye Nº Referencia PADRE's</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">21</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_71" model="aeat.model.export.config.line">
+        <field name="sequence">71</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco) Sello electrónico</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">13</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_72" model="aeat.model.export.config.line">
+        <field name="sequence">72</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Identificador cliente EEDD. Reservado para las EEDD.</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">20</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_73" model="aeat.model.export.config.line">
+        <field name="sequence">73</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco)</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">150</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub01_export_line_74" model="aeat.model.export.config.line">
+        <field name="sequence">74</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub01_export_config"/>
+        <field name="name">Indicador de fin de registro: &lt;/T39001000&gt;</field>
+        <field name="fixed_value">&lt;/T39001000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+</odoo>

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub02_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub02_data.xml
@@ -1,0 +1,814 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="aeat_mod390_2021_sub02_export_config" model="aeat.model.export.config">
+        <field name="name">Mod.390 2021 - Página 2</field>
+        <field name="model_number">390</field>
+        <field name="active" eval="False"/>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_01" model="aeat.model.export.config.line">
+        <field name="sequence">1</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">Constante: &lt;T</field>
+        <field name="fixed_value">&lt;T</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_02" model="aeat.model.export.config.line">
+        <field name="sequence">2</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">Constante: 390</field>
+        <field name="fixed_value">390</field>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_03" model="aeat.model.export.config.line">
+        <field name="sequence">3</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">Página</field>
+        <field name="fixed_value">02</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_04" model="aeat.model.export.config.line">
+        <field name="sequence">4</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">Constante: 000&gt;</field>
+        <field name="fixed_value">000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_05" model="aeat.model.export.config.line">
+        <field name="sequence">5</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">Indicador de página complementaria: En blanco</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_06" model="aeat.model.export.config.line">
+        <field name="sequence">6</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. ordin. - Base imponible [01]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 1).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_07" model="aeat.model.export.config.line">
+        <field name="sequence">7</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. ordin. - Cuota [02]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 2).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_08" model="aeat.model.export.config.line">
+        <field name="sequence">8</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. ordin. - Base imponible [03]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 3).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_09" model="aeat.model.export.config.line">
+        <field name="sequence">9</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. ordin. - Cuota [04]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 4).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_10" model="aeat.model.export.config.line">
+        <field name="sequence">10</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. ordin. - Base imponible [05]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 5).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_11" model="aeat.model.export.config.line">
+        <field name="sequence">11</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. ordin. - Cuota [06]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 6).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_12" model="aeat.model.export.config.line">
+        <field name="sequence">12</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - operaciones intragrupo - Base imponible [500]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_13" model="aeat.model.export.config.line">
+        <field name="sequence">13</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - operaciones intragrupo - Cuota [501]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_14" model="aeat.model.export.config.line">
+        <field name="sequence">14</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - operaciones intragrupo - Base imponible [502]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_15" model="aeat.model.export.config.line">
+        <field name="sequence">15</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - operaciones intragrupo - Cuota [503]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_16" model="aeat.model.export.config.line">
+        <field name="sequence">16</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - operaciones intragrupo - Base imponible [504]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_17" model="aeat.model.export.config.line">
+        <field name="sequence">17</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - operaciones intragrupo - Cuota [505]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_18" model="aeat.model.export.config.line">
+        <field name="sequence">18</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - regimen especial criterio caja - Base imponible [643]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_19" model="aeat.model.export.config.line">
+        <field name="sequence">19</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - regimen especial criterio caja - Cuota [644]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_20" model="aeat.model.export.config.line">
+        <field name="sequence">20</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - regimen especial criterio caja - Base imponible [645]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_21" model="aeat.model.export.config.line">
+        <field name="sequence">21</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - regimen especial criterio caja - Cuota [646]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_22" model="aeat.model.export.config.line">
+        <field name="sequence">22</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - regimen especial criterio caja - Base imponible [647]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_23" model="aeat.model.export.config.line">
+        <field name="sequence">23</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base imponible y cuota - regimen especial criterio caja - Cuota [648]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_24" model="aeat.model.export.config.line">
+        <field name="sequence">24</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. espec. bienes usados - Base imponible [07]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_25" model="aeat.model.export.config.line">
+        <field name="sequence">25</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. espec. bienes usados - Cuota [08]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_26" model="aeat.model.export.config.line">
+        <field name="sequence">26</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. espec. bienes usados - Base imponible [09]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_27" model="aeat.model.export.config.line">
+        <field name="sequence">27</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. espec. bienes usados - Cuota [10]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_28" model="aeat.model.export.config.line">
+        <field name="sequence">28</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. espec. bienes usados - Base imponible [11]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_29" model="aeat.model.export.config.line">
+        <field name="sequence">29</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. espec. bienes usados - Cuota [12]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_30" model="aeat.model.export.config.line">
+        <field name="sequence">30</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. espec. agencias viajes - Base imponible [13]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_31" model="aeat.model.export.config.line">
+        <field name="sequence">31</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Reg. espec. agencias viajes - Cuota [14]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_32" model="aeat.model.export.config.line">
+        <field name="sequence">32</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. bienes - Base imponible [21]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 21).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_33" model="aeat.model.export.config.line">
+        <field name="sequence">33</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. bienes - Cuota [22]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 22).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_34" model="aeat.model.export.config.line">
+        <field name="sequence">34</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. bienes - Base imponible [23]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 23).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_35" model="aeat.model.export.config.line">
+        <field name="sequence">35</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. bienes - Cuota [24]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 24).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_36" model="aeat.model.export.config.line">
+        <field name="sequence">36</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. bienes - Base imponible [25]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 25).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_37" model="aeat.model.export.config.line">
+        <field name="sequence">37</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. bienes - Cuota [26]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 26).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_38" model="aeat.model.export.config.line">
+        <field name="sequence">38</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. servicios - Base Imponible [545]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 545).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_39" model="aeat.model.export.config.line">
+        <field name="sequence">39</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. servicios - Cuota [546]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 546).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_40" model="aeat.model.export.config.line">
+        <field name="sequence">40</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. servicios - Base Imponible [547]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 547).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_41" model="aeat.model.export.config.line">
+        <field name="sequence">41</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. servicios - Cuota [548]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 548).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_42" model="aeat.model.export.config.line">
+        <field name="sequence">42</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. servicios - Base Imponible [551]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 551).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_43" model="aeat.model.export.config.line">
+        <field name="sequence">43</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Adquis. intracomunit. servicios - Cuota [552]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 552).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_44" model="aeat.model.export.config.line">
+        <field name="sequence">44</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - IVA deveng. invers. sujeto pasivo - Base imponible [27]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 27).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_45" model="aeat.model.export.config.line">
+        <field name="sequence">45</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - IVA deveng. invers. sujeto pasivo - Cuota [28]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 28).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_46" model="aeat.model.export.config.line">
+        <field name="sequence">46</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Modificac. bases y cuotas - Base imponible [29]</field>
+        <field name="expression">${sum(object.tax_line_ids.filtered(lambda r: r.field_number == 29).mapped('amount'))}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_47" model="aeat.model.export.config.line">
+        <field name="sequence">47</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Modificac. bases y cuotas - Cuota [30]</field>
+        <field name="expression">${sum(object.tax_line_ids.filtered(lambda r: r.field_number == 30).mapped('amount'))}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_48" model="aeat.model.export.config.line">
+        <field name="sequence">48</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Modificac. bases y cuotas intragrupo - Cuota [649]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_49" model="aeat.model.export.config.line">
+        <field name="sequence">49</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Modificac. bases y cuotas intragrupo - Cuota [650]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_50" model="aeat.model.export.config.line">
+        <field name="sequence">50</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Modificac. bases/cuotas concurso acreedores - Base imponible [31]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_51" model="aeat.model.export.config.line">
+        <field name="sequence">51</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Modificac. bases/cuotas concurso acreedores - Cuota [32]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_52" model="aeat.model.export.config.line">
+        <field name="sequence">52</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Total bases y cuotas IVA - Base imponible [33]</field>
+        <field name="expression">${object.casilla_33}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_53" model="aeat.model.export.config.line">
+        <field name="sequence">53</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Total bases y cuotas IVA - Cuota [34]</field>
+        <field name="expression">${object.casilla_34}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_54" model="aeat.model.export.config.line">
+        <field name="sequence">54</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Recargo de equivalencia - Base imponible [35]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 35).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_55" model="aeat.model.export.config.line">
+        <field name="sequence">55</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Recargo de equivalencia - Cuota [36]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 36).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_56" model="aeat.model.export.config.line">
+        <field name="sequence">56</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Recargo de equivalencia - Base imponible [599]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 599).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_57" model="aeat.model.export.config.line">
+        <field name="sequence">57</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Recargo de equivalencia - Cuota [600]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 600).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_58" model="aeat.model.export.config.line">
+        <field name="sequence">58</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Recargo de equivalencia - Base imponible [601]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 601).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_59" model="aeat.model.export.config.line">
+        <field name="sequence">59</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Recargo de equivalencia - Cuota [602]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 602).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_60" model="aeat.model.export.config.line">
+        <field name="sequence">60</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Recargo de equivalencia - Base imponible [41]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 41).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_61" model="aeat.model.export.config.line">
+        <field name="sequence">61</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Recargo de equivalencia - Cuota [42]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 42).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_62" model="aeat.model.export.config.line">
+        <field name="sequence">62</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Modific. recargo equivalencia - Base imponible [43]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 43).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_63" model="aeat.model.export.config.line">
+        <field name="sequence">63</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Modific. recargo equivalencia - Cuota [44]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 44).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_64" model="aeat.model.export.config.line">
+        <field name="sequence">64</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Modific. recargo equiv. Concurso acreedores - Base imponible [45]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_65" model="aeat.model.export.config.line">
+        <field name="sequence">65</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Modific. recargo equiv. Concurso acreedores - Cuota [46]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_66" model="aeat.model.export.config.line">
+        <field name="sequence">66</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Base Imponible y cuota - Total cuotas IVA y recargo equivalencia [47]</field>
+        <field name="expression">${object.casilla_47}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_67" model="aeat.model.export.config.line">
+        <field name="sequence">67</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco)</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">150</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub02_export_line_68" model="aeat.model.export.config.line">
+        <field name="sequence">68</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub02_export_config"/>
+        <field name="name">Indicador de fin de registro: &lt;/T39002000&gt;</field>
+        <field name="fixed_value">&lt;/T39002000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+</odoo>

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub03_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub03_data.xml
@@ -1,0 +1,946 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017-2021 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="aeat_mod390_2021_sub03_export_config" model="aeat.model.export.config">
+        <field name="name">Mod.390 2021 - Página 3</field>
+        <field name="model_number">390</field>
+        <field name="active" eval="False"/>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_01" model="aeat.model.export.config.line">
+        <field name="sequence">1</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">Constante: &lt;T</field>
+        <field name="fixed_value">&lt;T</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_02" model="aeat.model.export.config.line">
+        <field name="sequence">2</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">Constante: 390</field>
+        <field name="fixed_value">390</field>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_03" model="aeat.model.export.config.line">
+        <field name="sequence">3</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">Página</field>
+        <field name="fixed_value">03</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_04" model="aeat.model.export.config.line">
+        <field name="sequence">4</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">Constante: 000&gt;</field>
+        <field name="fixed_value">000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_05" model="aeat.model.export.config.line">
+        <field name="sequence">5</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">Indicador de página complementaria: En blanco</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_06" model="aeat.model.export.config.line">
+        <field name="sequence">6</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. corrientes bienes y servic. - Base imponible [190]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 190).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_07" model="aeat.model.export.config.line">
+        <field name="sequence">7</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. corrientes bienes y servic. - Cuota [191]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 191).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_08" model="aeat.model.export.config.line">
+        <field name="sequence">8</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. corrientes bienes y servic. - Base imponible [603]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 603).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_09" model="aeat.model.export.config.line">
+        <field name="sequence">9</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. corrientes bienes y servic. - Cuota [604]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 604).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_10" model="aeat.model.export.config.line">
+        <field name="sequence">10</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. corrientes bienes y servic. - Base imponible [605]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 605).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_11" model="aeat.model.export.config.line">
+        <field name="sequence">11</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. corrientes bienes y servic. - Cuota [606]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 606).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_12" model="aeat.model.export.config.line">
+        <field name="sequence">12</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total oper. inter. corrientes bienes y servic. - Base imponible [48]</field>
+        <field name="expression">${object.casilla_48}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_13" model="aeat.model.export.config.line">
+        <field name="sequence">13</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total oper. inter. corrientes bienes y servic. - Cuota [49]</field>
+        <field name="expression">${object.casilla_49}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_14" model="aeat.model.export.config.line">
+        <field name="sequence">14</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intragrupo corrientes - Base imponible [506]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_15" model="aeat.model.export.config.line">
+        <field name="sequence">15</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intragrupo corrientes - Cuota [507]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_16" model="aeat.model.export.config.line">
+        <field name="sequence">16</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intragrupo corrientes - Base imponible [607]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_17" model="aeat.model.export.config.line">
+        <field name="sequence">17</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intragrupo corrientes - Cuota [608]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_18" model="aeat.model.export.config.line">
+        <field name="sequence">18</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intragrupo corrientes - Base imponible [609]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_19" model="aeat.model.export.config.line">
+        <field name="sequence">19</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intragrupo corrientes - Cuota [610]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_20" model="aeat.model.export.config.line">
+        <field name="sequence">20</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total oper. intragrupo corrientes - Base imponible [512]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_21" model="aeat.model.export.config.line">
+        <field name="sequence">21</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total oper. intragrupo corrientes - Cuota [513]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_22" model="aeat.model.export.config.line">
+        <field name="sequence">22</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. bienes de inversion - Base imponible [196]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 196).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_23" model="aeat.model.export.config.line">
+        <field name="sequence">23</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. bienes de inversion - Cuota [197]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 197).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_24" model="aeat.model.export.config.line">
+        <field name="sequence">24</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. bienes de inversion - Base imponible [611]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 611).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_25" model="aeat.model.export.config.line">
+        <field name="sequence">25</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. bienes de inversion - Cuota [612]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 612).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_26" model="aeat.model.export.config.line">
+        <field name="sequence">26</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. bienes de inversion - Base imponible [613]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 613).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_27" model="aeat.model.export.config.line">
+        <field name="sequence">27</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. inter. bienes de inversion - Cuota [614]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 614).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_28" model="aeat.model.export.config.line">
+        <field name="sequence">28</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total oper. inter. bienes de inversion - Base imponible [50]</field>
+        <field name="expression">${object.casilla_50}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_29" model="aeat.model.export.config.line">
+        <field name="sequence">29</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total oper. inter. bienes de inversion - Cuota [51]</field>
+        <field name="expression">${object.casilla_51}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_30" model="aeat.model.export.config.line">
+        <field name="sequence">30</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intra. bienes de inversion - Base imponible [514]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_31" model="aeat.model.export.config.line">
+        <field name="sequence">31</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intra. bienes de inversion - Cuota [515]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_32" model="aeat.model.export.config.line">
+        <field name="sequence">32</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intra. bienes de inversion - Base imponible [615]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_33" model="aeat.model.export.config.line">
+        <field name="sequence">33</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intra. bienes de inversion - Cuota [616]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_34" model="aeat.model.export.config.line">
+        <field name="sequence">34</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intra. bienes de inversion - Base imponible [617]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_35" model="aeat.model.export.config.line">
+        <field name="sequence">35</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Oper. intra. bienes de inversion - Cuota [618]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_36" model="aeat.model.export.config.line">
+        <field name="sequence">36</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total oper. intra. bienes de inversion - Base imponible [520]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_37" model="aeat.model.export.config.line">
+        <field name="sequence">37</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total oper. intra. bienes de inversion - Cuota [521]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_38" model="aeat.model.export.config.line">
+        <field name="sequence">38</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Import. bienes corrientes - Base imponible [202]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 202).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_39" model="aeat.model.export.config.line">
+        <field name="sequence">39</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Import. bienes corrientes - Cuota [203]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 203).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_40" model="aeat.model.export.config.line">
+        <field name="sequence">40</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Import. bienes corrientes - Base imponible [619]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 619).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_41" model="aeat.model.export.config.line">
+        <field name="sequence">41</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Import. bienes corrientes - Cuota [620]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 620).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_42" model="aeat.model.export.config.line">
+        <field name="sequence">42</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Import. bienes corrientes - Base imponible [621]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 621).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_43" model="aeat.model.export.config.line">
+        <field name="sequence">43</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Import. bienes corrientes - Cuota [622]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 622).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_44" model="aeat.model.export.config.line">
+        <field name="sequence">44</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total import. bienes corrientes - Base imponible [52]</field>
+        <field name="expression">${object.casilla_52}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_45" model="aeat.model.export.config.line">
+        <field name="sequence">45</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total import. bienes corrientes - Cuota [53]</field>
+        <field name="expression">${object.casilla_53}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_46" model="aeat.model.export.config.line">
+        <field name="sequence">46</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Importacion bienes inversion - Base imponible [208]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 208).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_47" model="aeat.model.export.config.line">
+        <field name="sequence">47</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Importacion bienes inversion - Cuota [209]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 209).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_48" model="aeat.model.export.config.line">
+        <field name="sequence">48</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Importacion bienes inversion - Base imponible [623]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 623).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_49" model="aeat.model.export.config.line">
+        <field name="sequence">49</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Importacion bienes inversion - Cuota [624]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 624).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_50" model="aeat.model.export.config.line">
+        <field name="sequence">50</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Importacion bienes inversion - Base imponible [625]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 625).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_51" model="aeat.model.export.config.line">
+        <field name="sequence">51</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Importacion bienes inversion - Cuota [626]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 626).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_52" model="aeat.model.export.config.line">
+        <field name="sequence">52</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total importacion bienes inversion - Base imponible [54]</field>
+        <field name="expression">${object.casilla_54}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_53" model="aeat.model.export.config.line">
+        <field name="sequence">53</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total importacion bienes inversion - Cuota [55]</field>
+        <field name="expression">${object.casilla_55}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_54" model="aeat.model.export.config.line">
+        <field name="sequence">54</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes corrientes - Base imponible [214]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 214).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_55" model="aeat.model.export.config.line">
+        <field name="sequence">55</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes corrientes - Cuota [215]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 215).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_56" model="aeat.model.export.config.line">
+        <field name="sequence">56</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes corrientes - Base imponible [627]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 627).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_57" model="aeat.model.export.config.line">
+        <field name="sequence">57</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes corrientes - Cuota [628]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 628).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_58" model="aeat.model.export.config.line">
+        <field name="sequence">58</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes corrientes - Base imponible [629]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 629).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_59" model="aeat.model.export.config.line">
+        <field name="sequence">59</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes corrientes - Cuota [630]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 630).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_60" model="aeat.model.export.config.line">
+        <field name="sequence">60</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total adqui. intra. bienes corrientes - Base imponible [56]</field>
+        <field name="expression">${object.casilla_56}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_61" model="aeat.model.export.config.line">
+        <field name="sequence">61</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total adqui. intra. bienes corrientes - Cuota [57]</field>
+        <field name="expression">${object.casilla_57}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_62" model="aeat.model.export.config.line">
+        <field name="sequence">62</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes inversion - Base imponible [220]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 220).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_63" model="aeat.model.export.config.line">
+        <field name="sequence">63</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes inversion - Cuota [221]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 221).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_64" model="aeat.model.export.config.line">
+        <field name="sequence">64</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes inversion - Base imponible [631]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 631).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_65" model="aeat.model.export.config.line">
+        <field name="sequence">65</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes inversion - Cuota [632]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 632).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_66" model="aeat.model.export.config.line">
+        <field name="sequence">66</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes inversion - Base imponible [633]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 633).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_67" model="aeat.model.export.config.line">
+        <field name="sequence">67</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. bienes inversion - Cuota [634]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 634).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_68" model="aeat.model.export.config.line">
+        <field name="sequence">68</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total adqui. intra. bienes inversion - Base imponible [58]</field>
+        <field name="expression">${object.casilla_58}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_69" model="aeat.model.export.config.line">
+        <field name="sequence">69</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total adqui. intra. bienes inversion - Cuota [59]</field>
+        <field name="expression">${object.casilla_59}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_70" model="aeat.model.export.config.line">
+        <field name="sequence">70</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. servicios - Base imponible [587]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 587).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_71" model="aeat.model.export.config.line">
+        <field name="sequence">71</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. servicios - Cuota [588]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 588).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_72" model="aeat.model.export.config.line">
+        <field name="sequence">72</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. servicios - Base imponible [635]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 635).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_73" model="aeat.model.export.config.line">
+        <field name="sequence">73</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. servicios - Cuota [636]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 636).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_74" model="aeat.model.export.config.line">
+        <field name="sequence">74</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. servicios - Base imponible [637]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 637).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_75" model="aeat.model.export.config.line">
+        <field name="sequence">75</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Adqui. intra. servicios - Cuota [638]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 638).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_76" model="aeat.model.export.config.line">
+        <field name="sequence">76</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total adqui. intra. servicios - Base imponible [597]</field>
+        <field name="expression">${object.casilla_597}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_77" model="aeat.model.export.config.line">
+        <field name="sequence">77</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Total adqui. intra. servicios - Cuota [598]</field>
+        <field name="expression">${object.casilla_598}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_78" model="aeat.model.export.config.line">
+        <field name="sequence">78</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco)</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">150</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub03_export_line_79" model="aeat.model.export.config.line">
+        <field name="sequence">79</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub03_export_config"/>
+        <field name="name">Indicador de fin de registro: &lt;/T39003000&gt;</field>
+        <field name="fixed_value">&lt;/T39003000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+</odoo>

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub04_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub04_data.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="aeat_mod390_2021_sub04_export_config" model="aeat.model.export.config">
+        <field name="name">Mod.390 2021 - Página 4</field>
+        <field name="model_number">390</field>
+        <field name="active" eval="False"/>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_01" model="aeat.model.export.config.line">
+        <field name="sequence">1</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">Constante: &lt;T</field>
+        <field name="fixed_value">&lt;T</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_02" model="aeat.model.export.config.line">
+        <field name="sequence">2</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">Constante: 390</field>
+        <field name="fixed_value">390</field>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_03" model="aeat.model.export.config.line">
+        <field name="sequence">3</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">Página</field>
+        <field name="fixed_value">04</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_04" model="aeat.model.export.config.line">
+        <field name="sequence">4</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">Constante: 000&gt;</field>
+        <field name="fixed_value">000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_05" model="aeat.model.export.config.line">
+        <field name="sequence">5</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">Indicador de página complementaria: En blanco</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_06" model="aeat.model.export.config.line">
+        <field name="sequence">6</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Compensac. rég. especial agric./ganad./pesca - Base impon. [60]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_07" model="aeat.model.export.config.line">
+        <field name="sequence">7</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Compensac. rég. especial agric./ganad./pesca - Cuota deduc. [61]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_08" model="aeat.model.export.config.line">
+        <field name="sequence">8</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Cuotas deducibles en virtud de resolución administrativa o sentencia firmes con tipos no vigentes - Base impon.  [660]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_09" model="aeat.model.export.config.line">
+        <field name="sequence">8</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Cuotas deducibles en virtud de resolución administrativa o sentencia firmes con tipos no vigentes - Cuota deduc. [661]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_10" model="aeat.model.export.config.line">
+        <field name="sequence">10</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Rectificación de deducciones - Base imponible [639]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 639).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_11" model="aeat.model.export.config.line">
+        <field name="sequence">11</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Rectificación de deducciones - Cuota [62]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 62).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_12" model="aeat.model.export.config.line">
+        <field name="sequence">12</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Rectificación de deducciones intragrupo - Base impon. [651]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_13" model="aeat.model.export.config.line">
+        <field name="sequence">13</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Rectificación de deducciones intragrupo - Cuota [652]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_14" model="aeat.model.export.config.line">
+        <field name="sequence">14</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Regularización de inversiones [63]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_15" model="aeat.model.export.config.line">
+        <field name="sequence">15</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Regularización por aplicación porcentaje definitivo de prorrata [522]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_16" model="aeat.model.export.config.line">
+        <field name="sequence">16</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - IVA deducible - Suma de deducciones [64]</field>
+        <field name="expression">${object.casilla_64}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_17" model="aeat.model.export.config.line">
+        <field name="sequence">17</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">5. Operaciones Reg. Gral. - Resultado régimen general [65]</field>
+        <field name="expression">${object.casilla_65}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_18" model="aeat.model.export.config.line">
+        <field name="sequence">18</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco)</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">150</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub04_export_line_19" model="aeat.model.export.config.line">
+        <field name="sequence">19</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub04_export_config"/>
+        <field name="name">Indicador de fin de registro: &lt;/T39004000&gt;</field>
+        <field name="fixed_value">&lt;/T39004000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+</odoo>

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub05_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub05_data.xml
@@ -1,0 +1,1124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="aeat_mod390_2021_sub05_export_config" model="aeat.model.export.config">
+        <field name="name">Mod.390 2021 - Página 5</field>
+        <field name="model_number">390</field>
+        <field name="active" eval="False"/>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_01" model="aeat.model.export.config.line">
+        <field name="sequence">1</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">Constante: &lt;T</field>
+        <field name="fixed_value">&lt;T</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_02" model="aeat.model.export.config.line">
+        <field name="sequence">2</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">Constante: 390</field>
+        <field name="fixed_value">390</field>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_03" model="aeat.model.export.config.line">
+        <field name="sequence">3</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">Página</field>
+        <field name="fixed_value">05</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_04" model="aeat.model.export.config.line">
+        <field name="sequence">4</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">Constante: 000&gt;</field>
+        <field name="fixed_value">000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_05" model="aeat.model.export.config.line">
+        <field name="sequence">5</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">Indicador de página complementaria: En blanco</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_06" model="aeat.model.export.config.line">
+        <field name="sequence">6</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1  - Epígrafe I.A.E. [66]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_07" model="aeat.model.export.config.line">
+        <field name="sequence">7</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - A - Nº unidades Módulo 1</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_08" model="aeat.model.export.config.line">
+        <field name="sequence">8</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - B - Importe Módulo 1</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_09" model="aeat.model.export.config.line">
+        <field name="sequence">9</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - A - Nº unidades Módulo 2</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_10" model="aeat.model.export.config.line">
+        <field name="sequence">10</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - B - Importe Módulo 2</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_11" model="aeat.model.export.config.line">
+        <field name="sequence">11</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - A - Nº unidades Módulo 3</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_12" model="aeat.model.export.config.line">
+        <field name="sequence">12</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - B - Importe Módulo 3</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_13" model="aeat.model.export.config.line">
+        <field name="sequence">13</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - A - Nº unidades Módulo 4</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_14" model="aeat.model.export.config.line">
+        <field name="sequence">14</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - B - Importe Módulo 4</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_15" model="aeat.model.export.config.line">
+        <field name="sequence">15</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - A - Nº unidades Módulo 5</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_16" model="aeat.model.export.config.line">
+        <field name="sequence">16</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - B - Importe Módulo 5</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_17" model="aeat.model.export.config.line">
+        <field name="sequence">17</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - A - Nº unidades Módulo 6</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_18" model="aeat.model.export.config.line">
+        <field name="sequence">18</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - B - Importe Módulo 6</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_19" model="aeat.model.export.config.line">
+        <field name="sequence">19</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - A - Nº unidades Módulo 7</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_20" model="aeat.model.export.config.line">
+        <field name="sequence">20</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - B - Importe Módulo 7</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_21" model="aeat.model.export.config.line">
+        <field name="sequence">21</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - C- Cuota devengada operaciones corrientes</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_22" model="aeat.model.export.config.line">
+        <field name="sequence">22</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - Lorca</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_23" model="aeat.model.export.config.line">
+        <field name="sequence">23</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - D- Cuota soportadas operaciones corrientes</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_24" model="aeat.model.export.config.line">
+        <field name="sequence">24</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - E - Índice corrector</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">3</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_25" model="aeat.model.export.config.line">
+        <field name="sequence">25</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - F - Resultado</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_26" model="aeat.model.export.config.line">
+        <field name="sequence">26</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1- G - % Cuota mínima</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_27" model="aeat.model.export.config.line">
+        <field name="sequence">27</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1- H - Devolución cuotas soportadas otros países</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_28" model="aeat.model.export.config.line">
+        <field name="sequence">28</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1- I - Cuota mínima</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_29" model="aeat.model.export.config.line">
+        <field name="sequence">29</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 1 - Cuota derivada régimen simplificado [J1]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_30" model="aeat.model.export.config.line">
+        <field name="sequence">30</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2  - Epígrafe I.A.E. [66]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_31" model="aeat.model.export.config.line">
+        <field name="sequence">31</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - A - Nº unidades Módulo 1</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_32" model="aeat.model.export.config.line">
+        <field name="sequence">32</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - B - Importe Módulo 1</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_33" model="aeat.model.export.config.line">
+        <field name="sequence">33</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - A - Nº unidades Módulo 2</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_34" model="aeat.model.export.config.line">
+        <field name="sequence">34</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - B - Importe Módulo 2</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_35" model="aeat.model.export.config.line">
+        <field name="sequence">35</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - A - Nº unidades Módulo 3</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_36" model="aeat.model.export.config.line">
+        <field name="sequence">36</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - B - Importe Módulo 3</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_37" model="aeat.model.export.config.line">
+        <field name="sequence">37</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - A - Nº unidades Módulo 4</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_38" model="aeat.model.export.config.line">
+        <field name="sequence">38</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - B - Importe Módulo 4</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_39" model="aeat.model.export.config.line">
+        <field name="sequence">39</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - A - Nº unidades Módulo 5</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_40" model="aeat.model.export.config.line">
+        <field name="sequence">40</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - B - Importe Módulo 5</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_41" model="aeat.model.export.config.line">
+        <field name="sequence">41</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - A - Nº unidades Módulo 6</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_42" model="aeat.model.export.config.line">
+        <field name="sequence">42</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - B - Importe Módulo 6</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_43" model="aeat.model.export.config.line">
+        <field name="sequence">43</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - A - Nº unidades Módulo 7</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">10</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_44" model="aeat.model.export.config.line">
+        <field name="sequence">44</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - B - Importe Módulo 7</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_45" model="aeat.model.export.config.line">
+        <field name="sequence">45</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - C- Cuota devengada operaciones corrientes</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_46" model="aeat.model.export.config.line">
+        <field name="sequence">46</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - Lorca</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_47" model="aeat.model.export.config.line">
+        <field name="sequence">47</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - D- Cuota soportadas operaciones corrientes</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_48" model="aeat.model.export.config.line">
+        <field name="sequence">48</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - E - Índice corrector</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">3</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_49" model="aeat.model.export.config.line">
+        <field name="sequence">49</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - F - Resultado</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_50" model="aeat.model.export.config.line">
+        <field name="sequence">50</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2- G - % Cuota mínima</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_51" model="aeat.model.export.config.line">
+        <field name="sequence">51</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2- H - Devolución cuotas soportadas otros países</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_52" model="aeat.model.export.config.line">
+        <field name="sequence">52</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2- I - Cuota mínima</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_53" model="aeat.model.export.config.line">
+        <field name="sequence">53</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Actividad 2 - Cuota derivada régimen simplificado [J2]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_54" model="aeat.model.export.config.line">
+        <field name="sequence">54</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 1 -  Código</field>
+        <field name="fixed_value">00</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_55" model="aeat.model.export.config.line">
+        <field name="sequence">55</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 1 - Volumen  ingresos</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_56" model="aeat.model.export.config.line">
+        <field name="sequence">56</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 1 - Indice cuota</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">6</field>
+        <field name="decimal_size">5</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_57" model="aeat.model.export.config.line">
+        <field name="sequence">57</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 1 - Cuota devengada</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_58" model="aeat.model.export.config.line">
+        <field name="sequence">58</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 1 - Cuota soportada</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_59" model="aeat.model.export.config.line">
+        <field name="sequence">59</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 1 - Cuota derivada Regimen Simplificado [K1]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_60" model="aeat.model.export.config.line">
+        <field name="sequence">60</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 2 -  Código</field>
+        <field name="fixed_value">00</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_61" model="aeat.model.export.config.line">
+        <field name="sequence">61</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 2 - Volumen  ingresos</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_62" model="aeat.model.export.config.line">
+        <field name="sequence">62</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 2 - Indice cuota</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">6</field>
+        <field name="decimal_size">5</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_63" model="aeat.model.export.config.line">
+        <field name="sequence">63</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 2- Cuota devengada</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_64" model="aeat.model.export.config.line">
+        <field name="sequence">64</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 2 - Cuota soportada</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_65" model="aeat.model.export.config.line">
+        <field name="sequence">65</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 2 - Cuota derivada Regimen Simplificado [K2]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_66" model="aeat.model.export.config.line">
+        <field name="sequence">66</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 3 -  Código</field>
+        <field name="fixed_value">00</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_67" model="aeat.model.export.config.line">
+        <field name="sequence">67</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 3 - Volumen  ingresos</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_68" model="aeat.model.export.config.line">
+        <field name="sequence">68</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 3 - Indice cuota</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">6</field>
+        <field name="decimal_size">5</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_69" model="aeat.model.export.config.line">
+        <field name="sequence">69</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 3 - Cuota devengada</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_70" model="aeat.model.export.config.line">
+        <field name="sequence">70</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 3 - Cuota soportada</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_71" model="aeat.model.export.config.line">
+        <field name="sequence">71</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 3 - Cuota derivada Regimen Simplificado [K3]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_72" model="aeat.model.export.config.line">
+        <field name="sequence">72</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 4-  Código</field>
+        <field name="fixed_value">00</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_73" model="aeat.model.export.config.line">
+        <field name="sequence">73</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 4- Volumen  ingresos</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_74" model="aeat.model.export.config.line">
+        <field name="sequence">74</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 4 - Indice cuota</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">6</field>
+        <field name="decimal_size">5</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_75" model="aeat.model.export.config.line">
+        <field name="sequence">75</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 4 - Cuota devengada</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_76" model="aeat.model.export.config.line">
+        <field name="sequence">76</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 4 - Cuota soportada</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_77" model="aeat.model.export.config.line">
+        <field name="sequence">77</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 4 - Cuota derivada Regimen Simplificado [K4]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_78" model="aeat.model.export.config.line">
+        <field name="sequence">78</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 5-  Código</field>
+        <field name="fixed_value">00</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_79" model="aeat.model.export.config.line">
+        <field name="sequence">79</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 5 - Volumen  ingresos</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_80" model="aeat.model.export.config.line">
+        <field name="sequence">80</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 5 - Indice cuota</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">6</field>
+        <field name="decimal_size">5</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_81" model="aeat.model.export.config.line">
+        <field name="sequence">81</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 5 - Cuota devengada</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_82" model="aeat.model.export.config.line">
+        <field name="sequence">82</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 5 - Cuota soportada</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_83" model="aeat.model.export.config.line">
+        <field name="sequence">83</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Act. Agrícolas y Ganaderas - Actividad 5 - Cuota derivada Regimen Simplificado [K5]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_84" model="aeat.model.export.config.line">
+        <field name="sequence">84</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - IVA devengado - Suma cuotas actividades no agríc., ganad. y forest.  [74]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_85" model="aeat.model.export.config.line">
+        <field name="sequence">85</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - IVA devengado - Suma cuotas  actividades agríc., ganad. y forest. [75]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_86" model="aeat.model.export.config.line">
+        <field name="sequence">86</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - IVA devengado en adquisiciones intracomunitarias [76]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_87" model="aeat.model.export.config.line">
+        <field name="sequence">87</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - IVA devengado - IVA devengado por inversión del sujeto pasivo [77]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_88" model="aeat.model.export.config.line">
+        <field name="sequence">88</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - IVA devengado - IVA devengado en entregas de activos fijos [78]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_89" model="aeat.model.export.config.line">
+        <field name="sequence">89</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - IVA devengado - Total cuota resultante [79]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_90" model="aeat.model.export.config.line">
+        <field name="sequence">90</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Deducciones - IVA soportado en adquisicion de activos fijos [80]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_91" model="aeat.model.export.config.line">
+        <field name="sequence">91</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Deducciones - Regularización de bienes de inversion [81]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_92" model="aeat.model.export.config.line">
+        <field name="sequence">92</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Deducciones - Suma de deducciones [82]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_93" model="aeat.model.export.config.line">
+        <field name="sequence">93</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">6. Operaciones Reg. Simplificado - Resultado régimen simplificado [83]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_94" model="aeat.model.export.config.line">
+        <field name="sequence">94</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco)</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">150</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub05_export_line_95" model="aeat.model.export.config.line">
+        <field name="sequence">95</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub05_export_config"/>
+        <field name="name">Indicador de fin de registro: &lt;/T39005000&gt;</field>
+        <field name="fixed_value">&lt;/T39005000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+</odoo>

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub06_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub06_data.xml
@@ -1,0 +1,587 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="aeat_mod390_2021_sub06_export_config" model="aeat.model.export.config">
+        <field name="name">Mod.390 2021 - Página 6</field>
+        <field name="model_number">390</field>
+        <field name="active" eval="False"/>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_01" model="aeat.model.export.config.line">
+        <field name="sequence">1</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">Constante: &lt;T</field>
+        <field name="fixed_value">&lt;T</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_02" model="aeat.model.export.config.line">
+        <field name="sequence">2</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">Constante: 390</field>
+        <field name="fixed_value">390</field>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_03" model="aeat.model.export.config.line">
+        <field name="sequence">3</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">Página</field>
+        <field name="fixed_value">06</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_04" model="aeat.model.export.config.line">
+        <field name="sequence">4</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">Constante: 000&gt;</field>
+        <field name="fixed_value">000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_05" model="aeat.model.export.config.line">
+        <field name="sequence">5</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">Indicador de página complementaria: En blanco</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_06" model="aeat.model.export.config.line">
+        <field name="sequence">6</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">7. Resultado liquidación anual - Regularización cuotas art. 80.Cinco.5ª LIVA [658]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_07" model="aeat.model.export.config.line">
+        <field name="sequence">7</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">7. Resultado liquidación anual - Suma de resultados [84]</field>
+        <field name="expression">${object.casilla_65}</field>  <!-- Es el mismo resultado ya que el resto está a 0 -->
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_08" model="aeat.model.export.config.line">
+        <field name="sequence">8</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">7. Resultado liquidación anual - IVA a la importación liquidado por la Aduana (sólo sujetos pasivos con opción de diferimiento) [659]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_09" model="aeat.model.export.config.line">
+        <field name="sequence">9</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">7. Resultado liquidación anual - Compensación de cuotas ejercicio anterior [85]</field>
+        <field name="expression">${object.casilla_85}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_10" model="aeat.model.export.config.line">
+        <field name="sequence">10</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">7. Resultado liquidación anual - Resultado de la liquidación [86]</field>
+        <field name="expression">${object.casilla_86}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_11" model="aeat.model.export.config.line">
+        <field name="sequence">11</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - Territorio común [87]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_12" model="aeat.model.export.config.line">
+        <field name="sequence">12</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - Álava [88]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_13" model="aeat.model.export.config.line">
+        <field name="sequence">13</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - Guipúzcoa [89]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_14" model="aeat.model.export.config.line">
+        <field name="sequence">14</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - Vizcaya [90]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_15" model="aeat.model.export.config.line">
+        <field name="sequence">15</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - Navarra [91]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_16" model="aeat.model.export.config.line">
+        <field name="sequence">16</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - Regularización cuotas art. 80.Cinco.5ª LIVA [658]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_17" model="aeat.model.export.config.line">
+        <field name="sequence">17</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - Suma de resultados [84]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_18" model="aeat.model.export.config.line">
+        <field name="sequence">18</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - Resultado atribuible a territorio común [92]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_19" model="aeat.model.export.config.line">
+        <field name="sequence">19</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - IVA a la importación liquidado por la Aduana(sólo sujetos pasivos con opción de diferimiento) [659]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_20" model="aeat.model.export.config.line">
+        <field name="sequence">20</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - Compens. cuotas ej. anterior atrib. territ. com. [93]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_21" model="aeat.model.export.config.line">
+        <field name="sequence">21</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">8. Tributación razón de territorio - Administraciones - Resultado liq. anual atribuible territ. comun [94]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_22" model="aeat.model.export.config.line">
+        <field name="sequence">22</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">9. Resultado de las liquidaciones - Total resultados a ingresar autoliquidaciones de IVA del ejercicio [95]</field>
+        <field name="expression">${object.casilla_95}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_23" model="aeat.model.export.config.line">
+        <field name="sequence">23</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">9. Resultado de las liquidaciones - Total devoluc. mensuales IVA suj. pasivos Regtro. de devolución mensual [96]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_24" model="aeat.model.export.config.line">
+        <field name="sequence">24</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">9. Resultado de las liquidaciones - Total devoluc. Por cuotas en la adquisicion de elementos de transporte [524]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_25" model="aeat.model.export.config.line">
+        <field name="sequence">25</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">9. Resultado de las liquidaciones - Resultado declaración-liquidación último periodo - A compensar [97]</field>
+        <field name="expression">${object.casilla_97}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_26" model="aeat.model.export.config.line">
+        <field name="sequence">26</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">9. Resultado de las liquidaciones - Resultado declaración-liquidación último periodo - A devolver [98]</field>
+        <field name="expression">${object.casilla_98}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_27" model="aeat.model.export.config.line">
+        <field name="sequence">27</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">9. Resultado de las liquidaciones - Cuotas pendientes de compensación al término del ejercicio [662]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_28" model="aeat.model.export.config.line">
+        <field name="sequence">28</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">9. Resultado de las liquidaciones - Total resultados positivos del ejercicio (modelo 322) [525]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_29" model="aeat.model.export.config.line">
+        <field name="sequence">29</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">9. Resultado de las liquidaciones - Total resultados negativos del ejercicio (modelo 322) [526]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_30" model="aeat.model.export.config.line">
+        <field name="sequence">30</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones en régimen general [99]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 99).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_31" model="aeat.model.export.config.line">
+        <field name="sequence">31</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones régimen especial del criterio de caja [653]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_32" model="aeat.model.export.config.line">
+        <field name="sequence">32</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Entregas intracomunitarias de bienes y servicios [103]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 103).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_33" model="aeat.model.export.config.line">
+        <field name="sequence">33</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Exportaciones y otras operaciones exentas con derecho a deducción [104]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 104).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_34" model="aeat.model.export.config.line">
+        <field name="sequence">34</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones exentas sin derecho a deducción [105]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 105).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_35" model="aeat.model.export.config.line">
+        <field name="sequence">35</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones no sujetas por reglas de localización (excepto las incluidas en la casilla 126) [110]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_36" model="aeat.model.export.config.line">
+        <field name="sequence">36</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones sujetas con inversión del sujeto pasivo [125]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_37" model="aeat.model.export.config.line">
+        <field name="sequence">37</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - OSS. Operaciones no sujetas por reglas de localización acogidas a la OSS [126]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_38" model="aeat.model.export.config.line">
+        <field name="sequence">38</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - OSS. Operaciones sujetas y acogidas a la OSS [127]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+    
+    <record id="aeat_mod390_2021_sub06_export_line_39" model="aeat.model.export.config.line">
+        <field name="sequence">39</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones intragrupo valoradas conforme a lo dispuesto en los arts. 78 y 79 LIVA [128]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_40" model="aeat.model.export.config.line">
+        <field name="sequence">40</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones en régimen simplificado [100]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_41" model="aeat.model.export.config.line">
+        <field name="sequence">41</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones en régimen especias de la agricultura, ganadería y pesca [101]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_42" model="aeat.model.export.config.line">
+        <field name="sequence">42</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones en régimen especial del recargo de equivalencia [102].</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 102).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_43" model="aeat.model.export.config.line">
+        <field name="sequence">43</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones en régimen especias de bienes usados, objetos de arte, antigüedades y objetos de colección [227].</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_44" model="aeat.model.export.config.line">
+        <field name="sequence">44</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Operaciones en régimen especial de agencias de viajes [228].</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+        <field name="expression"></field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_45" model="aeat.model.export.config.line">
+        <field name="sequence">45</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Entrega de bienes inmuebles y operaciones financieras no habituales [106]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_46" model="aeat.model.export.config.line">
+        <field name="sequence">46</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Entrega de bienes de inversion [107]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_47" model="aeat.model.export.config.line">
+        <field name="sequence">47</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">10. Volumen de operaciones - Total volumen de operaciones [108]</field>
+        <field name="expression">${object.casilla_108}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_48" model="aeat.model.export.config.line">
+        <field name="sequence">48</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco)</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">150</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub06_export_line_49" model="aeat.model.export.config.line">
+        <field name="sequence">49</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub06_export_config"/>
+        <field name="name">Indicador de fin de registro: &lt;/T39006000&gt;</field>
+        <field name="fixed_value">&lt;/T39006000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+</odoo>

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub07_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub07_data.xml
@@ -1,0 +1,544 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="aeat_mod390_2021_sub07_export_config" model="aeat.model.export.config">
+        <field name="name">Mod.390 2021 - Página 7</field>
+        <field name="model_number">390</field>
+        <field name="active" eval="False"/>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_01" model="aeat.model.export.config.line">
+        <field name="sequence">1</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">Constante: &lt;T</field>
+        <field name="fixed_value">&lt;T</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_02" model="aeat.model.export.config.line">
+        <field name="sequence">2</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">Constante: 390</field>
+        <field name="fixed_value">390</field>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_03" model="aeat.model.export.config.line">
+        <field name="sequence">3</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">Página</field>
+        <field name="fixed_value">07</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_04" model="aeat.model.export.config.line">
+        <field name="sequence">4</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">Constante: 000&gt;</field>
+        <field name="fixed_value">000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_05" model="aeat.model.export.config.line">
+        <field name="sequence">5</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">Indicador de página complementaria: En blanco</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_06" model="aeat.model.export.config.line">
+        <field name="sequence">6</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. Específicas - Adquisiciones interiores exentas [230]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 230).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_07" model="aeat.model.export.config.line">
+        <field name="sequence">7</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. específicas - Adquisiciones intracomunitarias exentas [109]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 109).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_08" model="aeat.model.export.config.line">
+        <field name="sequence">8</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. Específicas - Importaciones exentas [231]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 231).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_09" model="aeat.model.export.config.line">
+        <field name="sequence">9</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. Específicas - Bases imponibles IVA soportado no deducible [232]</field>
+        <field name="expression">${object.tax_line_ids.filtered(lambda r: r.field_number == 232).amount}</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_10" model="aeat.model.export.config.line">
+        <field name="sequence">10</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. específicas - Oper. sujetas que originan el derecho a la devolución mensual [111]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_11" model="aeat.model.export.config.line">
+        <field name="sequence">11</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. específicas - Entrega interior bienes devengada por invers. sujet. pasiv. operac. triangul. [113]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_12" model="aeat.model.export.config.line">
+        <field name="sequence">12</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. Específicas - Servicios localizados en el territorio de aplicación del impuesto por inversión del sujeto pasivo [523]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_13" model="aeat.model.export.config.line">
+        <field name="sequence">13</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. Específicas - Importes de las entregas de bienes regimen especial criterio caja - Base imponible [654]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_14" model="aeat.model.export.config.line">
+        <field name="sequence">14</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. Específicas - Importes de las entregas de bienes regimen especial criterio caja - Cuota [655]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_15" model="aeat.model.export.config.line">
+        <field name="sequence">15</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. Específicas - Importes de las adquisiciones de bienes regimen especial criterio caja - Base imponible [656]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_16" model="aeat.model.export.config.line">
+        <field name="sequence">16</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">11. Oper. Específicas - Importes de las adquisiciones de bienes regimen especial criterio caja - Cuota [657]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_17" model="aeat.model.export.config.line">
+        <field name="sequence">17</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 1 - Actividad desarrollada</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_18" model="aeat.model.export.config.line">
+        <field name="sequence">18</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 1 - Código CNAE [114]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_19" model="aeat.model.export.config.line">
+        <field name="sequence">19</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 1 - Importe de operaciones [115]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_20" model="aeat.model.export.config.line">
+        <field name="sequence">20</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 1 - Importe de operaciones con derecho a deducción [116]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_21" model="aeat.model.export.config.line">
+        <field name="sequence">21</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 1 - Tipo de prorrata [117]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_22" model="aeat.model.export.config.line">
+        <field name="sequence">22</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 1 - % de prorrata [118]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_23" model="aeat.model.export.config.line">
+        <field name="sequence">23</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 2 - Actividad desarrollada</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_24" model="aeat.model.export.config.line">
+        <field name="sequence">24</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 2 - Código CNAE [119]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_25" model="aeat.model.export.config.line">
+        <field name="sequence">25</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 2 - Importe de operaciones [120]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_26" model="aeat.model.export.config.line">
+        <field name="sequence">26</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 2 - Importe de operaciones con derecho a deducción [121]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_27" model="aeat.model.export.config.line">
+        <field name="sequence">27</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 2 - Tipo de prorrata [122]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_28" model="aeat.model.export.config.line">
+        <field name="sequence">28</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 2 - % de prorrata [123]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_29" model="aeat.model.export.config.line">
+        <field name="sequence">29</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 3 - Actividad desarrollada</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_30" model="aeat.model.export.config.line">
+        <field name="sequence">30</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 3 - Código CNAE [124]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_31" model="aeat.model.export.config.line">
+        <field name="sequence">31</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 3 - Importe de operaciones [125]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_32" model="aeat.model.export.config.line">
+        <field name="sequence">32</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 3 - Importe de operaciones con derecho a deducción [126]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_33" model="aeat.model.export.config.line">
+        <field name="sequence">33</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 3 - Tipo de prorrata [127]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_34" model="aeat.model.export.config.line">
+        <field name="sequence">34</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 3 - % de prorrata [128]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_35" model="aeat.model.export.config.line">
+        <field name="sequence">35</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 4 - Actividad desarrollada</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_36" model="aeat.model.export.config.line">
+        <field name="sequence">36</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 4 - Código CNAE [129]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_37" model="aeat.model.export.config.line">
+        <field name="sequence">37</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 4 - Importe de operaciones [130]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_38" model="aeat.model.export.config.line">
+        <field name="sequence">38</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 4 - Importe de operaciones con derecho a deducción [131]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_39" model="aeat.model.export.config.line">
+        <field name="sequence">39</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 4 - Tipo de prorrata [132]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_40" model="aeat.model.export.config.line">
+        <field name="sequence">40</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 4 - % de prorrata [133]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_41" model="aeat.model.export.config.line">
+        <field name="sequence">41</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 5 - Actividad desarrollada</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">40</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_42" model="aeat.model.export.config.line">
+        <field name="sequence">42</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 5 - Código CNAE [134]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_43" model="aeat.model.export.config.line">
+        <field name="sequence">43</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 5 - Importe de operaciones [135]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_44" model="aeat.model.export.config.line">
+        <field name="sequence">44</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 5 - Importe de operaciones con derecho a deducción [136]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_45" model="aeat.model.export.config.line">
+        <field name="sequence">45</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 5 - Tipo de prorrata [137]</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_46" model="aeat.model.export.config.line">
+        <field name="sequence">46</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">12. Prorratas - 5 - % de prorrata [138]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="False"/>
+        <field name="size">5</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_47" model="aeat.model.export.config.line">
+        <field name="sequence">47</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco)</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">150</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub07_export_line_48" model="aeat.model.export.config.line">
+        <field name="sequence">48</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub07_export_config"/>
+        <field name="name">Indicador de fin de registro: &lt;/T39007000&gt;</field>
+        <field name="fixed_value">&lt;/T39007000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+</odoo>

--- a/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub08_data.xml
+++ b/l10n_es_aeat_mod390/data/aeat_export_mod390_2021_sub08_data.xml
@@ -1,0 +1,730 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Tecnativa - Pedro M. Baeza
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="aeat_mod390_2021_sub08_export_config" model="aeat.model.export.config">
+        <field name="name">Mod.390 2021 - Página 8</field>
+        <field name="model_number">390</field>
+        <field name="active" eval="False"/>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_01" model="aeat.model.export.config.line">
+        <field name="sequence">1</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">Constante: &lt;T</field>
+        <field name="fixed_value">&lt;T</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_02" model="aeat.model.export.config.line">
+        <field name="sequence">2</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">Constante: 390</field>
+        <field name="fixed_value">390</field>
+        <field name="export_type">string</field>
+        <field name="size">3</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_03" model="aeat.model.export.config.line">
+        <field name="sequence">3</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">Página</field>
+        <field name="fixed_value">08</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_04" model="aeat.model.export.config.line">
+        <field name="sequence">4</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">Constante: 000&gt;</field>
+        <field name="fixed_value">000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">4</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_05" model="aeat.model.export.config.line">
+        <field name="sequence">5</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">Indicador de página complementaria: En blanco</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">1</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_06" model="aeat.model.export.config.line">
+        <field name="sequence">6</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Operac. Interiores - Bienes y servic. - Base imponible [139]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_07" model="aeat.model.export.config.line">
+        <field name="sequence">7</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Operac. Interiores - Bienes y servic. - Cuota deducible [140]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_08" model="aeat.model.export.config.line">
+        <field name="sequence">8</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Operac. Interiores - Bienes inversión - Base imponible [141]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_09" model="aeat.model.export.config.line">
+        <field name="sequence">9</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Operac. Interiores - Bienes inversión - Cuota deducible [142]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_10" model="aeat.model.export.config.line">
+        <field name="sequence">10</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Importaciones - Bienes corrientes - Base imponible [143]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_11" model="aeat.model.export.config.line">
+        <field name="sequence">11</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Importaciones - Bienes corrientes - Cuota deducible [144]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_12" model="aeat.model.export.config.line">
+        <field name="sequence">12</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Importaciones - Bienes inversión - Base imponible [145]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_13" model="aeat.model.export.config.line">
+        <field name="sequence">13</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Importaciones - Bienes inversión - Cuota deducible [146]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_14" model="aeat.model.export.config.line">
+        <field name="sequence">14</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Adquisic. intracomun. - Bienes corrientes - Base imponible [147]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_15" model="aeat.model.export.config.line">
+        <field name="sequence">15</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Adquisic. intracomun.  - Bienes corrientes - Cuota deducible [148]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_16" model="aeat.model.export.config.line">
+        <field name="sequence">16</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Adquisic. intracomun. - Bienes inversión - Base imponible [149]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_17" model="aeat.model.export.config.line">
+        <field name="sequence">17</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - IVA ded. Adquisic. intracomun. - Bienes inversión - Cuota deducible [150]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_18" model="aeat.model.export.config.line">
+        <field name="sequence">18</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - Compensac. rég. especial agric./ganad./pesca - Base impon. [151]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_19" model="aeat.model.export.config.line">
+        <field name="sequence">19</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - Compensac. rég. especial agric./ganad./pesca - Cuota deduc. [152]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_20" model="aeat.model.export.config.line">
+        <field name="sequence">20</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - Rectificación de deducciones - Base impon.  [640]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_21" model="aeat.model.export.config.line">
+        <field name="sequence">21</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - Rectificación de deducciones - Cuota deduc. [153]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_22" model="aeat.model.export.config.line">
+        <field name="sequence">22</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - Regularización de inversiones [154]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_23" model="aeat.model.export.config.line">
+        <field name="sequence">23</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 1 - Suma de deducciones [155]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_24" model="aeat.model.export.config.line">
+        <field name="sequence">24</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Operac. Interiores - Bienes y servic. - Base imponible [156]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_25" model="aeat.model.export.config.line">
+        <field name="sequence">25</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Operac. Interiores - Bienes y servic. - Cuota deducible [157]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_26" model="aeat.model.export.config.line">
+        <field name="sequence">26</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Operac. Interiores - Bienes inversión - Base imponible [158]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_27" model="aeat.model.export.config.line">
+        <field name="sequence">27</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Operac. Interiores - Bienes inversión - Cuota deducible [159]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_28" model="aeat.model.export.config.line">
+        <field name="sequence">28</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Importaciones - Bienes corrientes - Base imponible [160]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_29" model="aeat.model.export.config.line">
+        <field name="sequence">29</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Importaciones - Bienes corrientes - Cuota deducible [161]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_30" model="aeat.model.export.config.line">
+        <field name="sequence">30</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Importaciones - Bienes inversión - Base imponible [162]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_31" model="aeat.model.export.config.line">
+        <field name="sequence">31</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Importaciones - Bienes inversión - Cuota deducible [163]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_32" model="aeat.model.export.config.line">
+        <field name="sequence">32</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Adquisic. intracomun. - Bienes corrientes - Base imponible [164]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_33" model="aeat.model.export.config.line">
+        <field name="sequence">33</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Adquisic. intracomun.  - Bienes corrientes - Cuota deducible [165]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_34" model="aeat.model.export.config.line">
+        <field name="sequence">34</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Adquisic. intracomun. - Bienes inversión - Base imponible [166]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_35" model="aeat.model.export.config.line">
+        <field name="sequence">35</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - IVA ded. Adquisic. intracomun. - Bienes inversión - Cuota deducible [167]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_36" model="aeat.model.export.config.line">
+        <field name="sequence">36</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - Compensac. rég. especial agric./ganad./pesca - Base impon. [168]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_37" model="aeat.model.export.config.line">
+        <field name="sequence">37</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - Compensac. rég. especial agric./ganad./pesca - Cuota deduc. [169]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_38" model="aeat.model.export.config.line">
+        <field name="sequence">38</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - Rectificación de deducciones - Base impon. [641]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_39" model="aeat.model.export.config.line">
+        <field name="sequence">39</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - Rectificación de deducciones - Cuota decuc. [170]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_40" model="aeat.model.export.config.line">
+        <field name="sequence">40</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - Regularización de inversiones [171]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_41" model="aeat.model.export.config.line">
+        <field name="sequence">41</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 2 - Suma de deducciones [172]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_42" model="aeat.model.export.config.line">
+        <field name="sequence">42</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Operac. Interiores - Bienes y servic. - Base imponible [173]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_43" model="aeat.model.export.config.line">
+        <field name="sequence">43</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Operac. Interiores - Bienes y servic. - Cuota deducible [174]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_44" model="aeat.model.export.config.line">
+        <field name="sequence">44</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Operac. Interiores - Bienes inversión - Base imponible [175]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_45" model="aeat.model.export.config.line">
+        <field name="sequence">45</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Operac. Interiores - Bienes inversión - Cuota deducible [176]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_46" model="aeat.model.export.config.line">
+        <field name="sequence">46</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Importaciones - Bienes corrientes - Base imponible [177]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_47" model="aeat.model.export.config.line">
+        <field name="sequence">47</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Importaciones - Bienes corrientes - Cuota deducible [178]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_48" model="aeat.model.export.config.line">
+        <field name="sequence">48</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Importaciones - Bienes inversión - Base imponible [179]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_49" model="aeat.model.export.config.line">
+        <field name="sequence">49</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Importaciones - Bienes inversión - Cuota deducible [180]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_50" model="aeat.model.export.config.line">
+        <field name="sequence">50</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Adquisic. intracomun. - Bienes corrientes - Base imponible [181]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_51" model="aeat.model.export.config.line">
+        <field name="sequence">51</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Adquisic. intracomun.  - Bienes corrientes - Cuota deducible [182]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_52" model="aeat.model.export.config.line">
+        <field name="sequence">52</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Adquisic. intracomun. - Bienes inversión - Base imponible [183]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_53" model="aeat.model.export.config.line">
+        <field name="sequence">53</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - IVA ded. Adquisic. intracomun. - Bienes inversión - Cuota deducible [184]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_54" model="aeat.model.export.config.line">
+        <field name="sequence">54</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - Compensac. rég. especial agric./ganad./pesca - Base impon. [185]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_55" model="aeat.model.export.config.line">
+        <field name="sequence">55</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - Compensac. rég. especial agric./ganad./pesca - Cuota deduc. [186]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_56" model="aeat.model.export.config.line">
+        <field name="sequence">56</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - Rectificación de deducciones - Base impon. [642]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_57" model="aeat.model.export.config.line">
+        <field name="sequence">57</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - Rectificación de deducciones - Cuota deduc. [187]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_58" model="aeat.model.export.config.line">
+        <field name="sequence">58</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - Regularización de inversiones [188]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_59" model="aeat.model.export.config.line">
+        <field name="sequence">59</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">13. Reg. Deducc. Diferenc.- 3 - Suma de deducciones [189]</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">float</field>
+        <field name="apply_sign" eval="True"/>
+        <field name="size">17</field>
+        <field name="decimal_size">2</field>
+        <field name="alignment">right</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_60" model="aeat.model.export.config.line">
+        <field name="sequence">60</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">Reservado para la A.E.A.T. (Dejar en blanco)</field>
+        <field name="fixed_value"/>
+        <field name="export_type">string</field>
+        <field name="size">150</field>
+        <field name="alignment">left</field>
+    </record>
+
+    <record id="aeat_mod390_2021_sub08_export_line_61" model="aeat.model.export.config.line">
+        <field name="sequence">61</field>
+        <field name="export_config_id" ref="aeat_mod390_2021_sub08_export_config"/>
+        <field name="name">Indicador de fin de registro: &lt;/T39008000&gt;</field>
+        <field name="fixed_value">&lt;/T39008000&gt;</field>
+        <field name="export_type">string</field>
+        <field name="size">12</field>
+        <field name="alignment">left</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
cherry pick del PR #2012 

Mod390 was not working for the register design dr209e2021. Changes commited:
 - Two fields were renamed in page 5 and 5 more added in page 6.
 - Start and end dates for 2019 model were also changed from 2019 to 2020.
 - Consequently, new model date starts at 2021 until now.