### PR TITLE
[FIX] l10n_es_facturae: facturae date periodes in spanish

### DIFF
--- a/l10n_es_facturae/i18n/es.po
+++ b/l10n_es_facturae/i18n/es.po
@@ -455,13 +455,13 @@ msgstr "Motivo de Reembolso según Facturae"
 #: model:ir.model.fields,field_description:l10n_es_facturae.field_account_invoice_line__facturae_end_date
 #, fuzzy
 msgid "Facturae End Date"
-msgstr "Código de Facturae"
+msgstr "Fecha de fin de Facturae"
 
 #. module: l10n_es_facturae
 #: model:ir.model.fields,field_description:l10n_es_facturae.field_account_invoice_line__facturae_file_date
 #, fuzzy
 msgid "Facturae File Date"
-msgstr "Fichero Factura-E"
+msgstr "Fecha Fichero Facturae"
 
 #. module: l10n_es_facturae
 #: model:ir.model.fields,field_description:l10n_es_facturae.field_account_invoice_line__facturae_file_reference
@@ -519,13 +519,13 @@ msgstr "Motivo de Reembolso según Facturae"
 #: model:ir.model.fields,field_description:l10n_es_facturae.field_account_invoice_line__facturae_start_date
 #, fuzzy
 msgid "Facturae Start Date"
-msgstr "Código de Facturae"
+msgstr "Fecha de inicio de la factura"
 
 #. module: l10n_es_facturae
 #: model:ir.model.fields,field_description:l10n_es_facturae.field_account_invoice_line__facturae_transaction_date
 #, fuzzy
 msgid "Facturae Transaction Date"
-msgstr "Código de Facturae"
+msgstr "Fecha de transacción de Facturae"
 
 #. module: l10n_es_facturae
 #: model:ir.model.fields,field_description:l10n_es_facturae.field_res_company__facturae_version


### PR DESCRIPTION
My first contribution, fixing a bit translation error.
That error does not exist in v.14 and v.15