### PR TITLE
[14.0][IMP]l10n_es_aeat: Base para mostrar numero errores en reports

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -252,6 +252,9 @@ class L10nEsAeatReport(models.AbstractModel):
         help="Company bank account used for the presentation",
         domain="[('acc_type', '=', 'iban'), ('partner_id', '=', partner_id)]",
     )
+    error_count = fields.Integer(
+        compute="_compute_error_count",
+    )
     _sql_constraints = [
         (
             "name_uniq",
@@ -269,6 +272,10 @@ class L10nEsAeatReport(models.AbstractModel):
     def _compute_allow_posting(self):
         for report in self:
             report.allow_posting = False
+
+    def _compute_error_count(self):
+        """To be overridden by each report."""
+        self.error_count = 0
 
     @api.constrains("statement_type", "previous_number")
     def _check_previous_number(self):

--- a/l10n_es_aeat/readme/CONFIGURE.rst
+++ b/l10n_es_aeat/readme/CONFIGURE.rst
@@ -22,3 +22,9 @@ dependencia en la definición del cálculo de un campo (entrada con
 mismo ID que el del registro en curso, lo que puede ser un problema en entornos
 multi-compañía. Una solución a ello (aunque no evita el recálculo), es poner en
 esos campos calculados `compute_sudo=True`.
+
+Se ha creado el campo base computado error_count en el modelo l10n.es.aeat.report,
+cuyo valor dependerá de sus herencias, que heredarán la función _compute_error_count
+para indicar cuantas líneas con errores hay en el informe. Si el valor es 0, no
+se mostrará ningún aviso; si el valor es mayor a 0, se mostrará un aviso en la
+parte superior de la vista formulario del informe.

--- a/l10n_es_aeat/views/aeat_report_view.xml
+++ b/l10n_es_aeat/views/aeat_report_view.xml
@@ -91,6 +91,19 @@
                         statusbar_colors="{'cancelled': 'red', 'done': 'blue', 'posted': 'blue'}"
                     />
                 </header>
+                <div
+                    class="alert alert-warning text-center"
+                    attrs="{'invisible': ['|', ('error_count', '=', 0), ('state', '!=', 'calculated')]}"
+                    role="alert"
+                >
+                    <span>
+                        You have <strong class="text-danger"><field
+                                name="error_count"
+                            /> errors</strong> in this report.
+                        You will not be able to <strong
+                        >confirm and submit it</strong> until they are resolved.
+                    </span>
+                </div>
                 <sheet>
                     <field name="allow_posting" invisible="1" />
                     <field name="number" invisible="1" />


### PR DESCRIPTION
Se ha creado el campo computado error_count en el modelo l10n.es.aeat.report, que sirve de base para otros reports. La función que calcula el valor tendrá que reescribirse en cada uno de los reports. También se ha añadido a la vista base de los reports la barra superior que mostrará el número de errores en caso de que existan.