### PR TITLE
[11.0][FIX] l10n_es_ticketbai_api - corregida generación de url en supuestos sin serie de factura

### DIFF
--- a/l10n_es_ticketbai_api/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice.py
@@ -635,8 +635,7 @@ class TicketBAIInvoice(models.Model):
         res = OrderedDict([
             (TicketBaiQRParams.tbai_identifier.value, self.tbai_identifier),
         ])
-        if self.number_prefix:
-            res[TicketBaiQRParams.invoice_number_prefix.value] = self.number_prefix
+        res[TicketBaiQRParams.invoice_number_prefix.value] = self.number_prefix or ""
         res[TicketBaiQRParams.invoice_number.value] = self.number
         res[TicketBaiQRParams.invoice_total_amount.value] = self.amount_total
         return res

--- a/l10n_es_ticketbai_api/ticketbai/xml_schema.py
+++ b/l10n_es_ticketbai_api/ticketbai/xml_schema.py
@@ -189,7 +189,7 @@ class XMLSchema:
                     self.create_node_from_dict(xml_element, subkey, subvalue)
         else:
             xml_element = etree.SubElement(xml_root, key)
-            xml_element.text = value
+            xml_element.text = value or ""
 
     def dict2xml(self, invoice_ordered_dict):
         tag = next(iter(invoice_ordered_dict))


### PR DESCRIPTION
En los casos en los que no hay un prefijo para definir los números de factura, la URL no se genera correctamente ya que no añade el parámetro serie factura.
Desde hacienda de bizkaia nos informan de que aunque no haya serie, es necesario enviar el parámetro con valor vació y calcular el crc en base a esto.

Hemos comprobado que en gipuzkoa (entorno test) también aceptan esto.