### PR TITLE
[13.0][IMP] delivery_dhl_parcel: Add all customer accounts check option to end day wizard.

### DIFF
--- a/delivery_dhl_parcel/i18n/delivery_dhl_parcel.pot
+++ b/delivery_dhl_parcel/i18n/delivery_dhl_parcel.pot
@@ -6,12 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-06-07 08:23+0000\n"
+"PO-Revision-Date: 2022-06-07 08:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__all_customer_accounts
+msgid "All customer accounts"
+msgstr ""
 
 #. module: delivery_dhl_parcel
 #: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_product__b2b

--- a/delivery_dhl_parcel/i18n/es.po
+++ b/delivery_dhl_parcel/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-02 07:36+0000\n"
-"PO-Revision-Date: 2021-11-02 08:37+0100\n"
+"POT-Creation-Date: 2022-06-07 08:23+0000\n"
+"PO-Revision-Date: 2022-06-07 10:24+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -16,6 +16,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
 "X-Generator: Poedit 2.3\n"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__all_customer_accounts
+msgid "All customer accounts"
+msgstr "Todas las cuentas de clientes"
 
 #. module: delivery_dhl_parcel
 #: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_product__b2b
@@ -161,6 +166,11 @@ msgid "Display Name"
 msgstr "Nombre mostrado"
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_label_format__epl
+msgid "EPL"
+msgstr "EPL"
+
+#. module: delivery_dhl_parcel
 #: model_terms:ir.ui.view,arch_db:delivery_dhl_parcel.delivery_endday_wizard_form
 #: model_terms:ir.ui.view,arch_db:delivery_dhl_parcel.view_delivery_carrier_form
 msgid "End day"
@@ -204,14 +214,9 @@ msgid "If the product is not specified, it is considered B2B"
 msgstr "Si no se especifica el producto, se considera producto B2B"
 
 #. module: delivery_dhl_parcel
-#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_last_request
-msgid "Last DHL Parcel API request"
-msgstr "Último pedido a la API DHL Parcel"
-
-#. module: delivery_dhl_parcel
-#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_last_response
-msgid "Last DHL Parcel API response"
-msgstr "Última respuesta a la API DHL Parcel"
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_label_format
+msgid "Label format"
+msgstr "Formato de etiqueta"
 
 #. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard____last_update
@@ -236,12 +241,17 @@ msgstr "Cerrar el día manualmente"
 #. module: delivery_dhl_parcel
 #: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_incoterm__exw
 msgid "Owed transport"
-msgstr ""
+msgstr "Transporte adeudado"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_label_format__pdf
+msgid "PDF"
+msgstr "PDF"
 
 #. module: delivery_dhl_parcel
 #: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_incoterm__cpt
 msgid "Paid transport"
-msgstr ""
+msgstr "Transporte pagado"
 
 #. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__delivery_type
@@ -271,11 +281,6 @@ msgid "Shipping Methods"
 msgstr "Métodos de envío"
 
 #. module: delivery_dhl_parcel
-#: model_terms:ir.ui.view,arch_db:delivery_dhl_parcel.view_delivery_carrier_form
-msgid "Technical"
-msgstr "Técnico"
-
-#. module: delivery_dhl_parcel
 #: code:addons/delivery_dhl_parcel/models/dhl_parcel_request.py:0
 #, python-format
 msgid "Timeout: the server did not reply within 60s"
@@ -293,7 +298,18 @@ msgid "Unsupported request type, please only use 'GET' or 'POST'"
 msgstr "Tipo de respuesta no soportado, por favor solo usa 'GET' o 'POST'"
 
 #. module: delivery_dhl_parcel
-#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_last_request
-#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_last_response
-msgid "Used for debugging"
-msgstr "Usado para debug"
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_label_format__zpl
+msgid "ZPL"
+msgstr "ZPL"
+
+#~ msgid "Last DHL Parcel API request"
+#~ msgstr "Último pedido a la API DHL Parcel"
+
+#~ msgid "Last DHL Parcel API response"
+#~ msgstr "Última respuesta a la API DHL Parcel"
+
+#~ msgid "Technical"
+#~ msgstr "Técnico"
+
+#~ msgid "Used for debugging"
+#~ msgstr "Usado para debug"

--- a/delivery_dhl_parcel/models/delivery_carrier.py
+++ b/delivery_dhl_parcel/models/delivery_carrier.py
@@ -267,7 +267,9 @@ class DeliveryCarrier(models.Model):
     def action_open_end_day(self):
         """Action to launch the end day wizard"""
         self.ensure_one()
-        wizard = self.env["dhl.parcel.endday.wizard"].create({"carrier_id": self.id})
+        wizard = self.env["dhl.parcel.endday.wizard"].create(
+            {"carrier_id": self.id, "customer_accounts": self.dhl_parcel_customer_code}
+        )
         view_id = self.env.ref("delivery_dhl_parcel.delivery_endday_wizard_form").id
         return {
             "name": _("DHL Parcel End Day"),

--- a/delivery_dhl_parcel/wizard/dhl_parcel_end_day_wizard.py
+++ b/delivery_dhl_parcel/wizard/dhl_parcel_end_day_wizard.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Studio73 - Ethan Hildick <ethan@studio73.es>
+# Copyright 2022 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from odoo import fields, models
 
@@ -17,6 +18,7 @@ class DhlParcelEndDayWizard(models.TransientModel):
             "You can also use 'ALL' to end all of them"
         ),
     )
+    all_customer_accounts = fields.Boolean(string="All customer accounts")
     carrier_id = fields.Many2one(
         string="DHL Parcel Service",
         comodel_name="delivery.carrier",
@@ -26,7 +28,10 @@ class DhlParcelEndDayWizard(models.TransientModel):
 
     def button_end_day(self):
         dhl_parcel_request = DhlParcelRequest(self.carrier_id)
-        res = dhl_parcel_request.end_day(self.customer_accounts, "PDF")
+        customer_accounts = (
+            "ALL" if self.all_customer_accounts else self.customer_accounts
+        )
+        res = dhl_parcel_request.end_day(customer_accounts, "PDF")
         self.carrier_id.write(
             {
                 "dhl_parcel_last_end_day_report": (res.get("Report", False)),

--- a/delivery_dhl_parcel/wizard/dhl_parcel_end_day_wizard_views.xml
+++ b/delivery_dhl_parcel/wizard/dhl_parcel_end_day_wizard_views.xml
@@ -5,7 +5,11 @@
         <field name="arch" type="xml">
             <form string="DHL Parcel End day">
                 <group>
-                    <field name="customer_accounts" />
+                    <field name="all_customer_accounts" />
+                    <field
+                        name="customer_accounts"
+                        attrs="{'invisible': [('all_customer_accounts', '=', True)]}"
+                    />
                 </group>
                 <footer>
                     <button


### PR DESCRIPTION
Se añade la opción de todas las cuentas de cliente en el asistente de cierre del día + se añade el código de la cuenta del método de envío desde el que se reliza la acción de cierre del día.

Por favor, @pedrobaeza y @chienandalu ¿podéis revisarlo?

@Tecnativa TT37046