### PR TITLE
[14.0][FIX] delivery_gls_asm: prevent escape of bool

### DIFF
--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -160,7 +160,7 @@ class DeliveryCarrier(models.Model):
             "destinatario_codigo": "",
             "destinatario_plaza": "",
             "destinatario_nombre": (
-                escape(consignee.name) or escape(consignee.commercial_partner_id.name)
+                escape(consignee.name or consignee.commercial_partner_id.name or "")
             ),
             "destinatario_direccion": escape(consignee.street or ""),
             "destinatario_poblacion": escape(consignee.city or ""),


### PR DESCRIPTION
Se modifica para evitar hacer el `escape` de `False` si el `consignee.name` no está definido.