### PR TITLE
[13.0][FIX] l10n_es_aeat_sii_oca: Remove ISP taxes from NotIncludedInTotalNegative

### DIFF
--- a/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
@@ -255,9 +255,6 @@
         <field
             name="taxes"
             eval="[(6, 0, [
-                ref('l10n_es.account_tax_template_p_iva21_isp'),
-                ref('l10n_es.account_tax_template_p_iva10_isp'),
-                ref('l10n_es.account_tax_template_p_iva4_isp'),
                 ref('l10n_es.account_tax_template_p_iva21_sp_ex'),
                 ref('l10n_es.account_tax_template_p_iva10_sp_ex'),
                 ref('l10n_es.account_tax_template_p_iva4_sp_ex'),


### PR DESCRIPTION
Including `l10n_es.account_tax_template_p_iva*_isp` taxes in `NotIncludedInTotalNegative` map section actually adds tax amount to `ImporteTotal`. Removing them ImporteTotal becomes `BaseImponible`, that is the expected behavior according AEAT.

Fixes #2669