### PR TITLE
[12.0][FIX] l10n_es_ticketbai_api_batuz - normalizar cálculo de ejercicio

### DIFF
--- a/l10n_es_ticketbai_api_batuz/lroe/lroe_api.py
+++ b/l10n_es_ticketbai_api_batuz/lroe/lroe_api.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from requests import exceptions
 import json
-from datetime import datetime
 from odoo.addons.l10n_es_ticketbai_api.ticketbai.api import TicketBaiApi
 from odoo.tools.safe_eval import safe_eval
 import logging
@@ -64,14 +63,6 @@ class LROETicketBaiApi(TicketBaiApi):
 
             def set_eus_bizkaia_n3_data():
 
-                def get_fiscal_year():
-                    if lroe_operation.tbai_invoice_ids:
-                        return str(datetime.strptime(
-                            lroe_operation.tbai_invoice_ids[0]
-                            .expedition_date, '%d-%m-%Y').date().year)
-                    else:
-                        return str(datetime.now().year)
-
                 if hasattr(lroe_operation, "lroe_chapter_id"):
                     apa = (
                         lroe_operation.lroe_subchapter_id.code
@@ -90,7 +81,7 @@ class LROETicketBaiApi(TicketBaiApi):
                     },
                     'drs': {
                         'mode': lroe_operation.model,
-                        'ejer': get_fiscal_year()}
+                        'ejer': lroe_operation.build_cabecera_ejercicio()}
                 }
                 return json.dumps(n3_dat_dict)
 

--- a/l10n_es_ticketbai_api_batuz/models/lroe_operation.py
+++ b/l10n_es_ticketbai_api_batuz/models/lroe_operation.py
@@ -278,14 +278,9 @@ class LROEOperation(models.Model):
     def build_cabecera_ejercicio(self):
         self.ensure_one()
         if self.tbai_invoice_ids:
-            if self.type == LROEOperationEnum.create.value:
-                return str(datetime.strptime(
-                    self.tbai_invoice_ids[0].expedition_date,
-                    '%d-%m-%Y').year)
-            elif self.type == LROEOperationEnum.cancel.value:
-                return str(datetime.strptime(
-                    self.tbai_invoice_ids[0].expedition_date,
-                    '%d-%m-%Y').year)
+            return str(datetime.strptime(
+                self.tbai_invoice_ids[0].expedition_date,
+                '%d-%m-%Y').year)
         elif self.invoice_ids and self.invoice_ids[0].date:
             date = fields.Date.from_string(self.invoice_ids[0].date)
             return str(date.year)

--- a/l10n_es_ticketbai_api_batuz/tests/test_lroe_api.py
+++ b/l10n_es_ticketbai_api_batuz/tests/test_lroe_api.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import json
 from requests import exceptions
+from datetime import datetime
 from odoo.tests import common
 from ..lroe.lroe_api import LROETicketBaiApi
 
@@ -22,6 +23,10 @@ class TestLroeTicketBaiApi(common.TransactionCase):
             tbai_invoice_ids = False
             company_id = Company()
             model = 'MODE'
+
+            def build_cabecera_ejercicio(self):
+                return str(datetime.now().year)
+
         h = api.get_request_headers(Op())
 
         data = json.loads(h['eus-bizkaia-n3-data'])


### PR DESCRIPTION
Se estaba calculando el ejercicio 2023 en facturas recibidas, independientemente de la fecha de las facturas contenidas en la `lroe.operation` a enviar.