### PR TITLE
[FIX]vat regime key now takes code (str 2 digits) instead of id(int)

### DIFF
--- a/l10n_es_ticketbai_pos/static/src/js/tbai_models.js
+++ b/l10n_es_ticketbai_pos/static/src/js/tbai_models.js
@@ -71,17 +71,32 @@ odoo.define("l10n_es_ticketbai_pos.tbai_models", function (require) {
                 var tbai_vat_regime_key = this.order.fiscal_position
                     .tbai_vat_regime_key;
                 if (tbai_vat_regime_key) {
-                    this.vat_regime_key = tbai_vat_regime_key[0];
+                    var id_vat_regime_key = this.order.fiscal_position
+                        .tbai_vat_regime_key[0];
+                    var object_vat_regime_key = self.pos.tbai_vat_regime_keys.find(
+                        (x) => x.id === id_vat_regime_key
+                    );
+                    this.vat_regime_key = object_vat_regime_key.code;
                 }
                 var tbai_vat_regime_key2 = this.order.fiscal_position
                     .tbai_vat_regime_key2;
                 if (tbai_vat_regime_key2) {
-                    this.vat_regime_key2 = tbai_vat_regime_key2[0];
+                    var id_vat_regime_key = this.order.fiscal_position
+                        .tbai_vat_regime_key2[0];
+                    var object_vat_regime_key = self.pos.tbai_vat_regime_keys.find(
+                        (x) => x.id === id_vat_regime_key
+                    );
+                    this.vat_regime_key2 = object_vat_regime_key.code;
                 }
                 var tbai_vat_regime_key3 = this.order.fiscal_position
                     .tbai_vat_regime_key3;
                 if (tbai_vat_regime_key3) {
-                    this.vat_regime_key3 = tbai_vat_regime_key3[0];
+                    var id_vat_regime_key = this.order.fiscal_position
+                        .tbai_vat_regime_key3[0];
+                    var object_vat_regime_key = self.pos.tbai_vat_regime_keys.find(
+                        (x) => x.id === id_vat_regime_key
+                    );
+                    this.vat_regime_key3 = object_vat_regime_key.code;
                 }
             }
 


### PR DESCRIPTION
Se corrige un comportamiento observado en el pos cuando estaba activada la opción de posición fiscal en dicho pos, en lugar de coger la clave en formato string de dos digitos completado con 0 a la izquierda si solo tenía un dígito, se estaba cogiendo un entero, por lo que en los valores del 1 al 9 el esquema en destino fallaba el esquema.

Además se estaba cogiendo el id de la clave de iva en lugar del campo code, con este PR pasamos a buscar en la precarga de claves de regimen de iva el objeto con el mismo id que el que incluye el pedido y de este cogemos el campo code.