### PR TITLE
[11.0][FIX] l10n_es_intrastat_report: missing country error replaced by note message

### DIFF
--- a/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
+++ b/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
@@ -59,11 +59,10 @@ class L10nEsIntrastatProductDeclaration(models.Model):
                 ) % inv_line.invoice_id.number
                 self._note += note
             if not line_vals["product_origin_country_id"]:
-                raise UserError(
-                    _(
-                        "Missing origin country on product %s."
-                    ) % inv_line.product_id.name_get()[0][1]
-                )
+                note = "\n" + _(
+                    "Missing origin country on product %s."
+                ) % inv_line.product_id.name_get()[0][1]
+                self._note += note
 
     def _gather_invoices_init(self):
         if self.company_id.country_id.code != 'ES':


### PR DESCRIPTION
Se sustituye el mensaje de error bloqueante por un mensaje en la nota del informe. Ya que si hay varios productos a los que les falta el país de origen, hay que recargar el informe por cada uno, generando una espera muy grande.