### PR TITLE
[15.0][FIX] l10n_es_aeat_mod349: Set the date field to store=True to allow the records to be sorted.

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -666,4 +666,5 @@ class Mod349PartnerRefundDetail(models.Model):
     date = fields.Date(
         related="refund_line_id.date",
         readonly=True,
+        store=True,  # Necessary for sorting records
     )


### PR DESCRIPTION
Set the date field to `store=True` to allow the records to be sorted (https://github.com/OCA/l10n-spain/blob/15.0/l10n_es_aeat_mod349/models/mod349.py#L266).

Please @pedrobaeza can you review it?

@Tecnativa