### PR TITLE
[13.0][IMP] l10n_es_intrastat_report: Add to notes when missing partner_vat and missing product_origin_country_id in line.

### DIFF
--- a/l10n_es_intrastat_report/i18n/es.po
+++ b/l10n_es_intrastat_report/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-26 18:10+0000\n"
-"PO-Revision-Date: 2020-05-26 20:27+0200\n"
+"POT-Creation-Date: 2022-02-22 12:41+0000\n"
+"PO-Revision-Date: 2022-02-22 13:42+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -35,17 +35,17 @@ msgstr "Acción necesaria"
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__activity_ids
 msgid "Activities"
-msgstr ""
+msgstr "Actividades"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__activity_exception_decoration
 msgid "Activity Exception Decoration"
-msgstr ""
+msgstr "Actividad Excepción Decoración"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__activity_state
 msgid "Activity State"
-msgstr ""
+msgstr "Estado de actividad"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration_line__amount_company_currency
@@ -154,6 +154,12 @@ msgstr ""
 "La compañía actual no es española, por lo que no puede ser configurada."
 
 #. module: l10n_es_intrastat_report
+#: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_computation_line__partner_vat
+#: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration_line__partner_vat
+msgid "Customer VAT"
+msgstr "NIF del cliente"
+
+#. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_computation_line__declaration_line_id
 msgid "Declaration Line"
 msgstr "Línea de declaración"
@@ -202,12 +208,12 @@ msgstr "ID"
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__activity_exception_icon
 msgid "Icon"
-msgstr ""
+msgstr "Icono"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,help:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__activity_exception_icon
 msgid "Icon to indicate an exception activity."
-msgstr ""
+msgstr "Icono para indicar una actividad de excepción."
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,help:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__message_needaction
@@ -305,6 +311,11 @@ msgid "Intrastat Transaction"
 msgstr "Transacción Intrastat"
 
 #. module: l10n_es_intrastat_report
+#: model:ir.model,name:l10n_es_intrastat_report.model_report_intrastat_product_product_declaration_xls
+msgid "Intrastat declaration"
+msgstr "Declaración de producto Intrastat"
+
+#. module: l10n_es_intrastat_report
 #: model:ir.model,name:l10n_es_intrastat_report.model_stock_location
 msgid "Inventory Locations"
 msgstr "Ubicaciones de inventario"
@@ -364,6 +375,18 @@ msgid "Messages"
 msgstr "Mensajes"
 
 #. module: l10n_es_intrastat_report
+#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:0
+#, python-format
+msgid "Missing origin country on product %s."
+msgstr "Falta el país de origen en el producto %s."
+
+#. module: l10n_es_intrastat_report
+#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:0
+#, python-format
+msgid "Missing partner vat on invoice %s."
+msgstr "Falta el NIF del contacto en la factura %s."
+
+#. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__month
 msgid "Month"
 msgstr "Mes"
@@ -376,17 +399,17 @@ msgstr "Peso neto en kg"
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__activity_date_deadline
 msgid "Next Activity Deadline"
-msgstr ""
+msgstr "Fecha límite de la siguiente actividad"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__activity_summary
 msgid "Next Activity Summary"
-msgstr ""
+msgstr "Resumen de la siguiente actividad"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__activity_type_id
 msgid "Next Activity Type"
-msgstr ""
+msgstr "Tipo de la siguiente actividad"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__note
@@ -406,7 +429,7 @@ msgstr "Nº de líneas de declaración"
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__message_has_error_counter
 msgid "Number of errors"
-msgstr ""
+msgstr "Número de errores"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,help:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__message_needaction_counter
@@ -443,7 +466,7 @@ msgstr "Nivel de informe"
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Usuario responsable"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__revision
@@ -453,7 +476,7 @@ msgstr "Revisión"
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__message_has_sms_error
 msgid "SMS Delivery error"
-msgstr ""
+msgstr "Error de entrega de SMS"
 
 #. module: l10n_es_intrastat_report
 #: model_terms:ir.ui.view,arch_db:l10n_es_intrastat_report.l10n_es_intrastat_product_declaration_view_search
@@ -498,6 +521,10 @@ msgid ""
 "Today: Activity date is today\n"
 "Planned: Future activities."
 msgstr ""
+"Estado basado en las actividades\n"
+"Atrasado: La fecha de vencimiento ya está vencida\n"
+"Hoy: La fecha de la actividad es hoy\n"
+"Planificado: Actividades futuras."
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_computation_line__intrastat_unit_id
@@ -567,7 +594,7 @@ msgstr "Tipo"
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,help:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__activity_exception_decoration
 msgid "Type of the exception activity on record."
