### PR TITLE
[14.0][IMP] l10n_es_aeat_sii_oca + l10n_es_facturae: Hide thirdparty fields in some cases

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_journal.py
+++ b/l10n_es_aeat_sii_oca/models/account_journal.py
@@ -30,7 +30,12 @@ class AccountFiscalPosition(models.Model):
             if node:
                 return res
             for node in doc.xpath("//field[@name='type']"):
-                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                attrs = {
+                    "invisible": [("type", "not in", ("sale", "purchase"))],
+                }
+                elem = etree.Element(
+                    "field", {"name": "thirdparty_invoice", "attrs": str(attrs)}
+                )
                 node.addnext(elem)
             res["arch"] = etree.tostring(doc)
             xarch, xfields = self.env["ir.ui.view"].postprocess_and_fields(

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -1527,7 +1527,20 @@ class AccountMove(models.Model):
                 transfer_modifiers_to_node(modifiers, elem)
                 node.addnext(elem)
                 res["fields"].update(self.fields_get(["thirdparty_number"]))
-                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                attrs = {
+                    "invisible": [
+                        (
+                            "move_type",
+                            "not in",
+                            ("in_invoice", "out_invoice", "out_refund", "in_refund"),
+                        )
+                    ],
+                }
+                elem = etree.Element(
+                    "field", {"name": "thirdparty_invoice", "attrs": str(attrs)}
+                )
+                transfer_node_to_modifiers(elem, modifiers)
+                transfer_modifiers_to_node(modifiers, elem)
                 node.addnext(elem)
                 res["fields"].update(self.fields_get(["thirdparty_invoice"]))
             res["arch"] = etree.tostring(doc)

--- a/l10n_es_facturae/models/account_journal.py
+++ b/l10n_es_facturae/models/account_journal.py
@@ -30,7 +30,12 @@ class AccountJournal(models.Model):
             if node:
                 return res
             for node in doc.xpath("//field[@name='type']"):
-                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                attrs = {
+                    "invisible": [("type", "not in", ("sale", "purchase"))],
+                }
+                elem = etree.Element(
+                    "field", {"name": "thirdparty_invoice", "attrs": str(attrs)}
+                )
                 node.addnext(elem)
             res["arch"] = etree.tostring(doc)
             xarch, xfields = self.env["ir.ui.view"].postprocess_and_fields(

--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -339,7 +339,20 @@ class AccountMove(models.Model):
                 transfer_modifiers_to_node(modifiers, elem)
                 node.addnext(elem)
                 res["fields"].update(self.fields_get(["thirdparty_number"]))
-                elem = etree.Element("field", {"name": "thirdparty_invoice"})
+                attrs = {
+                    "invisible": [
+                        (
+                            "move_type",
+                            "not in",
+                            ("in_invoice", "out_invoice", "out_refund", "in_refund"),
+                        )
+                    ],
+                }
+                elem = etree.Element(
+                    "field", {"name": "thirdparty_invoice", "attrs": str(attrs)}
+                )
+                transfer_node_to_modifiers(elem, modifiers)
+                transfer_modifiers_to_node(modifiers, elem)
                 node.addnext(elem)
                 res["fields"].update(self.fields_get(["thirdparty_invoice"]))
             res["arch"] = etree.tostring(doc)


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/l10n-spain/pull/2029

Hide thirdparty fields in some cases: 

- Hide thirdparty fields in moves when it is not an invoice.
- Hide thirdparty field in journals when it is not sale/purchase type.

Please @Tardo  and @pedrobaeza can you review it?

@Tecnativa TT32612