### PR TITLE
[IMP] delivery_gls_asm: International tracking links

### DIFF
--- a/delivery_dhl_parcel/__manifest__.py
+++ b/delivery_dhl_parcel/__manifest__.py
@@ -17,4 +17,5 @@
         "views/stock_picking_views.xml",
         "wizard/dhl_parcel_end_day_wizard_views.xml",
     ],
+    "maintainers": ["hildickethan-S73"],
 }

--- a/delivery_gls_asm/README.rst
+++ b/delivery_gls_asm/README.rst
@@ -174,6 +174,10 @@ Contributors
   * David Vidal
   * Víctor Martínez
 
+* `Studio73 <https://www.studio73.es>`_:
+
+  * Ethan Hildick
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/delivery_gls_asm/__manifest__.py
+++ b/delivery_gls_asm/__manifest__.py
@@ -20,4 +20,5 @@
         "views/stock_picking_views.xml",
         "wizard/gls_asm_manifest_wizard_views.xml",
     ],
+    "maintainers": ["chienandalu", "hildickethan-S73"],
 }

--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -13,6 +13,7 @@ from .gls_asm_master_data import (
     GLS_POSTAGE_TYPE,
     GLS_SHIPMENT_TYPE_STATES,
     GLS_SHIPPING_TIMES,
+    GLS_TRACKING_LINKS,
 )
 from .gls_asm_request import GlsAsmRequest
 
@@ -96,11 +97,18 @@ class DeliveryCarrier(models.Model):
 
     def gls_asm_get_tracking_link(self, picking):
         """Provide tracking link for the customer"""
-        tracking_url = (
-            "http://www.asmred.com/extranet/public/"
-            "ExpedicionASM.aspx?codigo={}&cpDst={}"
-        )
-        return tracking_url.format(picking.carrier_tracking_ref, picking.partner_id.zip)
+        # International
+        if picking.gls_asm_picking_ref:
+            if picking.partner_id.country_id.code == "PT":
+                base_link = GLS_TRACKING_LINKS.get("INT_PT")
+            else:
+                base_link = GLS_TRACKING_LINKS.get("INT")
+            tracking_url = base_link.format(picking.gls_asm_picking_ref)
+        else:
+            tracking_url = GLS_TRACKING_LINKS.get("ASM").format(
+                picking.carrier_tracking_ref, picking.partner_id.zip
+            )
+        return tracking_url
 
     def _prepare_gls_asm_shipping(self, picking):
         """Convert picking values for asm api

--- a/delivery_gls_asm/models/gls_asm_master_data.py
+++ b/delivery_gls_asm/models/gls_asm_master_data.py
@@ -323,3 +323,16 @@ GLS_PICKUP_ERROR_CODES = {
     -603: "Shipment References, tipo not exists.",
     -676: "Collection Zipcode is wrong, not exists.",
 }
+
+GLS_TRACKING_LINKS = {
+    "ASM": (
+        "http://www.asmred.com/extranet/public/ExpedicionASM.aspx?codigo={}&cpDst={}"
+    ),
+    "INT": (
+        "https://www.gls-spain.es/en/receiving-parcels/shipping-tracking/"
+        "?match={}&international=1"
+    ),
+    "INT_PT": (
+        "https://www.gls-portugal.pt/pt/seguimiento-envio/?match={}&international=1"
+    ),
+}

--- a/delivery_gls_asm/readme/CONTRIBUTORS.rst
+++ b/delivery_gls_asm/readme/CONTRIBUTORS.rst
@@ -2,3 +2,7 @@
 
   * David Vidal
   * Víctor Martínez
+
+* `Studio73 <https://www.studio73.es>`_:
+
+  * Ethan Hildick

--- a/delivery_gls_asm/views/stock_picking_views.xml
+++ b/delivery_gls_asm/views/stock_picking_views.xml
@@ -29,6 +29,10 @@
                     name="gls_asm_public_tracking_ref"
                     attrs="{'invisible':[('gls_asm_public_tracking_ref', '!=', 'False')]}"
                 />
+                <field
+                    name="gls_asm_picking_ref"
+                    attrs="{'invisible':[('gls_asm_picking_ref', '=', False)]}"
+                />
             </xpath>
             <xpath expr="//header" position='inside'>
                 <button


### PR DESCRIPTION
- Usar el campo `gls_asm_picking_ref` para sacar los enlaces de seguimiento correctos para envíos internacionales, si este campo se ha devuelto significa que el envío es internacional
- Se añade los links de la página PT y una base para el resto de casos con la página española pero con el idioma en inglés
- Se muestra el campo `gls_asm_picking_ref` en caso de que tenga valor
- Añadir maintainers para `delivery_dhl_parcel` y `delivery_gls_asm`