### PR TITLE
[15.0][IMP] l10n_es_partner: show wizard to import data banks in config

### DIFF
--- a/l10n_es_partner/README.rst
+++ b/l10n_es_partner/README.rst
@@ -23,7 +23,7 @@ Adaptación de los clientes, proveedores y bancos para España
     :target: https://runbot.odoo-community.org/runbot/189/15.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 Incluye la siguiente funcionalidad:
 
@@ -118,7 +118,7 @@ promote its widespread use.
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-pedrobaeza| 
+|maintainer-pedrobaeza|
 
 This module is part of the `OCA/l10n-spain <https://github.com/OCA/l10n-spain/tree/15.0/l10n_es_partner>`_ project on GitHub.
 

--- a/l10n_es_partner/__manifest__.py
+++ b/l10n_es_partner/__manifest__.py
@@ -21,6 +21,7 @@
         "views/res_bank_view.xml",
         "views/res_partner_view.xml",
         "wizard/l10n_es_partner_wizard.xml",
+        "views/account_config_settings_view.xml",
         "security/ir.model.access.csv",
     ],
     "installable": True,

--- a/l10n_es_partner/readme/CONFIGURE.rst
+++ b/l10n_es_partner/readme/CONFIGURE.rst
@@ -10,3 +10,6 @@ Configuración > Técnico > Parámetros > Parámetros del sistema
 Seleccionar la clave l10n_es_partner.name_pattern
 Definir el patron utilizando las etiquetas *%(name)s* para nombre y
 *%(comercial_name)s* para nombre comercial.
+
+Para importar los datos de los bancos españoles si no se ha hecho en la instalación,
+ir a Ajustes > Facturación/Contabilidad > Importar datos bancarios españoles

--- a/l10n_es_partner/views/account_config_settings_view.xml
+++ b/l10n_es_partner/views/account_config_settings_view.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">Open l10 Es Partner Wizard 2</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <div data-key="account" position="inside">
+                <h2>Import Spanish Bank Data</h2>
+                <div class="row mt16 o_settings_container">
+                    <div class="col-xs-12 col-md-6 o_setting_box">
+                        <div class="o_setting_left_pane" />
+                        <div class="o_setting_right_pane">
+                            <span class="o_form_label">Import Spanish Bank Data</span>
+                            <div class="text-muted">
+                                Import spanish bank data from internet or from local file mirror.
+                            </div>
+                            <div class="content-group">
+                                <div class="row mt16" />
+                                <div>
+                                    <button
+                                        string="Import spanish bank data"
+                                        name="%(action_l10n_es_partner_import)d"
+                                        context="{'default_company_id': company_id}"
+                                        type="action"
+                                        icon="fa-arrow-right"
+                                        class="oe_link"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When you skip the wizard in the installation of the module, it doesn't appear more. 
With this change you can show it again through settings > Invoicing > Import Spanish Bank Data.


@ForgeFlow

