### PR TITLE
[15.0][FIX] l10n_es_facturae: changes the way the 'inbound_payment_me…

### DIFF
--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -94,7 +94,9 @@ class CommonTest(TestL10nEsAeatCertificateBase):
                 "type": "bank",
                 "company_id": main_company.id,
                 "bank_account_id": self.bank.id,
-                "inbound_payment_method_line_ids": [(6, 0, payment_methods.ids)],
+                "inbound_payment_method_line_ids": [
+                    (0, 0, {"payment_method_id": x.id}) for x in payment_methods
+                ],
             }
         )
 


### PR DESCRIPTION
[FIX] The way in which the inbound_payment_method_line_ids were entered causes problems with other tests in the repository that create more than one inbound payment method.