### PR TITLE
[14.0][FIX] l10n_es_ticketbai_api: Load security data

### DIFF
--- a/l10n_es_ticketbai_api/__manifest__.py
+++ b/l10n_es_ticketbai_api/__manifest__.py
@@ -26,6 +26,7 @@
     },
     "data": [
         "security/ir.model.access.csv",
+        "security/l10n_es_ticketbai_security.xml",
         "data/tax_agency_data.xml",
         "data/ticketbai_invoice.xml",
         "views/l10n_es_ticketbai_api_views.xml",


### PR DESCRIPTION
Migrando a la V15 me he dado cuenta que faltaba la referencia al fichero xml de multicompañía en el manifest. Este cambio se realizó en el PR #2139  