### PR TITLE
[11.0][FIX] l10n_es_ticketbai: Assign sign to re tax amount

### DIFF
--- a/l10n_es_ticketbai/models/account_invoice_tax.py
+++ b/l10n_es_ticketbai/models/account_invoice_tax.py
@@ -150,10 +150,14 @@ class AccountInvoiceTax(models.Model):
         return res
 
     def tbai_get_value_cuota_recargo_equivalencia(self):
+        if RefundType.differences.value == self.invoice_id.tbai_refund_type:
+            sign = -1
+        else:
+            sign = 1
         re_invoice_tax = self.tbai_get_associated_re_tax()
         if re_invoice_tax:
             amount_total = re_invoice_tax.tbai_get_amount_total_company()
-            res = "%.2f" % amount_total
+            res = "%.2f" % (sign * amount_total)
         else:
             res = None
         return res


### PR DESCRIPTION
Al crear una factura rectificativa con recargo equivalencia hacienda respondía con el siguiente error:

B4_2000093: Si Cuota del recargo de equivalencia está cumplimentada y Claves de regímenes de IVA y operaciones con trascendencia tributaria diferente de 06, la Cuota recargo equivalencia y Base imponible deben tener el mismo signo (salvo que la cuota sea 0).

Esto es porque en la etiqueta 'CuotaRecargoEquivalencia' no se tenía en cuenta el signo en caso de que se tratara de una factura rectificativa. Aplicando el fix del PR se envían correctamente las facturas rectificativas con recargo equivalencia.