### PR TITLE
[14.0][IMP] delivery_gls_asm: Referencia albarán

### DIFF
--- a/delivery_gls_asm/i18n/delivery_gls_asm.pot
+++ b/delivery_gls_asm/i18n/delivery_gls_asm.pot
@@ -449,6 +449,11 @@ msgid "GLS Deliveries Manifest"
 msgstr ""
 
 #. module: delivery_gls_asm
+#: model:ir.model.fields,field_description:delivery_gls_asm.field_stock_picking__gls_asm_picking_ref
+msgid "GLS Picking Reference"
+msgstr ""
+
+#. module: delivery_gls_asm
 #: model_terms:ir.ui.view,arch_db:delivery_gls_asm.view_picking_form
 msgid "GLS Label"
 msgstr ""

--- a/delivery_gls_asm/i18n/es.po
+++ b/delivery_gls_asm/i18n/es.po
@@ -460,6 +460,11 @@ msgid "GLS Deliveries Manifest"
 msgstr "Manifiesto de Envíos GLS"
 
 #. module: delivery_gls_asm
+#: model:ir.model.fields,field_description:delivery_gls_asm.field_stock_picking__gls_asm_picking_ref
+msgid "GLS Picking Reference"
+msgstr "Referencia albarán GLS"
+
+#. module: delivery_gls_asm
 #: model_terms:ir.ui.view,arch_db:delivery_gls_asm.view_picking_form
 msgid "GLS Label"
 msgstr "Etiqueta GLS"

--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -268,7 +268,21 @@ class DeliveryCarrier(models.Model):
             # For compatibility we provide this number although we get
             # two more codes: codbarras and uid
             vals["tracking_number"] = response.get("_codexp")
-            picking.gls_asm_public_tracking_ref = response.get("_codbarras")
+            gls_asm_picking_ref = ""
+            try:
+                references = response.get("Referencias", {}).get("Referencia", [])
+                for ref in references:
+                    if ref.get("_tipo", "") == "N":
+                        gls_asm_picking_ref = ref.get("value", "")
+                        break
+            except Exception:
+                pass
+            picking.write(
+                {
+                    "gls_asm_public_tracking_ref": response.get("_codbarras"),
+                    "gls_asm_picking_ref": gls_asm_picking_ref,
+                }
+            )
             # We post an extra message in the chatter with the barcode and the
             # label because there's clean way to override the one sent by core.
             body = _("GLS Shipping extra info:\n" "barcode: %s") % response.get(
@@ -411,7 +425,12 @@ class DeliveryCarrier(models.Model):
                 )
                 picking.message_post(body=msg)
                 continue
-            picking.gls_asm_public_tracking_ref = False
+            picking.write(
+                {
+                    "gls_asm_public_tracking_ref": False,
+                    "gls_asm_picking_ref": False,
+                }
+            )
             self.gls_asm_tracking_state_update(picking=picking)
 
     def gls_asm_rate_shipment(self, order):

--- a/delivery_gls_asm/models/stock_picking.py
+++ b/delivery_gls_asm/models/stock_picking.py
@@ -11,6 +11,9 @@ class StockPicking(models.Model):
     gls_asm_public_tracking_ref = fields.Char(
         string="GLS Barcode", readonly=True, copy=False
     )
+    gls_asm_picking_ref = fields.Char(
+        string="GLS Picking Reference", readonly=True, copy=False
+    )
     gls_carrier_is_pickup_service = fields.Boolean(
         related="carrier_id.gls_is_pickup_service"
     )


### PR DESCRIPTION
- Añadir campo referencia albarán, esta se guarda de la respuesta de GLS
- No se usa en ningún sitio por ahora,  lo voy a usar personalmente para un cliente que lo quiere guardado, pero como hasta ahora nadie ha necesitado este campo lo dejo escondido por no molestar
- Lo he guardado con un `try except` para que no falle en algún caso que no se ha considerado y cause problemas a la hora de guardar el envío