### PR TITLE
[14.0][FIX] l10n_es_dua_ticketbai_batuz - hacer compatible con módulo l10n_es_dua_sii

### DIFF
--- a/l10n_es_dua_ticketbai_batuz/models/account_move.py
+++ b/l10n_es_dua_ticketbai_batuz/models/account_move.py
@@ -8,7 +8,7 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     tbai_dua_invoice = fields.Boolean(
-        "TBAI DUA Invoice", compute="_compute_dua_invoice"
+        "TBAI DUA Invoice", compute="_compute_tbai_dua_invoice"
     )
 
     @api.model
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
         )
 
     @api.depends("company_id", "fiscal_position_id", "invoice_line_ids.tax_ids")
-    def _compute_dua_invoice(self):
+    def _compute_tbai_dua_invoice(self):
         for invoice in self:
             taxes = invoice._get_lroe_taxes_map(["DUA"])
             invoice.tbai_dua_invoice = invoice.invoice_line_ids.filtered(


### PR DESCRIPTION
El método `_compute_dua_invoice()` se llama igual que el del módulo `l10n_es_dua_sii`
Si están ambos módulos instalados, el método del módulo `l10n_es_dua_ticketbai_batuz` pisa completamente el método de `l10n_es_dua_sii` y el campo `sii_dua_invoice` se queda sin valor ocasionando un error de `CacheMiss` 
Al no ser módulos dependientes no tiene sentido una llamada al `super()` así que se opta por modificar el nombre del método que calcula el campo para batuz