### PR TITLE
[13.0][FIX] delivery_dhl_parcel: Set the correct label format when creating the shipment.

### DIFF
--- a/delivery_dhl_parcel/models/delivery_carrier.py
+++ b/delivery_dhl_parcel/models/delivery_carrier.py
@@ -122,7 +122,7 @@ class DeliveryCarrier(models.Model):
             "GoodsDescription": "",  # [optional]
             "CustomsValue": "",  # [optional]
             "CustomsCurrency": "",  # [optional]
-            "Format": "PDF",  # [optional]
+            "Format": self.dhl_parcel_label_format,  # [optional]
             "tracking_number": False,
             "exact_price": 0,
         }


### PR DESCRIPTION
Definir el formato de etiqueta correcto al crear el envío.

Por favor @pedrobaeza ¿puedes revisarlo?

@Tecnativa TT37461