### PR TITLE
[FIX] l10n_es_aeat_sii_oca: Duplicated third party fields

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -1513,7 +1513,7 @@ class AccountMove(models.Model):
             node = doc.xpath("//field[@name='thirdparty_invoice']")
             if node:
                 return res
-            for node in doc.xpath("//field[@name='ref']"):
+            for node in doc.xpath("//field[@name='ref'][last()]"):
                 attrs = {
                     "required": [("thirdparty_invoice", "=", True)],
                     "invisible": [("thirdparty_invoice", "=", False)],

--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -325,7 +325,7 @@ class AccountMove(models.Model):
             node = doc.xpath("//field[@name='thirdparty_invoice']")
             if node:
                 return res
-            for node in doc.xpath("//field[@name='ref']"):
+            for node in doc.xpath("//field[@name='ref'][last()]"):
                 attrs = {
                     "required": [("thirdparty_invoice", "=", True)],
                     "invisible": [("thirdparty_invoice", "=", False)],


### PR DESCRIPTION
- Hacer que los campos `thirdparty_invoice` y `thirdparty_number` no sea vean por duplicado en la vista. Esto ocurre porque en la vista original, el campo `ref` está añadido dos veces (con las condiciones correspondientes para que solo se muestre una vez según el caso) https://github.com/odoo/odoo/blob/14.0/addons/account/views/account_move_views.xml#L658

Sin estos cambios:

![oca_thirdparty_invoice](https://user-images.githubusercontent.com/29223264/155555521-3d41dc3e-d082-4b51-a164-5526f8431845.gif)

