### PR TITLE
[13.0][IMP] l10n_es_aeat_sii_oca: Avoid modifying third-party number when an invoice has already been sent to the SII + Tests.

### DIFF
--- a/l10n_es_aeat_sii_oca/i18n/es.po
+++ b/l10n_es_aeat_sii_oca/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-22 14:33+0000\n"
-"PO-Revision-Date: 2021-07-22 16:34+0200\n"
+"POT-Creation-Date: 2022-07-27 15:55+0000\n"
+"PO-Revision-Date: 2022-07-27 17:58+0200\n"
 "Last-Translator: Josep M <jmyepes@mac.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -471,6 +471,11 @@ msgid "Is Test Environment?"
 msgstr "¿Es un entorno de pruebas?"
 
 #. module: l10n_es_aeat_sii_oca
+#: model:ir.model,name:l10n_es_aeat_sii_oca.model_account_journal
+msgid "Journal"
+msgstr "Diario"
+
+#. module: l10n_es_aeat_sii_oca
 #: model:ir.model,name:l10n_es_aeat_sii_oca.model_account_move
 msgid "Journal Entries"
 msgstr "Asientos contables"
@@ -602,6 +607,11 @@ msgstr "Ninguno"
 #: model:ir.model.fields.selection,name:l10n_es_aeat_sii_oca.selection__account_move__sii_state__not_sent
 msgid "Not sent"
 msgstr "No registrada"
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_account_move__thirdparty_number
+msgid "Número de la factura emitida por un tercero."
+msgstr ""
 
 #. module: l10n_es_aeat_sii_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii_oca.l10n_es_sii_form_view
@@ -771,7 +781,6 @@ msgstr "Agencias tributarias SII"
 
 #. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_res_company__sii_tax_agency_id
-#, fuzzy
 msgid "SII Tax Agency"
 msgstr "Agencia Tributaria SII"
 
@@ -849,16 +858,6 @@ msgstr "Estado de envío SII"
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii_oca.view_account_invoice_sii_filter
 msgid "SII sent"
 msgstr "Enviadas SII"
-
-#. module: l10n_es_aeat_sii_oca
-#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_thirdparty_invoice
-msgid "SII third-party invoice"
-msgstr "Factura de terceros SII"
-
-#. module: l10n_es_aeat_sii_oca
-#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_thirdparty_number
-msgid "SII third-party number"
-msgstr "Número de terceros SII"
 
 #. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields.selection,name:l10n_es_aeat_sii_oca.selection__aeat_sii_mapping_registration_keys__type__sale
@@ -1090,6 +1089,18 @@ msgid "There's a mismatch in taxes for RE. Check them."
 msgstr "Hay un cruce erróneo para tasas en RE. Chequéelas."
 
 #. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_bank_statement_import_journal_creation__thirdparty_invoice
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_journal__thirdparty_invoice
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__thirdparty_invoice
+msgid "Third-party invoice"
+msgstr "Factura de terceros SII"
+
+#. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__thirdparty_number
+msgid "Third-party number"
+msgstr "Número de factura de terceros"
+
+#. module: l10n_es_aeat_sii_oca
 #: code:addons/l10n_es_aeat_sii_oca/models/account_move.py:0
 #, python-format
 msgid "This company doesn't have SII enabled."
@@ -1197,6 +1208,17 @@ msgid ""
 msgstr ""
 "No puede cambiar el proveedor de una factura enviada al SII. Debe cancelar "
 "la factura y crear una nueva con el proveedor correcto"
+
+#. module: l10n_es_aeat_sii_oca
+#: code:addons/l10n_es_aeat_sii_oca/models/account_move.py:0
+#, python-format
+msgid ""
+"You cannot change the third-party number of an invoice already registered at "
+"the SII. You must cancel the invoice and create a new one with the correct "
+"number"
+msgstr ""
+"No puede cambiar el número de factura de terceros de una factura enviada al "
+"SII. Debe cancelar la factura y crear una nueva con el número correcto"
 
 #. module: l10n_es_aeat_sii_oca
 #: code:addons/l10n_es_aeat_sii_oca/models/account_move.py:0

