### PR TITLE
[12.0][IMP] l10n_es_intrastat_report: Add to notes when missing partner_vat and missing product_origin_country_id in line.

### DIFF
--- a/l10n_es_intrastat_report/i18n/es.po
+++ b/l10n_es_intrastat_report/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-26 18:10+0000\n"
-"PO-Revision-Date: 2020-05-26 20:27+0200\n"
+"POT-Creation-Date: 2022-02-08 09:32+0000\n"
+"PO-Revision-Date: 2022-02-08 10:33+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -202,7 +202,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_computation_line__partner_vat
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration_line__partner_vat
 msgid "Customer VAT"
-msgstr ""
+msgstr "NIF del cliente"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_computation_line__declaration_line_id
@@ -403,6 +403,18 @@ msgid "Messages"
 msgstr "Mensajes"
 
 #. module: l10n_es_intrastat_report
+#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:62
+#, python-format
+msgid "Missing origin country on product %s."
+msgstr "Falta el país de origen en el producto %s."
+
+#. module: l10n_es_intrastat_report
+#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:57
+#, python-format
+msgid "Missing partner vat on invoice %s."
+msgstr "Falta el NIF del contacto en la factura %s."
+
+#. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__month
 msgid "Month"
 msgstr "Mes"
@@ -523,7 +535,7 @@ msgid "Supplementary Units Quantity"
 msgstr "Cantidad de unidades suplementarias"
 
 #. module: l10n_es_intrastat_report
-#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:60
+#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:70
 #, python-format
 msgid ""
 "The Spanish Intrastat Declaration requires the Company's Country to be equal "
@@ -594,7 +606,7 @@ msgstr "Usado para rastrear los cambios"
 #: code:addons/l10n_es_intrastat_report/report/intrastat_product_report_xls.py:19
 #, python-format
 msgid "VAT"
-msgstr ""
+msgstr "NIF"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_computation_line__valid

--- a/l10n_es_intrastat_report/i18n/l10n_es_intrastat_report.pot
+++ b/l10n_es_intrastat_report/i18n/l10n_es_intrastat_report.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-02-08 09:32+0000\n"
+"PO-Revision-Date: 2022-02-08 09:32+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -387,6 +389,18 @@ msgid "Messages"
 msgstr ""
 
 #. module: l10n_es_intrastat_report
+#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:62
+#, python-format
+msgid "Missing origin country on product %s."
+msgstr ""
+
+#. module: l10n_es_intrastat_report
+#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:57
+#, python-format
+msgid "Missing partner vat on invoice %s."
+msgstr ""
+
+#. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__month
 msgid "Month"
 msgstr ""
@@ -503,7 +517,7 @@ msgid "Supplementary Units Quantity"
 msgstr ""
 
 #. module: l10n_es_intrastat_report
-#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:60
+#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:70
 #, python-format
 msgid "The Spanish Intrastat Declaration requires the Company's Country to be equal to 'Spain'."
 msgstr ""

--- a/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
+++ b/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
@@ -53,6 +53,17 @@ class L10nEsIntrastatProductDeclaration(models.Model):
         if self.type == 'dispatches' and int(self.year) >= 2022:
             line_vals['partner_vat'] =\
                 inv_line.invoice_id.partner_shipping_id.vat or 'QV999999999999'
+            if not inv_line.invoice_id.partner_shipping_id.vat:
+                note = "\n" + _(
+                    "Missing partner vat on invoice %s."
+                ) % inv_line.invoice_id.number
+                self._note += note
+            if not line_vals["product_origin_country_id"]:
+                raise UserError(
+                    _(
+                        "Missing origin country on product %s."
+                    ) % inv_line.product_id.name_get()[0][1]
+                )
 
     def _gather_invoices_init(self):
         if self.company_id.country_id.code != 'ES':


### PR DESCRIPTION
Se añade al campo "notas" un aviso cuando el NIF no está definido.
Se muestra un error cuando el país de origen del producto no está definido puesto que es ahora un dato obligatorio. 

El campo notas se usa a nivel general para mostrar todos esos avisos.

Relacionado con https://github.com/OCA/l10n-spain/pull/1969

Por favor, @chienandalu y @pedrobaeza puedes revisarlo?

@Tecnativa TT29332