### PR TITLE
[11.0] l10n_es_ticketbai update tratamiento respuesta de rechazo de ficheros TicketBai enviados

### DIFF
--- a/l10n_es_ticketbai/i18n/es.po
+++ b/l10n_es_ticketbai/i18n/es.po
@@ -71,11 +71,6 @@ msgid "By substitution"
 msgstr "Por sustitución"
 
 #. module: l10n_es_ticketbai
-#: model:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
-msgid "Cancel and recreate"
-msgstr "Cancelar y recrear"
-
-#. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:307
 #, python-format
 msgid "Cancellation"
@@ -694,16 +689,6 @@ msgstr ""
 #, python-format
 msgid "TicketBAI refund by substitution is not supported."
 msgstr "TicketBAI rectificativa por sustitución no está soportado."
-
-#. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/ticketbai_invoice.py:39
-#, python-format
-msgid ""
-"TicketBAI: You cannot cancel and recreate an Invoice with a state different "
-"than 'Error'."
-msgstr ""
-"TicketBAI: No es posible cancelar y recrear una factura cuyo estado no sea "
-"'Error'."
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_fp_tbai_tax_tbai_vat_exemption_key

--- a/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
+++ b/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
@@ -64,11 +64,6 @@ msgid "By substitution"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: model:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
-msgid "Cancel and recreate"
-msgstr ""
-
-#. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:307
 #, python-format
 msgid "Cancellation"
@@ -646,12 +641,6 @@ msgstr ""
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:145
 #, python-format
 msgid "TicketBAI refund by substitution is not supported."
-msgstr ""
-
-#. module: l10n_es_ticketbai
-#: code:addons/l10n_es_ticketbai/models/ticketbai_invoice.py:39
-#, python-format
-msgid "TicketBAI: You cannot cancel and recreate an Invoice with a state different than 'Error'."
 msgstr ""
 
 #. module: l10n_es_ticketbai

--- a/l10n_es_ticketbai/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai/models/ticketbai_invoice.py
@@ -1,7 +1,5 @@
 # Copyright 2021 Binovo IT Human Project SL
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo.addons.l10n_es_ticketbai_api.models.ticketbai_invoice import \
-    TicketBaiInvoiceState
 from odoo.addons.l10n_es_ticketbai_api.ticketbai.xml_schema import TicketBaiSchema
 from odoo.addons.l10n_es_ticketbai_api.utils import utils as tbai_utils
 from odoo import models, fields, api, exceptions, _
@@ -31,21 +29,6 @@ class TicketBAIInvoice(models.Model):
             return super().send(invoice_id=self.cancelled_invoice_id.id, **kwargs)
         else:
             return super().send(**kwargs)
-
-    @api.multi
-    def cancel_and_recreate(self):
-        if 0 < len(self.filtered(
-                lambda x: x.state != TicketBaiInvoiceState.error.value)):
-            raise exceptions.ValidationError(_(
-                "TicketBAI: You cannot cancel and recreate an Invoice with a state "
-                "different than 'Error'."))
-        for record in self.sudo():
-            record.cancel()
-            if TicketBaiSchema.TicketBai.value == record.schema and record.invoice_id:
-                record.invoice_id._tbai_build_invoice()
-            elif TicketBaiSchema.AnulaTicketBai.value == record.schema and \
-                    record.cancelled_invoice_id:
-                record.cancelled_invoice_id._tbai_invoice_cancel()
 
 
 class TicketBAIInvoiceRefundOrigin(models.Model):

--- a/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
+++ b/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
@@ -66,22 +66,19 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
         # 2nd rejected by the Tax Agency. Mark as an error.
         # 3rd mark as an error.
         invoice.tbai_invoice_id.sudo().mark_as_sent()
-        self.env['tbai.invoice'].mark_chain_as_error(invoice2.sudo().tbai_invoice_id)
+        self.env['tbai.invoice'].mark_as_error(invoice2.sudo().tbai_invoice_id)
         self.assertEqual(invoice2.tbai_invoice_id.state, 'error')
-        self.assertEqual(invoice3.tbai_invoice_id.state, 'error')
+        self.assertEqual(invoice3.tbai_invoice_id.state, 'pending')
         self.assertEqual(
-            self.main_company.tbai_last_invoice_id, invoice.tbai_invoice_id)
+            self.main_company.tbai_last_invoice_id, invoice3.tbai_invoice_id)
 
         # Cancel and recreate invoices with errors.
         with self.assertRaises(exceptions.ValidationError):
             invoice.tbai_invoice_id.cancel_and_recreate()
         invoices_with_errors = invoice2.tbai_invoice_id
-        invoices_with_errors |= invoice3.tbai_invoice_id
         invoices_with_errors.cancel_and_recreate()
         self.assertEqual(invoices_with_errors[0].state, 'cancel')
         self.assertEqual(invoice2.tbai_invoice_id.state, 'pending')
