### PR TITLE
[13.0][FIX] delivery_dhl_parcel: Save the file in the correct extension in all use cases.

### DIFF
--- a/delivery_dhl_parcel/models/delivery_carrier.py
+++ b/delivery_dhl_parcel/models/delivery_carrier.py
@@ -156,9 +156,13 @@ class DeliveryCarrier(models.Model):
             )
             attachment = []
             if response.get("Label"):
+                label_format = picking.carrier_id.dhl_parcel_label_format.lower()
                 attachment = [
                     (
-                        "dhl_parcel_{}.pdf".format(response.get("Tracking", "")),
+                        "dhl_parcel_{}.{}".format(
+                            response.get("Tracking", ""),
+                            "pdf" if label_format == "pdf" else "txt",
+                        ),
                         base64.b64decode(response.get("Label")),
                     )
                 ]

--- a/delivery_dhl_parcel/models/stock_picking.py
+++ b/delivery_dhl_parcel/models/stock_picking.py
@@ -20,7 +20,7 @@ class StockPicking(models.Model):
         label = base64.b64decode(self.carrier_id.dhl_parcel_get_label(tracking_ref))
         label_format = self.carrier_id.dhl_parcel_label_format.lower()
         label_name = "dhl_parcel_{}.{}".format(
-            tracking_ref, "txt" if label_format == "zpl" else "pdf"
+            tracking_ref, "pdf" if label_format == "pdf" else "txt",
         )
         self.message_post(
             body=(_("DHL Parcel label for %s") % tracking_ref),


### PR DESCRIPTION
Guardar el archivo generado de la etiqueta siempre con la misma extensión (la extensión del formato de etiqueta definida en el método de envío).

Por favor, @pedrobaeza y @chienandalu ¿podéis revisarlo?

@Tecnativa TT37136