### PR TITLE
[IMP]l10n_es_aeat_mod349: Mostrar errores en líneas del 349

### DIFF
--- a/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
@@ -22,3 +22,4 @@
 * `Sygel <https://www.sygel.es>`__:
 
   * Valentin Vinagre
+  * Manuel Regidor

--- a/l10n_es_aeat_mod349/views/mod349_view.xml
+++ b/l10n_es_aeat_mod349/views/mod349_view.xml
@@ -49,6 +49,11 @@
                 <field name="partner_id" />
                 <field name="operation_key" />
                 <field name="total_operation_amount" />
+                <field
+                    name="error_text"
+                    attrs="{'invisible': [('partner_record_ok', '=', True)]}"
+                    optional="show"
+                />
             </tree>
         </field>
     </record>
@@ -61,6 +66,12 @@
                 <notebook colspan="4">
                     <page string="Info">
                         <group>
+                            <field
+                                name="error_text"
+                                attrs="{'invisible': [('partner_record_ok', '=', True)]}"
+                                class="text-danger"
+                            />
+                            <field name="partner_record_ok" invisible="1" />
                             <field name="operation_key" />
                             <field name="partner_id" />
                             <field name="country_id" />


### PR DESCRIPTION
Mostrar en las líneas del 349 qué error se produde, tanto en la vista tree como en la form. La vista form del modelo también incluye un bloque en la parte superior con el número de errores detectados.
El campo partner_record_ok se ha establecido como almacenado en base de datos para poder ordenar las líneas en la vista lista según este criterio.
Depende de https://github.com/OCA/l10n-spain/pull/2335