### PR TITLE
[14.0][FIX] delivery_gls_asm: Convert into list if not Iterable

### DIFF
--- a/delivery_gls_asm/wizard/gls_asm_manifest_wizard.py
+++ b/delivery_gls_asm/wizard/gls_asm_manifest_wizard.py
@@ -32,6 +32,8 @@ class DeliverySeurManifiestoWizard(models.TransientModel):
                     "deliveries for the selected date."
                 )
             )
+        if isinstance(manifest_data, dict):
+            manifest_data = [manifest_data]
         datas = {
             "ids": self.env.context.get("active_ids", []),
             "model": "gls.asm.minifest.wizard",


### PR DESCRIPTION
- If the manifest only comes with 1 delivery it is in form of a singular dict instead of a list of dicts and this causes issues when iterating in the XML
- I've see this error multiple times over months but I've never caught the reasoning as the time between the ticket creation and me checking it is enough for another delivery to be made, but this time I checked it instantly and caught the reasoning