### PR TITLE
[14.0][FIX] l10n_es_facturae: obtener certificados con sudo.

### DIFF
--- a/l10n_es_facturae/reports/report_facturae.py
+++ b/l10n_es_facturae/reports/report_facturae.py
@@ -43,8 +43,10 @@ class ReportFacturae(models.AbstractModel):
         tree = etree.fromstring(xml_facturae, etree.XMLParser(remove_blank_text=True))
         xml_facturae = etree.tostring(tree, xml_declaration=True, encoding="UTF-8")
         self._validate_facturae(move, xml_facturae)
-        public_crt, private_key = self.env["l10n.es.aeat.certificate"].get_certificates(
-            move.company_id
+        public_crt, private_key = (
+            self.env["l10n.es.aeat.certificate"]
+            .sudo()
+            .get_certificates(move.company_id)
         )
         move_file = self._sign_file(move, xml_facturae, public_crt, private_key)
         return move_file, content_type


### PR DESCRIPTION
De esta forma se permite a usuarios de facturación poder generar
ficheros de factura electrónica firmados.

![image](https://user-images.githubusercontent.com/23449160/170655372-62655314-ae77-4288-951f-4524d167ccae.png)

@ForgeFlow