### PR TITLE
[FIX] l10n_es_aeat_sii_oca: EU VAT number requires country code

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -1362,7 +1362,12 @@ class AccountMove(models.Model):
                     "IDOtro": {
                         "CodigoPais": country_code,
                         "IDType": identifier_type,
-                        "ID": identifier,
+                        "ID": country_code + identifier
+                        if self.commercial_partner_id._map_aeat_country_code(
+                            country_code
+                        )
+                        in self.commercial_partner_id._get_aeat_europe_codes()
+                        else identifier,
                     },
                 }
         elif gen_type == 2:


### PR DESCRIPTION
Using l10n_es_aeat `_parse_aeat_vat_info`, the VAT number for European is returned without the country code, but we need to send it when informing a document type 02 to the SII.

This faces a problem where we do a national invoice but to an European VAT. Now is giving an error that before the refactor of `_parse_aeat_vat_info` was not given. There are some exceptions where we can do a national regular invoice with IVA to a non Spanish VAT and it's not "Régimen Intracomunitario" invoice.