### PR TITLE
[11.0][FIX] l10n_es_ticketbai_batuz - clave CuotaIVADeducible en capítulo 2

### DIFF
--- a/l10n_es_ticketbai/models/account_invoice.py
+++ b/l10n_es_ticketbai/models/account_invoice.py
@@ -66,7 +66,8 @@ class AccountInvoice(models.Model):
     @api.constrains('state')
     def _check_cancel_number_invoice(self):
         for record in self:
-            if record.tbai_enabled and 'draft' == record.state and record.number:
+            if record.type in ('out_invoice', 'out_refund') and \
+                    record.tbai_enabled and 'draft' == record.state and record.number:
                 raise exceptions.ValidationError(_(
                     "Invoice %s. You cannot change to draft a numbered invoice!"
                 ) % record.number)

--- a/l10n_es_ticketbai_api_batuz/models/lroe_operation.py
+++ b/l10n_es_ticketbai_api_batuz/models/lroe_operation.py
@@ -204,17 +204,21 @@ class LROEOperation(models.Model):
 
     def _get_printed_report_name(self):
         self.ensure_one()
-        report_name = None
+        report_name = self.model + '_' + self.type + '_' + str(self.id)
         if self.model == LROEModelEnum.model_pj_240.value:
             if self.type == LROEOperationEnum.create.value:
                 report_name = _('LROE_model_pj_240_create') + '_' + str(self.id)
             elif self.type == LROEOperationEnum.cancel.value:
                 report_name = _('LROE_model_pj_240_cancel') + '_' + str(self.id)
+            elif self.type == LROEOperationEnum.update.value:
+                report_name = _('LROE_model_pj_240_update') + '_' + str(self.id)
         elif self.model == LROEModelEnum.model_pf_140.value:
             if self.type == LROEOperationEnum.create.value:
                 report_name = _('LROE_model_pf_140_create') + '_' + str(self.id)
             elif self.type == LROEOperationEnum.cancel.value:
                 report_name = _('LROE_model_pf_140_cancel') + '_' + str(self.id)
+            elif self.type == LROEOperationEnum.update.value:
+                report_name = _('LROE_model_pf_140_update') + '_' + str(self.id)
         return report_name
 
     @api.multi


### PR DESCRIPTION
PR que consta de 2 commits:
- [FIX] l10n_es_ticketbai_batuz - cálculo de clave CuotaIVADeducible en capítulo 2
- [IMP] l10n_es_ticketbai & l10n_es_ticketbai_api_batuz - permitir cancelación de facturas de compra para poder enviar modificaciones. Para ello es necesario modificar el método `_check_cancel_number_invoice()` de `l10n_es_ticketbai` y discriminar las facturas de compra.

Para corregir las facturas mal informadas, es necesario el segundo commit, de ahí que se haga un único PR.