### PR TITLE
[15.0] [FIX] l10n_es_vat_book: Use aeat_identification_types

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -384,13 +384,24 @@ class L10nEsVatBook(models.Model):
             line_vals["line_type"] = "rectification_{}".format(line_type)
 
     def _check_exceptions(self, line_vals):
+        rp_model = self.env["res.partner"]
         if not line_vals["partner_id"]:
             line_vals["exception_text"] = _("Without Partner")
-        elif (
-            not line_vals["vat_number"]
-            and line_vals["partner_id"] not in self.get_pos_partner_ids()
-        ):
-            line_vals["exception_text"] = _("Without VAT")
+        elif not line_vals["vat_number"]:  # Doesn't have VAT
+            partner = rp_model.browse(line_vals["partner_id"])
+            country_code, identifier_type, vat_number = partner._parse_aeat_vat_info()
+            req_vat_identif_types = [
+                s_opt[0]
+                for s_opt in rp_model._fields["aeat_identification_type"].selection
+            ] + [
+                ""
+            ]  # "" is the identification type for Spain
+            # Partner type requires VAT
+            if (
+                identifier_type in req_vat_identif_types
+                and line_vals["partner_id"] not in self.get_pos_partner_ids()
+            ):
+                line_vals["exception_text"] = _("Without VAT")
 
     def create_vat_book_lines(self, move_lines, line_type, taxes):
         VatBookLine = self.env["l10n.es.vat.book.line"]

--- a/l10n_es_vat_book/models/l10n_es_vat_book_line.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book_line.py
@@ -32,7 +32,6 @@ class L10nEsVatBookLine(models.Model):
     invoice_date = fields.Date()
 
     partner_id = fields.Many2one(comodel_name="res.partner", string="Empresa")
-
     vat_number = fields.Char(string="NIF")
 
     vat_book_id = fields.Many2one(comodel_name="l10n.es.vat.book", string="Vat Book id")

--- a/l10n_es_vat_book/readme/CONTRIBUTORS.rst
+++ b/l10n_es_vat_book/readme/CONTRIBUTORS.rst
@@ -10,3 +10,4 @@
 * Fernando La Chica <fernandolachica@gmail.com>
 * Victor Garcia <victor.garcia@kayuulab.com>
 * Luis Lafaurie <ldlafaurie@gmail.com>
+* Eduardo de miguel <edu@moduon.team>

--- a/l10n_es_vat_book/views/l10n_es_vat_book.xml
+++ b/l10n_es_vat_book/views/l10n_es_vat_book.xml
@@ -11,21 +11,6 @@
             >
                 <attribute name="invisible">True</attribute>
             </button>
-            <header position="after">
-                <div
-                    class="alert alert-warning text-center"
-                    attrs="{'invisible': [('error_count', '=', 0)]}"
-                    role="alert"
-                >
-                    <span>
-                        You have <strong class="text-danger"><field
-                                name="error_count"
-                            /> errors</strong> in this report.
-                        You will not be able to <strong
-                        >confirm and submit</strong> it until they are resolved.
-                    </span>
-                </div>
-            </header>
             <header position="inside">
                 <button
                     name="view_issued_invoices"


### PR DESCRIPTION
Cherry-pick of https://github.com/OCA/l10n-spain/pull/2435