### PR TITLE
[12.0][IMP] l10n_es_ticketbai_api: multi-company rule for ticketbai invoices

### DIFF
--- a/l10n_es_ticketbai_api/__manifest__.py
+++ b/l10n_es_ticketbai_api/__manifest__.py
@@ -30,6 +30,7 @@
     },
     "data": [
         "security/ir.model.access.csv",
+        "security/l10n_es_ticketbai_security.xml",
         "data/tax_agency_data.xml",
         "data/ticketbai_invoice.xml",
         "views/l10n_es_ticketbai_api_views.xml",

--- a/l10n_es_ticketbai_api/i18n/es.po
+++ b/l10n_es_ticketbai_api/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-16 08:39+0000\n"
-"PO-Revision-Date: 2021-09-16 10:42+0200\n"
+"POT-Creation-Date: 2022-02-10 13:17+0000\n"
+"PO-Revision-Date: 2022-02-10 14:19+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -973,12 +973,11 @@ msgid "Tax Agency name"
 msgstr "Hacienda"
 
 #. module: l10n_es_ticketbai_api
-#: code:addons/l10n_es_ticketbai_api/models/res_company.py:131
+#: code:addons/l10n_es_ticketbai_api/models/res_company.py:101
 #, python-format
 msgid "Tax agency cannot be modified after a TicketBAI invoice has been sent."
 msgstr ""
-"Número de identificación fiscal. Llénelo si la compañía está sujeta a "
-"impuestos. Usado por algunos documentos legales."
+"No se puede cambiar de hacienda una vez se ha enviado una factura TicketBAI."
 
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_res_company__tbai_installation_id
@@ -1092,7 +1091,7 @@ msgid "TicketBAI Certificates"
 msgstr "TicketBAI Certificados"
 
 #. module: l10n_es_ticketbai_api
-#: code:addons/l10n_es_ticketbai_api/models/res_company.py:164
+#: code:addons/l10n_es_ticketbai_api/models/res_company.py:163
 #, python-format
 msgid ""
 "TicketBAI Developer %s VAT Number or another type of identification is "
@@ -1770,7 +1769,3 @@ msgstr "XML Respuesta"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_customer__zip
 msgid "ZIP Code"
 msgstr "Código postal"
-
-#~ msgid "Name %s too long. Should be 120 characters max.!"
-#~ msgstr ""
-#~ "Nombre %s demasiado largo. Debería tener un máximo de 120 caracteres."

--- a/l10n_es_ticketbai_api/i18n/l10n_es_ticketbai_api.pot
+++ b/l10n_es_ticketbai_api/i18n/l10n_es_ticketbai_api.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 12.0\n"
+"Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-02-10 13:17+0000\n"
+"PO-Revision-Date: 2022-02-10 13:17+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -910,7 +912,7 @@ msgid "Tax Agency name"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
-#: code:addons/l10n_es_ticketbai_api/models/res_company.py:131
+#: code:addons/l10n_es_ticketbai_api/models/res_company.py:101
 #, python-format
 msgid "Tax agency cannot be modified after a TicketBAI invoice has been sent."
 msgstr ""
@@ -1022,7 +1024,7 @@ msgid "TicketBAI Certificates"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
-#: code:addons/l10n_es_ticketbai_api/models/res_company.py:164
+#: code:addons/l10n_es_ticketbai_api/models/res_company.py:163
 #, python-format
 msgid "TicketBAI Developer %s VAT Number or another type of identification is required."
 msgstr ""

--- a/l10n_es_ticketbai_api/models/res_company.py
+++ b/l10n_es_ticketbai_api/models/res_company.py
@@ -93,6 +93,16 @@ class ResCompany(models.Model):
                     "Company %s TicketBAI Tax Agency is required."
                 ) % record.name)
 
+            tbai_invoices = record.env['tbai.invoice'].search([
+                ('company_id', '=', record.id)
+            ])
+
+            if 0 < len(tbai_invoices):
+                raise exceptions.ValidationError(_(
+                    "Tax agency cannot be modified after a TicketBAI "
+                    "invoice has been sent."
+                ))
+
     @api.onchange('tbai_tax_agency_id')
     def onchange_tbai_tax_agency(self):
         if not (self.tbai_tax_agency_id.test_qr_base_url and
@@ -121,17 +131,6 @@ class ResCompany(models.Model):
             self.tbai_tax_agency_id = False
             self.tbai_vat_regime_simplified = False
             self.tbai_certificate_id = False
-
-    @api.constrains('tbai_tax_agency_id')
-    def _check_tbai_tax_agency_id(self):
-        for record in self:
-            tbai_invoices = record.env['tbai.invoice'].search([])
-
-            if 0 < len(tbai_invoices):
-                raise exceptions.ValidationError(_(
-                    "Tax agency cannot be modified after a TicketBAI "
-                    "invoice has been sent."
-                ))
 
     def tbai_certificate_get_p12_buffer(self):
         if self.tbai_certificate_id:

--- a/l10n_es_ticketbai_api/security/l10n_es_ticketbai_security.xml
+++ b/l10n_es_ticketbai_api/security/l10n_es_ticketbai_security.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Binovo IT Human Project SL
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="l10n_es_tbai_invoice_rule" model="ir.rule">
+        <field name="name">Ticketbai Invoice Multi-Company</field>
+        <field name="model_id" ref="l10n_es_ticketbai_api.model_tbai_invoice"/>
+        <field eval="True" name="global"/>
+        <field name="domain_force">['|', ('company_id', '=', False), ('company_id', 'child_of', [user.company_id.id])]</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Agrega regla multicompañia para el modelo ticketbai invoice y también tiene en cuenta la compañía a la hora de ver si existen facturas ticketbai a la hora de intentar cambiar de hacienda en la compañía.