### PR TITLE
[FIX] l10n_es_aeat: do not require administration permissions

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -177,7 +177,7 @@ class L10nEsAeatReport(models.AbstractModel):
             (
                 "model_id",
                 "=",
-                self.env["ir.model"].search([("model", "=", self._name)]).id,
+                self.env["ir.model"].sudo().search([("model", "=", self._name)]).id,
             )
         ],
         compute="_compute_export_config_id",


### PR DESCRIPTION
Without this patch, whenever trying to access any of the AEAT reports, it would fail if your user wasn't an admin. Makes no sense.

To reproduce, set these permissions for Marc Demo:
![flameshot_2022-11-03_11-42](https://user-images.githubusercontent.com/973709/199714977-a3365100-04e4-4579-83b6-a1b567c5f3ba.png)

Now log in as demo and try to access any AEAT report. You'll get access error.

<details>

```
odoo.exceptions.AccessError

You are not allowed to access 'Models' (ir.model) records.

This operation is allowed for the following groups:
    - Administration/Access Rights

Contact your administrator to request access if necessary.

---

Traceback (most recent call last):
  File \"/opt/odoo/odoo/tools/cache.py\", line 85, in lookup
    r = d[key]
  File \"/opt/odoo/odoo/tools/func.py\", line 71, in wrapper
    return func(self, *args, **kwargs)
  File \"/opt/odoo/odoo/tools/lru.py\", line 34, in __getitem__
    a = self.d[obj]
KeyError: ('ir.model.access', <function IrModelAccess.check at 0x7f1155b8f040>, 6, False, 'ir.model', 'read', True, ('en_US',))

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File \"/opt/odoo/odoo/addons/base/models/ir_http.py\", line 237, in _dispatch
    result = request.dispatch()
  File \"/opt/odoo/odoo/http.py\", line 687, in dispatch
    result = self._call_function(**self.params)
  File \"/opt/odoo/odoo/http.py\", line 359, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File \"/opt/odoo/odoo/service/model.py\", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File \"/opt/odoo/odoo/http.py\", line 348, in checked_call
    result = self.endpoint(*a, **kw)
  File \"/opt/odoo/odoo/http.py\", line 916, in __call__
    return self.method(*args, **kw)
  File \"/opt/odoo/odoo/http.py\", line 535, in response_wrap
    response = f(*args, **kw)
  File \"/opt/odoo/addons/web/controllers/main.py\", line 1342, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File \"/opt/odoo/addons/web/controllers/main.py\", line 1334, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File \"/opt/odoo/odoo/api.py\", line 460, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File \"/opt/odoo/odoo/api.py\", line 433, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File \"/opt/odoo/odoo/models.py\", line 1634, in load_views
    result['fields'] = self.fields_get()
  File \"/opt/odoo/odoo/models.py\", line 3094, in fields_get
    description = field.get_description(self.env)
  File \"/opt/odoo/odoo/fields.py\", line 749, in get_description
    value = value(env)
  File \"/opt/odoo/odoo/fields.py\", line 2651, in _description_domain
    return self.domain(env[self.model_name]) if callable(self.domain) else self.domain
  File \"/mnt/data/odoo-addons-dir/l10n_es_aeat/models/l10n_es_aeat_report.py\", line 180, in <lambda>
    self.env[\"ir.model\"].search([(\"model\", \"=\", self._name)]).id,
  File \"/opt/odoo/odoo/models.py\", line 1810, in search
    res = self._search(args, offset=offset, limit=limit, order=order, count=count)
  File \"/opt/odoo/odoo/models.py\", line 4696, in _search
    model.check_access_rights('read')
  File \"/opt/odoo/odoo/models.py\", line 3538, in check_access_rights
    return self.env['ir.model.access'].check(self._name, operation, raise_exception)
  File \"<decorator-gen-33>\", line 2, in check
  File \"/opt/odoo/odoo/tools/cache.py\", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File \"/opt/odoo/odoo/addons/base/models/ir_model.py\", line 1820, in check
    raise AccessError(msg)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File \"/opt/odoo/odoo/http.py\", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File \"/opt/odoo/odoo/http.py\", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause
odoo.exceptions.AccessError: You are not allowed to access 'Models' (ir.model) records.

This operation is allowed for the following groups:
\t- Administration/Access Rights

Contact your administrator to request access if necessary.
",
		"message": "You are not allowed to access 'Models' (ir.model) records.

This operation is allowed for the following groups:
\t- Administration/Access Rights

Contact your administrator to request access if necessary.
```

</details>


@moduon MT-1495