### PR TITLE
[FIX] l10n_es_aeat_mod303: Change sign on compute_casilla_69 operation

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -72,7 +72,7 @@ class L10nEsAeatMod303Report(models.Model):
     def _compute_casilla_69(self):
         for report in self:
             report.casilla_69 = (
-                report.atribuible_estado + report.casilla_77 +
+                report.atribuible_estado + report.casilla_77 -
                 report.cuota_compensar + report.regularizacion_anual)
 
     @api.multi


### PR DESCRIPTION
Cambiado signo del campo "cuota_compensar" en la operación del compute_casilla_69, tal y como está en la versión 10.