### PR TITLE
[14.0][FIX] l10n_es_ticketbai: Fix draft and cancel buttons visibility on a…

### DIFF
--- a/l10n_es_ticketbai/views/account_move_views.xml
+++ b/l10n_es_ticketbai/views/account_move_views.xml
@@ -235,12 +235,12 @@
                 <xpath expr="//button[@name='button_draft']" position="attributes">
                     <attribute
                         name="attrs"
-                    >{'invisible' : ['|', ('restrict_mode_hash_table', '=', True), '|', ('tbai_enabled', '=', True), '&amp;', ('tbai_enabled', '=', False), ('state', 'not in', ('posted', 'cancel'))]}</attribute>
+                    >{'invisible' : ['|', ('restrict_mode_hash_table', '=', True), '|', '&amp;', ('tbai_enabled', '=', True), ('move_type', 'in', ('out_invoice', 'out_refund')), ('state', 'not in', ('posted', 'cancel'))]}</attribute>
                 </xpath>
                 <xpath expr="//button[@name='button_cancel']" position="attributes">
                     <attribute
                         name="attrs"
-                    >{'invisible' : ['|', ('id', '=', False), '&amp;', '|', ('tbai_enabled', '=', False), ('state', '!=', 'posted'), '|', ('tbai_enabled', '=', True), ('state', '!=', 'draft')]}</attribute>
+                    >{'invisible' : ['|', ('id', '=', False), '|', '&amp;', ('move_type', 'in', ('out_invoice', 'out_refund')), '&amp;', '|', ('tbai_enabled', '=', False), ('state', '!=', 'posted'), '|', ('tbai_enabled', '=', True), ('state', '!=', 'draft'), '&amp;', ('move_type', 'not in', ('out_invoice', 'out_refund')), ('state', '!=', 'draft')]}</attribute>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
…ccount.move model

Se cambia la visibilidad de los botones borrador y cancelar en la vista del modelo account.move para que funcione correctamente.

Sin modificar esto había distintos problemas de visibilidad, por ejemplo no era posible volver a pasar a borrador un asiento