### PR TITLE
[14.0][IMP+FIX] l10n_es_aeat: Added support for tax groups in the calculation of tax info

### DIFF
--- a/l10n_es_aeat/models/account_move.py
+++ b/l10n_es_aeat/models/account_move.py
@@ -1,5 +1,6 @@
 # Copyright 2022 CreuBlanca
 # Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2022 NuoBiT - Eric Antones
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import logging
@@ -34,13 +35,17 @@ class AccountMove(models.Model):
             item.thirdparty_invoice = item.journal_id.thirdparty_invoice
 
     def _get_aeat_tax_base_info(self, res, tax, line, sign):
-        res.setdefault(tax, {"tax": tax, "base": 0, "amount": 0, "quote_amount": 0})
-        res[tax]["base"] += line.balance * sign
+        taxes = tax.amount_type == "group" and tax.children_tax_ids or tax
+        for tax in taxes:
+            res.setdefault(tax, {"tax": tax, "base": 0, "amount": 0, "quote_amount": 0})
+            res[tax]["base"] += line.balance * sign
 
     def _get_aeat_tax_quote_info(self, res, tax, line, sign):
-        res.setdefault(tax, {"tax": tax, "base": 0, "amount": 0, "quote_amount": 0})
-        res[tax]["amount"] += line.balance * sign
-        res[tax]["quote_amount"] += line.balance * sign
+        taxes = tax.amount_type == "group" and tax.children_tax_ids or tax
+        for tax in taxes:
+            res.setdefault(tax, {"tax": tax, "base": 0, "amount": 0, "quote_amount": 0})
+            res[tax]["amount"] += line.balance * sign
+            res[tax]["quote_amount"] += line.balance * sign
 
     def _get_aeat_tax_info(self):
         self.ensure_one()

--- a/l10n_es_aeat/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat/readme/CONTRIBUTORS.rst
@@ -14,3 +14,4 @@
 * Iván Antón <ozono@ozonomultimedia.com>
 * Digital5 S.L.
 * Manuel Regidor <manuel.regidor@sygel.es>
+* Eric Antones <eantones@nuobit.com>

--- a/l10n_es_aeat/tests/test_l10n_es_aeat_taxinfo.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_taxinfo.py
@@ -1,4 +1,5 @@
 # © 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# © 2022 Eric Antones <eantones@nuobit.com>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0
 
 import logging
@@ -28,3 +29,65 @@ class TestL10nEsAeatModBase(TestL10nEsAeatModBase):
         tax = self._get_taxes("S_IVA21B")[0]
         self.assertEqual(tax_info[tax]["base"], -1000)
         self.assertEqual(tax_info[tax]["amount"], -210)
+
+
+class TestL10nEsAeatTaxGroup(TestL10nEsAeatModBase):
+    taxes_sale = {
+        # tax code: (base, tax_amount)
+        "S_IVAG1021B": (1000, 0),
+    }
+
+    @classmethod
+    def _chart_of_accounts_create(cls):
+        cls.env["account.tax.template"]._load_records(
+            [
+                {
+                    "xml_id": "l10n_es.account_tax_template_s_ivag1021b",
+                    "noupdate": True,
+                    "values": {
+                        "type_tax_use": "sale",
+                        "name": "Grupo IVA 10%/21% (Bienes)",
+                        "chart_template_id": cls.env.ref(
+                            "l10n_es.account_chart_template_common"
+                        ).id,
+                        "amount_type": "group",
+                        "children_tax_ids": [
+                            (
+                                6,
+                                0,
+                                [
+                                    cls.env.ref(
+                                        "l10n_es.account_tax_template_s_iva10b"
+                                    ).id,
+                                    cls.env.ref(
+                                        "l10n_es.account_tax_template_s_iva21b"
+                                    ).id,
+                                ],
+                            )
+                        ],
+                    },
+                }
+            ]
+        )
+        super()._chart_of_accounts_create()
+
+    def test_tax_info_1021B(self):
+        invoice = self._invoice_sale_create("2018-02-01", {})
+        tax_info = invoice._get_aeat_tax_info()
+        tax10 = self._get_taxes("S_IVA10B")[0]
+        tax21 = self._get_taxes("S_IVA21B")[0]
+        self.assertEqual(tax_info[tax10]["base"], 1000)
+        self.assertEqual(tax_info[tax10]["amount"], 100)
+        self.assertEqual(tax_info[tax21]["base"], 1000)
+        self.assertEqual(tax_info[tax21]["amount"], 210)
+
+    def test_tax_info_refund_1021B(self):
+        invoice = self._invoice_sale_create("2018-02-01", {})
+        refund = invoice._reverse_moves()
+        tax_info = refund._get_aeat_tax_info()
+        tax10 = self._get_taxes("S_IVA10B")[0]
+        tax21 = self._get_taxes("S_IVA21B")[0]
+        self.assertEqual(tax_info[tax10]["base"], -1000)
+        self.assertEqual(tax_info[tax10]["amount"], -100)
+        self.assertEqual(tax_info[tax21]["base"], -1000)
+        self.assertEqual(tax_info[tax21]["amount"], -210)


### PR DESCRIPTION
Actualmente los grupos de impuestos no se están teniendo en cuenta para calcular ni las bases ni las cuotas. Esto ocasiona errores en módulos hijos como en el caso de `l10n_es_aeat_sii_oca` al enviar al SII facturas con grupos de impuestos.

@etobella puedes revisarlo por favor?