### PR TITLE
[FIX] l10n_es_aeat_mod349: broken form UI

### DIFF
--- a/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
@@ -23,3 +23,5 @@
 
   * Valentin Vinagre
   * Manuel Regidor
+
+* Jairo Llopis (Moduon)

--- a/l10n_es_aeat_mod349/views/mod349_view.xml
+++ b/l10n_es_aeat_mod349/views/mod349_view.xml
@@ -9,11 +9,11 @@
         <field name="model">l10n.es.aeat.mod349.partner_record_detail</field>
         <field name="arch" type="xml">
             <tree>
-                <field name="move_line_id" />
-                <field name="move_id" />
-                <field name="partner_id" />
-                <field name="amount_untaxed" />
-                <field name="date" />
+                <field name="move_line_id" optional="show" />
+                <field name="move_id" optional="show" />
+                <field name="partner_id" optional="show" />
+                <field name="amount_untaxed" optional="show" />
+                <field name="date" optional="show" />
             </tree>
         </field>
     </record>
@@ -44,11 +44,11 @@
         <field name="arch" type="xml">
             <tree decoration-danger="not partner_record_ok">
                 <field name="partner_record_ok" invisible="1" />
-                <field name="country_id" />
-                <field name="partner_vat" />
-                <field name="partner_id" />
-                <field name="operation_key" />
-                <field name="total_operation_amount" />
+                <field name="country_id" optional="show" />
+                <field name="partner_vat" optional="show" />
+                <field name="partner_id" optional="show" />
+                <field name="operation_key" optional="show" />
+                <field name="total_operation_amount" optional="show" />
                 <field
                     name="error_text"
                     attrs="{'invisible': [('partner_record_ok', '=', True)]}"
@@ -95,11 +95,11 @@
         <field name="model">l10n.es.aeat.mod349.partner_refund_detail</field>
         <field name="arch" type="xml">
             <tree>
-                <field name="refund_line_id" />
-                <field name="move_id" />
-                <field name="partner_id" />
-                <field name="amount_untaxed" />
-                <field name="date" />
+                <field name="refund_line_id" optional="show" />
+                <field name="move_id" optional="show" />
+                <field name="partner_id" optional="show" />
+                <field name="amount_untaxed" optional="show" />
+                <field name="date" optional="show" />
             </tree>
         </field>
     </record>
@@ -130,14 +130,14 @@
         <field name="arch" type="xml">
             <tree decoration-danger="not partner_refund_ok">
                 <field name="partner_refund_ok" invisible="1" />
-                <field name="country_id" />
-                <field name="partner_vat" />
-                <field name="partner_id" />
-                <field name="operation_key" />
-                <field name="year" />
-                <field name="period_type" />
-                <field name="total_operation_amount" />
-                <field name="total_origin_amount" />
+                <field name="country_id" optional="show" />
+                <field name="partner_vat" optional="show" />
+                <field name="partner_id" optional="show" />
+                <field name="operation_key" optional="show" />
+                <field name="year" optional="show" />
+                <field name="period_type" optional="show" />
+                <field name="total_operation_amount" optional="show" />
+                <field name="total_origin_amount" optional="show" />
             </tree>
         </field>
     </record>
@@ -212,24 +212,16 @@
                         </group>
                     </page>
                     <page string="Partner records">
-                        <group name="summary_partner_records" string="Summary">
-                            <field name="partner_record_ids" nolabel="1" />
-                        </group>
-                        <group
-                            name="detail_partner_records"
-                            string="Details"
-                            create="0"
-                        >
-                            <field name="partner_record_detail_ids" nolabel="1" />
-                        </group>
+                        <separator string="Summary" />
+                        <field name="partner_record_ids" />
+                        <separator string="Details" />
+                        <field name="partner_record_detail_ids" />
                     </page>
                     <page string="Refunds from other periods">
-                        <group name="summary_refund_records" string="Summary">
-                            <field name="partner_refund_ids" nolabel="1" />
-                        </group>
-                        <group name="detail_refund_records" sting="Details" create="0">
-                            <field name="partner_refund_detail_ids" nolabel="1" />
-                        </group>
+                        <separator string="Summary" />
+                        <field name="partner_refund_ids" />
+                        <separator string="Details" />
+                        <field name="partner_refund_detail_ids" />
                     </page>
                 </notebook>
             </group>


### PR DESCRIPTION
Fixing subtree width not responsive. See https://github.com/odoo/odoo/pull/90946 for a similar situation where a similar fix was needed.
![screenshot_2022-09-13_07-31-21](https://user-images.githubusercontent.com/973709/189838776-fc01b483-8727-45b8-b50f-af204b0a04e3.png)
![screenshot_2022-09-13_07-31-46](https://user-images.githubusercontent.com/973709/189838784-62f5adcf-f8d6-462d-9f74-3594a0840740.png)




Took the chance to make more columns optional.

@moduon MT-1267