### PR TITLE
[11.0][FIX] l10n_es_ticketbai - corregir tratamiento de fechas

### DIFF
--- a/l10n_es_ticketbai/tests/common.py
+++ b/l10n_es_ticketbai/tests/common.py
@@ -42,7 +42,7 @@ class TestL10nEsTicketBAI(TestL10nEsTicketBAIAPI):
             'account_id': self.account_receivable.id,
             'type': invoice_type,
             'date_invoice': date.today(),
-            'tbai_date_operation': date.today(),
+            'date': date.today(),
             'fiscal_position_id': fp.id,
             'company_id': company_id or self.main_company.id
         })

--- a/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
+++ b/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Binovo IT Human Project SL
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import logging
-from datetime import date
+from datetime import date, timedelta
 from odoo import exceptions
 from odoo.tests import common
 from .common import TestL10nEsTicketBAI
@@ -33,6 +33,7 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
     def test_invoice_out_of_term(self):
         invoice = self.create_draft_invoice(
             self.account_billing.id, self.fiscal_position_national)
+        invoice.date = date(2021, 12, 31)
         invoice.date_invoice = date(2021, 12, 31)
         invoice.onchange_fiscal_position_id_tbai_vat_regime_key()
         invoice.compute_taxes()
@@ -495,3 +496,9 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
         for journal in journals:
             self.assertEqual(journal.sequence_id.suffix, '')
             self.assertEqual(journal.refund_sequence, True)
+
+    def test_invoice_out_check_dates(self):
+        invoice = self.create_draft_invoice(
+            self.account_billing.id, self.fiscal_position_national)
+        with self.assertRaises(exceptions.ValidationError):
+            invoice.date = date.today() + timedelta(days=45)

--- a/l10n_es_ticketbai/views/account_invoice_views.xml
+++ b/l10n_es_ticketbai/views/account_invoice_views.xml
@@ -22,7 +22,7 @@
                                        attrs="{'invisible': [('tbai_invoice_id', '=', False)]}"/>
                                 <field name="tbai_cancellation_id" readonly="1" options="{'no_create':True}"
                                        attrs="{'invisible': [('tbai_cancellation_id', '=', False)]}"/>
-                                <field name="tbai_date_operation" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
+                                <field name="date" string="Operation Date" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                 <field name="tbai_description_operation" widget="char" attrs="{'required': [('tbai_enabled', '=', True)], 'readonly': [('state', '!=', 'draft')]}"/>
                             </group>
                         </group>


### PR DESCRIPTION
Nos hemos encontrado un problema con respecto a las fechas en las facturas emitidas. Existen dos fechas:
- Fecha expedición: en Odoo sería fecha factura (`date_invoice`)
- Fecha operación: opcional, en Odoo actualmente es el campo `tbai_date_operation`

Nos comentan desde hacienda que el devengo del IVA debe hacerse con respecto a la fecha operación, es decir, en Odoo el asiento debe crearse en base a esta fecha (porque el cálculo de los IVAs se hace en base a ella). Actualmente el campo `tbai_date_operation` solo se tiene en cuenta para informar a hacienda de la fecha operación, pero no se tiene en cuenta para la generación del asiento.

Con lo cual, nuestra propuesta en este PR es:
- Fecha operación: hacer visible el campo `date` (fecha contable de Odoo) en la vista de facturas emitidas, y eliminar el campo `tbai_date_operation`.  Además controlamos que la fecha de operación no sea mayor que la fecha de factura. 
- Fecha expedición: tener en cuenta que ahora se puede modificar el campo `date`

No tenemos claro qué hacer con el valor del campo `tbai_date_operation` en un posible pre-migration, porque si lo trasladamos al campo `date` incurrimos también en otra incongruencia: los asientos de esas facturas no se han generado teniendo en cuenta esa fecha. ¿Sugerencias?