### PR TITLE
[13.0][FIX] l10n_es_intrastat_report: Add the necessary arguments to the functions

### DIFF
--- a/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
+++ b/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
@@ -45,8 +45,8 @@ class L10nEsIntrastatProductDeclaration(models.Model):
             intrastat_state = inv_line.company_id.partner_id.state_id
         return intrastat_state
 
-    def _gather_invoices(self):
-        old_lines = super()._gather_invoices()
+    def _gather_invoices(self, notedict):
+        old_lines = super()._gather_invoices(notedict)
         lines = []
         product_model = self.env["product.product"]
         for line in old_lines:
@@ -82,7 +82,7 @@ class L10nEsIntrastatProductDeclaration(models.Model):
                 )
                 self._note += note
 
-    def _gather_invoices_init(self):
+    def _gather_invoices_init(self, notedict):
         if self.company_id.country_id.code != "ES":
             raise UserError(
                 _(


### PR DESCRIPTION
Añadir los argumentos necesarios a las funciones (necesario desde https://github.com/OCA/intrastat-extrastat/commit/446dcb3f4e7b19b240a99d7e185b9af24e12cd37)

Bloqueado por: 
- https://github.com/OCA/intrastat-extrastat/pull/189

Por favor @pedrobaeza , ¿puedes revisarlo?

@Tecnativa