### PR TITLE
[13.0][FIX] l10n_es_ticketbai_pos: Fix tbai file generation with operation …

### DIFF
--- a/l10n_es_ticketbai_pos/models/account_move.py
+++ b/l10n_es_ticketbai_pos/models/account_move.py
@@ -15,7 +15,7 @@ class AccountMove(models.Model):
 
     def tbai_prepare_invoice_values(self):
         res = super().tbai_prepare_invoice_values()
-        if not res.get("tbai.vat.regime.key", False):
+        if not res.get("vat_regime_key", False):
             res["vat_regime_key"] = (
                 self.env["tbai.vat.regime.key"]
                 .search([("code", "=", "01")], limit=1)


### PR DESCRIPTION
…key different to 01 when this module is installed

Corregido el fix:
Una vez instalado este módulo, si la clave de operación era diferente de 01 en cualquier factura generada desde el POS o el módulo de contabilidad, se establecía por defecto 01.