### PR TITLE
[11.0][IMP] l10n_es_ticketbai* - añadir tbai_active_date al diario

### DIFF
--- a/l10n_es_ticketbai/__manifest__.py
+++ b/l10n_es_ticketbai/__manifest__.py
@@ -40,6 +40,7 @@
         "views/account_fiscal_position_template_views.xml",
         "views/account_fiscal_position_views.xml",
         "views/account_invoice_views.xml",
+        "views/account_journal_views.xml",
         "views/ir_sequence_views.xml",
         "views/report_invoice.xml",
         "views/res_company_views.xml",

--- a/l10n_es_ticketbai/i18n/es.po
+++ b/l10n_es_ticketbai/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-26 10:55+0000\n"
-"PO-Revision-Date: 2021-10-13 18:45+0200\n"
+"POT-Creation-Date: 2022-03-11 09:01+0000\n"
+"PO-Revision-Date: 2022-03-11 10:03+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "Language: \n"
@@ -171,6 +171,7 @@ msgstr "Nombre mostrado"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice_tbai_enabled
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal_tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_ir_sequence_tbai_enabled
 msgid "Enable TicketBAI"
 msgstr "Habilitar TicketBAI"
@@ -286,6 +287,11 @@ msgstr ""
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_tbai_invoice
 msgid "Invoices"
 msgstr "Facturas"
+
+#. module: l10n_es_ticketbai
+#: model:ir.model,name:l10n_es_ticketbai.model_account_journal
+msgid "Journal"
+msgstr "Diario"
 
 #. module: l10n_es_ticketbai
 #: model:ir.ui.view,arch_db:l10n_es_ticketbai.invoice_form_inherit
@@ -450,6 +456,12 @@ msgstr ""
 "estado incosistente, por favor corrija primero esos errores."
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_account_journal_tbai_active_date
+msgid "Start date for sending invoices to the tax authorities"
+msgstr ""
+"Fecha a partir de la cual se enviarán las facturas de este diario a hacienda"
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice_tbai_substitute_simplified_invoice
 msgid "Substitute Simplified Invoice"
 msgstr "Sustituye a una factura simplificada"
@@ -535,6 +547,7 @@ msgstr ""
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_finance_ticketbai
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_l10n_es_tbai_config
 #: model:ir.ui.view,arch_db:l10n_es_ticketbai.invoice_form_inherit
+#: model:ir.ui.view,arch_db:l10n_es_ticketbai.view_account_journal_form_inherit_ticketbai
 #: model:ir.ui.view,arch_db:l10n_es_ticketbai.view_account_position_form_inherit
 #: model:ir.ui.view,arch_db:l10n_es_ticketbai.view_partner_property_form_inherit
 msgid "TicketBAI"
@@ -676,6 +689,11 @@ msgid "TicketBAI VAT Regime mapping keys"
 msgstr "TicketBAI Mapeo claves de regímenes de IVA"
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal_tbai_active_date
+msgid "TicketBAI active date"
+msgstr "Fecha activación TicketBAI"
+
+#. module: l10n_es_ticketbai
 #: model:ir.ui.view,arch_db:l10n_es_ticketbai.view_ticketbai_info_form
 msgid "TicketBAI is disabled."
 msgstr "TicketBAI está deshabilitado."
@@ -774,6 +792,16 @@ msgstr ""
 "No es posible cancelar una factura con facturas rectificativas no "
 "canceladas.\n"
 "Facturas relacionadas: %s"
+
+#. module: l10n_es_ticketbai
+#: code:addons/l10n_es_ticketbai/models/account_journal.py:25
+#, python-format
+msgid ""
+"You cannot change the active date from this journal, because at least one "
+"invoice has already been sent."
+msgstr ""
+"No puede modificar la fecha de activación TicketBAI en este diario ya que "
+"existen facturas enviadas."
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:79

--- a/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
+++ b/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
@@ -164,6 +164,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice_tbai_enabled
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal_tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_ir_sequence_tbai_enabled
 msgid "Enable TicketBAI"
 msgstr ""
@@ -272,6 +273,11 @@ msgstr ""
 #. module: l10n_es_ticketbai
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_tbai_invoice
 msgid "Invoices"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model:ir.model,name:l10n_es_ticketbai.model_account_journal
+msgid "Journal"
 msgstr ""
 
 #. module: l10n_es_ticketbai
@@ -417,6 +423,11 @@ msgid "Some of the original invoices have related tbai invoices in inconsistent 
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_account_journal_tbai_active_date
+msgid "Start date for sending invoices to the tax authorities"
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice_tbai_substitute_simplified_invoice
 msgid "Substitute Simplified Invoice"
 msgstr ""
@@ -498,6 +509,7 @@ msgstr ""
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_finance_ticketbai
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_l10n_es_tbai_config
 #: model:ir.ui.view,arch_db:l10n_es_ticketbai.invoice_form_inherit
+#: model:ir.ui.view,arch_db:l10n_es_ticketbai.view_account_journal_form_inherit_ticketbai
 #: model:ir.ui.view,arch_db:l10n_es_ticketbai.view_account_position_form_inherit
 #: model:ir.ui.view,arch_db:l10n_es_ticketbai.view_partner_property_form_inherit
 msgid "TicketBAI"
@@ -632,6 +644,11 @@ msgid "TicketBAI VAT Regime mapping keys"
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal_tbai_active_date
+msgid "TicketBAI active date"
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model:ir.ui.view,arch_db:l10n_es_ticketbai.view_ticketbai_info_form
 msgid "TicketBAI is disabled."
 msgstr ""
