### PR TITLE
[11.0][FIX] l10n_es_ticketbai_pos: Permitir reimprimir ticket sin código QR

### DIFF
--- a/l10n_es_ticketbai_pos/models/pos_order.py
+++ b/l10n_es_ticketbai_pos/models/pos_order.py
@@ -152,7 +152,7 @@ class PosOrder(models.Model):
     @api.multi
     def _prepare_done_order_for_pos(self):
         res = super()._prepare_done_order_for_pos()
-        if self.tbai_enabled:
+        if self.tbai_enabled and self.tbai_invoice_id:
             res.update({
                 'tbai_identifier': self.tbai_invoice_id.tbai_identifier,
                 'tbai_qr_src': 'data:image/png;base64,' + str(


### PR DESCRIPTION
Permite volver a imprimir un ticket aunque este no tenga factura TicketBAI porque superaba el límite de factura simplificada.

También es conveniente en mi opinión que cuando se genere este ticket por primera vez no muestre ningún código QR, ya que nunca se llega a enviar a hacienda.