### PR TITLE
[IMP]l10n_es_aeat_mod347: Mostrar errores en líneas del 347

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -100,6 +100,24 @@ class L10nEsAeatMod347Report(models.Model):
         string="Real Estate Records",
     )
 
+    def _error_count(self, model):
+        records_error_group = self.env["l10n.es.aeat.mod347.%s" % model].read_group(
+            domain=[("check_ok", "=", False), ("report_id", "in", self.ids)],
+            fields=["report_id"],
+            groupby=["report_id"],
+        )
+        return {l["report_id"][0]: l["report_id_count"] for l in records_error_group}
+
+    def _compute_error_count(self):
+        super._compute_error_count()
+        partner_records_error_dict = self._error_count("partner_record")
+        real_estate_record_error_dict = self._error_count("real_estate_record")
+
+        for report in self:
+            report.error_count += partner_records_error_dict.get(
+                report.id, 0
+            ) + real_estate_record_error_dict.get(report.id, 0)
+
     def button_confirm(self):
         """Different check out in report"""
         for item in self:
@@ -310,6 +328,7 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
     _inherit = ["mail.thread", "mail.activity.mixin", "portal.mixin"]
     _description = "Partner Record"
     _rec_name = "partner_vat"
+    _order = "check_ok asc,id"
 
     @api.model
     def _default_record_id(self):
@@ -478,18 +497,24 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
         store=True,
         help="Checked if this record is OK",
     )
+    error_text = fields.Char(string="Error text", compute="_compute_check_ok",)
 
     @api.depends(
         "partner_country_code", "partner_state_code", "partner_vat", "community_vat"
     )
     def _compute_check_ok(self):
         for record in self:
-            record.check_ok = (
-                record.partner_country_code
-                and record.partner_state_code
-                and record.partner_state_code.isdigit()
-                and (record.partner_vat or record.partner_country_code != "ES")
-            )
+            errors = []
+            if not record.partner_country_code:
+                errors.append(_("Without country code"))
+            if not record.partner_state_code:
+                errors.append(_("Without state code"))
+            if record.partner_state_code and not record.partner_state_code.isdigit():
+                errors.append(_("State code can only contain digits"))
+            if not (record.partner_vat or record.partner_country_code != "ES"):
+                errors.append(_("VAT must be defined for Spanish Contacts"))
+            record.check_ok = not bool(errors)
+            record.error_text = ", ".join(errors)
 
     @api.onchange("partner_id")
     def _onchange_partner_id(self):
@@ -604,6 +629,7 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
     _name = "l10n.es.aeat.mod347.real_estate_record"
     _description = "Real Estate Record"
     _rec_name = "reference"
+    _order = "check_ok asc,id"
 
     @api.model
     def _default_record_id(self):
@@ -674,11 +700,16 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
         store=True,
         help="Checked if this record is OK",
     )
+    error_text = fields.Char(string="Errors", compute="_compute_check_ok", store=True)
 
     @api.depends("state_code")
     def _compute_check_ok(self):
         for record in self:
-            record.check_ok = bool(record.state_code)
+            errors = []
+            if not record.state_code:
+                errors.append(_("Without state code"))
+            record.check_ok = not bool(errors)
+            record.error_text = ", ".join(errors)
 
     @api.onchange("partner_id")
     def _onchange_partner_id(self):

--- a/l10n_es_aeat_mod347/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod347/readme/CONTRIBUTORS.rst
@@ -11,3 +11,6 @@
   * Pedro M. Baeza
   * Cristina Martín
   * Carlos Dauden
+* `Sygel <https://www.sygel.es>`_:
+
+  * Manuel Regidor

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -48,6 +48,11 @@
                     string="Set to invalid"
                 />
                 <field name="check_ok" />
+                <field
+                    name="error_text"
+                    optional="show"
+                    attrs="{'invisible': [('check_ok', '=', True)]}"
+                />
             </tree>
         </field>
     </record>
@@ -99,6 +104,12 @@
                             <group>
                                 <group>
                                     <field name="partner_id" />
+                                    <field name="check_ok" invisible="1" />
+                                    <field
+                                        name="error_text"
+                                        attrs="{'invisible': [('check_ok', '=', True)]}"
+                                        class="text-danger"
+                                    />
                                     <field name="partner_vat" select="1" />
                                     <field name="representative_vat" select="2" />
                                     <field name="community_vat" />
@@ -265,6 +276,11 @@
                 <field name="number" />
                 <field name="city" />
                 <field name="township" />
+                <field
+                    name="error_text"
+                    optional="show"
+                    attrs="{'invisible': ['|', ('check_ok', '=', True), ('partner_id', '=', False)]}"
+                />
             </tree>
         </field>
     </record>
@@ -276,6 +292,12 @@
                 <group string="Partner info">
                     <group>
                         <field name="partner_id" />
+                        <field name="check_ok" invisible="1" />
+                        <field
+                            name="error_text"
+                            attrs="{'invisible': [('check_ok', '=', True)]}"
+                            class="text-danger"
+                        />
                     </group>
                     <group>
                         <field name="partner_vat" />


### PR DESCRIPTION
Mostrar en las líneas del 347 qué error se producte, tanto en la vista tree como en la form. La vista form del modelo también incluye un bloque en la parte superior con el número de errores detectados.
Depende de: https://github.com/OCA/l10n-spain/pull/2300