### PR TITLE
[11.0][FIX] l10n_es_ticketbai_api - partner nacional con NIF empezando por N

### DIFF
--- a/l10n_es_ticketbai_api/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice.py
@@ -1162,7 +1162,10 @@ class TicketBAIInvoice(models.Model):
                     "All Invoice recipients must be from the same country."
                 ) % self.name)
             elif 1 == len(country_codes) and country_codes[0] == spain_country_code:
-                spanish_or_no_customers = True
+                # Solo se admite desglose por operación cuando existe destinatario
+                # extranjero (tipo IDOtro o que sea un NIF que empiece por N)
+                spanish_or_no_customers = not (
+                    self.tbai_customer_ids[:1].nif or "").startswith('N')
         if spanish_or_no_customers:
             res = {"DesgloseFactura": OrderedDict()}
             sujeta = self.build_sujeta()


### PR DESCRIPTION
Existe una validación en el tipo de desglose que afecta a clientes nacionales con NIF que empieza por N. Estos casos, se tratan a efectos de desglose, como un cliente extranjero.
El código de validación que salta sin aplicar este cambio en cada una de las haciendas forales son:
- Gipuzkoa: [5033](https://www.gipuzkoa.eus/documents/2456431/27508852/cast+04+01+TICKETBAI+ALTA+2.0.pdf/160167ef-6b84-3c0e-725a-9871e6aa553a)
- Bizkaia: [B4_2000027](https://www.batuz.eus/fitxategiak/batuz/lroe/Batuz_LROE_Validaciones_Errores_V1_0_7.pdf?hash=b730d49615a1df4bddb821ee7f412a5a)
- Araba: [10-60 o 10-61](https://web.araba.eus/documents/105044/5608600/Validaciones+fichero+de+Alta+TicketBAI+%281%29.pdf/00f59d88-343a-0fbd-0bdd-2a83ae991e73?t=1641299325874) (no he llegado a probar)