### PR TITLE
[14.0][FIX] delivery_dhl_parcel: Round the weight of the shipment to avoid errors at the end of the day.

### DIFF
--- a/delivery_dhl_parcel/models/delivery_carrier.py
+++ b/delivery_dhl_parcel/models/delivery_carrier.py
@@ -95,9 +95,10 @@ class DeliveryCarrier(models.Model):
         :returns dict values for the connector
         """
         self.ensure_one()
+        # El peso debe tener 2 decimales para evitar errores en el cierre del día
+        weight = round(picking.shipping_weight, 2)
         # El peso del envío tiene que ser como mínimo 1 kilo o como máximo 99999 kilos
-        weight = picking.shipping_weight
-        if float_compare(weight, 1, precision_digits=3) == -1:
+        if float_compare(weight, 1, precision_digits=2) == -1:
             weight = 1
         return {
             "Customer": self.dhl_parcel_customer_code,


### PR DESCRIPTION
FWP de 13.0: https://github.com/OCA/l10n-spain/pull/2346

Es necesario redondear el peso del envío para evitar errores en el cierre del día si se envía algo como: 13.740000000000002.

Por favor @pedrobaeza y @chienandalu ¿podéis revisarlo?

@Tecnativa TT37136