### PR TITLE
[FIX] delivery_seur: label filename

### DIFF
--- a/delivery_seur/models/delivery_carrier.py
+++ b/delivery_seur/models/delivery_carrier.py
@@ -141,13 +141,21 @@ class DeliveryCarrier(models.Model):
             label_content = base64.b64encode(label_content)
         else:
             label_content = res["PDF"]
+        filename = "seur_{}.{}".format(
+            picking.carrier_tracking_ref, self.seur_label_format
+        )
         self.env["ir.attachment"].create(
             {
-                "name": "SEUR %s" % picking.carrier_tracking_ref,
+                "name": filename,
                 "datas": label_content,
+                "store_fname": filename,
                 "res_model": "stock.picking",
                 "res_id": picking.id,
-                "mimetype": "application/%s" % self.seur_label_format,
+                "mimetype": (
+                    "application/pdf"
+                    if self.seur_label_format == "pdf"
+                    else "text/plain"
+                ),
             }
         )
         res["tracking_number"] = picking.carrier_tracking_ref


### PR DESCRIPTION
In v12, with the parameter datas_fname we could force the file to be
downloaded as such filename. Now that parameter doesn't exist and the
filename format is lost from the previous version.

odoo/odoo@c212cfe8992292f57acacd809de26e1817533095

This is specilly problematic with txt format and some printer which
doesnt support joliet filenames or even files without extension.

The mimetype for text files was also wrong, as 'application/txt' doesn't
exist. See Mozilla Dev docs for more info on this:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types

cc @Tecnativa TT34599

please review @victoralmau @pedrobaeza 