### PR TITLE
[12.0][FIX] l10n_es_ticketbai_batuz: En los diarios de compras hacer visibles los campos de Ticketbai

### DIFF
--- a/l10n_es_ticketbai_batuz/__manifest__.py
+++ b/l10n_es_ticketbai_batuz/__manifest__.py
@@ -38,6 +38,7 @@
         "views/res_company_views.xml",
         "views/res_partner_views.xml",
         "views/tbai_vat_regime_key_views.xml",
+        "views/account_journal_views.xml",
     ],
     "post_init_hook": "post_init_hook",
 }

--- a/l10n_es_ticketbai_batuz/views/account_journal_views.xml
+++ b/l10n_es_ticketbai_batuz/views/account_journal_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2021 Landoo Sistemas de Informacion SL
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <data>
+        <record id="view_account_journal_form_batuz" model="ir.ui.view">
+            <field name="model">account.journal</field>
+            <field name="inherit_id" ref="l10n_es_ticketbai.view_account_journal_form_inherit" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='tbai_active_date']" position="attributes">
+                    <attribute name="attrs">
+                        {'invisible': ['|', ('type', 'not in', ('sale', 'purchase')), ('tbai_enabled', '=', False)]}
+                    </attribute>
+                </xpath>
+                <xpath expr="//field[@name='tbai_send_invoice']" position="attributes">
+                    <attribute name="attrs">
+                        {'invisible': ['|', ('type', 'not in', ('sale', 'purchase')), ('tbai_enabled', '=', False)]}
+                    </attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
 En los diarios de compras hacer visibles los campos de Ticketbai
	tbai_send_invoive
	tbai_active_date

En Batuz también se envían las facturas de compras y gastos a hacienda. 