### PR TITLE
[14.0][FIX] l10n_es_facturae_face: "Sending method" field is not displayed on partner's main view (only in the child view)

### DIFF
--- a/l10n_es_facturae_face/readme/CONTRIBUTORS.rst
+++ b/l10n_es_facturae_face/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Enric Tobella <etobella@creublanca.es>
+* Eric Antones <eantones@nuobit.com>

--- a/l10n_es_facturae_face/views/res_partner.xml
+++ b/l10n_es_facturae_face/views/res_partner.xml
@@ -7,9 +7,18 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="l10n_es_facturae.view_partner_form" />
         <field name="arch" type="xml">
-            <field name="facturae_version" position="before">
+            <xpath
+                expr="//field[@name='child_ids']/form/sheet/group//field[@name='facturae_version']"
+                position="before"
+            >
                 <field name="l10n_es_facturae_sending_code" />
-            </field>
+            </xpath>
+            <xpath
+                expr="//group[@name='group_facturae']/field[@name='facturae_version']"
+                position="before"
+            >
+                <field name="l10n_es_facturae_sending_code" />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
The "Sending method" field is not displayed in the partner's view, so it is not possible to set it as "FACe" and therefore EDI records are not created when validating invoices