-        self.assertEqual(invoices_with_errors[1].state, 'cancel')
-        self.assertEqual(invoice3.tbai_invoice_id.state, 'pending')
 
     def test_invoice_ipsi_igic(self):
         invoice = self.create_draft_invoice(

--- a/l10n_es_ticketbai/views/ticketbai_invoice_views.xml
+++ b/l10n_es_ticketbai/views/ticketbai_invoice_views.xml
@@ -9,9 +9,6 @@
             <field name="arch" type="xml">
                 <form string="TicketBAI Invoice" create="false" delete="false" edit="false" import="false">
                     <header>
-                        <button name="cancel_and_recreate" string="Cancel and recreate"
-                                type="object" states="error" class="btn-primary"
-                                groups="account.group_account_manager"/>
                         <field name="state" widget="statusbar" readonly="1"/>
                     </header>
                     <group name="invoice" string="Invoice">

--- a/l10n_es_ticketbai_api/__manifest__.py
+++ b/l10n_es_ticketbai_api/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "TicketBAI - API",
-    "version": "11.0.0.7.3",
+    "version": "11.0.0.8.0",
     "category": "Accounting & Finance",
     "website": "http://www.binovo.es",
     "author": "Binovo,"

--- a/l10n_es_ticketbai_api/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice.py
@@ -532,16 +532,8 @@ class TicketBAIInvoice(models.Model):
         return taxes
 
     @api.model
-    def mark_chain_as_error(self, invoice_to_error):
-        # Restore last invoice successfully sent
-        if TicketBaiSchema.TicketBai.value == invoice_to_error.schema:
-            invoice_to_error.company_id.tbai_last_invoice_id = \
-                invoice_to_error.previous_tbai_invoice_id
-        while invoice_to_error:
-            invoice_to_error.error()
-            invoice_to_error = self.search([
-                ('previous_tbai_invoice_id', '=', invoice_to_error.id)
-            ])
+    def mark_as_error(self, invoice_to_error):
+        invoice_to_error.error()
 
     @api.model
     def send_pending_invoices(self):
@@ -600,7 +592,7 @@ class TicketBAIInvoice(models.Model):
                         retry_later = True
                         error = False
                 if error:
-                    self.mark_chain_as_error(next_pending_invoice)
+                    self.mark_as_error(next_pending_invoice)
                     rejected_retries += 1
             elif TicketBaiResponseState.REQUEST_ERROR.value == tbai_response.state:
                 # In case of multi-company it would be delaying independently from the

--- a/l10n_es_ticketbai_api/tests/test_l10n_es_ticketbai_customer_invoice.py
+++ b/l10n_es_ticketbai_api/tests/test_l10n_es_ticketbai_customer_invoice.py
@@ -155,12 +155,12 @@ class TestL10nEsTicketBAIInvoice(TestL10nEsTicketBAIAPI):
 
         # Simulate 1st invoice sent successfully.
         # 2nd rejected by the Tax Agency. Mark as an error.
-        # 3rd mark as an error.
+        # 3rd still pending.
         invoice.mark_as_sent()
-        self.env['tbai.invoice'].mark_chain_as_error(invoice2)
+        self.env['tbai.invoice'].mark_as_error(invoice2)
         self.assertEqual(invoice2.state, 'error')
-        self.assertEqual(invoice3.state, 'error')
-        self.assertEqual(self.main_company.tbai_last_invoice_id, invoice)
+        self.assertEqual(invoice3.state, 'pending')
+        self.assertEqual(self.main_company.tbai_last_invoice_id, invoice3)
 
     def test_exempted_invoice(self):
         uid = self.tech_user.id


### PR DESCRIPTION
Dos modificaciones en el tratamiento ante la respuesta de rechazo de envío de ficheros TicketBai por parte de Hacienda:

1. Marcar como error sólo la factura rechazada, no marcar como error el resto de facturas pendientes en la cola de envío,
por lo tanto tampoco se retrotrae el puntero de la última factura enviada (por compañía)

2. Se quita el botón y los métodos de implementación de "Cancelar y recrear" de una factura ticketbai: en base a la interpretación de los últimos boletines de la hacienda de Gipuzkoa (Bizkaia también tiene publicaciones previas parecidas), consideramos que una factura rechazada ticketbai asociada a una factura de Odoo no puede ser recreada con un QR, identificador y firmas nuevas. Las diferentes haciendas tienen servicios alternativos (p.e. Zuzendu en Gipuzkoa) para subsanar estos errores o en otros casos se debería de hacer una factura rectificativa, pero en ningún caso crear una nueva factura ticketbai asociada a la misma factura, está facturar quedará registrada y almacenada como errónea.
