### PR TITLE
[OU] l10n_es_aeat_sii_oca: Fix migration

### DIFF
--- a/l10n_es_aeat_sii_oca/migrations/14.0.1.0.0/pre-migrate.py
+++ b/l10n_es_aeat_sii_oca/migrations/14.0.1.0.0/pre-migrate.py
@@ -10,16 +10,34 @@ def migrate_l10n_es_aeat_sii(env):
     """Migrate l10n.es.aeat.sii to l10n.es.aeat.certificate"""
     openupgrade.logged_query(
         env.cr,
+        "ALTER TABLE l10n_es_aeat_certificate ADD COLUMN IF NOT EXISTS %s INT"
+        % openupgrade.get_legacy_name("l10n_es_aeat_sii_id"),
+    )
+    openupgrade.logged_query(
+        env.cr,
         sql.SQL(
             """
         INSERT INTO l10n_es_aeat_certificate
-        (name, state, file, date_start, date_end, folder,
-         public_key, private_key, company_id)
+        (name, state, date_start, date_end, folder,
+         public_key, private_key, company_id, %s)
         SELECT
-        name, state, file, date_start, date_end, 'OU',
-        public_key, private_key, company_id
+        name, state, date_start, date_end, 'OU',
+        public_key, private_key, company_id, id
         FROM l10n_es_aeat_sii
         """
+            % openupgrade.get_legacy_name("l10n_es_aeat_sii_id")
+        ),
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE ir_attachment ia
+            SET res_model = 'l10n.es.aeat.certificate',
+                res_id = leac.{field_name}
+            FROM l10n_es_aeat_certificate leac
+            WHERE ia.res_model = 'l10n.es.aeat.sii' AND leac.{field_name} = ia.res_id
+        """.format(
+            field_name=openupgrade.get_legacy_name("l10n_es_aeat_sii_id")
         ),
     )
 

--- a/l10n_es_aeat_sii_oca/migrations/14.0.2.1.0/post-migration.py
+++ b/l10n_es_aeat_sii_oca/migrations/14.0.2.1.0/post-migration.py
@@ -20,6 +20,12 @@ def _get_tax_agency_map(env):
         get_id("l10n_es_aeat_sii_oca.aeat_sii_tax_agency_bizkaia"): get_id(
             "l10n_es_aeat.aeat_tax_agency_bizkaia"
         ),
+        get_id("l10n_es_aeat_sii_oca.aeat_sii_tax_agency_spain_1_0_old"): get_id(
+            "l10n_es_aeat_sii_oca.aeat_sii_tax_agency_spain_1_0"
+        ),
+        get_id("l10n_es_aeat_sii_oca.aeat_sii_tax_agency_gipuzkoa_1_0_old"): get_id(
+            "l10n_es_aeat_sii_oca.aeat_sii_tax_agency_gipuzkoa_1_0"
+        ),
     }
     return mig_map
 

--- a/l10n_es_aeat_sii_oca/migrations/14.0.2.1.0/pre-migration.py
+++ b/l10n_es_aeat_sii_oca/migrations/14.0.2.1.0/pre-migration.py
@@ -6,6 +6,21 @@ from openupgradelib import openupgrade
 
 @openupgrade.migrate()
 def migrate(env, version):
+    # We force a change of name due to a change of model,
+    # it will be changed back on post-migration
+    openupgrade.rename_xmlids(
+        env.cr,
+        [
+            (
+                "l10n_es_aeat_sii_oca.aeat_sii_tax_agency_spain_1_0",
+                "l10n_es_aeat_sii_oca.aeat_sii_tax_agency_spain_1_0_old",
+            ),
+            (
+                "l10n_es_aeat_sii_oca.aeat_sii_tax_agency_gipuzkoa_1_0",
+                "l10n_es_aeat_sii_oca.aeat_sii_tax_agency_gipuzkoa_1_0_old",
+            ),
+        ],
+    )
     column_name = openupgrade.get_legacy_name("sii_tax_agency_id")
     if not openupgrade.column_exists(env.cr, "res_company", column_name):
         openupgrade.rename_columns(


### PR DESCRIPTION
Tras el siguiente commit de odoo no se puede cambiar un modelo de un ir.model.data de forma tan sencilla:

https://github.com/odoo/odoo/commit/854cc0acfff9c3564fde872e4218cbdd0888e2a7

He modificado la migración que eliminaba los tax.sii.agency por tax.agency para que funcione correctamente.

@LoisRForgeFlow 