### PR TITLE
[15.0][FIX] l10n_es_facturae_face: changes the way the 'inbound_payment_method_line_ids' is entered in the journal in the tests.

### DIFF
--- a/l10n_es_facturae_face/tests/test_facturae_face.py
+++ b/l10n_es_facturae_face/tests/test_facturae_face.py
@@ -101,7 +101,9 @@ class EDIBackendTestCase(
                 "type": "bank",
                 "company_id": main_company.id,
                 "bank_account_id": self.bank.id,
-                "inbound_payment_method_line_ids": [(6, 0, payment_methods.ids)],
+                "inbound_payment_method_line_ids": [
+                    (0, 0, {"payment_method_id": x.id}) for x in payment_methods
+                ],
             }
         )
 


### PR DESCRIPTION
[FIX] The way in which the inbound_payment_method_line_ids were entered causes problems with other tests in the repository that create more than one inbound payment method.