### PR TITLE
[13.0][FIX] l10n_es_ticketbai: Corrección de valores de impuestos y posición fiscal default en facturas

### DIFF
--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -16,6 +16,13 @@ from odoo.addons.l10n_es_ticketbai_api.ticketbai.xml_schema import TicketBaiSche
 class AccountMove(models.Model):
     _inherit = "account.move"
 
+    def _default_tbai_vat_regime_key(self):
+        context = self.env.context
+        invoice_type = context.get("type", context.get("default_type"))
+        if invoice_type in ["out_invoice", "out_refund"]:
+            key = self.env["tbai.vat.regime.key"].search([("code", "=", "01")], limit=1)
+            return key
+
     tbai_enabled = fields.Boolean(related="company_id.tbai_enabled", readonly=True)
     tbai_send_invoice = fields.Boolean(related="journal_id.tbai_send_invoice")
     tbai_substitution_invoice_id = fields.Many2one(
@@ -77,7 +84,10 @@ class AccountMove(models.Model):
         copy=False,
     )
     tbai_vat_regime_key = fields.Many2one(
-        comodel_name="tbai.vat.regime.key", string="VAT Regime Key", copy=True
+        comodel_name="tbai.vat.regime.key",
+        string="VAT Regime Key",
+        copy=True,
+        default=_default_tbai_vat_regime_key,
     )
     tbai_vat_regime_key2 = fields.Many2one(
         comodel_name="tbai.vat.regime.key", string="VAT Regime 2nd Key", copy=True
@@ -321,9 +331,19 @@ class AccountMove(models.Model):
                     and tax.tbai_get_value_tipo_no_exenta()
                     or ""
                 )
-                exemption = self.fiscal_position_id.tbai_vat_exemption_ids.filtered(
-                    lambda e: e.tax_id.id == tax["id"]
-                )
+                exemption = ""
+                if tax.tbai_is_tax_exempted():
+                    if self.fiscal_position_id:
+                        exemption = self.fiscal_position_id.tbai_vat_exemption_ids.filtered(
+                            lambda e: e.tax_id.id == tax["id"]
+                        )
+                        if len(exemption) == 1:
+                            exemption = exemption.tbai_vat_exemption_key.code
+                    else:
+                        exemption = self.env["tbai.vat.exemption.key"].search(
+                            [("code", "=", "E1")], limit=1
+                        )
+                        exemption = exemption.code
                 taxes.append(
                     (
                         0,
@@ -333,9 +353,7 @@ class AccountMove(models.Model):
                             "is_subject_to": tax_subject_to,
                             "not_subject_to_cause": not_subject_to_cause,
                             "is_exempted": is_exempted,
-                            "exempted_cause": is_exempted
-                            and exemption.tbai_vat_exemption_key.code
-                            or "",
+                            "exempted_cause": is_exempted and exemption or "",
                             "not_exempted_type": not_exempted_type,
                             "amount": "%.2f" % abs(tax.amount),
                             "amount_total": tax.tbai_get_value_cuota_impuesto(self),
@@ -455,28 +473,6 @@ class AccountMove(models.Model):
         refund_common_fields.append("tbai_substitution_invoice_id")
         refund_common_fields.append("company_id")
         return refund_common_fields
-
-    @api.model
-    def _get_tax_grouping_key_from_tax_line(self, tax_line):
-        vals = super()._get_tax_grouping_key_from_tax_line(tax_line)
-        if self.fiscal_position_id:
-            exemption = self.fiscal_position_id.tbai_vat_exemption_ids.filtered(
-                lambda e: e.tax_id.id == tax_line.tax_line_id.id
-            )
-            if 1 == len(exemption):
-                vals["tbai_vat_exemption_key"] = exemption.tbai_vat_exemption_key.id
-        return vals
-
-    @api.model
-    def _get_tax_grouping_key_from_base_line(self, base_line, tax_vals):
-        vals = super()._get_tax_grouping_key_from_base_line(base_line, tax_vals)
-        if self.fiscal_position_id:
-            exemption = self.fiscal_position_id.tbai_vat_exemption_ids.filtered(
-                lambda e: e.tax_id.id == tax_vals["id"]
-            )
-            if 1 == len(exemption):
-                vals["tbai_vat_exemption_key"] = exemption.tbai_vat_exemption_key.id
-        return vals
 
     def tbai_is_invoice_refund(self):
         if "out_refund" == self.type or (

--- a/l10n_es_ticketbai/models/account_tax.py
+++ b/l10n_es_ticketbai/models/account_tax.py
@@ -211,13 +211,15 @@ class AccountTax(models.Model):
         return res
 
     def tbai_get_invoice_base_balace_for_tax_group(self, invoice_id):
+        base = 0
         for line in invoice_id.line_ids:
-            if line.tax_line_id.id == self.id:
-                return line.tax_base_amount
-        return 0
+            if self.id in line.tax_ids.ids:
+                base += line.price_subtotal
+        return base
 
     def tbai_get_invoice_amount_for_tax_group(self, invoice_id):
+        amount = 0
         for line in invoice_id.line_ids:
-            if line.tax_line_id.id == self.id:
-                return line.price_total
-        return 0
+            if self.id in line.tax_ids.ids:
+                amount += line.price_subtotal * self.amount / 100
+        return amount


### PR DESCRIPTION
Corrige problemas detectados en los valores de los impuestos al enviar las facturas a hacienda. También hace que crear una factura si no tiene posición fiscal se le asigne la de régimen nacional. 

Para reproducir el error, enviar una factura con impuestos no sujetos, hacienda recibe la factura pero devuelve lo siguientes errores:
- 2025 - El Importe total debe ser igual a la suma de las bases imponibles más las cuotas del impuesto, más las cuotas recargo equivalencia del bloque Sujeta NoExenta, más la suma de las bases imponibles del bloque Sujeta Exenta y la suma de los impor...
- 5017 -  Los importes indicados en los desgloses NoSujeto o Exento no coinciden con lo recogido en las líneas de detalle. Esta validación no se aplicará cuando alguna clave de régimen sea 03, 05, 06 o 09