### PR TITLE
[13.0][FIX] delivery_seur: trackings

### DIFF
--- a/delivery_seur/models/delivery_carrier.py
+++ b/delivery_seur/models/delivery_carrier.py
@@ -173,6 +173,9 @@ class DeliveryCarrier(models.Model):
 
         seur_request = SeurRequest(self, picking)
         res = seur_request.tracking_state_update()
+        # We won't have tracking states when the shipping is just created
+        if not res:
+            return
         picking.tracking_state_history = res["tracking_state_history"]
         if "delivery_state" in res:
             picking.delivery_state = res["delivery_state"]


### PR DESCRIPTION
Depends on:

- [x] https://github.com/OCA/delivery-carrier/pull/579

SEUR trackings are gathered from the shipping reference (picking name for our case), not from the barcode. Did it change? Dit it ever work?

The main issue is that the tracking states were never getting to an end and as a result the tracking update cron would check them every time. Over time hundreds of pickings were being checked and causing subsequent blocks.

cc @Tecnativa TT40774

please review @pedrobaeza @victoralmau 