### PR TITLE
[13.0][FIX] l10n_es_aeat_mod303: Default value for regularizacion_anual

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -94,6 +94,7 @@ class L10nEsAeatMod303Report(models.Model):
         compute="_compute_regularizacion_anual",
         readonly=False,
         store=True,
+        default=0.0,
         help="In the last auto settlement of the year, shall be recorded "
         "(the fourth period or 12th month), with the appropriate sign, "
         "the result of the annual adjustment as have the laws by the "


### PR DESCRIPTION
For trying to avoid random failures on CIs when flushing fields.

The theory, although not really confirmed, is that the 13.0 ORM doesn't have a valid value for the field, provoking a cache miss when this field is not populated through the corresponding compute.

@Tecnativa