### PR TITLE
[14.0][IMP] l10n_es_aeat_sii_oca: Remove required condition in reference field from invoices.

### DIFF
--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -26,11 +26,6 @@
                     attrs="{'invisible': ['|','|',('sii_enabled', '=', False), ('state', 'not in', ['cancel']), ('sii_state', 'not in', ['sent','sent_w_errors','sent_modified'])]}"
                 />
             </button>
-            <field name="ref" position="attributes">
-                <attribute
-                    name="attrs"
-                >{'required':[('state','=', 'draft'), ('move_type', 'in', ['in_invoice', 'in_refund'])]}</attribute>
-            </field>
             <notebook position="inside">
                 <page
                     string="SII"


### PR DESCRIPTION
Se elimina la condición de obligatoriedad del campo referencia en la factura para una correcta visualización.

Antes:
![14-factura-antes](https://user-images.githubusercontent.com/4117568/155671760-db6d7284-0b7d-419f-95d1-53cb269380d6.png)

Esto será necesario también aplicarlo a 15.0

Por favor @pedrobaeza y @chienandalu ¿podéis revisarlo?

@Tecnativa TT32612
