### PR TITLE
[FIX] 11.0 l10n_es_ticketbai corregir signo del importe del descuento tbai en las líneas de las facturas rectificadass

### DIFF
--- a/l10n_es_ticketbai/__manifest__.py
+++ b/l10n_es_ticketbai/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "TicketBAI - "
             "declaración de todas las operaciones de venta realizadas por las personas "
             "y entidades que desarrollan actividades económicas",
-    "version": "11.0.1.3.0",
+    "version": "11.0.1.3.1",
     "category": "Accounting & Finance",
     "website": "http://www.binovo.es",
     "author": "Binovo,"

--- a/l10n_es_ticketbai/models/account_invoice.py
+++ b/l10n_es_ticketbai/models/account_invoice.py
@@ -503,7 +503,15 @@ class AccountInvoiceLine(models.Model):
 
     def tbai_get_value_descuento(self):
         if self.discount:
-            res = "%.2f" % (self.quantity * self.price_unit * self.discount / 100.0)
+            if RefundType.differences.value == self.invoice_id.tbai_refund_type:
+                sign = -1
+            else:
+                sign = 1
+            res = \
+                "%.2f" \
+                % \
+                (sign * self.quantity * self.price_unit *
+                 self.discount / 100.0)
         else:
             res = '0.00'
         return res


### PR DESCRIPTION
Fix del método tbai_get_value_descuento que devuelve el importe total del descuento a indicar en la factura Tbai: invertir el signo del importe del descuento. Se sigue así el mismo criterio que los tbai_get de la cantidad de unidades o el importe total de la línea.

De esta manera, se quiere corregir el caso por ejemplo de una factura original con un importe de descuento de 10€, a la hora del caso de hacer una factura rectificada de esta factura original (devolución al cliente), hay que indicar que el descuento es de -10€.