### PR TITLE
[14.0][FIX] l10n_es_facturae_face: validate fields before creting exchange record

### DIFF
--- a/l10n_es_facturae_face/components/account_move_l10n_es_facturae_listener.py
+++ b/l10n_es_facturae_face/components/account_move_l10n_es_facturae_listener.py
@@ -30,6 +30,9 @@ class AccountMoveL10nEsFacturaeListener(Component):
             if not backend:
                 continue
             exchange_type = "l10n_es_facturae"
+            # We check fields now to raise an error to the user, otherwise the
+            # error will be raising silently in the queue job.
+            record.validate_facturae_fields()
             if record._has_exchange_record(exchange_type, backend):
                 continue
             exchange_record = backend.create_record(


### PR DESCRIPTION
We check fields now to raise an error to the user, otherwise the
error will be raising silently in the queue job.

@ForgeFlow