### PR TITLE
[14.0][FIX] l10n_es_ticketbai: Get company IRPF taxes correctly

### DIFF
--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -630,7 +630,7 @@ class AccountMoveLine(models.Model):
 
     def tbai_get_value_importe_total(self):
         tbai_maps = self.env["tbai.tax.map"].search([("code", "=", "IRPF")])
-        irpf_taxes = self.env["l10n.es.aeat.report"].get_taxes_from_templates(
+        irpf_taxes = self.company_id.get_taxes_from_templates(
             tbai_maps.mapped("tax_template_ids")
         )
         currency = self.move_id and self.move_id.currency_id or None


### PR DESCRIPTION
Se ha detectado un bug que hace que no se enviaran bien las facturas con IRPF en multi-compañía en caso de enviar la factura desde una compañía que no fuera la primera que fue creada.