### PR TITLE
[14.0][FIX] l10n_es_aeat_mod347: Set zip in partner to prevent error in account_edi_ubl_cii account.

### DIFF
--- a/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
+++ b/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
@@ -34,12 +34,14 @@ class TestL10nEsAeatMod347(TestL10nEsAeatModBase):
         cls.customer_4 = cls.customer.copy(
             {"name": "Test customer 4", "vat": "ESB29805314"}
         )
+        # TODO: Zip set is not necessary https://github.com/odoo/odoo/pull/94333
         cls.customer_5 = cls.customer.copy(
             {
                 "name": "Test customer 5",
                 # For testing spanish states mapping
                 "country_id": cls.env.ref("base.es").id,
                 "vat": "12345678Z",
+                "zip": 28001,
             }
         )
         cls.customer_6 = cls.customer.copy(
@@ -47,6 +49,7 @@ class TestL10nEsAeatMod347(TestL10nEsAeatModBase):
                 "name": "Test customer 6",
                 "country_id": cls.env.ref("base.es").id,
                 "vat": "B29805314",
+                "zip": 28001,
             }
         )
         cls.supplier_2 = cls.supplier.copy({"name": "Test supplier 2"})


### PR DESCRIPTION
Definir el zip en el cliente para evitar el error en `account_edi_ubl_cii` https://github.com/OCA/l10n-spain/runs/6998291155?check_suite_focus=true#step:8:310

NO necesario si se fusiona: https://github.com/odoo/odoo/pull/94333

Por favor @pedrobaeza ¿puedes revisarlo?

@Tecnativa TT36147