### PR TITLE
[15.0][FIX] l10n_es_aeat_mod303: Error fichero 303 2022

### DIFF
--- a/l10n_es_aeat_mod303/data/2022/aeat.model.export.config.line.csv
+++ b/l10n_es_aeat_mod303/data/2022/aeat.model.export.config.line.csv
@@ -170,6 +170,6 @@
 "aeat_mod303_2022_main_export_line_14","aeat_mod303_2022_main_export_config",14,"P01 - Régimen general/simplificado","subconfig",0,0,"left",1,"N",0," ","X",,,,,"aeat_mod303_2022_sub01_export_config"
 "aeat_mod303_2022_main_export_line_15","aeat_mod303_2022_main_export_config",15,"P02 - Régimen agrícola, ganadero y forestal (Omitido)","string",0,0,"left",1,"N",0," ","X",,,,,
 "aeat_mod303_2022_main_export_line_16","aeat_mod303_2022_main_export_config",16,"P03 - Informacion adicional + resultado","subconfig",0,0,"left",1,"N",0," ","X",,,,,"aeat_mod303_2022_sub03_export_config"
-"aeat_mod303_2022_main_export_line_17","aeat_mod303_2022_main_export_config",17,"P04 - Informacion adicional - Último periodo exonerados 390","subconfig",0,0,"left",1,"N",0," ","X",,,"object.period_type in ('4T', '12') and object.exonerated_390 == '1'",,"aeat_mod303_2022_sub04_export_config"
+"aeat_mod303_2022_main_export_line_17","aeat_mod303_2022_main_export_config",17,"P04 - Informacion adicional - Último periodo exonerados 390","subconfig",0,0,"left",1,"N",0," ","X",,,"${object.period_type in ('4T', '12') and object.exonerated_390 == '1'}",,"aeat_mod303_2022_sub04_export_config"
 "aeat_mod303_2022_main_export_line_18","aeat_mod303_2022_main_export_config",18,"P05 - Prorratas y deducciones diferenciales (Omitido)","string",0,0,"left",1,"N",0," ","X",,,,,
 "aeat_mod303_2022_main_export_line_19","aeat_mod303_2022_main_export_config",19,"Constante. </T3030+Ejercicio+periodo+0000>","string",18,0,"left",1,"N",0," ","X","</T3030${object.year}${object.period_type}0000>",,,,


### PR DESCRIPTION
Está añadiendo siempre el P04 al generar el fichero del 303 porque no evalúa correctamente la expresión