### PR TITLE
[15.0][IMP] l10n_es_ticketbai: Dynamic TicketBAI menu parent

### DIFF
--- a/l10n_es_ticketbai/views/l10n_es_ticketbai_views.xml
+++ b/l10n_es_ticketbai/views/l10n_es_ticketbai_views.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2021 Binovo IT Human Project SL
+     Copyright 2022 Landoo Sistemas de Informacion SL
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
     <!-- Public available Information -->
-    <menuitem
-        id="menu_finance_ticketbai"
-        name="TicketBAI"
-        parent="account.menu_finance"
-        sequence="100"
-    />
+    <record id="menu_finance_ticketbai" model="ir.ui.menu">
+        <field name="name">TicketBAI</field>
+        <field name="sequence" eval="100" />
+        <field
+            name="parent_id"
+            search="[('child_id', 'in', ref('account.menu_finance_receivables'))]"
+        />
+    </record>
     <!-- Configuration / Settings -->
     <menuitem
         id="menu_l10n_es_tbai_config"


### PR DESCRIPTION
El menú 'TicketBAI' tiene padre dinámico para que se cambie de padre si se instala el módulo enterprise  `account_accountant`.

Se ha utilizado la misma estrategia que en el módulo `l10n_es_aeat`