### PR TITLE
[14.0][FIX] l10n_es_aeat_mod_349: Múltiples rectificativas con el mismo periodo y empresa

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -289,7 +289,7 @@ class Mod349(models.Model):
             key_vals = data.setdefault(
                 key, {"original_amount": 0, "refund_details": refund_detail_obj}
             )
-            key_vals["original_amount"] += origin_amount
+            key_vals["original_amount"] = origin_amount
             key_vals["refund_details"] += refund_details
         for key, key_vals in data.items():
             partner, op_key, period_type, year = key

--- a/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
@@ -1,5 +1,5 @@
 * Luis Manuel Angueira Blanco (Pexego)
-* Omar Castiñeira Saavedra<omar@pexego.es>
+* Omar Castiñeira Saavedra <omar@comunitea.com>
 * Miguel López (Top Consultant)
 * Ignacio Martínez (Top Consultant)
 * `Tecnativa <https://www.tecnativa.com>`__:


### PR DESCRIPTION
Hola,

Un pequeño error en el 349, en el apartado de rectificativas busca para cada factura su periodo de declaración original y se traer el importe original para calcular el importe rectificado, el problema surge si hay más de una rectificatica del mismo cliente/proveedor para el mismo periodo, que este importe original se duplica y por lo tanto, el importe rectificado también.

El error está ahí desde la versión 9.0

Un saludo