### PR TITLE
[15.0][IMP] l10n_es_facturae: Prevent error if bank account is not set

### DIFF
--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -178,11 +178,13 @@ class AccountMove(models.Model):
             raise ValidationError(_("Payment mode is required"))
         if self.payment_mode_id.facturae_code:
             partner_bank = self.partner_banks_to_show()[:1]
-            if not partner_bank:
-                raise ValidationError(_("Partner bank is missing"))
-            if partner_bank.bank_id.bic and len(partner_bank.bank_id.bic) != 11:
+            if (
+                partner_bank
+                and partner_bank.bank_id.bic
+                and len(partner_bank.bank_id.bic) != 11
+            ):
                 raise ValidationError(_("Selected account BIC must be 11"))
-            if len(partner_bank.acc_number) < 5:
+            if partner_bank and len(partner_bank.acc_number) < 5:
                 raise ValidationError(_("Selected account is too small"))
         if self.state not in self._get_valid_move_statuses():
             raise ValidationError(

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -610,15 +610,17 @@
                             <InstallmentAmount
                                 t-esc="'%.2f' % (move.amount_residual)"
                             />
-                            <PaymentMeans t-esc="move.payment_mode_id.facturae_code" />
                             <t
                                 t-set="partner_bank"
                                 t-value="move.partner_banks_to_show()[:1]"
                             />
                             <t t-set="bank" t-value="partner_bank.bank_id" />
-                            <AccountToBeDebited
-                                t-if="move.payment_mode_id.facturae_code == '02'"
-                            >
+                            <t
+                                t-set="payment_means"
+                                t-value="move.payment_mode_id.facturae_code if partner_bank or move.payment_mode_id.facturae_code not in ['02', '04'] else '01'"
+                            />
+                            <PaymentMeans t-esc="payment_means" />
+                            <AccountToBeDebited t-if="payment_means == '02'">
                                 <IBAN
                                     t-minlength="5"
                                     t-length="34"
@@ -641,9 +643,7 @@
                                     t-if="False"
                                 />
                             </AccountToBeDebited>
-                            <AccountToBeCredited
-                                t-if="move.payment_mode_id.facturae_code != '02'"
-                            >
+                            <AccountToBeCredited t-if="payment_means == '04'">
                                 <IBAN
                                     t-minlength="5"
                                     t-length="34"


### PR DESCRIPTION
FWP de 14.0: https://github.com/OCA/l10n-spain/pull/2318

Evitar el error al generar el archivo si la cuenta bancaria no está definida.

Por favor, @pedrobaeza ¿puedes revisarlo?

@Tecnativa TT36128