### PR TITLE
[IMP]l10n_es_aeat_sii_oss: hook para aplicar tipo identificacion de contacto a posiciones fiscales OSS

### DIFF
--- a/l10n_es_aeat_sii_oss/__init__.py
+++ b/l10n_es_aeat_sii_oss/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from .hooks import add_sii_partner_identification_type

--- a/l10n_es_aeat_sii_oss/__manifest__.py
+++ b/l10n_es_aeat_sii_oss/__manifest__.py
@@ -19,4 +19,5 @@
         "l10n_eu_oss",
     ],
     "data": ["data/aeat_sii_mapping_registration_keys_data.xml"],
+    "post_init_hook": "add_sii_partner_identification_type",
 }

--- a/l10n_es_aeat_sii_oss/hooks.py
+++ b/l10n_es_aeat_sii_oss/hooks.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Sygel - Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def add_sii_partner_identification_type(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    es_country_id = env.ref('base.es')
+    if es_country_id:
+        company_ids = env['res.company'].search([
+            ('country_id', '=', es_country_id.id),
+        ])
+        if company_ids:
+            env['account.fiscal.position'].search([
+                ('company_id', 'in', company_ids.ids),
+                ('name', 'ilike', 'OSS')
+            ]).write({
+                'sii_partner_identification_type': '2'
+            })

--- a/l10n_es_aeat_sii_oss/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_sii_oss/readme/CONTRIBUTORS.rst
@@ -2,3 +2,6 @@
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * Pedro M. Baeza
+* `Sygel <https://www.sygel.es>`__:
+
+  * Manuel Regidor


### PR DESCRIPTION
Se ha añadido un hook que se lanza después de instalar el módulo para establecer el valor 'Intracom' en el campo tipo de identificación sii del contacto de las posiciones fiscales del OSS.