### PR TITLE
[11.0][ADD] l10n_es_extra_data: añadir 0% para alimentación

### DIFF
--- a/l10n_es_extra_data/README.rst
+++ b/l10n_es_extra_data/README.rst
@@ -78,6 +78,10 @@ Contributors
 
   * Vicent Cubells
 
+* `Acysos SL <https://www.acysos.es>`__:
+
+  * Ignacio Ibeas
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/l10n_es_extra_data/__manifest__.py
+++ b/l10n_es_extra_data/__manifest__.py
@@ -17,5 +17,6 @@
     "data": [
         "data/account_data.xml",
         "data/account_tax_data.xml",
+        "data/account_fiscal_position_template_data.xml",
     ],
 }

--- a/l10n_es_extra_data/data/account_data.xml
+++ b/l10n_es_extra_data/data/account_data.xml
@@ -3,4 +3,10 @@
     <record id="tax_group_iva_5" model="account.tax.group">
         <field name="name">IVA 5%</field>
     </record>
+    <record id="tax_group_recargo_0" model="account.tax.group">
+        <field name="name">Recargo de Equivalencia 0%</field>
+    </record>
+    <record id="tax_group_recargo_0-62" model="account.tax.group">
+        <field name="name">Recargo de Equivalencia 0.62%</field>
+    </record>
 </odoo>

--- a/l10n_es_extra_data/data/account_fiscal_position_template_data.xml
+++ b/l10n_es_extra_data/data/account_fiscal_position_template_data.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="fptt_extra_0a" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_extra"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva0_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_p_iva0_ia"/>
+    </record>
+    <record id="fptt_extra_5a" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_extra"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva5_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_p_iva5_ia"/>
+    </record>
+    <record id="fptt_intra_0a" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_intra"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva0_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_p_iva0_ic_a"/>
+    </record>
+    <record id="fptt_intra_5a" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_intra"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva5_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_p_iva5_ic_a"/>
+    </record>
+    <record id="fptt_recargo_0a" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_recargo"/>
+        <field name="tax_src_id" ref="account_tax_template_s_iva0_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_s_iva0_a"/>
+    </record>
+    <record id="fptt_recargo_0a_2"
+        model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_recargo"/>
+        <field name="tax_src_id" ref="account_tax_template_s_iva0_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_s_req0"/>
+    </record>
+    <record id="fptt_recargo_5a" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_recargo"/>
+        <field name="tax_src_id" ref="account_tax_template_s_iva5_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_s_iva5_a"/>
+    </record>
+    <record id="fptt_recargo_5a_2"
+        model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_recargo"/>
+        <field name="tax_src_id" ref="account_tax_template_s_iva5_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_s_req062"/>
+    </record>
+    <record id="fptt_recargo_buy_0a"
+        model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_recargo"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva0_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_p_iva0_a"/>
+    </record>
+    <record id="fptt_recargo_buy_0a_2"
+        model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_recargo"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva0_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_p_req0"/>
+    </record>
+    <record id="fptt_recargo_buy_5a"
+        model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_recargo"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva5_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_p_iva5_a"/>
+    </record>
+    <record id="fptt_recargo_buy_5a_2"
+        model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_recargo"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva5_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_p_req062"/>
+    </record>
+    <record id="fptt_reagyp_a_0a_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_reagyp_a"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva0_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_p_iva0_a"/>
+    </record>
+    <record id="fptt_reagyp_a_0a_2" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_reagyp_a"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva0_a"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf2"/>
+    </record>
+    <record id="fptt_reagyp_a_5a_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_reagyp_a"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva5_a"/>
+        <field name="tax_dest_id" ref="account_tax_template_p_iva5_a"/>
+    </record>
+    <record id="fptt_reagyp_a_5a_2" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="l10n_es.fp_reagyp_a"/>
+        <field name="tax_src_id" ref="account_tax_template_p_iva5_a"/>
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf2"/>
+    </record>
+</odoo>

--- a/l10n_es_extra_data/data/account_tax_data.xml
+++ b/l10n_es_extra_data/data/account_tax_data.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="account_tax_template_p_iva5_sc" model="account.tax.template">
-        <field name="description"/> <!-- for resetting the value on existing DBs -->
         <field name="type_tax_use">purchase</field>
         <field name="account_id" ref="l10n_es.account_common_472"/>
-        <field name="name">5% IVA soportado</field>
+        <field name="name">5% IVA soportado (Servicios corrientes)</field>
         <field name="refund_account_id" ref="l10n_es.account_common_472"/>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="5"/>
@@ -13,15 +12,184 @@
         <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_28_29'), ref('l10n_es.mod_303_40_41')])]"/>
     </record>
     <record id="account_tax_template_s_iva5s" model="account.tax.template">
-        <field name="description"/> <!-- for resetting the value on existing DBs -->
         <field name="type_tax_use">sale</field>
         <field name="account_id" ref="l10n_es.account_common_477"/>
-        <field name="name">IVA 5%</field>
+        <field name="name">IVA 5% (Servicios corrientes)</field>
         <field name="refund_account_id" ref="l10n_es.account_common_477"/>
         <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
         <field name="amount" eval="5"/>
         <field name="amount_type">percent</field>
         <field name="tax_group_id" ref="tax_group_iva_5"/>
         <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_01_03'), ref('l10n_es.mod_303_14_15_sale')])]"/>
