### PR TITLE
[14.0][IMP] l10n_es_aeat: hook for thirdparty_invoice

### DIFF
--- a/l10n_es_aeat/__init__.py
+++ b/l10n_es_aeat/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizard
+from .hooks import pre_init_hook

--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -47,4 +47,5 @@
     ],
     "installable": True,
     "maintainers": ["pedrobaeza"],
+    "pre_init_hook": "pre_init_hook",
 }

--- a/l10n_es_aeat/hooks.py
+++ b/l10n_es_aeat/hooks.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Acsone SA - Xavier Bouquiaux
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+from odoo import tools
+from odoo.tools.sql import column_exists
+
+_logger = logging.getLogger(__name__)
+
+
+def create_column_thirdparty_invoice(cr):
+    if not column_exists(
+        cr, "account_journal", "thirdparty_invoice"
+    ) and not column_exists(cr, "account_move", "thirdparty_invoice"):
+        _logger.info("Initializing column thirdparty_invoice on table account_move")
+        tools.create_column(
+            cr=cr,
+            tablename="account_move",
+            columnname="thirdparty_invoice",
+            columntype="boolean",
+            comment="Third-party invoice",
+        )
+        tools.create_column(
+            cr=cr,
+            tablename="account_journal",
+            columnname="thirdparty_invoice",
+            columntype="boolean",
+            comment="Third-party invoice",
+        )
+        cr.execute("UPDATE account_move SET thirdparty_invoice = False")
+        cr.execute("UPDATE account_journal SET thirdparty_invoice = False")
+
+
+def pre_init_hook(cr):
+    create_column_thirdparty_invoice(cr)

--- a/l10n_es_aeat/migrations/14.0.2.4.0/pre-migration.py
+++ b/l10n_es_aeat/migrations/14.0.2.4.0/pre-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Acsone SA - Xavier Bouquiaux
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+from odoo.addons.l10n_es_aeat.hooks import create_column_thirdparty_invoice
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    create_column_thirdparty_invoice(env.cr)


### PR DESCRIPTION
this commit : https://github.com/OCA/l10n-spain/commit/2dc5f549f91bda2f97f8b39624c1ea137ec18042 <br/>
 introduces thirdparty_invoice as a compute store true on account_move table <br/>
on large database, the initial compute is too long I created a hook and a migrate in order to fill it