### PR TITLE
[FIX] l10n_es_aeat: _parse_aeat_vat_info - show correct aeat identification

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Tecnativa - Carlos Dauden
+# Copyright 2022 Moduon - Eduardo de Miguel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
@@ -49,7 +50,9 @@ class ResPartner(models.Model):
             )
         return europe.country_ids.mapped("code")
 
-    @ormcache("self.vat, self.country_id")
+    @ormcache(
+        "self.vat, self.country_id, self.aeat_identification, self.aeat_identification_type"
+    )
     def _parse_aeat_vat_info(self):
         """Return tuple with split info (country_code, identifier_type and
         vat_number) from vat and country partner
@@ -72,8 +75,7 @@ class ResPartner(models.Model):
                 identifier_type = "04"
         if country_code == "ES":
             identifier_type = ""
-        return (
-            country_code,
-            self.aeat_identification_type or identifier_type,
-            self.aeat_identification if self.aeat_identification_type else vat_number,
-        )
+        if self.aeat_identification_type:
+            identifier_type = self.aeat_identification_type
+            vat_number = self.aeat_identification
+        return country_code, identifier_type, vat_number

--- a/l10n_es_aeat/tests/test_l10n_es_aeat.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat.py
@@ -35,6 +35,30 @@ class TestL10nEsAeat(SavepointCase):
         self.assertEqual(identifier_type, "")
         self.assertEqual(vat_number, "12345678Z")
 
+    def test_parse_vat_info_aeat_identification(self):
+        # Test ormcache
+        self.partner.vat = "ES12345678Z"
+        self.partner.aeat_identification_type = "03"
+        self.partner.aeat_identification = "MY_PASSPORT_03"
+        country_code, identifier_type, vat_number = self.partner._parse_aeat_vat_info()
+        self.assertEqual(country_code, "ES")
+        self.assertEqual(identifier_type, "03")
+        self.assertEqual(vat_number, "MY_PASSPORT_03")
+        # Test aeat_identification_type empty
+        self.partner.aeat_identification_type = False
+        self.partner.aeat_identification = "MY_PASSPORT_FALSE"
+        country_code, identifier_type, vat_number = self.partner._parse_aeat_vat_info()
+        self.assertEqual(country_code, "ES")
+        self.assertEqual(identifier_type, "")
+        self.assertEqual(vat_number, "12345678Z")
+        # Test aeat_identification empty
+        self.partner.aeat_identification_type = "05"
+        self.partner.aeat_identification = False
+        country_code, identifier_type, vat_number = self.partner._parse_aeat_vat_info()
+        self.assertEqual(country_code, "ES")
+        self.assertEqual(identifier_type, "05")
+        self.assertFalse(vat_number)
+
     def test_parse_vat_info_es_passport_exception(self):
         with self.assertRaises(exceptions.ValidationError):
             self.partner.write(


### PR DESCRIPTION
Conversation from https://github.com/OCA/l10n-spain/pull/2433

- Tests for aeat_identification_type and aeat_identification
- Adds to ormcache those fields
- If user has aeat_identification_type, use aeat_identification

MT-706 @moduon

@pedrobaeza