+    </record>
+    <record id="account_tax_template_p_iva5_a" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="name">5% IVA soportado (Alimentos)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_5"/>
+    </record>
+    <record id="account_tax_template_s_iva5_a" model="account.tax.template">
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="l10n_es.account_common_477"/>
+        <field name="name">IVA 5% (Alimentos)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_477"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_5"/>
+    </record>
+    <record id="account_tax_template_p_iva0_a" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="name">0% IVA soportado (Alimentos)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="l10n_es.tax_group_iva_0"/>
+    </record>
+    <record id="account_tax_template_s_iva0_a" model="account.tax.template">
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="l10n_es.account_common_477"/>
+        <field name="name">IVA 0% (Alimentos)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_477"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="l10n_es.tax_group_iva_0"/>
+    </record>
+    <record id="account_tax_template_p_iva0_ic_a_1" model="account.tax.template">
+        <field name="description">P_IVA0_IC_A_1</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="sequence" eval="10"/>
+        <field name="name">IVA 0% Adquisición Intracomunitaria. Alimentos (1)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="l10n_es.tax_group_iva_0"/>
+    </record>
+    <record id="account_tax_template_p_iva0_ic_a_2" model="account.tax.template">
+        <field name="description">P_IVA0_IC_A_2</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_477"/>
+        <field name="sequence" eval="20"/>
+        <field name="name">IVA 0% Adquisición Intracomunitaria. Alimentos (2)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_477"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="-0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="l10n_es.tax_group_iva_0"/>
+    </record>
+    <record id="account_tax_template_p_iva0_ic_a" model="account.tax.template">
+        <field name="amount" eval="100"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount_type">group</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA 0% Adquisición Intracomunitaria. Alimentos</field>
+        <field name="children_tax_ids" eval="[(6, 0, [ref('account_tax_template_p_iva0_ic_a_1'), ref('account_tax_template_p_iva0_ic_a_2')])]"/>
+        <field name="tax_group_id" ref="l10n_es.tax_group_iva_0"/>
+    </record>
+    <record id="account_tax_template_p_iva5_ic_a_1" model="account.tax.template">
+        <field name="description">P_IVA5_IC_A_1</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="sequence" eval="10"/>
+        <field name="name">IVA 5% Adquisición Intracomunitaria. Alimentos (1)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_5"/>
+    </record>
+    <record id="account_tax_template_p_iva5_ic_a_2" model="account.tax.template">
+        <field name="description">P_IVA5_IC_A_2</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_477"/>
+        <field name="sequence" eval="20"/>
+        <field name="name">IVA 5% Adquisición Intracomunitaria. Alimentos (2)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_477"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="-5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_5"/>
+    </record>
+    <record id="account_tax_template_p_iva5_ic_a" model="account.tax.template">
+
+        <field name="amount" eval="100"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount_type">group</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IVA 5% Adquisición Intracomunitaria. Alimentos</field>
+        <field name="children_tax_ids" eval="[(6, 0, [ref('account_tax_template_p_iva5_ic_a_1'), ref('account_tax_template_p_iva5_ic_a_2')])]"/>
+        <field name="tax_group_id" ref="tax_group_iva_5"/>
+    </record>
+    <record id="account_tax_template_p_iva0_ia" model="account.tax.template">
+
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="name">IVA 0% Importaciones bienes corrientes</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="l10n_es.tax_group_iva_0"/>
+    </record>
+    <record id="account_tax_template_p_iva5_ia" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="name">IVA 5% Importaciones bienes corrientes</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_5"/>
+    </record>
+    <record id="account_tax_template_s_req0" model="account.tax.template">
+        <field name="description">0% Rec. Eq.</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="l10n_es.account_common_477"/>
+        <field name="name">0% Recargo Equivalencia Ventas</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_477"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_0"/>
+    </record>
+    <record id="account_tax_template_s_req062" model="account.tax.template">
+        <field name="description">0.62% Rec. Eq.</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="l10n_es.account_common_477"/>
+        <field name="name">0.62% Recargo Equivalencia Ventas</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_477"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0.62"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_0-62"/>
+    </record>
+    <record id="account_tax_template_p_req0" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="name">0% Recargo Equivalencia Compras</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_0"/>
+    </record>
+    <record id="account_tax_template_p_req062" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="name">0.62% Recargo Equivalencia Compras</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0.62"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_0-62"/>
     </record>
 </odoo>

--- a/l10n_es_extra_data/readme/CONTRIBUTORS.rst
+++ b/l10n_es_extra_data/readme/CONTRIBUTORS.rst
@@ -1,3 +1,7 @@
 * `Trey Kilobytes de Soluciones SL <https://www.trey.es>`__:
 
   * Vicent Cubells
+
+* `Acysos SL <https://www.acysos.es>`__:
+
+  * Ignacio Ibeas


### PR DESCRIPTION
Hola,

Añade los impuestos nuevos para la alimentación. Faltaría 303, Aeat ha indicado usar una casilla nueva pero no la especificado y el SII que se registrarán en el SII en el Libro Registro de Facturas emitidas, indicando 02 como clave de régimen especial, consignando "Sujeta" y "Exenta" dentro del bloque "Desglose Factura", indicando la base imponible y, opcionalmente, como causa de exención E6.

Saludos