### PR TITLE
[14.0][FIX] l10n_es_vat_book: Use aeat identification types

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -384,13 +384,24 @@ class L10nEsVatBook(models.Model):
             line_vals["line_type"] = "rectification_{}".format(line_type)
 
     def _check_exceptions(self, line_vals):
+        rp_model = self.env["res.partner"]
         if not line_vals["partner_id"]:
             line_vals["exception_text"] = _("Without Partner")
-        elif (
-            not line_vals["vat_number"]
-            and line_vals["partner_id"] not in self.get_pos_partner_ids()
-        ):
-            line_vals["exception_text"] = _("Without VAT")
+        elif not line_vals["vat_number"]:  # Doesn't have VAT
+            partner = rp_model.browse(line_vals["partner_id"])
+            country_code, identifier_type, vat_number = partner._parse_aeat_vat_info()
+            req_vat_identif_types = [
+                s_opt[0]
+                for s_opt in rp_model._fields["aeat_identification_type"].selection
+            ] + [
+                ""
+            ]  # "" is the identification type for Spain
+            # Partner type requires VAT
+            if (
+                identifier_type in req_vat_identif_types
+                and line_vals["partner_id"] not in self.get_pos_partner_ids()
+            ):
+                line_vals["exception_text"] = _("Without VAT")
 
     def create_vat_book_lines(self, move_lines, line_type, taxes):
         VatBookLine = self.env["l10n.es.vat.book.line"]

--- a/l10n_es_vat_book/models/l10n_es_vat_book_line.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book_line.py
@@ -33,7 +33,6 @@ class L10nEsVatBookLine(models.Model):
     invoice_date = fields.Date(string="Invoice Date")
 
     partner_id = fields.Many2one(comodel_name="res.partner", string="Empresa")
-
     vat_number = fields.Char(string="NIF")
 
     vat_book_id = fields.Many2one(comodel_name="l10n.es.vat.book", string="Vat Book id")

--- a/l10n_es_vat_book/readme/CONTRIBUTORS.rst
+++ b/l10n_es_vat_book/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
   * Carlos Dauden
   * Ernesto Tejeda
 * Omar Castiñeira <omar@comunitea.com>
+* Eduardo de miguel <edu@moduon.team>

--- a/l10n_es_vat_book/views/l10n_es_vat_book.xml
+++ b/l10n_es_vat_book/views/l10n_es_vat_book.xml
@@ -11,21 +11,6 @@
             >
                 <attribute name="invisible">True</attribute>
             </button>
-            <header position="after">
-                <div
-                    class="alert alert-warning text-center"
-                    attrs="{'invisible': [('error_count', '=', 0)]}"
-                    role="alert"
-                >
-                    <span>
-                        You have <strong class="text-danger"><field
-                                name="error_count"
-                            /> errors</strong> in this report.
-                        You will not be able to <strong
-                        >confirm and submit</strong> it until they are resolved.
-                    </span>
-                </div>
-            </header>
             <header position="inside">
                 <button
                     name="view_issued_invoices"


### PR DESCRIPTION
Ahora el l10n_es_vat_book utiliza los aeat_identification_types y permite exportar clientes extranjeros

Discutido en la issue: https://github.com/OCA/l10n-spain/issues/2247

Se han añadido los campos de `aeat_identification_type` y `country_code` en las líneas del informe para que los datos mostrados coincidan exactamente con lo que se exporta, si no se corre el riesgo de que al vuelo coja los datos de un partner modificado y no coincida. [Línea en la que lo calculo](https://github.com/OCA/l10n-spain/pull/2435/files#diff-d5ce6c4350400194793250a7121824f9dd96da5dc5382b9131c691fae8bec33fR233)

También utilizo el campo de aeat_identification_types como campo que indica si es obligatorio un VAT (o pasaporte o lo que sea, para que en el futuro si se expande, no sea necesario tocar nada), también añado el de españa, que es una cadena vacía. [Líneas en las que saco si es requerido el vat](https://github.com/OCA/l10n-spain/pull/2435/files#diff-d5ce6c4350400194793250a7121824f9dd96da5dc5382b9131c691fae8bec33fR396-R403)
Éste PR debe mergearse después del fix https://github.com/OCA/l10n-spain/pull/2433 de l10n_es_aeat.

Cuando esté fusionado haré cherry-pick a la v15.

MT-706 @moduon

@pedrobaeza @rafaelbn @HaraldPanten 