### PR TITLE
[FIX] l10n_es_aeat: specify cryptography version

### DIFF
--- a/l10n_es_aeat/README.rst
+++ b/l10n_es_aeat/README.rst
@@ -156,6 +156,7 @@ Contributors
 * Digital5 S.L.
 * Valentin Vinagre <valentin.vinagre@sygel.es>
 * Manuel Regidor <manuel.regidor@sygel.es>
+* Jairo Llopis (https://www.moduon.team)
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -22,7 +22,7 @@
     "development_status": "Mature",
     "depends": ["l10n_es", "account_tax_balance"],
     # odoo_test_helper is needed for the tests
-    "external_dependencies": {"python": ["unidecode", "cryptography"]},
+    "external_dependencies": {"python": ["unidecode", "cryptography>=3"]},
     "data": [
         "security/aeat_security.xml",
         "security/ir.model.access.csv",

--- a/l10n_es_aeat/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat/readme/CONTRIBUTORS.rst
@@ -15,3 +15,4 @@
 * Digital5 S.L.
 * Valentin Vinagre <valentin.vinagre@sygel.es>
 * Manuel Regidor <manuel.regidor@sygel.es>
+* Jairo Llopis (https://www.moduon.team)

--- a/l10n_es_aeat/static/description/index.html
+++ b/l10n_es_aeat/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>AEAT Base</title>
 <style type="text/css">
 
@@ -503,6 +503,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Digital5 S.L.</li>
 <li>Valentin Vinagre &lt;<a class="reference external" href="mailto:valentin.vinagre&#64;sygel.es">valentin.vinagre&#64;sygel.es</a>&gt;</li>
 <li>Manuel Regidor &lt;<a class="reference external" href="mailto:manuel.regidor&#64;sygel.es">manuel.regidor&#64;sygel.es</a>&gt;</li>
+<li>Jairo Llopis (<a class="reference external" href="https://www.moduon.team">https://www.moduon.team</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_es_aeat/wizard/aeat_certificate_password.py
+++ b/l10n_es_aeat/wizard/aeat_certificate_password.py
@@ -26,6 +26,7 @@ try:
 except (ImportError, IOError) as err:
     _logger.debug(err)
 
+# FIXME To be removed in v16, as it is now specified in the manifest
 if tuple(map(int, cryptography.__version__.split("."))) < (3, 0):
     _logger.warning(
         "Cryptography version is not supported. Upgrade to 3.0.0 or greater."
@@ -78,6 +79,7 @@ class L10nEsAeatCertificatePassword(models.TransientModel):
             record.folder,
         )
         file = base64.decodebytes(record.file)
+        # FIXME To be removed in v16, as it is now specified in the manifest
         if tuple(map(int, cryptography.__version__.split("."))) < (3, 0):
             raise exceptions.UserError(
                 _("Cryptography version is not supported. Upgrade to 3.0.0 or greater.")

--- a/l10n_es_aeat_sii_oca/__manifest__.py
+++ b/l10n_es_aeat_sii_oca/__manifest__.py
@@ -33,7 +33,7 @@
     "installable": True,
     "development_status": "Mature",
     "maintainers": ["pedrobaeza"],
-    "external_dependencies": {"python": ["zeep", "requests", "cryptography"]},
+    "external_dependencies": {"python": ["zeep", "requests"]},
     "depends": ["account_invoice_refund_link", "l10n_es", "l10n_es_aeat", "queue_job"],
     "data": [
         "data/aeat_sii_queue_job.xml",

--- a/l10n_es_aeat_sii_oca/readme/INSTALL.rst
+++ b/l10n_es_aeat_sii_oca/readme/INSTALL.rst
@@ -2,7 +2,6 @@ Para instalar esté módulo necesita:
 
 #. Libreria Python Zeep, se puede instalar con el comando 'pip install zeep'
 #. Libreria Python Requests, se puede instalar con el comando 'pip install requests'
-#. Libreria pyOpenSSL, versión 0.15 o posterior
 
 y el módulo `queue_job` que se encuentra en:
 

--- a/l10n_es_facturae/__manifest__.py
+++ b/l10n_es_facturae/__manifest__.py
@@ -40,9 +40,7 @@
         "wizard/account_move_reversal_view.xml",
         "views/account_move_view.xml",
     ],
-    "external_dependencies": {
-        "python": ["cryptography", "pyOpenSSL", "pycountry", "xmlsig"]
-    },
+    "external_dependencies": {"python": ["pycountry", "xmlsig"]},
     "installable": True,
     "maintainers": ["etobella"],
 }

--- a/l10n_es_facturae_face/__manifest__.py
+++ b/l10n_es_facturae_face/__manifest__.py
@@ -26,7 +26,7 @@
         "views/res_partner.xml",
         "views/edi_exchange_record.xml",
     ],
-    "external_dependencies": {"python": ["OpenSSL", "zeep", "cryptography"]},
+    "external_dependencies": {"python": ["zeep"]},
     "installable": True,
     "maintainers": ["etobella"],
 }

--- a/l10n_es_ticketbai/__manifest__.py
+++ b/l10n_es_ticketbai/__manifest__.py
@@ -22,7 +22,6 @@
         "account",
         "l10n_es_ticketbai_api",
     ],
-    "external_dependencies": {"python": ["cryptography"]},
     "data": [
         "security/ir.model.access.csv",
         "data/tax_map_data.xml",

--- a/l10n_es_ticketbai_api/__manifest__.py
+++ b/l10n_es_ticketbai_api/__manifest__.py
@@ -17,8 +17,6 @@
     "depends": ["base", "base_setup"],
     "external_dependencies": {
         "python": [
-            "cryptography",
-            "pyOpenSSL",
             "qrcode",
             "xmlsig",
             "xmltodict",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # generated from manifests external_dependencies
 chardet
 cryptography
+cryptography>=3
 pycountry
 pyOpenSSL
 qrcode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 # generated from manifests external_dependencies
 chardet
-cryptography
 cryptography>=3
 pycountry
-pyOpenSSL
 qrcode
 requests
 requests_pkcs12


### PR DESCRIPTION
This module requires the specified cryptography version. Make that explicit in its manifest, now that thanks to https://github.com/odoo/odoo/pull/25549 we can specify the package version.

@moduon MT-1067