### PR TITLE
[11.0][FIX] Github Actions: ubuntu-lasted not working python version 3.6

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Change pre-commit run in ubuntu-lasted to ubuntu-20.04, ubuntu-lasted not support python version 3.6 view [issue](https://github.com/actions/setup-python/issues/544) 