### PR TITLE
[14.0][FIX] delivery_dhl_parcel: Set the correct label format when creating the shipment.

### DIFF
--- a/delivery_dhl_parcel/models/delivery_carrier.py
+++ b/delivery_dhl_parcel/models/delivery_carrier.py
@@ -124,7 +124,7 @@ class DeliveryCarrier(models.Model):
             "GoodsDescription": "",  # [optional]
             "CustomsValue": "",  # [optional]
             "CustomsCurrency": "",  # [optional]
-            "Format": "PDF",  # [optional]
+            "Format": self.dhl_parcel_label_format,  # [optional]
             "tracking_number": False,
             "exact_price": 0,
         }


### PR DESCRIPTION
FWP de 13.0: https://github.com/OCA/l10n-spain/pull/2354

Definir el formato de etiqueta correcto al crear el envío.

Por favor @pedrobaeza ¿puedes revisarlo?

@Tecnativa TT37461