### PR TITLE
[15.0][FIX] l10n_es_intrastat_report: Set the correct country code in csv file.

### DIFF
--- a/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
+++ b/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
@@ -160,7 +160,7 @@ class L10nEsIntrastatProductDeclaration(models.Model):
         state_code = line.intrastat_state_id.code
         vals = (
             # Estado destino/origen
-            line.src_dest_country_id.code,
+            line.src_dest_country_code,
             # Provincia destino/origen
             SPANISH_STATES.get(state_code, state_code),
             # Condiciones de entrega


### PR DESCRIPTION
FWP de 14.0: https://github.com/OCA/l10n-spain/pull/2605

Definir el código de país correcto en el archivo `csv`.

Por favor, @pedrobaeza y @sergio-teruel podéis revisarlo?

@Tecnativa TT39888