### PR TITLE
[13.0][IMP]l10n_es_aeat_mod349: Mostrar errores en líneas del 349

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -73,6 +73,21 @@ class Mod349(models.Model):
     )
     number = fields.Char(default="349")
 
+    def _compute_error_count(self):
+        super()._compute_error_count()
+        partner_records_error_dict = self.env[
+            "l10n.es.aeat.mod349.partner_record"
+        ].read_group(
+            domain=[("partner_record_ok", "=", False), ("report_id", "in", self.ids)],
+            fields=["report_id"],
+            groupby=["report_id"],
+        )
+        partner_records_error_dict = {
+            l["report_id"][0]: l["report_id_count"] for l in partner_records_error_dict
+        }
+        for report in self:
+            report.error_count += partner_records_error_dict.get(report.id, 0)
+
     @api.depends("partner_record_ids", "partner_record_ids.total_operation_amount")
     def _compute_report_regular_totals(self):
         for report in self:
@@ -380,7 +395,7 @@ class Mod349PartnerRecord(models.Model):
 
     _name = "l10n.es.aeat.mod349.partner_record"
     _description = "AEAT 349 Model - Partner record"
-    _order = "operation_key asc"
+    _order = "partner_record_ok asc, operation_key asc, id"
     _rec_name = "partner_vat"
 
     def _selection_operation_key(self):
@@ -392,11 +407,15 @@ class Mod349PartnerRecord(models.Model):
     def _compute_partner_record_ok(self):
         """Checks if all line fields are filled."""
         for record in self:
-            record.partner_record_ok = bool(
-                record.partner_vat
-                and record.country_id
-                and record.total_operation_amount
-            )
+            errors = []
+            if not record.partner_vat:
+                errors.append(_("Without VAT"))
+            if not record.country_id:
+                errors.append(_("Without Country"))
+            if not record.total_operation_amount:
+                errors.append(_("Without Total Operation Amount"))
+            record.partner_record_ok = bool(not errors)
+            record.error_text = ", ".join(errors)
 
     report_id = fields.Many2one(
         comodel_name="l10n.es.aeat.mod349.report",
@@ -420,6 +439,10 @@ class Mod349PartnerRecord(models.Model):
         compute="_compute_partner_record_ok",
         string="Partner Record OK",
         help="Checked if partner record is OK",
+        store=True,
+    )
+    error_text = fields.Char(
+        string="Error text", compute="_compute_partner_record_ok", store=True,
     )
     record_detail_ids = fields.One2many(
         comodel_name="l10n.es.aeat.mod349.partner_record_detail",

--- a/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
@@ -18,3 +18,5 @@
 * Acysos:
 
   * Ignacio Ibeas
+
+* Manuel Regidor <manuel.regidor@sygel.es>

--- a/l10n_es_aeat_mod349/views/mod349_view.xml
+++ b/l10n_es_aeat_mod349/views/mod349_view.xml
@@ -52,6 +52,11 @@
                 <field name="partner_id" />
                 <field name="operation_key" />
                 <field name="total_operation_amount" />
+                <field
+                    name="error_text"
+                    attrs="{'invisible': [('partner_record_ok', '=', True)]}"
+                    optional="show"
+                />
             </tree>
         </field>
     </record>
@@ -64,6 +69,12 @@
                 <notebook colspan="4">
                     <page string="Info">
                         <group>
+                            <field
+                                name="error_text"
+                                attrs="{'invisible': [('partner_record_ok', '=', True)]}"
+                                class="text-danger"
+                            />
+                            <field name="partner_record_ok" invisible="1" />
                             <field name="operation_key" />
                             <field name="partner_id" />
                             <field name="country_id" />


### PR DESCRIPTION
Mostrar en las líneas del 349 qué error se produde, tanto en la vista tree como en la form. La vista form del modelo también incluye un bloque en la parte superior con el número de errores detectados.
El campo partner_record_ok se ha establecido como almacenado en base de datos para poder ordenar las líneas en la vista lista según este criterio.
Depende de https://github.com/OCA/l10n-spain/pull/2300