### PR TITLE
[11.0][FIX] l10n_es_ticketbai_batuz: Fix multi-currency rate selection depe…

### DIFF
--- a/l10n_es_ticketbai_batuz/models/account_invoice.py
+++ b/l10n_es_ticketbai_batuz/models/account_invoice.py
@@ -326,7 +326,7 @@ class AccountInvoice(models.Model):
                     OrderedDict([
                         ("BaseRectificada", abs(origin.amount_untaxed_signed)),
                         ("CuotaRectificada", abs(
-                            origin.amount_total_company_signed -
+                            origin._get_amount_company_currency(origin.amount_total) -
                             origin.amount_untaxed_signed
                         )),
                         # (CuotaRecargoRectificada, False),
@@ -546,7 +546,8 @@ class AccountInvoice(models.Model):
         res = OrderedDict([
             ("DescripcionOperacion", self._get_batuz_description()[:250]),
             ("Claves", self._get_lroe_claves()),
-            ("ImporteTotalFactura", amount_total or self.amount_total_company_signed),
+            ("ImporteTotalFactura",
+             amount_total or self._get_amount_company_currency(self.amount_total)),
             # Base imponible a coste (para grupos de IVA – nivel avanzado (240))
             # ("BaseImponibleACoste", False),
         ])
@@ -581,7 +582,8 @@ class AccountInvoice(models.Model):
             sign = self._get_lroe_sign()
             taxes_dict, tax_amount, not_in_amount_total = self._get_lroe_in_taxes(sign)
             amount_total = (
-                abs(self.amount_total_company_signed) - not_in_amount_total
+                abs(self._get_amount_company_currency(self.amount_total))
+                - not_in_amount_total
             ) * sign
             inv_dict = OrderedDict([
                 ("Gasto", OrderedDict([
@@ -624,7 +626,8 @@ class AccountInvoice(models.Model):
             sign = self._get_lroe_sign()
             taxes_dict, tax_amount, not_in_amount_total = self._get_lroe_in_taxes(sign)
             amount_total = (
-                abs(self.amount_total_company_signed) - not_in_amount_total
+                abs(self._get_amount_company_currency(self.amount_total))
+                - not_in_amount_total
             ) * sign
             inv_dict = OrderedDict([
                 ("FacturaRecibida", OrderedDict([


### PR DESCRIPTION
…nding on date

Se ha detectado que al enviar a Batuz una factura de proveedor con una moneda que no sea la de la compañía, si la fecha de factura y fecha contable no coinciden se hace mal la conversión ya que se seleccionan diferentes tasas de cambio.

Para poner un ejemplo, tenemos una factura con fecha 15 de enero de 2022 (`date_invoice`), y fecha contable 15 de febrero de 2022 (`date`). El importe de la factura es de $ 9.745,00.

Tenemos en las tasas de cambio un registro del 31 de diciembre 2021 que dice que 1€ equivale a 1.132600$, y otra con fecha 31 de enero 2022 que lo establece a 1.115600$. Se observa que al generar el registro para enviar a Batuz en el campo _ImporteTotalFactura_ marca 8604.1€ (ha utilizado la tasa antigua, porque está usando la fecha de la factura, campo `date_invoice`), en cambio, en el campo _BaseImponible_ del _DetalleIVA_ marca 8735.21€ (para este cálculo ha utilizado la tasa que corresponde a la fecha contable, campo `date`).

Como solución se ha hecho que siempre se utilice el valor obtenido de la conversión mediante la tasa correspondiente a la fecha contable (`date`).

PING @enriquemartin @xAdrianC-Kernet