### PR TITLE
[14.0][FIX] l10n_es_account_bank_statement_import_n43: Requerir 6 caracteres…

### DIFF
--- a/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py
+++ b/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py
@@ -303,7 +303,7 @@ class AccountStatementImport(models.TransientModel):
         # Try to match from partner name
         if conceptos.get("01"):
             name = conceptos["01"][1]
-            if name:
+            if name and len(name) > 5:
                 partner = partner_obj.search([("name", "ilike", name)], limit=1)
         return partner
 


### PR DESCRIPTION
… para buscar partners usando ilike

Tenemos esta línea en un fichero:
2301IMPUESTO: 2022 I.V.A. AUTOLIQUIDACION
name = conceptos['01'][1]
la variable name contiene ON

Comportamiento antes de este PR:
Asocia el primer partner cuyo nombre contenga ON

Comportamiento antes de este PR:
No asocia automaticamente ningún partner por no llegar un mínimo de caracteres "sano" para utilizar el operador ilike

https://github.com/Tecnativa TT39892