### PR TITLE
[FIX] l10n_es_pos: prevent race condition computing simplified invoic…

### DIFF
--- a/l10n_es_pos/models/pos_config.py
+++ b/l10n_es_pos/models/pos_config.py
@@ -19,6 +19,13 @@ class PosConfig(models.Model):
                 seq._get_prefix_suffix()[0])
             pos.l10n_es_simplified_invoice_padding = seq.padding
 
+    def _compute_last_pos_order(self):
+        for pos in self:
+            pos.l10n_es_last_pos_order = self.env['pos.order'].search([
+                ('config_id', '=', pos.id),
+                ('is_l10n_es_simplified_invoice', '=', True)
+            ], order='id DESC', limit=1).pos_reference
+
     iface_l10n_es_simplified_invoice = fields.Boolean(
         string='Use simplified invoices for this POS',
     )
@@ -54,6 +61,11 @@ class PosConfig(models.Model):
         readonly=True,
         compute='_compute_simplified_invoice_sequence',
         oldname='simple_invoice_number',
+    )
+    l10n_es_last_pos_order = fields.Char(
+        'Last Order',
+        readonly=True,
+        compute='_compute_last_pos_order'
     )
 
     @api.model

--- a/l10n_es_pos/static/src/js/models.js
+++ b/l10n_es_pos/static/src/js/models.js
@@ -8,6 +8,8 @@ odoo.define('l10n_es_pos.models', function (require) {
 
     var models = require('point_of_sale.models');
 
+    models.load_fields('pos.config', ['l10n_es_last_pos_order']);
+
     var pos_super = models.PosModel.prototype;
     models.PosModel = models.PosModel.extend({
         initialize: function (attributes, options) {
@@ -15,10 +17,14 @@ odoo.define('l10n_es_pos.models', function (require) {
             this.pushed_simple_invoices = [];
             return this;
         },
+        after_load_server_data: function() {
+            var self = this;
+            var orders = this.db.get_orders();
+            var resIndex = orders.findIndex((p) => p.data.name == this.config.l10n_es_last_pos_order);
+            orders.slice(0, resIndex + 1).forEach(o => self.db.remove_order(o.id));
+            return pos_super.after_load_server_data.call(this);
+        },
         get_simple_inv_next_number: function () {
-            if (this.pushed_simple_invoices.indexOf(this.config.l10n_es_simplified_invoice_number) > -1) {
-                ++this.config.l10n_es_simplified_invoice_number;
-            }
             return this.config.l10n_es_simplified_invoice_prefix+this.get_padding_simple_inv(this.config.l10n_es_simplified_invoice_number);
         },
         get_padding_simple_inv: function (number) {
@@ -39,6 +45,13 @@ odoo.define('l10n_es_pos.models', function (require) {
                 this.pushed_simple_invoices.push(order.data.simplified_invoice);
                 ++this.config.l10n_es_simplified_invoice_number;
             }
+        },
+        push_order: function(order, opts) {
+            if (order && order.simplified_invoice && this.pushed_simple_invoices.indexOf(order.simplified_invoice) === -1) {
+                this.pushed_simple_invoices.push(order.simplified_invoice);
+                ++this.config.l10n_es_simplified_invoice_number;
+            }
+            return pos_super.push_order.apply(this, arguments);
         },
         _flush_orders: function (orders, options) {
             var self = this;


### PR DESCRIPTION
…e numbers.

The l10n_es_pos implementation  opted not to keep  the next simplified
invoice  number   in  the  persistent   state  and  instead   use  its
implementation  of _flush_orders  to recalculate  the counter  after a
browser reload. In that case it works without problems but in the case
described  below  increments may  be  lost.   This commits  fixes  the
problem by also updating the counter in the push_order function taking
into  account that  for each  simplified invoice  the counter  is only
incremented once  regardless of  whether it is  done in  push_order or
_flush_orders.

This commit also removes  dead code get_simple_inv_next_number: the if
is always  false because  pushed_simple_invoices contains  strings and
l10n_es_simplified_invoice_number is a number.

If the calls to to create_from_ui must take a long time to respond (it
doesn't seem  to matter if  successfully or with  error as long  as it
takes more  than 30") l10n_es_pos may  fail to update the  counter. To
see how this happens first we have to take the following into account:

  - l10n_es_pos updates the counter  inside _flush_orders.  Under most
    conditions this is correct.

  - The common  way to launch  a _flush_orders is by  push_order which
    first queues  the simplified invoice and  then calls _flush_orders
    to send the queued orders (the new one and the previous ones).

  - point_of_sale  protects  the calls  to  _flush_orders  by a  mutex
    object that takes care of serializing the calls.

With this in place this case is possible:

  1.- A simplified  invoice is created and  validated.  Its simplified
  invoice number is  generated and push_order is  called. Let's assume
  that this simplified invoice is number 1.

  2.-  push_order calls  _flush_orders which  is executed  immediately
  since the mutex object is  free. The _flush_orders implementation of
  l10n_es_pos increments the simplified invoice number counter (now it
  will have the value 2) and calls the base implementation which calls
  create_from_ui (remote call).

  3.- At this  point we assume that create_from_ui takes  some time to
  respond.

  4.-  A second  simplified  invoice is  created  and validated.   Its
  simplified   invoice  number   is   generated   and  push_order   is
  called. This simplified invoice will be correct with the number 2.

  5.- push_order calls  _flush_orders but as a) the  call is protected
  by a  mutex object and  b) create_from_ui is  taking a long  time to
  answer and thus the call of point 2 is not yet finished, the call to
  _flush_orders  is  not  executed.  Therefore,  the  counter  is  not
  updated.

  6.-  A  second simplified  invoice  is  created and  validated.   It
  generates its simplified  invoice number which will be  again 2 when
  it should be 3.

  7.-  The call  of  point  2 is  finally  finished, _flush_orders  of
  l10n_es_pos is executed and the counter is updated to 3.

The next simplified invoice will have the number 3 but we already have
two simplified invoices with the number 2.