-msgstr ""
+msgstr "Tipo de actividad de excepción registrada."
 
 #. module: l10n_es_intrastat_report
 #: code:addons/l10n_es_intrastat_report/wizards/l10n_es_intrastat_code_import.py:0
@@ -594,6 +621,12 @@ msgstr "Usado en vistas y métodos de módulos de localización."
 #: model:ir.model.fields,help:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__revision
 msgid "Used to keep track of changes"
 msgstr "Usado para rastrear los cambios"
+
+#. module: l10n_es_intrastat_report
+#: code:addons/l10n_es_intrastat_report/report/intrastat_product_report_xls.py:0
+#, python-format
+msgid "VAT"
+msgstr "NIF"
 
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_computation_line__valid

--- a/l10n_es_intrastat_report/i18n/l10n_es_intrastat_report.pot
+++ b/l10n_es_intrastat_report/i18n/l10n_es_intrastat_report.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-02-22 12:41+0000\n"
+"PO-Revision-Date: 2022-02-22 12:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -362,6 +364,18 @@ msgstr ""
 #. module: l10n_es_intrastat_report
 #: model:ir.model.fields,field_description:l10n_es_intrastat_report.field_l10n_es_intrastat_product_declaration__message_ids
 msgid "Messages"
+msgstr ""
+
+#. module: l10n_es_intrastat_report
+#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:0
+#, python-format
+msgid "Missing origin country on product %s."
+msgstr ""
+
+#. module: l10n_es_intrastat_report
+#: code:addons/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py:0
+#, python-format
+msgid "Missing partner vat on invoice %s."
 msgstr ""
 
 #. module: l10n_es_intrastat_report

--- a/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
+++ b/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
@@ -45,6 +45,24 @@ class L10nEsIntrastatProductDeclaration(models.Model):
             intrastat_state = inv_line.company_id.partner_id.state_id
         return intrastat_state
 
+    def _gather_invoices(self):
+        old_lines = super()._gather_invoices()
+        lines = []
+        product_model = self.env["product.product"]
+        for line in old_lines:
+            if self.type == "dispatches" and int(self.year) >= 2022:
+                if not line["product_origin_country_id"]:
+                    product = product_model.browse(line["product_id"])
+                    note = (
+                        "\n"
+                        + _("Missing origin country on product %s.")
+                        % product.name_get()[0][1]
+                    )
+                    self._note += note
+                    continue
+            lines.append(line)
+        return lines
+
     def _update_computation_line_vals(self, inv_line, line_vals):
         super()._update_computation_line_vals(inv_line, line_vals)
         intrastat_state = self._get_intrastat_state(inv_line)
@@ -57,6 +75,12 @@ class L10nEsIntrastatProductDeclaration(models.Model):
             line_vals["partner_vat"] = (
                 inv_line.move_id.partner_shipping_id.vat or "QV999999999999"
             )
+            if not inv_line.move_id.partner_shipping_id.vat:
+                note = (
+                    "\n"
+                    + _("Missing partner vat on invoice %s.") % inv_line.move_id.name
+                )
+                self._note += note
 
     def _gather_invoices_init(self):
         if self.company_id.country_id.code != "ES":

--- a/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
+++ b/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
@@ -38,7 +38,11 @@ class TestL10nIntraStatReport(SavepointCase):
         cls.env["l10n.es.intrastat.code.import"].create({}).execute()
         # Create product ans assign random HS Code
         cls.product = cls.env["product.product"].create(
-            {"name": "Test product", "hs_code_id": cls.env["hs.code"].browse(1).id}
+            {
+                "name": "Test product",
+                "hs_code_id": cls.env["hs.code"].browse(1).id,
+                "origin_country_id": cls.env.ref("base.fr").id,
+            }
         )
         # Invoices to be used in dispatches
         cls.invoices = {


### PR DESCRIPTION
FWP de 12.0: https://github.com/OCA/l10n-spain/pull/2101

Se añade al campo "notas" un aviso cuando el NIF no está definido.
Se muestra un error cuando el país de origen del producto no está definido puesto que es ahora un dato obligatorio. 

El campo notas se usa a nivel general para mostrar todos esos avisos.

Relacionado con https://github.com/OCA/l10n-spain/pull/1969

Por favor, @chienandalu y @pedrobaeza puedes revisarlo?

@Tecnativa TT29332