### PR TITLE
[15.0][FIX] l10n_es_vat_book: UX Improvements

### DIFF
--- a/l10n_es_vat_book/report/vat_book_xlsx.py
+++ b/l10n_es_vat_book/report/vat_book_xlsx.py
@@ -163,7 +163,7 @@ class VatNumberXlsx(models.AbstractModel):
         ):
             sheet.write("I" + str(row), "Venta anónima")
         else:
-            sheet.write("I" + str(row), line.partner_id.name[:40])
+            sheet.write("I" + str(row), (line.partner_id.name or "")[:40])
         # TODO: Substitute Invoice
         # sheet.write('J' + str(row),
         #             line.invoice_id.refund_invoice_id.number or '')
@@ -308,7 +308,7 @@ class VatNumberXlsx(models.AbstractModel):
         sheet.write("A" + str(row), self.format_boe_date(line.invoice_date))
         if date_invoice and date_invoice != line.invoice_date:
             sheet.write("B" + str(row), self.format_boe_date(date_invoice))
-        sheet.write("C" + str(row), line.external_ref and line.external_ref[:40] or "")
+        sheet.write("C" + str(row), (line.external_ref or "")[:40])
         sheet.write("D" + str(row), "")
         sheet.write("E" + str(row), line.ref[:20])
         sheet.write("F" + str(row), "")
@@ -316,7 +316,7 @@ class VatNumberXlsx(models.AbstractModel):
         if country_code != "ES":
             sheet.write("H" + str(row), country_code)
         sheet.write("I" + str(row), vat_number)
-        sheet.write("J" + str(row), line.partner_id.name[:40])
+        sheet.write("J" + str(row), (line.partner_id.name or "")[:40])
         # TODO: Substitute Invoice
         # sheet.write('K' + str(row),
         #             line.invoice_id.refund_invoice_id.number or '')

--- a/l10n_es_vat_book/views/l10n_es_vat_book.xml
+++ b/l10n_es_vat_book/views/l10n_es_vat_book.xml
@@ -11,6 +11,20 @@
             >
                 <attribute name="invisible">True</attribute>
             </button>
+            <header position="after">
+                <div
+                    class="alert alert-warning text-center"
+                    attrs="{'invisible': [('error_count', '=', 0)]}"
+                >
+                    <span>
+                        You have <strong class="text-danger"><field
+                                name="error_count"
+                            /> errors</strong> in this report.
+                        You will not be able to <strong
+                        >confirm and submit</strong> it until they are resolved.
+                    </span>
+                </div>
+            </header>
             <header position="inside">
                 <button
                     name="view_issued_invoices"
@@ -48,40 +62,36 @@
             <xpath expr="//group[@name='group_declaration']" position="after">
                 <notebook>
                     <page string="Summary" name="summary">
-                        <group string="Issued Tax Summary" name="issued_tax_summary">
-                            <field name="issued_tax_summary_ids" nolabel="1" />
-                        </group>
-                        <group
-                            string="Received Tax Summary"
-                            name="received_tax_summary"
-                        >
-                            <field name="received_tax_summary_ids" nolabel="1" />
-                        </group>
-                        <group string="Total" name="total_summary">
-                            <field name="summary_ids" nolabel="1" />
-                        </group>
+                        <separator string="Issued Tax Summary" />
+                        <field name="issued_tax_summary_ids" nolabel="1" colspan="2" />
+                        <separator string="Received Tax Summary" />
+                        <field
+                            name="received_tax_summary_ids"
+                            nolabel="1"
+                            colspan="2"
+                        />
+                        <separator string="Total" />
+                        <field name="summary_ids" nolabel="1" colspan="2" />
                     </page>
                     <page string="Issued Invoices" name="invoices_issued">
-                        <group string="Issued Invoices" name="issued_invoices">
-                            <field name="issued_line_ids" nolabel="1" />
-                        </group>
-                        <group
-                            string="Issued Refund Invoices"
-                            name="issued_rectification_invoices"
-                        >
-                            <field name="rectification_issued_line_ids" nolabel="1" />
-                        </group>
+                        <separator string="Issued Invoices" />
+                        <field name="issued_line_ids" nolabel="1" colspan="2" />
+                        <separator string="Issued Refund Invoices" />
+                        <field
+                            name="rectification_issued_line_ids"
+                            nolabel="1"
+                            colspan="2"
+                        />
                     </page>
                     <page string="Received Invoices" name="received_invoices">
-                        <group string="Received Invoices" name="received_invoices">
-                            <field name="received_line_ids" nolabel="1" />
-                        </group>
-                        <group
-                            string="Received Refund Invoices"
-                            name="received_rectification_invoices"
-                        >
-                            <field name="rectification_received_line_ids" nolabel="1" />
-                        </group>
+                        <separator string="Received Invoices" />
+                        <field name="received_line_ids" nolabel="1" colspan="2" />
+                        <separator string="Received Refund Invoices" />
+                        <field
+                            name="rectification_received_line_ids"
+                            nolabel="1"
+                            colspan="2"
+                        />
                     </page>
                 </notebook>
             </xpath>


### PR DESCRIPTION
Lines without partner will fail on `fill_received_row_data` function throwing an error. Partner must be present in all lines.
Proper Excel icon in `Export draft` and `Export BOE` buttons.

@rafaelbn @yajo @pedrobaeza 

MT-638 @moduon