### PR TITLE
[14.0][FIX] l10n_es_ticketbai: Make reversed_entry_id field not readonly on…

### DIFF
--- a/l10n_es_ticketbai/views/account_move_views.xml
+++ b/l10n_es_ticketbai/views/account_move_views.xml
@@ -54,7 +54,8 @@
                                 <field
                                     name="reversed_entry_id"
                                     domain="[('move_type', '=', 'out_invoice'), ('state', '=', 'posted'), ('company_id', '=', company_id), ('partner_id', '=', partner_id)]"
-                                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                                    attrs="{'readonly': ['|', ('state', '!=', 'draft'), ('move_type', '!=', 'out_refund')]}"
+                                    force_save="1"
                                 />
                             </group>
                             <group


### PR DESCRIPTION
… invoices

Fix simple, el campo `reversed_entry_ids` es `readonly` de manera core en Odoo, por esa razón al intentar editar su valor desde la vista formulario su valor no se guarda.

Se hace que el campo no sea readonly y se modifica la vista del `account.move` para que solo sea modificable cuando sea borrador y de tipo `out_invoice`.

@xAdrianC-Kernet @Bilbonet 