--- a/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
+++ b/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-27 15:55+0000\n"
+"PO-Revision-Date: 2022-07-27 15:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -390,12 +392,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_l10n_es_aeat_sii__id
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_l10n_es_aeat_sii_password__id
 msgid "ID"
-msgstr ""
-
-#. module: l10n_es_aeat_sii_oca
-#: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_res_company__delay_time
-#: model:ir.model.fields,help:l10n_es_aeat_sii_oca.field_res_company__sent_time
-msgid "In hours"
 msgstr ""
 
 #. module: l10n_es_aeat_sii_oca
@@ -1157,6 +1153,15 @@ msgstr ""
 msgid ""
 "You cannot change the supplier of an invoice already registered at the SII. "
 "You must cancel the invoice and create a new one with the correct supplier"
+msgstr ""
+
+#. module: l10n_es_aeat_sii_oca
+#: code:addons/l10n_es_aeat_sii_oca/models/account_move.py:0
+#, python-format
+msgid ""
+"You cannot change the third-party number of an invoice already registered at"
+" the SII. You must cancel the invoice and create a new one with the correct "
+"number"
 msgstr ""
 
 #. module: l10n_es_aeat_sii_oca

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -6,6 +6,7 @@
 # Copyright 2011-2021 Tecnativa - Pedro M. Baeza
 # Copyright 2020 Valentin Vinagre <valent.vinagre@sygel.es>
 # Copyright 2021 Tecnativa - João Marques
+# Copyright 2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import json
@@ -241,6 +242,7 @@ class AccountMove(models.Model):
         states={"draft": [("readonly", False)]},
         copy=False,
         help="Número de la factura emitida por un tercero.",
+        tracking=True,
     )
     invoice_jobs_ids = fields.Many2many(
         comodel_name="queue.job",
@@ -346,7 +348,16 @@ class AccountMove(models.Model):
                         "invoice and create a new one with the correct date"
                     )
                 )
-            if invoice.type in ["in_invoice", "in refund"]:
+            elif "thirdparty_number" in vals:
+                raise exceptions.Warning(
+                    _(
+                        "You cannot change the third-party number of "
+                        "an invoice already registered at the SII. You must "
+                        "cancel the invoice and create a new one with the "
+                        "correct number"
+                    )
+                )
+            if invoice.type in ["in_invoice", "in_refund"]:
                 if "partner_id" in vals:
                     correct_partners = invoice.partner_id.commercial_partner_id
                     correct_partners |= correct_partners.child_ids

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -444,3 +444,22 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         doc = etree.XML(view["arch"])
         self.assertTrue(doc.xpath("//field[@name='thirdparty_number']"))
         self.assertTrue(doc.xpath("//field[@name='thirdparty_invoice']"))
+        self.invoice.thirdparty_number = "thirdparty_number"
+
+    def test_account_move_sii_write_exceptions(self):
+        # out_invoice
+        self.invoice.sii_state = "sent"
+        with self.assertRaises(exceptions.Warning):
+            self.invoice.write({"invoice_date": "2022-01-01"})
+        with self.assertRaises(exceptions.Warning):
+            self.invoice.write({"thirdparty_number": "CUSTOM"})
+        # in_invoice
+        in_invoice = self.invoice.copy(
+            {"type": "in_invoice", "journal_id": self.journal_purchase.id, "ref": "REF"}
+        )
+        in_invoice.sii_state = "sent"
+        partner = self.partner.copy()
+        with self.assertRaises(exceptions.Warning):
+            in_invoice.write({"partner_id": partner.id})
+        with self.assertRaises(exceptions.Warning):
+            in_invoice.write({"ref": "REF2"})


### PR DESCRIPTION
Cambios realizados:
- [x] Evitar modificar el nº de factura de terceros cuando la factura se ha enviado al SII
- [x] Añadir `tracking=true` al campo de factura de terceros
- [x] Corrección del tipo de factura.
- [x] Añadir tests

Por favor @pedrobaeza puedes revisarlo?

@Tecnativa TT38248