### PR TITLE
[13.0][FIX] l10n_es_ticketbai - añadidos impuestos al mapeo de No sujeto Re…

### DIFF
--- a/l10n_es_ticketbai/data/tax_map_data.xml
+++ b/l10n_es_ticketbai/data/tax_map_data.xml
@@ -32,6 +32,8 @@
             <field
                 name="tax_template_ids"
                 eval="[(6, 0, [
+                ref('l10n_es.account_tax_template_s_iva_e'),
+                ref('l10n_es.account_tax_template_s_iva0_sp_i'),
                 ref('l10n_es.account_tax_template_s_iva_ns'),
             ])]"
             />


### PR DESCRIPTION
…percutido (Servicios)

Se añaden al mapeo de impuestos tbai.tax.map No sujeto Repercutido (Servicios) los impuestos:

IVA 0% Prestación de servicios extracomunitaria
IVA 0% Prestación de servicios intracomunitario

Cherry-pick de #2006 

@pedrobaeza ¿Se puede mergear también?