### PR TITLE
[13.0][FIX]l10n_es_facturae: Show printer icon in facturae export wizard

### DIFF
--- a/l10n_es_facturae/wizard/create_facturae_view.xml
+++ b/l10n_es_facturae/wizard/create_facturae_view.xml
@@ -18,7 +18,7 @@
                 </group>
                 <footer>
                     <button
-                        icon="fa fa-print"
+                        icon="fa-print"
                         name="create_facturae_file"
                         string="Export"
                         type="object"


### PR DESCRIPTION
supersedes: https://github.com/OCA/l10n-spain/pull/2359

Before this fix, the printer fa icon in the Export button in the facturae export wizard was not working.

Before:
![before](https://user-images.githubusercontent.com/62256279/177288884-31307051-207e-4d5c-b4f0-02ec3f38e1a3.png)

After:
![after](https://user-images.githubusercontent.com/62256279/177288907-7b910682-eee3-45cc-9bd4-1170d4b3f2f8.png)

