### PR TITLE
[14.0][FIX] l10n_es_aeat: renombrar impuesto 5%

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -11,7 +11,7 @@
 {
     "name": "AEAT Base",
     "summary": "Modulo base para declaraciones de la AEAT",
-    "version": "14.0.2.4.0",
+    "version": "14.0.2.5.0",
     "author": "Pexego, "
     "Acysos S.L., "
     "AvanzOSC, "

--- a/l10n_es_aeat/migrations/14.0.2.5.0/pre-migration.py
+++ b/l10n_es_aeat/migrations/14.0.2.5.0/pre-migration.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Studio73 - Guillermo Llinares <guillermo@studio73.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+xmlid_renames = [
+    (
+        "l10n_es_extra_data.{}_account_tax_template_s_iva5s",
+        "l10n_es.{}_account_tax_template_s_iva5s",
+    ),
+    (
+        "l10n_es_extra_data.{}_account_tax_template_p_iva5_sc",
+        "l10n_es.{}_account_tax_template_p_iva5_sc",
+    ),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    xmlid_renames_per_companies = []
+    companies = env["res.company"].search([])
+    for company_id in companies.ids:
+        xmlid_renames_per_companies.append(
+            (
+                xmlid_renames[0][0].format(company_id),
+                xmlid_renames[0][1].format(company_id),
+            )
+        )
+        xmlid_renames_per_companies.append(
+            (
+                xmlid_renames[1][0].format(company_id),
+                xmlid_renames[1][1].format(company_id),
+            )
+        )
+    openupgrade.rename_xmlids(env.cr, xmlid_renames_per_companies)


### PR DESCRIPTION
Añadir script de migración para renombrar los identificadores externos de los impuestos del 5%. En versiones anteriores, estos dos impuestos se crearon en el módulo l10n_es_extra_data pero a partir de la versión 14.0 están en l10n_es.