### PR TITLE
Set the standar name for all AEAT modules

### DIFF
--- a/l10n_es_aeat_mod349/__manifest__.py
+++ b/l10n_es_aeat_mod349/__manifest__.py
@@ -8,7 +8,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
-    "name": "Modelo 349 AEAT",
+    "name": "AEAT modelo 349",
     "version": "14.0.1.1.1",
     "author": "Tecnativa, Eficent, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/l10n_es_aeat_mod349/__manifest__.py
+++ b/l10n_es_aeat_mod349/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     "name": "AEAT modelo 349",
-    "version": "14.0.1.1.1",
+    "version": "14.0.1.1.2",
     "author": "Tecnativa, Eficent, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Localisation/Accounting",


### PR DESCRIPTION
Hello,

All the AEAT modules have a name like:

AEAT modelo 111
AEAT modelo 115
AEAT modelo 123
AEAT modelo 303
AEAT modelo 347
Modelo 349 AEAT
AEAT modelo 390

This change just estandarize the name of this module.

![imagen](https://user-images.githubusercontent.com/8736623/154581277-f32e9a90-5c7e-4a72-9838-beea163e248d.png)


Thanks