### PR TITLE
[14.0][FIX] l10n_es_aeat: Consider correctly French overseas

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -37,8 +37,18 @@ class ResPartner(models.Model):
     # 04 - Official document from the original country
     # 07 - Not registered on census
 
-    def _map_aeat_country_code(self, country_code):
-        country_code_map = {"RE": "FR", "GP": "FR", "MQ": "FR", "GF": "FR", "EL": "GR"}
+    def _map_aeat_country_code(self, country_code, extended=False):
+        """Map country codes according the fiscal conditions.
+
+        :arg boolean extended: If True, it means you want to convert also special
+          territories like Overseas France. That ones are not considered for
+          intracommunity operations, but they need to use FR country code for
+          identification purposes.
+        :return: The mapped country code if exists, or the same country code if not.
+        """
+        country_code_map = {"EL": "GR"}
+        if extended:
+            country_code_map.update({"RE": "FR", "GP": "FR", "MQ": "FR", "GF": "FR"})
         return country_code_map.get(country_code, country_code)
 
     @ormcache("self.env")
@@ -65,13 +75,19 @@ class ResPartner(models.Model):
             vat_number = vat_number[2:]
             identifier_type = "02"
         else:
-            country_code = self.country_id.code or ""
+            if self.country_id.code:
+                country_code = self.country_id.code
+            elif self.env["res.country"].search([("code", "=", prefix)]):
+                country_code = prefix
+            else:
+                country_code = ""
             if (
                 self._map_aeat_country_code(country_code)
                 in self._get_aeat_europe_codes()
             ):
                 identifier_type = "02"
             else:
+                country_code = self._map_aeat_country_code(country_code, extended=True)
                 identifier_type = "04"
         if country_code == "ES":
             identifier_type = ""

--- a/l10n_es_aeat/tests/test_l10n_es_aeat.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat.py
@@ -98,15 +98,16 @@ class TestL10nEsAeat(SavepointCase):
             {"vat": "61954506077", "country_id": self.env.ref("base.gf").id}
         )
         country_code, identifier_type, vat_number = self.partner._parse_aeat_vat_info()
-        self.assertEqual(country_code, "GF")
+        self.assertEqual(country_code, "FR")
+        self.assertEqual(identifier_type, "04")
         self.assertEqual(vat_number, "61954506077")
 
     def test_parse_vat_info_gf_w_prefix(self):
         self.partner.vat = "GF61954506077"
         country_code, identifier_type, vat_number = self.partner._parse_aeat_vat_info()
-        self.assertEqual(country_code, "GF")
-        self.assertEqual(identifier_type, "02")
-        self.assertEqual(vat_number, "61954506077")
+        self.assertEqual(country_code, "FR")
+        self.assertEqual(identifier_type, "04")
+        self.assertEqual(vat_number, "GF61954506077")
 
     def test_parse_vat_info_cu_wo_prefix(self):
         self.partner.write(
@@ -120,7 +121,7 @@ class TestL10nEsAeat(SavepointCase):
     def test_parse_vat_info_cu_w_prefix(self):
         self.partner.vat = "CU12345678Z"
         country_code, identifier_type, vat_number = self.partner._parse_aeat_vat_info()
-        self.assertEqual(country_code, "")
+        self.assertEqual(country_code, "CU")
         self.assertEqual(identifier_type, "04")
         self.assertEqual(vat_number, "CU12345678Z")
 


### PR DESCRIPTION
For French overseas territories
(https://en.wikipedia.org/wiki/Overseas_France), there are no intracommunity fiscal rules, but the country code that AEAT requires should be FR, as it can be seen here:

https://sede.agenciatributaria.gob.es/Sede/todas-gestiones/impuestos-tasas/declaraciones-informativas/modelo-347-decla_____racion-anual-operaciones-personas_/instrucciones/codigos-paises-territorios.html

Thus, we need to call the mapping function differently if you want to convert `EL` to `GR` for getting the European countries than to pass the proper country code.

This is done adding an extra parameter for saying if we want to include such replacements, and only being executed when the check about European country is rejected, on contrary than with Greece (EL), that should be included as intracommunity.

The country code is now also obtained from the vat itself if the first 2 letter belongs to any country code.

@Tecnativa TT38835