### PR TITLE
[13.0][FIX] l10n_es_ticketbai: no dejar validar facturas rectificativas sin…

### DIFF
--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -163,6 +163,14 @@ class AccountMove(models.Model):
             self.tbai_vat_regime_key2 = self.fiscal_position_id.tbai_vat_regime_key2.id
             self.tbai_vat_regime_key3 = self.fiscal_position_id.tbai_vat_regime_key3.id
 
+    @api.onchange("reversed_entry_id")
+    def onchange_tbai_reversed_entry_id(self):
+        if self.reversed_entry_id:
+            if not self.tbai_refund_type:
+                self.tbai_refund_type = RefundType.differences.value
+            if not self.tbai_refund_key:
+                self.tbai_refund_key = RefundCode.R1.value
+
     def tbai_prepare_invoice_values(self):
         def tbai_prepare_refund_values():
             refunded_inv = self.reversed_entry_id
@@ -431,7 +439,8 @@ class AccountMove(models.Model):
         refund_invoices = self.sudo().filtered(
             lambda x: x.tbai_enabled
             and "out_refund" == x.type
-            and x.tbai_refund_type == RefundType.differences.value
+            and not x.tbai_refund_type
+            or x.tbai_refund_type == RefundType.differences.value
             and x.tbai_send_invoice
         )
 

--- a/l10n_es_ticketbai/views/account_move_views.xml
+++ b/l10n_es_ticketbai/views/account_move_views.xml
@@ -47,7 +47,16 @@
                             string="Refund"
                             attrs="{'invisible': [('type', '!=', 'out_refund')]}"
                         >
-                            <field name="reversed_entry_id" invisible="1" />
+                            <group
+                                name="tbai_reversed_entry_id"
+                                attrs="{'invisible': ['|', '|', ('tbai_enabled', '!=', True), ('tbai_refund_origin_ids', '!=', []), ('type', '!=', 'out_refund')]}"
+                            >
+                                <field
+                                    name="reversed_entry_id"
+                                    domain="[('type', '=', 'out_invoice'), ('state', '=', 'posted'), ('company_id', '=', company_id), ('partner_id', '=', partner_id)]"
+                                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                                />
+                            </group>
                             <group
                                 name="tbai_refund_key_type"
                                 string="Key/Type"


### PR DESCRIPTION
… factura rectificada asociada o datos de facturas origen sin especificar

Cherry-pick de bd7d0d48497bb6f6718684a50710de959e76e361 del PR #2147 con migración a V13