### PR TITLE
[15.0][FIX] l10n_es_facturae: Fill InvoiceDescription with plain text

### DIFF
--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -327,8 +327,8 @@
                         <t t-if="version not in ('3_2', '3_2_1')">
                             <InvoiceDescription
                                 t-length="2500"
-                                t-if="move.narration"
-                                t-esc="move.narration"
+                                t-if="move.get_narration()"
+                                t-esc="move.get_narration()"
                             />
                             <ReceiverTransactionReference t-length="20" t-if="False" />
                             <FileReference t-length="20" t-if="False" />
@@ -672,7 +672,7 @@
                         t-set="attachments"
                         t-value="move._get_facturae_move_attachments()"
                     />
-                    <AdditionalData t-if="move.narration or attachments">
+                    <AdditionalData t-if="move.get_narration() or attachments">
                         <RelatedInvoice t-if="False" />
                         <RelatedDocuments t-if="attachments">
                             <Attachment t-foreach="attachments" t-as="attachment">


### PR DESCRIPTION
El campo `InvoiceDescription` se estaba rellenando directamente con el valor del campo `narration`, que se trata de un campo tipo html.

Se utiliza la función `get_narration()` que define el módulo para pasar el contenido del campo a texto mediante `html2plaintext`


El problema ha sido detectado en el PR #2149 