### PR TITLE
[12.0][FIX]-l10n_es_ticketbai_batuz-fields_have_same_label

### DIFF
--- a/l10n_es_ticketbai_batuz/models/account_invoice.py
+++ b/l10n_es_ticketbai_batuz/models/account_invoice.py
@@ -72,7 +72,7 @@ class AccountInvoice(models.Model):
     lroe_response_line_ids = fields.Many2many(
         comodel_name="lroe.operation.response.line",
         compute="_compute_lroe_response_line_ids",
-        string="Responses",
+        string="LROE Responses",
     )
     lroe_operation_ids = fields.Many2many(
         comodel_name="lroe.operation",


### PR DESCRIPTION
En el log hay warning por campos del mismo modelo con la misma etiqueta