### PR TITLE
[14.0][IMP] l10n_es_vat_prorate: include SII without glue module

### DIFF
--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -110,8 +110,8 @@ class TestL10nEsAeatSiiBase(TestL10nEsAeatModBase, TestL10nEsAeatCertificateBase
         return invoice
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def _setup_records(cls):
+        # This hook is used in other modules that might need this test
         cls.maxDiff = None  # needed for the dict comparison
         cls.partner = cls.env["res.partner"].create(
             {"name": "Test partner", "vat": "ESF35999705"}
@@ -153,6 +153,11 @@ class TestL10nEsAeatSiiBase(TestL10nEsAeatModBase, TestL10nEsAeatCertificateBase
                 "tax_agency_id": cls.env.ref("l10n_es_aeat.aeat_tax_agency_spain"),
             }
         )
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_records()
 
 
 class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):

--- a/l10n_es_vat_prorate/__manifest__.py
+++ b/l10n_es_vat_prorate/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "author": "Creu Blanca,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
-    "depends": ["l10n_es"],
+    "depends": ["l10n_es_aeat"],
     "data": [
         "security/ir.model.access.csv",
         "data/account_template_tax.xml",

--- a/l10n_es_vat_prorate/models/account_move.py
+++ b/l10n_es_vat_prorate/models/account_move.py
@@ -8,6 +8,11 @@ class AccountMove(models.Model):
 
     _inherit = "account.move"
 
+    def _get_aeat_tax_quote_info(self, res, tax, line, sign):
+        super()._get_aeat_tax_quote_info(res, tax, line, sign)
+        if line.vat_prorate:
+            res[tax]["quote_amount"] -= line.balance * sign
+
     def _recompute_tax_lines(
         self, recompute_tax_base_amount=False, tax_rep_lines_to_recompute=None
     ):

--- a/l10n_es_vat_prorate/tests/__init__.py
+++ b/l10n_es_vat_prorate/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_vat_prorate
+from . import test_prorate_sii

--- a/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva0_ns_p_iva10_bc_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva0_ns_p_iva10_bc_dict.json
@@ -1,0 +1,25 @@
+{
+  "IDFactura": {
+    "FechaExpedicionFacturaEmisor": "01-01-2020",
+    "NumSerieFacturaEmisor": "sup0005",
+    "IDEmisorFactura": {"NIF": "F35999705"}
+  },
+  "FacturaRecibida": {
+    "TipoFactura": "F1",
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"},
+    "DescripcionOperacion": "/",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "ImporteTotal": 320.0,
+    "FechaRegContable": "01-10-2020",
+    "DesgloseFactura": {
+      "DesgloseIVA": {
+        "DetalleIVA": [
+          {"BaseImponible": 100.0},
+          {"BaseImponible": 200.0, "TipoImpositivo": "10.0", "CuotaSoportada": 20.0}
+        ]
+      }
+    },
+    "CuotaDeducible": 4.0
+  },
+  "PeriodoLiquidacion": {"Periodo": "01", "Ejercicio": 2020}
+}

--- a/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva10_bc_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva10_bc_dict.json
@@ -1,0 +1,24 @@
+{
+  "IDFactura": {
+    "FechaExpedicionFacturaEmisor": "01-01-2020",
+    "NumSerieFacturaEmisor": "sup0006",
+    "IDEmisorFactura": {"NIF": "F35999705"}
+  },
+  "FacturaRecibida": {
+    "TipoFactura": "F1",
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"},
+    "DescripcionOperacion": "/",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "ImporteTotal": 91.67,
+    "FechaRegContable": "01-10-2020",
+    "DesgloseFactura": {
+      "DesgloseIVA": {
+        "DetalleIVA": [
+          {"BaseImponible": 83.33, "CuotaSoportada": 8.34, "TipoImpositivo": "10.0"}
+        ]
+      }
+    },
+    "CuotaDeducible": 1.67
+  },
+  "PeriodoLiquidacion": {"Periodo": "01", "Ejercicio": 2020}
+}

--- a/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva10_bc_p_irpf19_p_iva21_sc_p_irpf19_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva10_bc_p_irpf19_p_iva21_sc_p_irpf19_dict.json
@@ -1,0 +1,25 @@
+{
+  "IDFactura": {
+    "FechaExpedicionFacturaEmisor": "01-01-2020",
+    "NumSerieFacturaEmisor": "sup0001",
+    "IDEmisorFactura": {"NIF": "F35999705"}
+  },
+  "FacturaRecibida": {
+    "TipoFactura": "F1",
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"},
+    "DescripcionOperacion": "/",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "ImporteTotal": 352.0,
+    "FechaRegContable": "01-10-2020",
+    "DesgloseFactura": {
+      "DesgloseIVA": {
+        "DetalleIVA": [
+          {"BaseImponible": 100.0, "CuotaSoportada": 10.0, "TipoImpositivo": "10.0"},
+          {"BaseImponible": 200.0, "CuotaSoportada": 42.0, "TipoImpositivo": "21.0"}
+        ]
+      }
+    },
+    "CuotaDeducible": 10.4
+  },
+  "PeriodoLiquidacion": {"Periodo": "02", "Ejercicio": 2020}
+}

--- a/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva10_bc_p_irpf1_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva10_bc_p_irpf1_dict.json
@@ -1,0 +1,24 @@
+{
+  "IDFactura": {
+    "FechaExpedicionFacturaEmisor": "01-01-2020",
+    "NumSerieFacturaEmisor": "sup0007",
+    "IDEmisorFactura": {"NIF": "F35999705"}
+  },
+  "FacturaRecibida": {
+    "TipoFactura": "F1",
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"},
+    "DescripcionOperacion": "/",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "ImporteTotal": 91.67,
+    "FechaRegContable": "01-10-2020",
+    "DesgloseFactura": {
+      "DesgloseIVA": {
+        "DetalleIVA": [
+          {"BaseImponible": 83.33, "CuotaSoportada": 8.34, "TipoImpositivo": "10.0"}
+        ]
+      }
+    },
+    "CuotaDeducible": 1.67
+  },
+  "PeriodoLiquidacion": {"Periodo": "01", "Ejercicio": 2020}
+}

--- a/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva10_bc_p_req014_p_iva21_sc_p_req52_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva10_bc_p_req014_p_iva21_sc_p_req52_dict.json
@@ -1,0 +1,45 @@
+{
+  "IDFactura": {
+    "FechaExpedicionFacturaEmisor": "01-01-2020",
+    "NumSerieFacturaEmisor": "sup0003",
+    "IDEmisorFactura": {
+      "NIF": "F35999705"
+    }
+  },
+  "FacturaRecibida": {
+    "TipoFactura": "F1",
+    "Contraparte": {
+      "NombreRazon": "Test partner",
+      "NIF": "F35999705"
+    },
+    "DescripcionOperacion": "/",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "ImporteTotal": 363.8,
+    "FechaRegContable": "01-10-2020",
+    "DesgloseFactura": {
+      "DesgloseIVA": {
+        "DetalleIVA": [
+          {
+            "BaseImponible": 100,
+            "CuotaSoportada": 10,
+            "TipoImpositivo": "10.0",
+            "CuotaRecargoEquivalencia": 1.4,
+            "TipoRecargoEquivalencia": 1.4
+          },
+          {
+            "BaseImponible": 200,
+            "CuotaSoportada": 42,
+            "TipoImpositivo": "21.0",
+            "CuotaRecargoEquivalencia": 10.4,
+            "TipoRecargoEquivalencia": 5.2
+          }
+        ]
+      }
+    },
+    "CuotaDeducible": 10.4
+  },
+  "PeriodoLiquidacion": {
+    "Periodo": "01",
+    "Ejercicio": 2020
+  }
+}

--- a/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva21_sp_ex_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva21_sp_ex_dict.json
@@ -1,0 +1,24 @@
+{
+  "IDFactura": {
+    "FechaExpedicionFacturaEmisor": "01-01-2020",
+    "NumSerieFacturaEmisor": "sup0004",
+    "IDEmisorFactura": {"NIF": "F35999705"}
+  },
+  "FacturaRecibida": {
+    "TipoFactura": "F1",
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"},
+    "DescripcionOperacion": "/",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "ImporteTotal": 121.0,
+    "FechaRegContable": "01-10-2020",
+    "DesgloseFactura": {
+      "InversionSujetoPasivo": {
+        "DetalleIVA": [
+          {"BaseImponible": 100.0, "CuotaSoportada": 21.0, "TipoImpositivo": "21.0"}
+        ]
+      }
+    },
+    "CuotaDeducible": 21.0
+  },
+  "PeriodoLiquidacion": {"Periodo": "01", "Ejercicio": 2020}
+}

--- a/l10n_es_vat_prorate/tests/json/sii_in_refund_p_iva10_bc_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_in_refund_p_iva10_bc_dict.json
@@ -1,0 +1,25 @@
+{
+  "IDFactura": {
+    "FechaExpedicionFacturaEmisor": "01-01-2020",
+    "NumSerieFacturaEmisor": "sup0002",
+    "IDEmisorFactura": {"NIF": "F35999705"}
+  },
+  "FacturaRecibida": {
+    "TipoFactura": "R4",
+    "TipoRectificativa": "I",
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"},
+    "DescripcionOperacion": "/",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "ImporteTotal": -110.0,
+    "FechaRegContable": "01-10-2020",
+    "DesgloseFactura": {
+      "DesgloseIVA": {
+        "DetalleIVA": [
+          {"BaseImponible": -100.0, "CuotaSoportada": -10.0, "TipoImpositivo": "10.0"}
+        ]
+      }
+    },
+    "CuotaDeducible": -2.0
+  },
+  "PeriodoLiquidacion": {"Periodo": "01", "Ejercicio": 2020}
+}

--- a/l10n_es_vat_prorate/tests/json/sii_in_refund_p_iva21_sp_in_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_in_refund_p_iva21_sp_in_dict.json
@@ -1,0 +1,25 @@
+{
+  "IDFactura": {
+    "FechaExpedicionFacturaEmisor": "01-01-2020",
+    "NumSerieFacturaEmisor": "sup0008",
+    "IDEmisorFactura": {"NIF": "F35999705"}
+  },
+  "FacturaRecibida": {
+    "TipoFactura": "R4",
+    "TipoRectificativa": "I",
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"},
+    "DescripcionOperacion": "/",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "ImporteTotal": -121.0,
+    "FechaRegContable": "01-10-2020",
+    "DesgloseFactura": {
+      "DesgloseIVA": {
+        "DetalleIVA": [
+          {"BaseImponible": -100.0, "CuotaSoportada": -21.0, "TipoImpositivo": "21.0"}
+        ]
+      }
+    },
+    "CuotaDeducible": -21.0
+  },
+  "PeriodoLiquidacion": {"Periodo": "01", "Ejercicio": 2020}
+}

--- a/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva0_sp_i_s_iva0_ic_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva0_sp_i_s_iva0_ic_dict.json
@@ -1,0 +1,36 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "F1",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseTipoOperacion": {
+        "PrestacionServicios": {
+          "NoSujeta": {
+            "ImporteTAIReglasLocalizacion": 100.0
+          }
+        },
+        "Entrega": {
+          "Sujeta": {
+            "Exenta": {
+              "DetalleExenta": [
+                {
+                  "BaseImponible": 200,
+                  "CausaExencion": "E5"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": 300.0,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_dict.json
@@ -1,0 +1,33 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "F1",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseFactura": {
+        "Sujeta": {
+          "NoExenta": {
+            "TipoNoExenta": "S1",
+            "DesgloseIVA": {
+              "DetalleIVA": [
+                {
+                  "TipoImpositivo": "10.0",
+                  "BaseImponible": 83.33,
+                  "CuotaRepercutida": 8.33
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": 91.66,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_s_irpf1_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_s_irpf1_dict.json
@@ -1,0 +1,33 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "F1",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseFactura": {
+        "Sujeta": {
+          "NoExenta": {
+            "TipoNoExenta": "S1",
+            "DesgloseIVA": {
+              "DetalleIVA": [
+                {
+                  "TipoImpositivo": "10.0",
+                  "BaseImponible": 83.33,
+                  "CuotaRepercutida": 8.33
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": 91.66,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_s_iva0_ns_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_s_iva0_ns_dict.json
@@ -1,0 +1,47 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "F1",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseTipoOperacion": {
+        "PrestacionServicios": {
+          "Sujeta": {
+            "Exenta": {
+              "DetalleExenta": [
+                {
+                  "BaseImponible": 200.0,
+                  "CausaExencion": "E5"
+                }
+              ]
+            }
+          }
+        },
+        "Entrega": {
+          "Sujeta": {
+            "NoExenta": {
+              "TipoNoExenta": "S1",
+              "DesgloseIVA": {
+                "DetalleIVA": [
+                  {
+                    "TipoImpositivo": "10.0",
+                    "BaseImponible": 100.0,
+                    "CuotaRepercutida": 10.0
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": 110.0,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_s_iva21s_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_s_iva21s_dict.json
@@ -1,0 +1,51 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "F1",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseTipoOperacion": {
+        "PrestacionServicios": {
+          "Sujeta": {
+            "NoExenta": {
+              "TipoNoExenta": "S1",
+              "DesgloseIVA": {
+                "DetalleIVA": [
+                  {
+                    "TipoImpositivo": "21.0",
+                    "BaseImponible": 200.0,
+                    "CuotaRepercutida": 42.0
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "Entrega": {
+          "Sujeta": {
+            "NoExenta": {
+              "TipoNoExenta": "S1",
+              "DesgloseIVA": {
+                "DetalleIVA": [
+                  {
+                    "TipoImpositivo": "10.0",
+                    "BaseImponible": 100.0,
+                    "CuotaRepercutida": 10.0
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": 352.0,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_s_req014_s_iva21s_s_req52_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_s_req014_s_iva21s_s_req52_dict.json
@@ -1,0 +1,55 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "F1",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseTipoOperacion": {
+        "PrestacionServicios": {
+          "Sujeta": {
+            "NoExenta": {
+              "TipoNoExenta": "S1",
+              "DesgloseIVA": {
+                "DetalleIVA": [
+                  {
+                    "TipoImpositivo": "21.0",
+                    "BaseImponible": 200.0,
+                    "CuotaRepercutida": 42.0,
+                    "CuotaRecargoEquivalencia": 10.4,
+                    "TipoRecargoEquivalencia": 5.2
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "Entrega": {
+          "Sujeta": {
+            "NoExenta": {
+              "TipoNoExenta": "S1",
+              "DesgloseIVA": {
+                "DetalleIVA": [
+                  {
+                    "TipoImpositivo": "10.0",
+                    "BaseImponible": 100.0,
+                    "CuotaRepercutida": 10.0,
+                    "CuotaRecargoEquivalencia": 1.4,
+                    "TipoRecargoEquivalencia": 1.4
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": 363.8,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva_e_s_iva0_e_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva_e_s_iva0_e_dict.json
@@ -1,0 +1,36 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "F1",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseTipoOperacion": {
+        "PrestacionServicios": {
+          "NoSujeta": {
+            "ImporteTAIReglasLocalizacion": 100.0
+          }
+        },
+        "Entrega": {
+          "Sujeta": {
+            "Exenta": {
+              "DetalleExenta": [
+                {
+                  "BaseImponible": 200,
+                  "CausaExencion": "E5"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": 300.0,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_vat_prorate/tests/json/sii_out_refund_s_iva0_sp_i_s_iva0_ic_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_refund_s_iva0_sp_i_s_iva0_ic_dict.json
@@ -1,0 +1,37 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "R1",
+    "TipoRectificativa": "I",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseTipoOperacion": {
+        "PrestacionServicios": {
+          "NoSujeta": {
+            "ImporteTAIReglasLocalizacion": -100.0
+          }
+        },
+        "Entrega": {
+          "Sujeta": {
+            "Exenta": {
+              "DetalleExenta": [
+                {
+                  "BaseImponible": -200.0,
+                  "CausaExencion": "E5"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": -300.0,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_vat_prorate/tests/json/sii_out_refund_s_iva10b_s_iva10b_s_iva21s_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_refund_s_iva10b_s_iva10b_s_iva21s_dict.json
@@ -1,0 +1,52 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "R1",
+    "TipoRectificativa": "I",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseTipoOperacion": {
+        "PrestacionServicios": {
+          "Sujeta": {
+            "NoExenta": {
+              "TipoNoExenta": "S1",
+              "DesgloseIVA": {
+                "DetalleIVA": [
+                  {
+                    "TipoImpositivo": "21.0",
+                    "BaseImponible": -200.0,
+                    "CuotaRepercutida": -42.0
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "Entrega": {
+          "Sujeta": {
+            "NoExenta": {
+              "TipoNoExenta": "S1",
+              "DesgloseIVA": {
+                "DetalleIVA": [
+                  {
+                    "TipoImpositivo": "10.0",
+                    "BaseImponible": -200.0,
+                    "CuotaRepercutida": -20.0
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": -462.0,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_vat_prorate/tests/json/sii_out_refund_s_iva_e_s_iva0_e_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_refund_s_iva_e_s_iva0_e_dict.json
@@ -1,0 +1,37 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "R1",
+    "TipoRectificativa": "I",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseTipoOperacion": {
+        "PrestacionServicios": {
+          "NoSujeta": {
+            "ImporteTAIReglasLocalizacion": -100.0
+          }
+        },
+        "Entrega": {
+          "Sujeta": {
+            "Exenta": {
+              "DetalleExenta": [
+                {
+                  "BaseImponible": -200.0,
+                  "CausaExencion": "E5"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": -300.0,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_vat_prorate/tests/test_prorate_sii.py
+++ b/l10n_es_vat_prorate/tests/test_prorate_sii.py
@@ -1,0 +1,125 @@
+from datetime import date
+from unittest import SkipTest
+
+from odoo.tests.common import tagged
+
+from odoo.addons.l10n_es_aeat_sii_oca.tests import test_l10n_es_aeat_sii
+
+
+@tagged("-at_install", "post_install")
+class TestSIIVatProrate(test_l10n_es_aeat_sii.TestL10nEsAeatSiiBase):
+    @classmethod
+    def _setup_records(cls):
+        if cls.env["ir.module.module"].search(
+            [("name", "=", "l10n_es_aeat_sii_oca"), ("state", "=", "installed")]
+        ):
+            # We want to avoid the execution of tests if it is not installed.
+            # SetUpClass does not allow SkipTest properly, so we need to do it twice,
+            # one here and one in setUp
+            raise SkipTest("l10n_es_aeat_sii_oca is not installed")
+        super()._setup_records()
+        cls.company.write(
+            {
+                "with_vat_prorate": True,
+                "vat_prorate_ids": [
+                    (0, 0, {"date": date(2000, 1, 1), "vat_prorate": 10}),
+                    (0, 0, {"date": date(2001, 1, 1), "vat_prorate": 20}),
+                ],
+            }
+        )
+
+    def setUp(self):
+        super().setUp()
+        if not self.env["ir.module.module"].search(
+            [("name", "=", "l10n_es_aeat_sii_oca"), ("state", "=", "installed")]
+        ):
+            # We want to avoid the execution of tests if it is not installed
+            self.skipTest("l10n_es_aeat_sii_oca is not installed")
+
+    def test_get_invoice_data(self):
+        mapping = [
+            ("out_invoice", [(100, ["s_iva10b"]), (200, ["s_iva21s"])], {}),
+            ("out_invoice", [(100, ["s_iva10b"]), (200, ["s_iva0_ns"])], {}),
+            (
+                "out_invoice",
+                [(100, ["s_iva10b", "s_req014"]), (200, ["s_iva21s", "s_req52"])],
+                {},
+            ),
+            (
+                "out_refund",
+                [(100, ["s_iva10b"]), (100, ["s_iva10b"]), (200, ["s_iva21s"])],
+                {},
+            ),
+            ("out_invoice", [(100, ["s_iva0_sp_i"]), (200, ["s_iva0_ic"])], {}),
+            ("out_refund", [(100, ["s_iva0_sp_i"]), (200, ["s_iva0_ic"])], {}),
+            ("out_invoice", [(100, ["s_iva_e"]), (200, ["s_iva0_e"])], {}),
+            ("out_refund", [(100, ["s_iva_e"]), (200, ["s_iva0_e"])], {}),
+            (
+                "in_invoice",
+                [(100, ["p_iva10_bc", "p_irpf19"]), (200, ["p_iva21_sc", "p_irpf19"])],
+                {
+                    "ref": "sup0001",
+                    "date": "2020-02-01",
+                    "sii_account_registration_date": "2020-10-01",
+                },
+            ),
+            (
+                "in_refund",
+                [(100, ["p_iva10_bc"])],
+                {"ref": "sup0002", "sii_account_registration_date": "2020-10-01"},
+            ),
+            (
+                "in_invoice",
+                [(100, ["p_iva10_bc", "p_req014"]), (200, ["p_iva21_sc", "p_req52"])],
+                {"ref": "sup0003", "sii_account_registration_date": "2020-10-01"},
+            ),
+            (
+                "in_invoice",
+                [(100, ["p_iva21_sp_ex"])],
+                {"ref": "sup0004", "sii_account_registration_date": "2020-10-01"},
+            ),
+            (
+                "in_invoice",
+                [(100, ["p_iva0_ns"]), (200, ["p_iva10_bc"])],
+                {"ref": "sup0005", "sii_account_registration_date": "2020-10-01"},
+            ),
+            # Out invoice with currency
+            ("out_invoice", [(100, ["s_iva10b"])], {"currency_id": self.usd.id}),
+            # Out invoice with currency and with not included in total amount
+            (
+                "out_invoice",
+                [(100, ["s_iva10b", "s_irpf1"])],
+                {"currency_id": self.usd.id},
+            ),
+            # In invoice with currency
+            (
+                "in_invoice",
+                [(100, ["p_iva10_bc"])],
+                {
+                    "ref": "sup0006",
+                    "sii_account_registration_date": "2020-10-01",
+                    "currency_id": self.usd.id,
+                },
+            ),
+            # In invoice with currency and with not included in total amount
+            (
+                "in_invoice",
+                [(100, ["p_iva10_bc", "p_irpf1"])],
+                {
+                    "ref": "sup0007",
+                    "sii_account_registration_date": "2020-10-01",
+                    "currency_id": self.usd.id,
+                },
+            ),
+            # Intra-community supplier refund with ImporteTotal with "one side"
+            (
+                "in_refund",
+                [(100, ["p_iva21_sp_in"])],
+                {"ref": "sup0008", "sii_account_registration_date": "2020-10-01"},
+            ),
+        ]
+        for inv_type, lines, extra_vals in mapping:
+            self._create_and_test_invoice_sii_dict(
+                inv_type, lines, extra_vals, module="l10n_es_vat_prorate"
+            )
+        return


### PR DESCRIPTION
Con este pequeño cambio el sistema es compatible con SII sin necesidad de un glue module como pasaba en 13.0

La mayor parte del código corresponde a diferentes tests para comprobar que toda la parte del SII funciona de forma correcta.