### PR TITLE
[14.0][FIX]l10n_es_facturae: Show printer icon in facturae export wizard

### DIFF
--- a/l10n_es_facturae/wizard/create_facturae_view.xml
+++ b/l10n_es_facturae/wizard/create_facturae_view.xml
@@ -18,7 +18,7 @@
                 </group>
                 <footer>
                     <button
-                        icon="fa fa-print"
+                        icon="fa-print"
                         name="create_facturae_file"
                         string="Export"
                         type="object"


### PR DESCRIPTION
Same fix applied in v13: https://github.com/OCA/l10n-spain/pull/2392