### PR TITLE
[UPD] l10n_es_ticketbai certificado aeat tratamiento de caracteres nulos en el campo tbai_p12_friendlyname

### DIFF
--- a/l10n_es_ticketbai/__manifest__.py
+++ b/l10n_es_ticketbai/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "TicketBAI - "
             "declaración de todas las operaciones de venta realizadas por las personas "
             "y entidades que desarrollan actividades económicas",
-    "version": "11.0.1.4.1",
+    "version": "11.0.1.4.2",
     "category": "Accounting & Finance",
     "website": "http://www.binovo.es",
     "author": "Binovo,"

--- a/l10n_es_ticketbai/wizard/aeat_certificate_password.py
+++ b/l10n_es_ticketbai/wizard/aeat_certificate_password.py
@@ -15,6 +15,10 @@ except(ImportError, IOError) as err:
 class L10nEsAeatCertificatePassword(models.TransientModel):
     _inherit = 'l10n.es.aeat.certificate.password'
 
+    @staticmethod
+    def _sanitize_p12_friendly_name(p12_friendly_name):
+        return p12_friendly_name.decode('utf-8').strip('\x00')
+
     @api.multi
     def get_keys(self):
         super().get_keys()
@@ -22,4 +26,5 @@ class L10nEsAeatCertificatePassword(models.TransientModel):
             self.env.context.get('active_id'))
         file = base64.decodebytes(record.file)
         p12 = crypto.load_pkcs12(file, self.password)
-        record.tbai_p12_friendlyname = p12.get_friendlyname()
+        record.tbai_p12_friendlyname = \
+            self._sanitize_p12_friendly_name(p12.get_friendlyname())


### PR DESCRIPTION
Afecta al módulo l10n_es_ticketbai, a la hora de importar los certificados AEAT que se utilizan para la firma del fichero XML, se calcula el alias, el campo tbai_p12_friendlyname. En este commit se añade el tratamiento de los caracteres nulos, se sanean quitandolos de la cadena antes de la asignación. 

Odoo no permite estos caracteres en los registros de tipo "fields.Char", levanta la siguiente
excepción "A string literal cannot contain NUL (0x00) characters.", definido en el core, en el conector entre Odoo y PostgreSQL.