### PR TITLE
[FIX][15.0] l10n_es_vat_book: add missing tax in vat book

### DIFF
--- a/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
+++ b/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
@@ -70,6 +70,7 @@
             (4, ref('l10n_es.account_tax_template_p_iva10_bi')),
             (4, ref('l10n_es.account_tax_template_p_iva21_bi')),
             (4, ref('l10n_es.account_tax_template_p_iva0_ns')),
+            (4, ref('l10n_es.account_tax_template_p_iva0_ns_b')),
             (4, ref('l10n_es.account_tax_template_p_iva5_sc')),
         ]"
         />


### PR DESCRIPTION
- Added tax 'Iva soportado no sujeto (bienes)'

Faltaba este impuesto en el libro de iva.