### PR TITLE
[13.0][IMP] l10n_es_intrastat_report: Improve tests to test an invoice with delivery address in a country other than the country of contact.

### DIFF
--- a/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
+++ b/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
@@ -12,7 +12,10 @@ class TestL10nIntraStatReport(SavepointCase):
         move_form = Form(cls.env["account.move"].with_context(default_type=inv_type))
         move_form.ref = "ABCDE"
         move_form.partner_id = partner
-        move_form.partner_shipping_id = partner
+        partner_shipping = partner.child_ids.filtered(lambda x: x.type == "delivery")
+        move_form.partner_shipping_id = (
+            partner_shipping if partner_shipping else partner
+        )
         with move_form.invoice_line_ids.new() as line_form:
             line_form.name = "test"
             line_form.quantity = 1.0
@@ -29,7 +32,15 @@ class TestL10nIntraStatReport(SavepointCase):
         cls.env.user.company_id.country_id = cls.env.ref("base.es").id
         # Create Intrastat partners
         cls.partner_1 = cls.env["res.partner"].create(
-            {"name": "Test Partner FR", "country_id": cls.env.ref("base.fr").id}
+            {"name": "Test Partner ES", "country_id": cls.env.ref("base.es").id}
+        )
+        cls.env["res.partner"].create(
+            {
+                "name": "Test Partner FR",
+                "country_id": cls.env.ref("base.fr").id,
+                "parent_id": cls.partner_1.id,
+                "type": "delivery",
+            }
         )
         cls.partner_2 = cls.env["res.partner"].create(
             {"name": "Test Partner PT", "country_id": cls.env.ref("base.pt").id}


### PR DESCRIPTION
Improve tests to test an invoice with delivery address in a country other than the country of contact.

Locked by:
- [x] `intrastat_product` https://github.com/OCA/intrastat-extrastat/pull/202

Please @pedrobaeza can you review it?

@Tecnativa TT40764