### PR TITLE
[13.0][IMP] l10n_es_facturae_face: Only attach data if data changes

### DIFF
--- a/l10n_es_facturae_face/models/edi_exchange_record.py
+++ b/l10n_es_facturae_face/models/edi_exchange_record.py
@@ -82,6 +82,14 @@ class EdiExchangeRecord(models.Model):
                 if invoice.codigo != "0":
                     # Probably processed from another system
                     continue
+                process_code = "face-" + invoice.factura.tramitacion.codigo
+                revocation_code = "face-" + invoice.factura.anulacion.codigo
+                if (
+                    exchange_record.l10n_es_facturae_status == process_code
+                    and exchange_record.l10n_es_facturae_cancellation_status
+                    == revocation_code
+                ):
+                    continue
                 update_record = face.create_record(
                     "l10n_es_facturae_face_update",
                     {

--- a/l10n_es_facturae_face/tests/test_facturae_face.py
+++ b/l10n_es_facturae_face/tests/test_facturae_face.py
@@ -347,6 +347,15 @@ class EDIBackendTestCase(SavepointComponentRegistryCase, common.SavepointCase):
         exchange_record.flush()
         exchange_record.refresh()
         self.assertEqual(exchange_record.l10n_es_facturae_status, "face-1300")
+
+        self.assertEqual(len(exchange_record.related_exchange_ids), 3)
+        with mock.patch("zeep.client.ServiceProxy") as mock_client:
+            mock_client.return_value = DemoService(multi_response)
+            self.env["edi.exchange.record"].with_context()._cron_face_update_method()
+        exchange_record.flush()
+        exchange_record.refresh()
+        self.assertEqual(len(exchange_record.related_exchange_ids), 3)
+        # New record should not have been created
         cancel = self.env["edi.l10n.es.facturae.face.cancel"].create(
             {"move_id": self.move.id, "motive": "Anulacion"}
         )


### PR DESCRIPTION
Se estaba creando un mensaje por dia hasta llegar a un estado válido. Ahora solo se creará si se ha modificado algo.