### PR TITLE
[15.0][FIX] l10n_es_aeat_sii_oca, l10n_es_facturae: remove fields view get account move

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -44,6 +44,7 @@
         "views/res_partner_view.xml",
         "views/aeat_certificate_view.xml",
         "views/account_journal_view.xml",
+        "views/account_move_view.xml",
     ],
     "installable": True,
     "maintainers": ["pedrobaeza"],

--- a/l10n_es_aeat/models/__init__.py
+++ b/l10n_es_aeat/models/__init__.py
@@ -1,6 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import account_journal
+from . import account_move
 from . import account_tax
 from . import res_company
 from . import res_partner

--- a/l10n_es_aeat/models/account_move.py
+++ b/l10n_es_aeat/models/account_move.py
@@ -1,0 +1,29 @@
+# Copyright 2022 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    thirdparty_invoice = fields.Boolean(
+        string="Third-party invoice",
+        copy=False,
+        compute="_compute_thirdparty_invoice",
+        store=True,
+        readonly=False,
+    )
+    thirdparty_number = fields.Char(
+        string="Third-party number",
+        index=True,
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        copy=False,
+        help="Número de la factura emitida por un tercero.",
+    )
+
+    @api.depends("journal_id")
+    def _compute_thirdparty_invoice(self):
+        for item in self:
+            item.thirdparty_invoice = item.journal_id.thirdparty_invoice

--- a/l10n_es_aeat/views/account_move_view.xml
+++ b/l10n_es_aeat/views/account_move_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2022 Tecnativa - Víctor Martínez
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='ref'][last()]" position="after">
+                <field name="thirdparty_invoice" attrs="{'invisible': 1}" />
+                <field name="thirdparty_number" attrs="{'invisible': 1}" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -215,22 +215,6 @@ class AccountMove(models.Model):
         "The invoice number should start with LC, QZC, QRC, A01 or A02.",
         copy=False,
     )
-    thirdparty_invoice = fields.Boolean(
-        string="Third-party invoice",
-        copy=False,
-        compute="_compute_thirdparty_invoice",
-        store=True,
-        readonly=False,
-    )
-    thirdparty_number = fields.Char(
-        string="Third-party number",
-        index=True,
-        readonly=True,
-        states={"draft": [("readonly", False)]},
-        copy=False,
-        help="Número de la factura emitida por un tercero.",
-        tracking=True,
-    )
     invoice_jobs_ids = fields.Many2many(
         comodel_name="queue.job",
         column1="invoice_id",
@@ -239,11 +223,6 @@ class AccountMove(models.Model):
         string="Connector Jobs",
         copy=False,
     )
-
-    @api.depends("journal_id")
-    def _compute_thirdparty_invoice(self):
-        for item in self:
-            item.thirdparty_invoice = item.journal_id.thirdparty_invoice
 
     @api.depends("move_type")
     def _compute_sii_registration_key_domain(self):

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -7,8 +7,6 @@
 
 import json
 
-from lxml import etree
-
 from odoo import exceptions
 from odoo.modules.module import get_resource_path
 
@@ -406,16 +404,6 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.invoice.sii_state = "sent"
         with self.assertRaises(exceptions.UserError):
             self.invoice.unlink()
-
-    def test_account_move_thirdparty_fields(self):
-        view = self.env["account.move"].fields_view_get(
-            view_id=self.env.ref("account.view_move_form").id,
-            view_type="form",
-        )
-        doc = etree.XML(view["arch"])
-        self.assertTrue(doc.xpath("//field[@name='thirdparty_number']"))
-        self.assertTrue(doc.xpath("//field[@name='thirdparty_invoice']"))
-        self.invoice.thirdparty_number = "thirdparty_number"
 
     def test_account_move_sii_write_exceptions(self):
         # out_invoice

--- a/l10n_es_aeat_sii_oca/views/account_journal_view.xml
+++ b/l10n_es_aeat_sii_oca/views/account_journal_view.xml
@@ -4,7 +4,7 @@
 <odoo>
     <record id="view_account_journal_thirdparty_form" model="ir.ui.view">
         <field name="model">account.journal</field>
-        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="inherit_id" ref="l10n_es_aeat.view_account_journal_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='thirdparty_invoice']" position="attributes">
                 <attribute

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -7,9 +7,19 @@
     <record id="invoice_sii_form" model="ir.ui.view">
         <field name="name">account.invoice.sii.form</field>
         <field name="model">account.move</field>
-        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="inherit_id" ref="l10n_es_aeat.view_move_form" />
         <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]" />
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='thirdparty_invoice']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('move_type', 'not in', ('in_invoice', 'out_invoice', 'out_refund', 'in_refund'))]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='thirdparty_number']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'required': [('thirdparty_invoice', '=', True)], 'invisible': [('thirdparty_invoice', '=', False)]}</attribute>
+            </xpath>
             <button name="button_draft" position="after">
                 <button
                     type="object"

--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -4,16 +4,9 @@
 import base64
 from collections import defaultdict
 
-from lxml import etree
-
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
 from odoo.tools import html2plaintext
-
-from odoo.addons.base.models.ir_ui_view import (
-    transfer_modifiers_to_node,
-    transfer_node_to_modifiers,
-)
 
 
 class AccountMove(models.Model):
