### PR TITLE
[FIX][12.0] l10n_es_vat_book: add missing tax in vat book

### DIFF
--- a/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
+++ b/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
@@ -66,6 +66,7 @@
             (4, ref('l10n_es.account_tax_template_p_iva10_bi')),
             (4, ref('l10n_es.account_tax_template_p_iva21_bi')),
             (4, ref('l10n_es.account_tax_template_p_iva0_ns')),
+            (4, ref('l10n_es.account_tax_template_p_iva0_ns_b')),
         ]"/>
     </record>
 


### PR DESCRIPTION
Añadido el impuesto "Iva soportado no sujeto (bienes)".

Otro impuesto que falta en el libro de iva.

Listo para hacer un port a las versiones superiores si se mergea este.