### PR TITLE
[FIX]l10n_es_aeat: Considerar modelo en comprobación de rango de fechas

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_map_tax.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_map_tax.py
@@ -19,10 +19,10 @@ class L10nEsAeatMapTax(models.Model):
     )
     model = fields.Integer(string="AEAT Model", required=True)
 
-    @api.constrains("date_from", "date_to")
+    @api.constrains("date_from", "date_to", "model")
     def _unique_date_range(self):
         for map_tax in self:
-            domain = [("id", "!=", map_tax.id)]
+            domain = ["&", ("model", "=", map_tax.model), ("id", "!=", map_tax.id)]
             if map_tax.date_from and map_tax.date_to:
                 domain += [
                     "|",

--- a/l10n_es_aeat/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat/readme/CONTRIBUTORS.rst
@@ -13,3 +13,4 @@
 * Miquel Raïch <miquel.raich@forgeflow.com>
 * Iván Antón <ozono@ozonomultimedia.com>
 * Digital5 S.L.
+* Manuel Regidor <manuel.regidor@sygel.es>

--- a/l10n_es_aeat/tests/test_l10n_es_aeat.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat.py
@@ -1,7 +1,7 @@
 # Copyright 2016-2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.exceptions import ValidationError
+from odoo import exceptions
 from odoo.tests.common import SavepointCase
 
 
@@ -36,7 +36,7 @@ class TestL10nEsAeat(SavepointCase):
         self.assertEqual(vat_number, "12345678Z")
 
     def test_parse_vat_info_es_passport_exception(self):
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(exceptions.ValidationError):
             self.partner.write(
                 {"vat": "ZZ_MY_PASSPORT", "country_id": self.env.ref("base.es").id}
             )
@@ -99,3 +99,12 @@ class TestL10nEsAeat(SavepointCase):
         self.assertEqual(country_code, "")
         self.assertEqual(identifier_type, "04")
         self.assertEqual(vat_number, "CU12345678Z")
+
+    def test_unique_date_range(self):
+        self.env["l10n.es.aeat.map.tax"].create(
+            {"date_from": "2020-01-01", "model": 303}
+        )
+        with self.assertRaises(exceptions.Warning):
+            self.env["l10n.es.aeat.map.tax"].create(
+                {"date_to": "2021-01-01", "model": 303}
+            )


### PR DESCRIPTION
Anteriormente, la función que comprueba si hay mapeos de impuestos con fechas solapadas no tenía en cuenta el modelo.