### PR TITLE
[12.0][FIX] l10n_es_ticketbai*: Send country code when neccesary and get correct country code

### DIFF
--- a/l10n_es_ticketbai/models/account_invoice.py
+++ b/l10n_es_ticketbai/models/account_invoice.py
@@ -225,7 +225,7 @@ class AccountInvoice(models.Model):
         if partner and not partner.aeat_anonymous_cash_customer:
             vals['tbai_customer_ids'] = [(0, 0, {
                 'name': partner.tbai_get_value_apellidos_nombre_razon_social(),
-                'country_code': partner.tbai_get_partner_country_code(),
+                'country_code': partner._parse_aeat_vat_info()[0],
                 'nif': partner.tbai_get_value_nif(),
                 'identification_number':
                     partner.tbai_partner_identification_number or partner.vat,

--- a/l10n_es_ticketbai/models/account_invoice_tax.py
+++ b/l10n_es_ticketbai/models/account_invoice_tax.py
@@ -89,7 +89,7 @@ class AccountInvoiceTax(models.Model):
         return self.tax_id in taxes
 
     def tbai_get_value_causa(self):
-        country_code = self.invoice_id.partner_id.tbai_get_partner_country_code()
+        country_code = self.invoice_id.partner_id._parse_aeat_vat_info()[0]
         if country_code and self.env.ref('base.es').code.upper() == country_code:
             fp_not_subject_tai = self.invoice_id.company_id.get_fps_from_templates(
                 self.env.ref("l10n_es.fp_not_subject_tai"))

--- a/l10n_es_ticketbai_api/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 from .ticketbai_invoice_tax import TicketBaiTaxType, VATRegimeKey
 from .ticketbai_response import TicketBaiResponseState, TicketBaiInvoiceResponseCode, \
     TicketBaiCancellationResponseCode
+from .ticketbai_invoice_customer import TicketBaiCustomerIdType
 from ..ticketbai.api import TicketBaiApi
 from ..ticketbai.xml_schema import XMLSchema, TicketBaiSchema, \
     XMLSchemaModeNotSupported
@@ -784,7 +785,10 @@ class TicketBAIInvoice(models.Model):
                 customer_res["NIF"] = customer.nif
             elif customer.idtype and customer.identification_number:
                 customer_res["IDOtro"] = OrderedDict()
-                if customer.country_code:
+                if (
+                    customer.country_code and
+                    customer.idtype != TicketBaiCustomerIdType.T02.value
+                ):
                     customer_res["IDOtro"]["CodigoPais"] = customer.country_code
                 customer_res["IDOtro"]["IDType"] = customer.idtype
                 customer_res["IDOtro"]["ID"] = customer.identification_number

--- a/l10n_es_ticketbai_batuz/models/account_invoice.py
+++ b/l10n_es_ticketbai_batuz/models/account_invoice.py
@@ -17,12 +17,6 @@ from odoo.addons.l10n_es_ticketbai_api_batuz.models.lroe_operation import (
 from collections import OrderedDict
 import json
 
-LROE_COUNTRY_CODE_MAPPING = {
-    "RE": "FR",
-    "GP": "FR",
-    "MQ": "FR",
-    "GF": "FR",
-}
 LROE_VALID_INVOICE_STATES = ["open", "in_payment", "paid"]
 LROE_STATES = [
     ("not_sent", "Not recorded"),
@@ -182,15 +176,6 @@ class AccountInvoice(models.Model):
             return chapter.code, subchapter.code
 
     @api.multi
-    def _get_lroe_country_code(self):
-        self.ensure_one()
-        country_code = (
-            self.partner_id.commercial_partner_id.country_id.code
-            or (self.partner_id.vat or "")[:2]
-        ).upper()
-        return LROE_COUNTRY_CODE_MAPPING.get(country_code, country_code)
-
-    @api.multi
     def _get_batuz_description(self):
         """Concatenamos la referencia/descripción de la factura con el
         número interno de la misma. De esta forma es más sencillo identificarla
@@ -240,13 +225,12 @@ class AccountInvoice(models.Model):
             vat = "".join(e for e in partner.vat if e.isalnum()).upper()
         else:
             vat = "NO_DISPONIBLE"
-        country_code = self._get_lroe_country_code()
+        country_code = partner._parse_aeat_vat_info()[0]
         if idtype == TicketBaiCustomerIdType.T02.value:
             if country_code != "ES":
                 id_type = "06" if vat == "NO_DISPONIBLE" else "02"
                 res["IDOtro"] = OrderedDict(
                     [
-                        ("CodigoPais", country_code),
                         ("IDType", id_type),
                         ("ID", vat),
                     ]

--- a/l10n_es_ticketbai_pos/models/pos_order.py
+++ b/l10n_es_ticketbai_pos/models/pos_order.py
@@ -64,7 +64,7 @@ class PosOrder(models.Model):
         if partner:
             vals['tbai_customer_ids'] = [(0, 0, {
                 'name': partner.tbai_get_value_apellidos_nombre_razon_social(),
-                'country_code': partner.tbai_get_partner_country_code(),
+                'country_code': partner._parse_aeat_vat_info()[0],
                 'nif': partner.tbai_get_value_nif(),
                 'identification_number':
                     partner.tbai_partner_identification_number or partner.vat,


### PR DESCRIPTION
Aprovecha la función `_parse_aeat_vat_info` definida en el módulo `l10n_es_aeat` para evitar errores a la hora de obtener el código de país del cliente, la función original da fallos (con Grecia por ejemplo, el código de país es GR, no EL aunque se utilice en su VAT).

Solo se envía el código país cuando es necesario, si el TypeId es 02, no se envía.