### PR TITLE
[FIX][13.0]l10n_es_ticketbai,l10n_es_ticketbai_batuz: Correcciones cuando no está activado ticketbai

### DIFF
--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -460,8 +460,10 @@ class AccountMove(models.Model):
         refund_invoices = self.sudo().filtered(
             lambda x: x.tbai_enabled
             and "out_refund" == x.type
-            and not x.tbai_refund_type
-            or x.tbai_refund_type == RefundType.differences.value
+            and (
+                not x.tbai_refund_type
+                or x.tbai_refund_type == RefundType.differences.value
+            )
             and x.tbai_send_invoice
         )
 

--- a/l10n_es_ticketbai_batuz/views/account_move_views.xml
+++ b/l10n_es_ticketbai_batuz/views/account_move_views.xml
@@ -80,7 +80,7 @@
                     >
                         <field
                             name="reversed_entry_id"
-                            attrs="{'required': [('tbai_enabled', '!=', True), ('type', '=', 'in_refund'), ('tbai_refund_origin_ids', '=', [])], 'readonly': [('state', '!=', 'draft')]}"
+                            attrs="{'required': [('tbai_enabled', '=', True), ('type', '=', 'in_refund'), ('tbai_refund_origin_ids', '=', [])], 'readonly': [('state', '!=', 'draft')]}"
                         />
                     </group>
                     <group>


### PR DESCRIPTION
Durante la migración a v14 nos hemos encontrado con este problema cuando ticketbai está deshabilitado.

- l10n_es_ticketbai: Al estar el filtered mal formado, intenta enviar facturas aunque tbai_enabled sea False.
- l10n_es_ticketbai_batuz: Debido al invisible incorrecto no es posible crear rectificativas manualmente con ticketbai deshabilitado.

CC: @jfernandez-busman 