### PR TITLE
[15.0][FIX] l10n_es_dua_sii: mantener liquidación complementaria

### DIFF
--- a/l10n_es_dua_sii/models/account_move.py
+++ b/l10n_es_dua_sii/models/account_move.py
@@ -63,10 +63,15 @@ class AccountMove(models.Model):
         propia compañia en IDEmisorFactura y Contraparte
         Más información en: 8.1.2.2. Ejemplo mensaje XML de alta de importación
         en el documento de descripción de los servicios web.
+
+        En el caso de una factura (con la casilla LC activa) que complemente a una
+        factura DUA se debe mantener el TipoFactura = LC. Puntos 4.24 y 4.25 de este pdf:
+        https://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/V_1_1/Faqs_General/FAQs11_11_2020.pdf  # noqa
         """
         res = super()._get_sii_invoice_dict_in(cancel=cancel)
         if res.get("FacturaRecibida") and self.sii_dua_invoice:
-            res["FacturaRecibida"]["TipoFactura"] = "F5"
+            if not self.sii_lc_operation:
+                res["FacturaRecibida"]["TipoFactura"] = "F5"
             res["FacturaRecibida"].pop("FechaOperacion", None)
             nif = self.company_id.partner_id._parse_aeat_vat_info()[2]
             res["FacturaRecibida"]["IDEmisorFactura"] = {"NIF": nif}


### PR DESCRIPTION
Mantener el tipo LC en el caso de que una factura sea DUA y a la vez se le marque la casilla de Liquidación complementaria.

Cambios traídos de la v14.0:
- [X] https://github.com/OCA/l10n-spain/pull/2358