### PR TITLE
[IMP] delivery_dhl_parcel: Cash on delivery

### DIFF
--- a/delivery_dhl_parcel/i18n/delivery_dhl_parcel.pot
+++ b/delivery_dhl_parcel/i18n/delivery_dhl_parcel.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-15 08:57+0000\n"
+"PO-Revision-Date: 2022-07-15 08:57+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -31,6 +33,11 @@ msgstr ""
 #. module: delivery_dhl_parcel
 #: model_terms:ir.ui.view,arch_db:delivery_dhl_parcel.delivery_endday_wizard_form
 msgid "Cancel"
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_cash_on_delivery
+msgid "Cash on delivery"
 msgstr ""
 
 #. module: delivery_dhl_parcel
@@ -189,6 +196,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__id
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_stock_picking__id
 msgid "ID"
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_cash_on_delivery
+msgid ""
+"If checked, it means that the carrier is paid with cash. It assumes there is"
+" a sale order linked and it will use that total amount as the value to be "
+"paid"
 msgstr ""
 
 #. module: delivery_dhl_parcel

--- a/delivery_dhl_parcel/i18n/es.po
+++ b/delivery_dhl_parcel/i18n/es.po
@@ -6,11 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-30 10:29+0000\n"
-"PO-Revision-Date: 2021-10-30 10:29+0000\n"
+"POT-Creation-Date: 2022-07-15 08:58+0000\n"
+"PO-Revision-Date: 2022-07-15 08:58+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -37,6 +36,11 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_cash_on_delivery
+msgid "Cash on delivery"
+msgstr "Contra reembolso"
+
+#. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__create_uid
 msgid "Created by"
 msgstr "Creado por"
@@ -58,17 +62,15 @@ msgstr "DHL Parcel"
 
 #. module: delivery_dhl_parcel
 #: code:addons/delivery_dhl_parcel/models/delivery_carrier.py:0
+#: code:addons/delivery_dhl_parcel/models/delivery_carrier.py:0
 #, python-format
 msgid ""
 "DHL Parcel API doesn't provide methods to compute delivery rates, so\n"
-"                you should rely on another price method instead or override "
-"this\n"
+"                you should rely on another price method instead or override this\n"
 "                one in your custom code."
 msgstr ""
-"DHL Parcel API no provee ninguna forma de calcular las tarifas de envío, "
-"por\n"
-"                lo tanto se deberia usar otro método o sobreescribir este en "
-"una herencia"
+"DHL Parcel API no provee ninguna forma de calcular las tarifas de envío, por\n"
+"                lo tanto se deberia usar otro método o sobreescribir este en una herencia"
 
 #. module: delivery_dhl_parcel
 #: code:addons/delivery_dhl_parcel/models/delivery_carrier.py:0
@@ -201,6 +203,15 @@ msgid "ID"
 msgstr "ID"
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_cash_on_delivery
+msgid ""
+"If checked, it means that the carrier is paid with cash. It assumes there is"
+" a sale order linked and it will use that total amount as the value to be "
+"paid"
+msgstr "Si está marcado, significa que el transportista se paga a la hora de entregar. Asume que hay un pedido"
+" de venta relacionado del cual usará la cantidad total como el valor a pagar"
+
+#. module: delivery_dhl_parcel
 #: model:ir.model.fields,help:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__customer_accounts
 msgid ""
 "If doing multiple, input them separated by commas without spaces.\n"
@@ -222,6 +233,7 @@ msgid "Label format"
 msgstr "Formato de etiqueta"
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier____last_update
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard____last_update
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_stock_picking____last_update
 msgid "Last Modified on"

--- a/delivery_dhl_parcel/models/delivery_carrier.py
+++ b/delivery_dhl_parcel/models/delivery_carrier.py
@@ -46,6 +46,14 @@ class DeliveryCarrier(models.Model):
         default="PDF",
         string="Label format",
     )
+    dhl_parcel_cash_on_delivery = fields.Boolean(
+        string="Cash on delivery",
+        help=(
+            "If checked, it means that the carrier is paid with cash. It assumes "
+            "there is a sale order linked and it will use that "
+            "total amount as the value to be paid"
+        ),
+    )
 
     def dhl_parcel_get_tracking_link(self, picking):
         """Provide tracking link for the customer"""
@@ -102,7 +110,7 @@ class DeliveryCarrier(models.Model):
         # El peso del envío tiene que ser como mínimo 1 kilo o como máximo 99999 kilos
         if float_compare(weight, 1, precision_digits=2) == -1:
             weight = 1
-        return {
+        vals = {
             "Customer": self.dhl_parcel_customer_code,
             "Receiver": self._get_dhl_parcel_receiver_info(picking),
             "Sender": self._get_dhl_parcel_sender_info(picking),  # [optional]
@@ -130,6 +138,17 @@ class DeliveryCarrier(models.Model):
             "tracking_number": False,
             "exact_price": 0,
         }
+        if self.dhl_parcel_cash_on_delivery:
+            sale = picking.sale_id
+            mapped_expenses = {"CPT": "P", "EXW": "D"}
+            vals.update(
+                {
+                    "CODAmount": sale.amount_total,
+                    "CODExpenses": mapped_expenses.get(self.dhl_parcel_incoterm, "P"),
+                    "CODCurrency": sale.currency_id.name,
+                }
+            )
+        return vals
 
     def dhl_parcel_send_shipping(self, pickings):
         """Send the package to DHL Parcel

--- a/delivery_dhl_parcel/views/delivery_carrier_view.xml
+++ b/delivery_dhl_parcel/views/delivery_carrier_view.xml
@@ -36,6 +36,9 @@
                                 name="dhl_parcel_label_format"
                                 attrs="{'required': [('delivery_type', '=', 'dhl_parcel')]}"
                             />
+                        </group>
+                        <group>
+                            <field name="dhl_parcel_cash_on_delivery" />
                             <field
                                 name="dhl_parcel_last_end_day_report"
                                 filename="dhl_parcel_last_end_day_report_name"


### PR DESCRIPTION
- Opción para el contra-reembolso, usa el valor del pedido de venta
- Separa los campos de configuración en 2 campos, por no alargarlo todo en 1 lado