### PR TITLE
[14.0][FIX] l10n_es_ticketbai_batuz - corregir filtered y tener en cuenta checkbox de diario

### DIFF
--- a/l10n_es_ticketbai_batuz/models/account_move.py
+++ b/l10n_es_ticketbai_batuz/models/account_move.py
@@ -740,6 +740,7 @@ class AccountMove(models.Model):
     def action_send_lroe_manually(self):
         lroe_invoices = self.sudo().filtered(
             lambda x: x.tbai_enabled
+            and x.tbai_send_invoice
             and (
                 x.move_type == "in_invoice"
                 or (
@@ -749,6 +750,7 @@ class AccountMove(models.Model):
                     in (RefundType.differences.value, RefundType.substitution.value)
                 )
             )
+            and x.invoice_date >= x.journal_id.tbai_active_date
         )
         for lroe_invoice in lroe_invoices:
             if lroe_invoice.lroe_state in (
@@ -798,7 +800,7 @@ class AccountMove(models.Model):
         res = super().button_cancel()
         lroe_invoices = self.sudo().filtered(
             lambda x: x.tbai_enabled
-            and x.invoice_date >= x.journal_id.tbai_active_date
+            and x.tbai_send_invoice
             and x.lroe_state not in ("error")
             and (
                 x.move_type == "in_invoice"
@@ -809,6 +811,7 @@ class AccountMove(models.Model):
                     in (RefundType.differences.value, RefundType.substitution.value)
                 )
             )
+            and x.invoice_date >= x.journal_id.tbai_active_date
         )
         for invoice in lroe_invoices:
             if invoice.lroe_state == "recorded":
@@ -834,7 +837,7 @@ class AccountMove(models.Model):
         res = super(AccountMove, self)._post(soft)
         lroe_invoices = self.sudo().filtered(
             lambda x: x.tbai_enabled
-            and x.invoice_date >= x.journal_id.tbai_active_date
+            and x.tbai_send_invoice
             and (
                 x.move_type == "in_invoice"
                 or (
@@ -844,6 +847,7 @@ class AccountMove(models.Model):
                     in (RefundType.differences.value, RefundType.substitution.value)
                 )
             )
+            and x.invoice_date >= x.journal_id.tbai_active_date
         )
         for lroe_invoice in lroe_invoices:
             if lroe_invoice.lroe_state in (


### PR DESCRIPTION
Al registrar el pago de una factura da error al no tener `invoice_date`
Modificamos el orden en el filtered y añadimos el criterio de que el diario tenga marcado el envío de facturas.