### PR TITLE
Add 11.0 l10n es extra data l10n es ticketbai nuevos ivas

### DIFF
--- a/l10n_es_extra_data/__manifest__.py
+++ b/l10n_es_extra_data/__manifest__.py
@@ -17,5 +17,6 @@
     "data": [
         "data/account_data.xml",
         "data/account_tax_data.xml",
+        "data/account_fiscal_position_template_data.xml",
     ],
 }

--- a/l10n_es_extra_data/data/account_data.xml
+++ b/l10n_es_extra_data/data/account_data.xml
@@ -3,4 +3,13 @@
     <record id="tax_group_iva_5" model="account.tax.group">
         <field name="name">IVA 5%</field>
     </record>
+    <record id="tax_group_iva_0_no_e" model="account.tax.group">
+        <field name="name">IVA 0% (No exento)</field>
+    </record>
+    <record id="tax_group_recargo_0_625" model="account.tax.group">
+        <field name="name">Recargo de Equivalencia 0.625%</field>
+    </record>
+    <record id="tax_group_recargo_0" model="account.tax.group">
+        <field name="name">Recargo de Equivalencia 0%</field>
+    </record>
 </odoo>

--- a/l10n_es_extra_data/data/account_fiscal_position_template_data.xml
+++ b/l10n_es_extra_data/data/account_fiscal_position_template_data.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <!-- Recargo de equivalencia -->
+        <record id="fptt_recargo_0b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="l10n_es.fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva0b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva0b"/>
+        </record>
+        <record id="fptt_recargo_0b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="l10n_es.fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva0b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_req0"/>
+        </record>
+        <record id="fptt_recargo_5b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="l10n_es.fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva5b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_iva5b"/>
+        </record>
+        <record id="fptt_recargo_5b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="l10n_es.fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_s_iva5b"/>
+            <field name="tax_dest_id" ref="account_tax_template_s_req0625"/>
+        </record>
+
+        <record id="fptt_recargo_buy_0b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="l10n_es.fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva0_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva0_bc"/>
+        </record>
+        <record id="fptt_recargo_buy_0b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="l10n_es.fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva0_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_req0"/>
+        </record>
+        <record id="fptt_recargo_buy_5b" model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="l10n_es.fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva5_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_iva5_bc"/>
+        </record>
+        <record id="fptt_recargo_buy_5b_2"
+            model="account.fiscal.position.tax.template">
+            <field name="position_id" ref="l10n_es.fp_recargo"/>
+            <field name="tax_src_id" ref="account_tax_template_p_iva5_bc"/>
+            <field name="tax_dest_id" ref="account_tax_template_p_req0625"/>
+        </record>
+
+    </data>
+</odoo>

--- a/l10n_es_extra_data/data/account_tax_data.xml
+++ b/l10n_es_extra_data/data/account_tax_data.xml
@@ -24,4 +24,104 @@
         <field name="tax_group_id" ref="tax_group_iva_5"/>
         <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_01_03'), ref('l10n_es.mod_303_14_15_sale')])]"/>
     </record>
