### PR TITLE
[FIX] l10n_es_extra_data: country_id does not exist

### DIFF
--- a/l10n_es_extra_data/data/account_data.xml
+++ b/l10n_es_extra_data/data/account_data.xml
@@ -2,6 +2,5 @@
 <odoo noupdate="1">
     <record id="tax_group_iva_5" model="account.tax.group">
         <field name="name">IVA 5%</field>
-        <field name="country_id" ref="base.es"/>
     </record>
 </odoo>


### PR DESCRIPTION
El modelo `account.tax.group` no tiene el campo `country_id`. Salta el mensahe de error al instalar.

Error introducido aquí:
https://github.com/odoo/odoo/pull/95967/files#diff-be65fc06bf41c02157a65fa726a0c8e3cbc7c477eafa7fc9dc0fb87ae5d76d9fR71

Se debería de corregir en la versión 13.0 y superiores.