### PR TITLE
[14.0][IMP] l10n_es_aeat: Show used Fiscal Position Templates on Map Tax models

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_map_tax_line.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_map_tax_line.py
@@ -1,7 +1,9 @@
 # Copyright 2013-2018 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl
 
-from odoo import fields, models
+from collections import defaultdict
+
+from odoo import api, fields, models
 
 
 class L10nEsAeatMapTaxLine(models.Model):
@@ -12,6 +14,14 @@ class L10nEsAeatMapTaxLine(models.Model):
     field_number = fields.Integer(string="Field number", required=True)
     tax_ids = fields.Many2many(
         comodel_name="account.tax.template", string="Taxes templates"
+    )
+    fiscal_position_ids = fields.Many2many(
+        comodel_name="account.fiscal.position.template",
+        string="Fiscal Position Templates",
+        compute="_compute_fiscal_position_ids",
+        store=True,
+        compute_sudo=True,
+        help="Taxes mapped with different source tax on this Fiscal Position Templates",
     )
     account_id = fields.Many2one(
         comodel_name="account.account.template",
@@ -53,3 +63,26 @@ class L10nEsAeatMapTaxLine(models.Model):
     )
     inverse = fields.Boolean(string="Inverse summarize sign", default=False)
     to_regularize = fields.Boolean(string="To regularize")
+
+    @api.depends("tax_ids")
+    def _compute_fiscal_position_ids(self):
+        afpt_model = self.env["account.fiscal.position.tax.template"]
+        afpt_map = defaultdict(list)
+        for afpt_data in afpt_model.search_read(
+            [
+                ("tax_dest_id", "in", self.mapped("tax_ids").ids),
+                ("position_id", "!=", False),
+            ],
+            ["position_id", "tax_dest_id", "tax_src_id"],
+        ):
+            # Exclude Fiscal Position Templates if source tax == dest tax
+            if afpt_data["tax_src_id"][0] != afpt_data["tax_dest_id"][0]:
+                afpt_map[afpt_data["tax_dest_id"][0]].append(
+                    afpt_data["position_id"][0]
+                )
+
+        for map_tax_line in self:
+            fiscal_position_list_ids = []
+            for tax_id in map_tax_line.tax_ids.ids:
+                fiscal_position_list_ids.extend(afpt_map.get(tax_id, []))
+            map_tax_line.fiscal_position_ids = fiscal_position_list_ids

--- a/l10n_es_aeat/views/aeat_tax_code_mapping_view.xml
+++ b/l10n_es_aeat/views/aeat_tax_code_mapping_view.xml
@@ -35,6 +35,11 @@
                 <field name="name" />
                 <field name="to_regularize" />
                 <field name="tax_ids" widget="many2many_tags" />
+                <field
+                    name="fiscal_position_ids"
+                    widget="many2many_tags"
+                    optional="hide"
+                />
                 <field name="account_id" />
                 <field name="move_type" />
                 <field name="field_type" />
@@ -57,6 +62,7 @@
                     </group>
                     <group>
                         <field name="tax_ids" widget="many2many_tags" />
+                        <field name="fiscal_position_ids" widget="many2many_tags" />
                         <field name="account_id" />
                         <field name="move_type" />
                         <field name="field_type" />


### PR DESCRIPTION
El nuevo campo `fiscal_position_ids` en las líneas de los mapeos de los modelos sirve para indicar qué posición Fiscal nos cambiará a esos impuestos.

La casuística es para poder explicar y deducir qué posición fiscal debe utilizarse si queremos que un impuesto vaya a la casilla XX del modelo YYY.
Por ejemplo: Si buscamos el Régimen Intracomunitario en el mapeo del 303, se ve claramente que se van a rellenar las casillas 10, 11, 14, 15, 36, 37, 37, 39, 40, etc...

Es meramente informativo y no impacta en el rendimiento ya que es store=True.

Sólo se muestran las posiciones fiscales en las que la tasa de origen es diferente a la de destino, porque si no aparecen muchas posiciones fiscales irrelevantes y ensucia la información que queremos visualizar.

@moduon