### PR TITLE
[IMP][15.0][l10n_es_aeat_mod123] Igualar el nombre del menu como en v14

### DIFF
--- a/l10n_es_aeat_mod123/views/mod123_view.xml
+++ b/l10n_es_aeat_mod123/views/mod123_view.xml
@@ -126,6 +126,6 @@
         parent="l10n_es_aeat.menu_root_aeat"
         action="action_l10n_es_aeat_mod123_report"
         sequence="123"
-        name="AEAT 123 Model"
+        name="Modelo 123"
     />
 </odoo>


### PR DESCRIPTION
El nombre del menú no es estándar con este pequeño cambio igualamos todos y así v15 pasa a estar igual que v14

https://github.com/OCA/l10n-spain/blob/14.0/l10n_es_aeat_mod123/views/mod123_view.xml#L129

![imagen](https://user-images.githubusercontent.com/8736623/156885049-4cd0af4a-3a80-4c39-95c8-2a1d83bd2347.png)

@moduon