### PR TITLE
[14.0][FIX] l10n_es_facturae_face: skip check step.

### DIFF
--- a/l10n_es_facturae_efact/tests/test_efact.py
+++ b/l10n_es_facturae_efact/tests/test_efact.py
@@ -301,13 +301,15 @@ class EDIBackendTestCase(TestL10nEsAeatCertificateBase, SavepointComponentRegist
         self.assertFalse(self.move.exchange_record_ids)
         with mock.patch("zeep.client.ServiceProxy") as mock_client:
             mock_client.return_value = DemoService(response_ok)
-            self.move.with_context(force_edi_send=True).post()
+            self.move.with_context(force_edi_send=True).action_post()
             self.move.refresh()
             self.assertTrue(self.move.exchange_record_ids)
             exchange_record = self.move.exchange_record_ids
             self.assertEqual(exchange_record.edi_exchange_state, "output_pending")
             exchange_record.backend_id.exchange_send(exchange_record)
-            self.assertEqual(exchange_record.edi_exchange_state, "output_sent")
+            self.assertEqual(
+                exchange_record.edi_exchange_state, "output_sent_and_processed"
+            )
         # We force it to be efact just for a test, that should never happen for new
         #  invoices
         exchange_record.write(
@@ -347,13 +349,15 @@ class EDIBackendTestCase(TestL10nEsAeatCertificateBase, SavepointComponentRegist
         self.assertFalse(self.move.exchange_record_ids)
         with mock.patch("zeep.client.ServiceProxy") as mock_client:
             mock_client.return_value = DemoService(response_ok)
-            self.move.with_context(force_edi_send=True).post()
+            self.move.with_context(force_edi_send=True).action_post()
             self.move.refresh()
             self.assertTrue(self.move.exchange_record_ids)
             exchange_record = self.move.exchange_record_ids
             self.assertEqual(exchange_record.edi_exchange_state, "output_pending")
             exchange_record.backend_id.exchange_send(exchange_record)
-            self.assertEqual(exchange_record.edi_exchange_state, "output_sent")
+            self.assertEqual(
+                exchange_record.edi_exchange_state, "output_sent_and_processed"
+            )
         # We force it to be efact just for a test, that should never happen for new
         #  invoices
         exchange_record.write(

--- a/l10n_es_facturae_face/data/face_data.xml
+++ b/l10n_es_facturae_face/data/face_data.xml
@@ -56,6 +56,7 @@ Zz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0KCg==</field>
         <field name="name">FACe</field>
         <field name="backend_type_id" ref="facturae_backend_type" />
         <field name="webservice_backend_id" ref="face_webservice" />
+        <field name="output_sent_processed_auto" eval="True" />
     </record>
     <record id="facturae_face_update_exchange_type" model="edi.exchange.type">
         <field name="name">Update Facturae FACe</field>

--- a/l10n_es_facturae_face/migrations/14.0.1.2.0/noupdate_changes.xml
+++ b/l10n_es_facturae_face/migrations/14.0.1.2.0/noupdate_changes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="face_backend" model="edi.backend">
+        <field name="output_sent_processed_auto" eval="True" />
+    </record>
+</odoo>

--- a/l10n_es_facturae_face/migrations/14.0.1.2.0/post-migration.py
+++ b/l10n_es_facturae_face/migrations/14.0.1.2.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "l10n_es_facturae_face", "migrations/14.0.1.2.0/noupdate_changes.xml"
+    )

--- a/l10n_es_facturae_face/tests/test_facturae_face.py
+++ b/l10n_es_facturae_face/tests/test_facturae_face.py
@@ -296,7 +296,9 @@ class EDIBackendTestCase(TestL10nEsAeatCertificateBase, SavepointComponentRegist
             )
             self.assertEqual(exchange_record.edi_exchange_state, "output_pending")
             exchange_record.backend_id.exchange_send(exchange_record)
-            self.assertEqual(exchange_record.edi_exchange_state, "output_sent")
+            self.assertEqual(
+                exchange_record.edi_exchange_state, "output_sent_and_processed"
+            )
             mock_client.assert_called_once()
         self.move.refresh()
         self.assertTrue(self.move.exchange_record_ids)


### PR DESCRIPTION
The backend does not have a check component, so it will raise
a NotImplementedError if we do not skip the check.

@ForgeFlow