### PR TITLE
[13.0][FIX+IMP] l10n_es_vat_book: Filter accounts only for the restricted taxes + regression tests

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -406,6 +406,8 @@ class L10nEsVatBook(models.Model):
             if not rec.company_id.partner_id.vat:
                 raise UserError(_("This company doesn't have VAT"))
             rec._clear_old_data()
+            # Searches for all possible usable lines to report
+            moves = rec._get_account_move_lines()
             for book_type in ["issued", "received"]:
                 map_lines = self.env["aeat.vat.book.map.line"].search(
                     [("book_type", "=", book_type)]
@@ -418,8 +420,6 @@ class L10nEsVatBook(models.Model):
                     if map_line.tax_account_id:
                         account = rec.get_account_from_template(map_line.tax_account_id)
                         accounts.update({tax: account for tax in line_taxes})
-                # Searches for all possible usable lines to report
-                moves = self._get_account_move_lines()
                 # Filter in all possible data using sets for improving performance
                 if accounts:
                     lines = moves.filtered(

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -22,12 +22,12 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatModBase):
     taxes_purchase = {
         # tax code: (base, tax_amount)
         "P_IVA21_SC": (230, 48.3),
+        "P_IVA0_ND": (100, 21),
     }
 
     def test_model_vat_book(self):
         # Purchase invoices
-        purchase = self._invoice_purchase_create("2017-01-01")
-        self._invoice_refund(purchase, "2017-01-18")
+        self._invoice_purchase_create("2017-01-01")
         # Sale invoices
         sale = self._invoice_sale_create("2017-01-13")
         self._invoice_refund(sale, "2017-01-14")
@@ -68,6 +68,16 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatModBase):
         for line in vat_book.issued_tax_summary_ids:
             self.assertEqual(line.base_amount, 0.0)
             self.assertEqual(line.tax_amount, 0.0)
+        # Check tax summary for received invoices
+        self.assertEqual(len(vat_book.received_tax_summary_ids), 2)
+        # P_IVA21_SC - 21% IVA soportado (servicios corrientes)
+        line = vat_book.received_tax_summary_ids[0]
+        self.assertAlmostEqual(line.base_amount, 230)
+        self.assertAlmostEqual(line.tax_amount, 48.3)
+        # P_IVA0_ND - 21% IVA Soportado no deducible
+        line = vat_book.received_tax_summary_ids[1]
+        self.assertAlmostEqual(line.base_amount, 100)
+        self.assertAlmostEqual(line.tax_amount, 21)
         # Print to PDF
         report_pdf = self.env.ref(
             "l10n_es_vat_book.act_report_vat_book_invoices_issued_pdf"

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -23,6 +23,7 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatModBase):
         # tax code: (base, tax_amount)
         "P_IVA21_SC": (230, 48.3),
         "P_IVA0_ND": (100, 21),
+        "P_IVA21_IC_BC": (200, 42),
     }
 
     def test_model_vat_book(self):
@@ -69,13 +70,17 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatModBase):
             self.assertEqual(line.base_amount, 0.0)
             self.assertEqual(line.tax_amount, 0.0)
         # Check tax summary for received invoices
-        self.assertEqual(len(vat_book.received_tax_summary_ids), 2)
+        self.assertEqual(len(vat_book.received_tax_summary_ids), 3)
         # P_IVA21_SC - 21% IVA soportado (servicios corrientes)
         line = vat_book.received_tax_summary_ids[0]
         self.assertAlmostEqual(line.base_amount, 230)
         self.assertAlmostEqual(line.tax_amount, 48.3)
-        # P_IVA0_ND - 21% IVA Soportado no deducible
+        # P_IVA21_IC_BC - IVA 21% Adquisición Intracomunitaria. Bienes corrientes
         line = vat_book.received_tax_summary_ids[1]
+        self.assertAlmostEqual(line.base_amount, 200)
+        self.assertAlmostEqual(line.tax_amount, 42)
+        # P_IVA0_ND - 21% IVA Soportado no deducible
+        line = vat_book.received_tax_summary_ids[2]
         self.assertAlmostEqual(line.base_amount, 100)
         self.assertAlmostEqual(line.tax_amount, 21)
         # Print to PDF


### PR DESCRIPTION
Fine tuning of 84b25992c54f1d4f0941cb353ea9de66a5ce97c.

For the non deductible taxes like "21% IVA Soportado no deducible", the tax amount doesn't go to account 472, so it was filtered out on received book, as there was one map line with such filter, and the previous code was filtering all entries. Now the filtering is done selectively by taxes.

It includes a test for avoiding regressions, and also another one for the previous fix.

@Tecnativa TT35966