@@ -714,6 +731,12 @@ msgstr ""
 #, python-format
 msgid "You cannot cancel an invoice with non cancelled credit notes.\n"
 "Related invoices: %s"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: code:addons/l10n_es_ticketbai/models/account_journal.py:25
+#, python-format
+msgid "You cannot change the active date from this journal, because at least one invoice has already been sent."
 msgstr ""
 
 #. module: l10n_es_ticketbai

--- a/l10n_es_ticketbai/models/__init__.py
+++ b/l10n_es_ticketbai/models/__init__.py
@@ -1,5 +1,6 @@
 from . import account_fiscal_position
 from . import account_invoice
+from . import account_journal
 from . import account_invoice_tax
 from . import account_tax
 from . import aeat_certificate

--- a/l10n_es_ticketbai/models/account_invoice.py
+++ b/l10n_es_ticketbai/models/account_invoice.py
@@ -382,13 +382,16 @@ class AccountInvoice(models.Model):
         # There is no 'by substitution' credit note, only 'by differences'.
         tbai_invoices = self.sudo().env['account.invoice']
         tbai_invoices |= self.sudo().filtered(
-            lambda x: x.tbai_enabled and 'out_invoice' == x.type)
+            lambda x:
+            x.tbai_enabled and 'out_invoice' == x.type and
+            x.date and x.date >= x.journal_id.tbai_active_date)
         refund_invoices = \
             self.sudo().filtered(
                 lambda x:
                 x.tbai_enabled and 'out_refund' == x.type and
                 not x.tbai_refund_type or
-                x.tbai_refund_type == RefundType.differences.value)
+                x.tbai_refund_type == RefundType.differences.value and
+                x.date and x.date >= x.journal_id.tbai_active_date)
 
         validate_refund_invoices()
         tbai_invoices |= refund_invoices

--- a/l10n_es_ticketbai/models/account_journal.py
+++ b/l10n_es_ticketbai/models/account_journal.py
@@ -1,0 +1,26 @@
+#  Copyright 2022 Digital5, S.L.
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    tbai_enabled = fields.Boolean(
+        related="company_id.tbai_enabled", readonly=True)
+    tbai_active_date = fields.Date(
+        string="TicketBAI active date",
+        help="Start date for sending invoices to the tax authorities",
+        default=fields.Date.from_string("2022-01-01"))
+
+    @api.onchange("tbai_active_date")
+    def onchange_tbai_active_date(self):
+        tbai_invoices = self.env["account.invoice"].search(
+            [("journal_id", "=", self._origin.id),
+                ("tbai_invoice_id", "!=", False)]
+        )
+        if len(tbai_invoices) > 0:
+            raise UserError(_("You cannot change the active date from this journal,"
+                              " because at least one invoice has already been sent."))

--- a/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
+++ b/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
@@ -30,6 +30,16 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
         res = XMLSchema.xml_is_valid(self.test_xml_invoice_schema_doc, root)
         self.assertTrue(res)
 
+    def test_invoice_out_of_term(self):
+        invoice = self.create_draft_invoice(
+            self.account_billing.id, self.fiscal_position_national)
+        invoice.date_invoice = date(2021, 12, 31)
+        invoice.onchange_fiscal_position_id_tbai_vat_regime_key()
+        invoice.compute_taxes()
+        invoice.action_invoice_open()
+        self.assertEqual(invoice.state, 'open')
+        self.assertEqual(0, len(invoice.tbai_invoice_ids))
+
     def test_cancel_and_recreate(self):
         # Build three invoices and check the chaining.
         invoice = self.create_draft_invoice(

--- a/l10n_es_ticketbai/views/account_journal_views.xml
+++ b/l10n_es_ticketbai/views/account_journal_views.xml
@@ -1,0 +1,21 @@
+<odoo>
+    <record id="view_account_journal_form_inherit_ticketbai" model="ir.ui.view">
+        <field name="name">view_account_journal_form_inherit_ticketbai</field>
+        <field name="model">account.journal</field>
+        <field name="type">form</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="groups_id" eval="[(4, ref('base.group_erp_manager'))]"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page name="ticketbai_config" string="TicketBAI" attrs="{'invisible': [('tbai_enabled', '=', False)]}">
+                    <group>
+                        <group>
+                            <field name="tbai_enabled" invisible="1" />
+                            <field name="tbai_active_date"/>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/l10n_es_ticketbai_batuz/models/account_invoice.py
+++ b/l10n_es_ticketbai_batuz/models/account_invoice.py
@@ -807,6 +807,7 @@ class AccountInvoice(models.Model):
         res = super().action_cancel()
         lroe_invoices = self.sudo().filtered(
             lambda x: x.tbai_enabled
+            and x.date and x.date >= x.journal_id.tbai_active_date
             and x.lroe_state not in ("error")
             and (
                 x.type == "in_invoice"
@@ -844,6 +845,7 @@ class AccountInvoice(models.Model):
         res = super(AccountInvoice, self).invoice_validate()
         lroe_invoices = self.sudo().filtered(
             lambda x: x.tbai_enabled
+            and x.date and x.date >= x.journal_id.tbai_active_date
             and (
                 x.type == "in_invoice"
                 or (


### PR DESCRIPTION
Teniendo en cuenta que existe un periodo voluntario para darse de alta en ticketbai (o batuz en Bizkaia), se añade campo fecha en el diario para controlar a partir de qué fecha realizar comunicaciones con hacienda.

Ese campo solo es visible para usuarios con permisos de _Administración / Permisos de acceso_