### PR TITLE
[13.0][FIX] l10n_es_aeat: Avoid error on record initialization

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -194,6 +194,9 @@ class L10nEsAeatReport(models.AbstractModel):
         string="Currency",
         readonly=True,
         related="company_id.currency_id",
+        # Needed for initializing the value on time for avoiding an error when being
+        # used for compute methods
+        default=lambda self: self.env.company.currency_id,
     )
     period_type = fields.Selection(
         selection="get_period_type_selection",


### PR DESCRIPTION
On the v13 ORM, the related fields are not initialized on time before doing the rest of the computations, including computed fields, so we get an empty currency for doing the rounds, obtaining a crash.

For avoiding this, let's include a default value on the related field that allows it to be initialized on time.

This doesn't happen on v14+.

@Tecnativa TT40824