+
+    <record id="account_tax_template_p_iva5_bc" model="account.tax.template">
+        <field name="description"/> <!-- for resetting the value on existing DBs -->
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="name">5% IVA soportado (bienes corrientes)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_5"/>
+        <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_28_29'), ref('l10n_es.mod_303_40_41')])]"/>
+    </record>
+    <record id="account_tax_template_s_iva5b" model="account.tax.template">
+        <field name="description"/> <!-- for resetting the value on existing DBs -->
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="l10n_es.account_common_477"/>
+        <field name="name">IVA 5% (Bienes)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_477"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="5"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_5"/>
+        <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_04_06'), ref('l10n_es.mod_303_14_15_sale')])]"/>
+    </record>
+
+    <record id="account_tax_template_p_iva0_bc" model="account.tax.template">
+        <field name="description"/> <!-- for resetting the value on existing DBs -->
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="name">0% IVA soportado (bienes corrientes)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_0_no_e"/>
+        <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_28_29'), ref('l10n_es.mod_303_40_41')])]"/>
+    </record>
+    <record id="account_tax_template_s_iva0b" model="account.tax.template">
+        <field name="description"/> <!-- for resetting the value on existing DBs -->
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="l10n_es.account_common_477"/>
+        <field name="name">IVA 0% (Bienes)</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_477"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_iva_0_no_e"/>
+        <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_14_15_sale'), ref('l10n_es.mod_303_01_03')])]"/>
+    </record>
+
+    <record id="account_tax_template_s_req0625" model="account.tax.template">
+        <field name="description"/> <!-- for resetting the value on existing DBs -->
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="l10n_es.account_common_477"/>
+        <field name="name">0.625% Recargo Equivalencia Ventas</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_477"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0.625"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_0_625"/>
+        <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_19_21'), ref('l10n_es.mod_303_25_26')])]"/>
+    </record>
+    <record id="account_tax_template_p_req0625" model="account.tax.template">
+        <field name="description"/> <!-- for resetting the value on existing DBs -->
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="name">0.625% Recargo Equivalencia Compras</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0.625"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_0_625"/>
+        <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_28_29'), ref('l10n_es.mod_303_40_41')])]"/>
+    </record>
+
+    <record id="account_tax_template_s_req0" model="account.tax.template">
+        <field name="description"/> <!-- for resetting the value on existing DBs -->
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="l10n_es.account_common_477"/>
+        <field name="name">0% Recargo Equivalencia Ventas</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_477"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_0"/>
+        <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_19_21'), ref('l10n_es.mod_303_25_26')])]"/>
+    </record>
+    <record id="account_tax_template_p_req0" model="account.tax.template">
+        <field name="description"/> <!-- for resetting the value on existing DBs -->
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="l10n_es.account_common_472"/>
+        <field name="name">0% Recargo Equivalencia Compras</field>
+        <field name="refund_account_id" ref="l10n_es.account_common_472"/>
+        <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+        <field name="amount" eval="0"/>
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_recargo_0"/>
+        <field name="tag_ids" eval="[(6, False, [ref('l10n_es.mod_303_28_29'), ref('l10n_es.mod_303_40_41')])]"/>
+    </record>
 </odoo>

--- a/l10n_es_ticketbai/__manifest__.py
+++ b/l10n_es_ticketbai/__manifest__.py
@@ -21,6 +21,7 @@
     "depends": [
         "base_vat",
         "l10n_es",
+        "l10n_es_extra_data",
         "l10n_es_aeat",
         "l10n_es_aeat_certificate",
         "l10n_es_ticketbai_api",

--- a/l10n_es_ticketbai/data/tax_map_data.xml
+++ b/l10n_es_ticketbai/data/tax_map_data.xml
@@ -9,6 +9,8 @@
                 ref('l10n_es.account_tax_template_s_iva21b'),
                 ref('l10n_es.account_tax_template_s_iva4b'),
                 ref('l10n_es.account_tax_template_s_iva10b'),
+                ref('l10n_es_extra_data.account_tax_template_s_iva5b'),
+                ref('l10n_es_extra_data.account_tax_template_s_iva0b'),
             ])]"/>
             <field name="name">Bienes</field>
         </record>
@@ -74,6 +76,8 @@
                 ref('l10n_es.account_tax_template_s_req52'),
                 ref('l10n_es.account_tax_template_s_req014'),
                 ref('l10n_es.account_tax_template_s_req05'),
+                ref('l10n_es_extra_data.account_tax_template_s_req0625'),
+                ref('l10n_es_extra_data.account_tax_template_s_req0'),
             ])]"/>
             <field name="name">Recargo Equivalencia</field>
         </record>

--- a/l10n_es_ticketbai/models/account_invoice_tax.py
+++ b/l10n_es_ticketbai/models/account_invoice_tax.py
@@ -144,7 +144,13 @@ class AccountInvoiceTax(models.Model):
     def tbai_get_value_tipo_recargo_equivalencia(self):
         re_invoice_tax = self.tbai_get_associated_re_tax()
         if re_invoice_tax:
-            res = "%.2f" % abs(re_invoice_tax.tax_id.amount)
+            if (
+                self.env.ref("l10n_es_extra_data.tax_group_recargo_0_625").id
+                == re_invoice_tax.tax_id.tax_group_id.id
+            ):
+                res = "%.3f" % abs(re_invoice_tax.tax_id.amount)
+            else:
+                res = "%.2f" % abs(re_invoice_tax.tax_id.amount)
         else:
             res = None
         return res


### PR DESCRIPTION
Añadir nuevos IVAs del 5% y 0% de BIenes y sus correspondiente recargos de equivalencia del 0.625% y 0% respectivamente en relación al RD 20/2022 y ajustar mapeo TicketBai teniendo en cuenta a demás los 3 decimales del nuevo recargo de equivalencia.