### PR TITLE
[FIX] [15.0] l10n_es_vat_book: Change order on lines

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book_line.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book_line.py
@@ -10,7 +10,7 @@ from odoo import api, fields, models
 class L10nEsVatBookLine(models.Model):
     _name = "l10n.es.vat.book.line"
     _description = "Spanish VAT book line"
-    _order = "entry_number asc, ref asc, invoice_date asc"
+    _order = "exception_text asc, entry_number asc, invoice_date asc, ref asc"
 
     def _selection_special_tax_group(self):
         return self.env["l10n.es.vat.book.line.tax"].fields_get(


### PR DESCRIPTION
New order on lines:
- Exception Text first: No more scroll to find lines with errors.
- Entry number: If renumbered, show this order too.
- Invoice date: Invoices with different journals will appear together if they are in the same date.
- Ref: Reference of the invoice in the last place to ensure the proper order of the invoices (date).

MT-638 @moduon 