### PR TITLE
[11.0] [FIX] l10n_es_ticketbai_pos corregir el valor de la versión del software

### DIFF
--- a/l10n_es_ticketbai_pos/static/src/js/models.js
+++ b/l10n_es_ticketbai_pos/static/src/js/models.js
@@ -17,7 +17,8 @@ odoo.define('l10n_es_ticketbai_pos.models', function (require) {
 
     models.load_fields('res.company', [
         'tbai_enabled', 'tbai_test_enabled', 'tbai_license_key', 'tbai_developer_id',
-        'tbai_software_name', 'tbai_tax_agency_id', 'tbai_protected_data', 'tbai_protected_data_txt'
+        'tbai_software_name', 'tbai_tax_agency_id', 'tbai_protected_data', 'tbai_protected_data_txt',
+        'tbai_software_version'
     ]);
 
     models.load_fields('res.country', ['code']);
@@ -88,7 +89,7 @@ odoo.define('l10n_es_ticketbai_pos.models', function (require) {
         },
         {
             model: 'tbai.tax.agency',
-            fields: ['version', 'qr_base_url', 'test_qr_base_url'],
+            fields: ['qr_base_url', 'test_qr_base_url'],
             condition: function (self, tmp) {
                 return self.company.tbai_enabled;
             },
@@ -96,7 +97,6 @@ odoo.define('l10n_es_ticketbai_pos.models', function (require) {
                 return [['id', '=', self.company.tbai_tax_agency_id[0]]];
             },
             loaded: function (self, tax_agencies) {
-                self.tbai_version = tax_agencies[0].version;
                 if (self.company.tbai_test_enabled) {
                     self.tbai_qr_base_url = tax_agencies[0].test_qr_base_url;
                 } else {
@@ -121,7 +121,6 @@ odoo.define('l10n_es_ticketbai_pos.models', function (require) {
 
     models.PosModel = models.PosModel.extend({
         initialize: function (session, attributes) {
-            this.tbai_version = null;
             this.tbai_signer = null;
             this.tbai_qr_base_url = null;
             this.tbai_vat_regime_keys = null;

--- a/l10n_es_ticketbai_pos/static/src/js/tbai_models.js
+++ b/l10n_es_ticketbai_pos/static/src/js/tbai_models.js
@@ -196,7 +196,7 @@ odoo.define('l10n_es_ticketbai_pos.tbai_models', function (require) {
                     license: company.tbai_license_key,
                     developerIrsId: this.get_tbai_partner_vat(company.tbai_developer_id[0]),
                     name: company.tbai_software_name,
-                    version: this.pos.tbai_version,
+                    version: company.tbai_software_version,
                 };
             }
             return tbai;


### PR DESCRIPTION
**l10n_es_ticketbai_pos corregir el valor de la etiqueta _Version_ del nodo _Software_ dentro de la _HuellaTBAI_ .** 

Afecta a las facturas simplificadas del POS, las facturas realizadas tanto en el backend como en el POS llevan 
la versión del software correctamente.

Actualmente la versión del software en las facturas simplificadas del POS, se extrae de los datos relacionados con el modelo de la hacienda (tbai.tax.agency.version), esto no es correcto, esa es la versión de desarrollo de la Hacienda y no la versión del desarrollador del software garante de TBAI.

El objetivo del fix es extraer la versión del software de la configuración de la compañía del campo _tbai_software_version_ , es un campo relacionado con el dato de la instalación TicketBai que rellena el usuario con los datos del desarrollador del software garante de TBAI.


