### PR TITLE
[10.0][FIX] l10n_es_account_bank_statement_import_n43: line.get('conceptos'…

### DIFF
--- a/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
+++ b/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
@@ -358,7 +358,7 @@ class AccountBankStatementImport(models.TransientModel):
             for line_vals in st_vals['transactions']:
                 if not line_vals.get('partner_id') and line_vals.get('note'):
                     line_vals['partner_id'] = self._get_partner(
-                        line_vals['note'],
+                        line_vals,
                     ).id
                 # This can't be used, as Odoo doesn't present the lines
                 # that already have a counterpart account as final


### PR DESCRIPTION
…) : 'unicode' object has no attribute 'get'

See issue https://github.com/OCA/l10n-spain/issues/766