### PR TITLE
[12.0][FIX] l10n_es_aeat_mod347: Preserve balance sign on partner move records

### DIFF
--- a/l10n_es_aeat_mod347/__manifest__.py
+++ b/l10n_es_aeat_mod347/__manifest__.py
@@ -5,12 +5,12 @@
 # Copyright 2016 Tecnativa - Antonio Espinosa
 # Copyright 2016 Tecnativa - Angel Moya <odoo@tecnativa.com>
 # Copyright 2018 PESOL - Angel Moya <info@pesol.es>
-# Copyright 2014-2020 Tecnativa - Pedro M. Baeza
+# Copyright 2014-2022 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     'name': "AEAT modelo 347",
-    'version': "12.0.1.8.0",
+    'version': "12.0.2.0.0",
     'author': "Tecnativa,"
               "PESOL,"
               "Odoo Community Association (OCA)",

--- a/l10n_es_aeat_mod347/data/aeat_export_mod347_partner_data.xml
+++ b/l10n_es_aeat_mod347/data/aeat_export_mod347_partner_data.xml
@@ -133,7 +133,7 @@
         <field name="sequence">13</field>
         <field name="export_config_id" ref="aeat_mod347_partner_export_config"/>
         <field name="name">Importe de las operaciones</field>
-        <field name="expression">${object.amount}</field>
+        <field name="expression">${abs(object.amount)}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True"/>
         <field name="positive_sign"> </field>

--- a/l10n_es_aeat_mod347/migrations/12.0.2.0.0/pre-migration.py
+++ b/l10n_es_aeat_mod347/migrations/12.0.2.0.0/pre-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    cr.execute(
+        """UPDATE l10n_es_aeat_mod347_move_record
+        SET amount = -amount
+        WHERE move_type in ('receivable_refund', 'payable_refund')"""
+    )

--- a/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
+++ b/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Tecnativa - Pedro M. Baeza
+# Copyright 2019-2022 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.addons.l10n_es_aeat.tests.test_l10n_es_aeat_mod_base import \

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -121,10 +121,9 @@
                     <page string="Details">
                         <div><strong>Color codes: </strong> <span class="text-info">Refund invoices</span> - Normal invoices</div>
                         <field name="move_record_ids" context="{'partner_record_id': active_id}" readonly="True">
-                            <tree string="Move records" decoration-info="'refund' in move_type">
+                            <tree string="Move records" decoration-info="(amount &gt; 0 and parent.operation_key == 'B') or (amount &lt; 0 and parent.operation_key == 'A')">
                                 <field name="invoice_id"/>
                                 <field name="move_id"/>
-                                <field name="move_type" invisible="1"/>
                                 <field name="date"/>
                                 <field name="amount"/>
                             </tree>

--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -61,7 +61,7 @@
                     <td><span t-esc="l.move_id.ref or l.move_id.name"/></td>
                     <td><span t-field="l.move_id.date"/></td>
                     <td class="text-right" id="subtotal">
-                      <span t-field="l.amount_signed"/>
+                      <span t-field="l.amount"/>
                     </td>
                   </tr>
                   <tr t-foreach="range(max(5-len(o.move_record_ids),0))" t-as="l">


### PR DESCRIPTION
When populating move records for a partner, an abs operation is performed, as AEAT requires to express amount as positive for all records.

Previous code trusts on the journal entry type for determining later the sign of the operation, but there can be the possibility of having a big journal entry where the type is of one sign, but the specific operation for that partner is another. The canonical example is on PoS, with the closing entry including together all the operations of the session.

So let's keep the balance sign all the time, and remove the checks on move type, converting the amount to positive where needed (BOE export), and this also makes a bit lighter the quarter computation, not needing to filter by move_type.

It includes the migration scripts for adapting following the same previous approach the existing amounts.

@Tecnativa TT34561