### PR TITLE
[14.0][FIX] payment_redsys: Use updated library

### DIFF
--- a/payment_redsys/__manifest__.py
+++ b/payment_redsys/__manifest__.py
@@ -6,10 +6,10 @@
     "category": "Payment Acquirer",
     "summary": "Payment Acquirer: Redsys Implementation",
     "version": "14.0.2.0.2",
-    "author": "Tecnativa," "Odoo Community Association (OCA)",
+    "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "depends": ["payment", "website_sale"],
-    "external_dependencies": {"python": ["pycrypto"]},
+    "external_dependencies": {"python": ["pycryptodome"]},
     "data": [
         "views/redsys.xml",
         "views/payment_acquirer.xml",

--- a/payment_redsys/models/redsys.py
+++ b/payment_redsys/models/redsys.py
@@ -10,6 +10,7 @@ import json
 import logging
 import urllib
 
+from Crypto.Cipher import DES3  # pylint: disable=W7936 - No real warning
 from werkzeug import urls
 
 from odoo import _, api, exceptions, fields, http, models
@@ -19,11 +20,6 @@ from odoo.tools.float_utils import float_compare
 from odoo.addons.payment.models.payment_acquirer import ValidationError
 
 _logger = logging.getLogger(__name__)
-
-try:
-    from Crypto.Cipher import DES3
-except ImportError:
-    _logger.info("Missing dependency (pycryptodome). See README.")
 
 
 class AcquirerRedsys(models.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ chardet
 cryptography
 paramiko
 pycountry
-pycrypto
+pycryptodome
 pyOpenSSL
 qrcode
 requests


### PR DESCRIPTION
`pycrypto` is unmaintained since several ago, and in fact `pycryptodome` was the library being used in previous version. The API we are using is compatible between both libraries though.

There's no problem for already deployed systems, as the check on the external dependencies is only done at install.

We took the occasion to remove the try mechanism that is not needed now, although the linter emits a warning.