### PR TITLE
[15.0][l10n_es_aeat_mod349] Set the standar name for all AEAT modules

### DIFF
--- a/l10n_es_aeat_mod349/__manifest__.py
+++ b/l10n_es_aeat_mod349/__manifest__.py
@@ -8,7 +8,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
-    "name": "Modelo 349 AEAT",
+    "name": "AEAT modelo 349",
     "version": "15.0.1.0.1",
     "author": "Tecnativa, Eficent, Odoo Community Association (OCA)",
     "license": "AGPL-3",


### PR DESCRIPTION
The same detail from here: https://github.com/OCA/l10n-spain/pull/2129#issue-1141983559

Just same name as other AEAT modules

![imagen](https://user-images.githubusercontent.com/8736623/154601992-9c938fda-7696-45a4-8088-f6f6d128f5ea.png)
