### PR TITLE
[13.0][FIX] l10n_es_aeat_mod347: Proper invoice name

### DIFF
--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -74,7 +74,7 @@
                                     <tr t-foreach="o.move_record_ids" t-as="l">
                                         <td>
                                             <span
-                                                t-esc="l.move_id.ref or l.move_id.name"
+                                                t-esc="l.move_id.ref if l.move_id.type[:2] == 'in' else l.move_id.name"
                                             />
                                         </td>
                                         <td>


### PR DESCRIPTION
In a customer invoice, the field `name` contains the number of the invoice, and the field `ref` can contain any other arbitrary content put by the user, so we should only use this second one in the case of vendor bills, as this is the invoice number for the vendor.

@Tecnativa TT34430