### PR TITLE
[13.0][DCK] freeze version of cryptography

### DIFF
--- a/l10n_es_ticketbai_api/__manifest__.py
+++ b/l10n_es_ticketbai_api/__manifest__.py
@@ -19,7 +19,8 @@
         "python": [
             "OpenSSL",
             "xmlsig",
-            "cryptography",
+            # for compatibility with urllib shipped with Odoo 13
+            "cryptography<39",
             "qrcode",
             "xmltodict",
             "requests_pkcs12",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests
 xmlsec==1.3.3
 xmlsig>=0.1.2
 suds-py3
-cryptography
+cryptography==38.0.4
 qrcode
 xmltodict==0.11.0
 requests-pkcs12

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ requests
 xmlsec==1.3.3
 xmlsig>=0.1.2
 suds-py3
-cryptography==38.0.4
+cryptography<39
 qrcode
 xmltodict==0.11.0
 requests-pkcs12


### PR DESCRIPTION
Congelar la versión `cryptography` a 38.0.4 para evitar el error que aparece en la nueva versión:

`ERROR odoo odoo.addons.l10n_es_ticketbai_api.ticketbai.api: No module named 'cryptography.hazmat.backends.openssl.x509'`

@Tecnativa