### PR TITLE
[14.0] [IMP] Facturae

### DIFF
--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -92,10 +92,14 @@ class AccountMove(models.Model):
     @api.depends("partner_id.facturae", "move_type")
     def _compute_facturae(self):
         for record in self:
-            record.facturae = record.partner_id.facturae and record.move_type in [
-                "out_invoice",
-                "out_refund",
-            ]
+            record.facturae = (
+                record.commercial_partner_id.facturae
+                and record.move_type
+                in [
+                    "out_invoice",
+                    "out_refund",
+                ]
+            )
 
     def get_exchange_rate(self, euro_rate, currency_rate):
         if not euro_rate and not currency_rate:

--- a/l10n_es_facturae/models/res_partner.py
+++ b/l10n_es_facturae/models/res_partner.py
@@ -9,6 +9,7 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     facturae = fields.Boolean("Factura electrónica")
+    parent_facturae = fields.Boolean(related="commercial_partner_id.facturae")
     facturae_version = fields.Selection(
         [("3_2", "3.2"), ("3_2_1", "3.2.1"), ("3_2_2", "3.2.2")]
     )

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -93,9 +93,12 @@
             </t>
             <t
                 t-call="l10n_es_facturae.administrative_center"
-                t-if="partner.organo_proponente"
+                t-if="administrative_partner.organo_proponente or partner.organo_proponente"
             >
-                <t t-set="centre_code" t-value="partner.organo_proponente" />
+                <t
+                    t-set="centre_code"
+                    t-value="administrative_partner.organo_proponente or partner.organo_proponente"
+                />
                 <t t-set="role_type_code" t-value="'04'" />
             </t>
         </AdministrativeCentres>

--- a/l10n_es_facturae/views/res_partner_view.xml
+++ b/l10n_es_facturae/views/res_partner_view.xml
@@ -24,12 +24,13 @@
             </xpath>
             <group name='accounting_entries' position="inside">
                 <field name="facturae" />
+                <field name="parent_facturae" invisible="1" />
             </group>
             <group name="accounting_entries" position="after">
                 <group
                     name="group_facturae"
                     string="Facturae"
-                    attrs="{'invisible': [('facturae', '=', False)]}"
+                    attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)]}"
                 >
                     <field name="facturae_version" />
                     <field
@@ -48,6 +49,29 @@
                     <field name="attach_invoice_as_annex" />
                 </group>
             </group>
+            <page name="accounting_disabled" position="inside">
+                <group
+                    name="group_facturae"
+                    string="Facturae"
+                    attrs="{'invisible': ['|', ('type', '!=', 'invoice'), ('parent_facturae', '=', False)]}"
+                >
+                <field name="facturae_version" />
+                <field
+                        name="organo_gestor"
+                        attrs="{'required': [('facturae', '=', True)]}"
+                    />
+                <field
+                        name="unidad_tramitadora"
+                        attrs="{'required': [('facturae', '=', True)]}"
+                    />
+                <field
+                        name="oficina_contable"
+                        attrs="{'required': [('facturae', '=', True)]}"
+                    />
+                <field name="organo_proponente" />
+                <field name="attach_invoice_as_annex" />
+            </group>
+            </page>
         </field>
     </record>
 </odoo>

--- a/l10n_es_facturae_face/components/account_move_l10n_es_facturae_listener.py
+++ b/l10n_es_facturae_face/components/account_move_l10n_es_facturae_listener.py
@@ -23,9 +23,9 @@ class AccountMoveL10nEsFacturaeListener(Component):
         for record in records:
             if record.disable_edi_auto:
                 continue
-            partner = record.partner_id
             if record.move_type not in ["out_invoice", "out_refund"]:
                 continue
+            partner = record.commercial_partner_id
             if not partner.facturae or not partner.l10n_es_facturae_sending_code:
                 continue
             backend = self._get_backend(record)

--- a/l10n_es_facturae_face/data/edi.xml
+++ b/l10n_es_facturae_face/data/edi.xml
@@ -12,10 +12,11 @@
         <field name="exchange_filename_pattern">{record_name}--{dt}</field>
         <field name="exchange_file_ext">xsig</field>
         <field name="model_ids" eval="[(4, ref('account.model_account_move'))]" />
+        <field name="model_manual_btn" eval="True" />
         <field name="exchange_file_auto_generate" eval="True" />
         <field
             name="enable_domain"
-        >[('state', '!=', 'draft'), ('partner_id', '!=', False), ('partner_id.l10n_es_facturae_sending_code', '=', "face"),('move_type', 'in', ['out_invoice', 'out_refund'])]</field>
+        >[('state', '!=', 'draft'), ('commercial_partner_id', '!=', False), ('commercial_partner_id.l10n_es_facturae_sending_code', '=', "face"),('move_type', 'in', ['out_invoice', 'out_refund'])]</field>
         <field
             name="enable_snippet"
         >result = not record._has_exchange_record(exchange_type)</field>


### PR DESCRIPTION
Este PR incluye los cambios para que se muestre correcatamente los datos de factura electrónica a nivel de partner y comercial_partner
Usa la configuración del segundo para decidir si se envía a FACe
Incluye un commit que no se añadió en su momento para deshabilitar el envío automático.