### PR TITLE
[14.0][FIX] l10n_es_vat_book: Cuota de adquisiciones intracomunitarias

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -415,7 +415,9 @@ class L10nEsVatBook(models.Model):
                 taxes = self.env["account.tax"]
                 for map_line in map_lines:
                     taxes |= map_line.get_taxes(rec)
-                account = rec.get_account_from_template(map_line.tax_account_id)
+                account = rec.get_account_from_template(
+                    map_lines.mapped("tax_account_id")
+                )
                 # Filters in all possible data using, sets for improving performance
                 if account:
                     lines = moves.filtered(


### PR DESCRIPTION
Hola @pedrobaeza 

El último cherry-pick sobre el Libro de IVA para recuperar la visualización correcta de los recargos de equivalencia, para 13.0, 14.0 y 15.0 necesita esta corrección, ya que sin esto, se están sacando las cuotas de los impuestos que tienen doble tributación a 0 y debería de computar sólo la soportada, por eso se hacía desde la 13.0 lo de filtrar por cuenta 472 en el mapeo de soportadas.

Habría que aplicarlo para 13.0 y 15.0 también

Un saludo