### PR TITLE
[14.0][FIX] l10n_es_ticketbai* - corregir problemas en entornos multicompany

### DIFF
--- a/l10n_es_ticketbai/wizard/ticketbai_info.py
+++ b/l10n_es_ticketbai/wizard/ticketbai_info.py
@@ -8,15 +8,13 @@ class TicketBaiGeneralInfo(models.TransientModel):
     _name = "tbai.info"
     _description = "TicketBAI general information"
 
-    tbai_enabled = fields.Boolean(
-        default=lambda self: self.env.user.company_id.tbai_enabled
-    )
+    tbai_enabled = fields.Boolean(default=lambda self: self.env.company.tbai_enabled)
     name = fields.Char(string="Developer name", compute="_compute_name")
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
         readonly=True,
-        default=lambda self: self.env.user.company_id,
+        default=lambda self: self.env.company,
     )
     developer_id = fields.Many2one(
         comodel_name="res.partner",

--- a/l10n_es_ticketbai_api/models/ticketbai_certificate.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_certificate.py
@@ -23,7 +23,7 @@ class TicketBaiCertificate(models.Model):
         string="Company",
         comodel_name="res.company",
         required=True,
-        default=lambda self: self.env.user.company_id.id,
+        default=lambda self: self.env.company.id,
     )
     datas = fields.Binary("P12 Certificate", required=True, attachment=True)
     password = fields.Char(default="")

--- a/l10n_es_ticketbai_batuz/models/account_move.py
+++ b/l10n_es_ticketbai_batuz/models/account_move.py
@@ -134,7 +134,7 @@ class AccountMove(models.Model):
     @api.model
     def create(self, vals):
         company = self.env["res.company"].browse(
-            vals.get("company_id", self.env.user.company_id.id)
+            vals.get("company_id", self.env.company.id)
         )
         tbai_tax_agency_id = company.tbai_tax_agency_id
         if (


### PR DESCRIPTION
Siguiendo las [Multi-company Guidelines de Odoo](https://www.odoo.com/documentation/14.0/developer/howtos/company.html).
Sin este fix, no es posible crear facturas para una compañía distinta a la establecida en el usuario, en un entorno multi compañía.

Probado en un runboat con usuario demo.