### PR TITLE
[11.0][FIX] l10n_es_ticketbai_api_batuz: Response values

### DIFF
--- a/l10n_es_ticketbai_api_batuz/models/lroe_operation_response.py
+++ b/l10n_es_ticketbai_api_batuz/models/lroe_operation_response.py
@@ -18,13 +18,13 @@ class LROEOperationResponseState(Enum):
     BUILD_ERROR = '-2'
     REQUEST_ERROR = '-1'
     CORRECT = 'Correcto'
-    PARTIALLY_CORRECT = 'Parcialmente correcto'
+    PARTIALLY_CORRECT = 'ParcialmenteCorrecto'
     INCORRECT = 'Incorrecto'
 
 
 class LROEOperationResponseLineState(Enum):
     CORRECT = 'Correcto'
-    CORRECT_WITH_ERRORS = 'Aceptado con errores'
+    CORRECT_WITH_ERRORS = 'AceptadoConErrores'
     INCORRECT = 'Incorrecto'
 
 

--- a/l10n_es_ticketbai_api_batuz/tests/test_lroe_operation.py
+++ b/l10n_es_ticketbai_api_batuz/tests/test_lroe_operation.py
@@ -352,7 +352,7 @@ class TestL10nEsTicketBAIAPIBatuz(TestL10nEsTicketBAIAPI):
         lroe_op_alta_model_pj_240 = self.lroe_op_model.create(lroe_op_alta_pj_240_dict)
         response_headers = {
             'date': str(datetime.datetime.now()),
-            'eus-bizkaia-n3-tipo-respuesta': 'Parcialmente correcto',
+            'eus-bizkaia-n3-tipo-respuesta': 'ParcialmenteCorrecto',
             'eus-bizkaia-n3-identificativo': '1',
             'eus-bizkaia-n3-numero-registro': '1001'}
         with open(TEST_07_RESPONSE_GZ_FILENAME, 'rb') as response_data_file:
@@ -400,7 +400,7 @@ class TestL10nEsTicketBAIAPIBatuz(TestL10nEsTicketBAIAPI):
         lroe_op_alta_model_pf_140 = self.lroe_op_model.create(lroe_op_alta_pf_140_dict)
         response_headers = {
             'date': str(datetime.datetime.now()),
-            'eus-bizkaia-n3-tipo-respuesta': 'Parcialmente correcto',
+            'eus-bizkaia-n3-tipo-respuesta': 'ParcialmenteCorrecto',
             'eus-bizkaia-n3-identificativo': '1',
             'eus-bizkaia-n3-numero-registro': '1001'}
         with open(TEST_08_RESPONSE_GZ_FILENAME, 'rb') as response_data_file:


### PR DESCRIPTION
Se corrigen los valores de respuesta de hacienda para los siguientes casos

Parcialmente correcto -> ParcialmenteCorrecto
Aceptado con errores -> AceptadoConErrores


Se puede ver en los ficheros XSD de la documentación de BATUZ que efectivamente estos son los valores correctos

`<simpleType name="EstadoEnvioEnum">
        <restriction base="string">
            <enumeration value="Correcto">
                <annotation>
                    <documentation>Correcto</documentation>
                </annotation>
            </enumeration>
            <enumeration value="ParcialmenteCorrecto">
                <annotation>
                    <documentation>Parcialmente correcto.</documentation>
                </annotation>
            </enumeration>
            <enumeration value="Incorrecto">
                <annotation>
                    <documentation>Incorrecto</documentation>
                </annotation>
            </enumeration>
        </restriction>
    </simpleType>`

`<simpleType name="EstadoRegistroEnum">
        <restriction base="string">
            <enumeration value="Correcto">
                <annotation>
                    <documentation>Correcto</documentation>
                </annotation>
            </enumeration>
            <enumeration value="AceptadoConErrores">
                <annotation>
                    <documentation>Aceptado con Errores</documentation>
                </annotation>
            </enumeration>
            <enumeration value="Anulado">
                <annotation>
                    <documentation>Anulado</documentation>
                </annotation>
            </enumeration>
            <enumeration value="Incorrecto">
                <annotation>
                    <documentation>Incorrecto</documentation>
                </annotation>
            </enumeration>
        </restriction>
    </simpleType>`