### PR TITLE
[14.0][FIX] delivery_gls_asm: stock_picking_batch fail

### DIFF
--- a/delivery_gls_asm/views/stock_picking_views.xml
+++ b/delivery_gls_asm/views/stock_picking_views.xml
@@ -75,6 +75,7 @@
                 }</attribute>
             </xpath>
             <xpath expr="//field[@name='tracking_state']" position="after">
+                <field name="gls_carrier_is_pickup_service" invisible="1" />
                 <field
                     name="gls_pickup_state"
                     attrs="{


### PR DESCRIPTION
Fix error that shows when when activating Batch Pickings in stock configuration

<details>

```

odoo.exceptions.ValidationError: Ocurrió un error al validar la vista:

El campo gls_carrier_is_pickup_service que se usa en attrs.invisible ({                     'invisible': [                         '|',                         ('gls_carrier_is_pickup_service', '=', True),                         ('delivery_type', '!=', 'gls_asm')                     ]                 }) debe estar presente en la vista, pero no se encuentra

View name: stock_picking_batch.picking.form
Error context:
 view: ir.ui.view(2385,)
 xmlid: view_picking_form_inherited
 view.model: stock.picking
 view.parent: ir.ui.view(1025,)
 file: /opt/odoo/src/odoo/odoo/addons/stock_picking_batch/views/stock_picking_batch_views.xml


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/src/odoo/odoo/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 685, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 361, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/src/odoo/odoo/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 349, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 914, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 533, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/src/odoo/odoo/addons/web/controllers/main.py", line 1398, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/src/odoo/odoo/addons/web/controllers/main.py", line 1386, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/src/odoo/odoo/odoo/api.py", line 399, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/src/odoo/odoo/odoo/api.py", line 386, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/src/odoo/odoo/odoo/addons/base/models/res_config.py", line 642, in execute
    installation_status = self._install_modules(to_install)
  File "/opt/odoo/src/odoo/odoo/odoo/addons/base/models/res_config.py", line 36, in _install_modules
    result = to_install_modules.button_immediate_install()
  File "<decorator-gen-72>", line 2, in button_immediate_install
  File "/opt/odoo/src/odoo/odoo/odoo/addons/base/models/ir_module.py", line 74, in check_and_log
    return method(self, *args, **kwargs)
  File "/opt/odoo/src/odoo/odoo/odoo/addons/base/models/ir_module.py", line 475, in button_immediate_install
    return self._button_immediate_function(type(self).button_install)
  File "/opt/odoo/src/odoo/odoo/odoo/addons/base/models/ir_module.py", line 593, in _button_immediate_function
    modules.registry.Registry.new(self._cr.dbname, update_module=True)
  File "/opt/odoo/src/odoo/odoo/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/src/odoo/odoo/odoo/modules/loading.py", line 459, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/opt/odoo/src/odoo/odoo/odoo/modules/loading.py", line 347, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/src/odoo/odoo/odoo/modules/loading.py", line 222, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/opt/odoo/src/odoo/odoo/odoo/modules/loading.py", line 69, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/opt/odoo/src/odoo/odoo/odoo/tools/convert.py", line 733, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/opt/odoo/src/odoo/odoo/odoo/tools/convert.py", line 799, in convert_xml_import
    obj.parse(doc.getroot())
  File "/opt/odoo/src/odoo/odoo/odoo/tools/convert.py", line 719, in parse
    self._tag_root(de)
  File "/opt/odoo/src/odoo/odoo/odoo/tools/convert.py", line 681, in _tag_root
    raise ParseError('while parsing %s:%s, near\n%s' % (
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 641, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
odoo.tools.convert.ParseError: while parsing /opt/odoo/src/odoo/odoo/addons/stock_picking_batch/views/stock_picking_batch_views.xml:3, near
<record id="view_picking_form_inherited" model="ir.ui.view">
        <field name="name">stock_picking_batch.picking.form</field>
        <field name="model">stock.picking</field>
        <field name="inherit_id" ref="stock.view_picking_form"/>
        <field name="mode">primary</field>
        <field name="priority" eval="1000"/>
        <field name="arch" type="xml">
            <xpath expr="//header" position="replace">
                <header>
                    <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,assigned,done"/>
                </header>
            </xpath>
        </field>
    </record>
```

<details>
