### PR TITLE
[FIX] 11.0 l10n_es_ticketbai no dejar validar facturas rectificativas sin datos de rectificación

### DIFF
--- a/l10n_es_ticketbai/__manifest__.py
+++ b/l10n_es_ticketbai/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "TicketBAI - "
             "declaración de todas las operaciones de venta realizadas por las personas "
             "y entidades que desarrollan actividades económicas",
-    "version": "11.0.1.1.2",
+    "version": "11.0.1.3.0",
     "category": "Accounting & Finance",
     "website": "http://www.binovo.es",
     "author": "Binovo,"

--- a/l10n_es_ticketbai/views/account_invoice_views.xml
+++ b/l10n_es_ticketbai/views/account_invoice_views.xml
@@ -27,7 +27,12 @@
                             </group>
                         </group>
                         <group name="tbai_refund" string="Refund" attrs="{'invisible': [('type', '=', 'out_invoice'), ('tbai_substitute_simplified_invoice', '=', False)]}">
-                            <field name="refund_invoice_id" invisible="1"/>
+                            <group name="tbai_refund_invoice_id"
+                                   attrs="{'invisible': ['|', '|', ('tbai_enabled', '!=', True), ('tbai_refund_origin_ids', '!=', []), ('type', '!=', 'out_refund')]}">
+                                <field name="refund_invoice_id"
+                                       domain="[('type', '=', 'out_invoice'), ('state', '=', 'open'), ('company_id', '=', company_id), ('partner_id', '=', partner_id)]"
+                                       attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                            </group>
                             <group name="tbai_refund_key_type" string="Key/Type" colspan="4">
                                 <field name="tbai_refund_key" attrs="{'required': [('tbai_enabled', '=', True), ('type', '=', 'out_refund'), ('refund_invoice_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"/>
                                 <field name="tbai_refund_type" attrs="{'required': [('tbai_enabled', '=', True), ('type', '=', 'out_refund'), ('refund_invoice_id', '!=', False)], 'readonly': [('state', '!=', 'draft')]}"/>


### PR DESCRIPTION
Si el módulo de TicketBai está instalado y activado, no se deja realizar la validación de una factura rectificativa sin datos de rectificación asociados. 

Hay 2 maneras de asociar los datos de rectificación: indicando una factura a través del campo refund_invoice_id original del core de Odoo que se hace visible y editable en este PR (en caso de que esté aún en borrador) o a través del campo tbai_refund_origin_ids añadido anteriormente en este módulo.

Se desea corregir por ejemplo el siguiente comportamiento: previo a estas modificaciones, no se crea la factura de TicketBai (en consuencia no se envía a la Hacienda) al validar una factura rectificativa creada a través de la devolución de productos albaranados a través de un pedido de venta. Odoo crea a través de este flujo una rectificativa sin refund_invoice_id asociado y queremos evitar que la validación de la misma se produzca en el escenario TicketBai, dejamos en manos del usuario el poder asociar esa información y después validarla.