@@ -80,26 +73,6 @@ class AccountMove(models.Model):
         inverse_name="move_id",
         copy=False,
     )
-    thirdparty_invoice = fields.Boolean(
-        string="Third-party invoice",
-        copy=False,
-        compute="_compute_thirdparty_invoice",
-        store=True,
-        readonly=False,
-    )
-    thirdparty_number = fields.Char(
-        string="Third-party number",
-        index=True,
-        readonly=True,
-        states={"draft": [("readonly", False)]},
-        copy=False,
-        help="Número de la factura emitida por un tercero.",
-    )
-
-    @api.depends("journal_id")
-    def _compute_thirdparty_invoice(self):
-        for item in self:
-            item.thirdparty_invoice = item.journal_id.thirdparty_invoice
 
     @api.constrains("facturae_start_date", "facturae_end_date")
     def _check_facturae_date(self):
@@ -248,57 +221,6 @@ class AccountMove(models.Model):
                 withheld_taxes[tax]["base"] * tax.amount / 100
             )
         return output_taxes, withheld_taxes
-
-    @api.model
-    def fields_view_get(
-        self, view_id=None, view_type="form", toolbar=False, submenu=False
-    ):
-        """Thirdparty fields are added to the form view only if they don't exist
-        previously (l10n_es_aeat_sii_oca addon also has the same field names).
-        """
-        res = super().fields_view_get(
-            view_id=view_id,
-            view_type=view_type,
-            toolbar=toolbar,
-            submenu=submenu,
-        )
-        if view_type == "form":
-            doc = etree.XML(res["arch"])
-            node = doc.xpath("//field[@name='thirdparty_invoice']")
-            if node:
-                return res
-            for node in doc.xpath("//field[@name='ref'][last()]"):
-                attrs = {
-                    "required": [("thirdparty_invoice", "=", True)],
-                    "invisible": [("thirdparty_invoice", "=", False)],
-                }
-                elem = etree.Element(
-                    "field",
-                    {"name": "thirdparty_number", "attrs": str(attrs)},
-                )
-                modifiers = {}
-                transfer_node_to_modifiers(elem, modifiers)
-                transfer_modifiers_to_node(modifiers, elem)
-                node.addnext(elem)
-                res["fields"].update(self.fields_get(["thirdparty_number"]))
-                attrs = {
-                    "invisible": [
-                        (
-                            "move_type",
-                            "not in",
-                            ("in_invoice", "out_invoice", "out_refund", "in_refund"),
-                        )
-                    ],
-                }
-                elem = etree.Element(
-                    "field", {"name": "thirdparty_invoice", "attrs": str(attrs)}
-                )
-                transfer_node_to_modifiers(elem, modifiers)
-                transfer_modifiers_to_node(modifiers, elem)
-                node.addnext(elem)
-                res["fields"].update(self.fields_get(["thirdparty_invoice"]))
-            res["arch"] = etree.tostring(doc)
-        return res
 
     def get_narration(self):
         self.ensure_one()

--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -638,12 +638,3 @@ class CommonTest(TestL10nEsAeatCertificateBase):
             }
         )
         self._check_amounts(move, *self.second_check_amount)
-
-    def test_account_move_thirdparty_fields(self):
-        view = self.env["account.move"].fields_view_get(
-            view_id=self.env.ref("account.view_move_form").id,
-            view_type="form",
-        )
-        doc = etree.XML(view["arch"])
-        self.assertTrue(doc.xpath("//field[@name='thirdparty_number']"))
-        self.assertTrue(doc.xpath("//field[@name='thirdparty_invoice']"))

--- a/l10n_es_facturae/views/account_journal_view.xml
+++ b/l10n_es_facturae/views/account_journal_view.xml
@@ -4,7 +4,7 @@
 <odoo>
     <record id="view_account_journal_thirdparty_form" model="ir.ui.view">
         <field name="model">account.journal</field>
-        <field name="inherit_id" ref="account.view_account_journal_form" />
+        <field name="inherit_id" ref="l10n_es_aeat.view_account_journal_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='thirdparty_invoice']" position="attributes">
                 <attribute

--- a/l10n_es_facturae/views/account_move_view.xml
+++ b/l10n_es_facturae/views/account_move_view.xml
@@ -3,9 +3,19 @@
     <record id="view_move_form" model="ir.ui.view">
         <field name="name">account.move.form</field>
         <field name="model">account.move</field>
-        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="inherit_id" ref="l10n_es_aeat.view_move_form" />
         <field name="type">form</field>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='thirdparty_invoice']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('move_type', 'not in', ('in_invoice', 'out_invoice', 'out_refund', 'in_refund'))]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='thirdparty_number']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'required': [('thirdparty_invoice', '=', True)], 'invisible': [('thirdparty_invoice', '=', False)]}</attribute>
+            </xpath>
             <field name="name" position="after">
                 <field name="facturae" invisible="1" />
             </field>


### PR DESCRIPTION
FWP de 14.0 https://github.com/OCA/l10n-spain/pull/2619

Cambios realizados:
- Elminar el `fields_view_get` delmodelo `account.move` y crear vistas nuevas iguales.

@Tecnativa