### PR TITLE
[15.0][FIX] l10n_es_aeat_mod347: Formato informe PDF

### DIFF
--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -4,167 +4,47 @@
         <t t-call="web.external_layout">
             <t t-set="o" t-value="o.with_context({'lang':o.partner_id.lang})" />
             <div class="page">
-                <div class="row">
-                    <div name="invoice_address" class="col-xs-5 col-xs-offset-7">
-                        <address
-                            t-field="o.partner_id"
-                            t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
+                <t t-set="address">
+                    <address
+                        t-field="o.partner_id"
+                        t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
+                    />
+                    <div t-if="o.partner_id.vat" class="mt16">
+                        <t
+                            t-if="o.report_id.company_id.account_fiscal_country_id.vat_label"
+                            t-esc="o.report_id.company_id.account_fiscal_country_id.vat_label"
                         />
-                        <div t-if="o.partner_id.vat" class="mt16"><t
-                                t-esc="o.report_id.company_id.country_id.vat_label or 'TIN'"
-                            />:
-            <span t-field="o.partner_id.vat" /></div>
+                        <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat" />
+                    </div>
+                </t>
+                <div class="row mt32 mb32">
+                    <div class="col-auto col-3 mw-100 mb-2" t-if="o.operation_key">
+                        <strong>Operation Key:</strong>
+                        <p class="m-0" t-field="o.operation_key" />
                     </div>
                 </div>
-                <div class="row mt32 mb32">
-                    <div class="col-xs-12" t-if="o.operation_key">
-                        <strong>Operation Key:</strong>
-                        <p t-field="o.operation_key" />
-                    </div>
-                    <t t-if="o.amount">
-                        <h2>Invoices</h2>
-                        <div class="row mt32 mb32">
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount: <span
-                                        t-field="o.amount"
-                                    />
-                </strong>
-                            </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 1Q: <span
-                                        t-field="o.first_quarter"
-                                    />
-                </strong>
-                            </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 2Q: <span
-                                        t-field="o.second_quarter"
-                                    />
-                </strong>
-                            </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 3Q: <span
-                                        t-field="o.third_quarter"
-                                    />
-                </strong>
-                            </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 4Q:  <span
-                                        t-field="o.fourth_quarter"
-                                    />
-                </strong>
-                            </div>
+                <t t-if="o.amount">
+                    <h2>Invoices</h2>
+                    <div class="row mt32 mb32">
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount:</strong>
+                            <p class="m-0" t-field="o.amount" />
                         </div>
-                        <t t-if="o.move_record_ids">
-                            <table
-                                class="table table-condensed"
-                                name="invoice_line_table"
-                            >
-                                <thead>
-                                    <tr>
-                                        <th>Invoice</th>
-                                        <th>Date</th>
-                                        <th class="text-right">Amount</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="invoice_tbody">
-                                    <tr t-foreach="o.move_record_ids" t-as="l">
-                                        <td>
-                                            <span
-                                                t-esc="l.move_id.ref if l.move_id.move_type[:2] == 'in' else l.move_id.name"
-                                            />
-                                        </td>
-                                        <td>
-                                            <span t-field="l.move_id.date" />
-                                        </td>
-                                        <td class="text-right" id="subtotal">
-                                            <span t-field="l.amount" />
-                                        </td>
-                                    </tr>
-                                    <tr
-                                        t-foreach="range(max(5-len(o.move_record_ids),0))"
-                                        t-as="l"
-                                    >
-                                        <td t-translation="off">&amp;nbsp;</td>
-                                        <td />
-                                        <td />
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </t>
-                    </t>
-                    <t t-if="o.cash_amount">
-                        <h2>Cash Register</h2>
-                        <div class="row mt32 mb32">
-                            <div class="col-xs-4">
-                                <strong class="text-right">Amount:</strong>
-                                <p class="text-right" t-field="o.cash_amount" />
-                            </div>
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount 1Q:</strong>
+                            <p class="m-0" t-field="o.first_quarter" />
                         </div>
-                        <t t-if="o.cash_record_ids">
-                            <table
-                                class="table table-condensed"
-                                name="invoice_line_table"
-                            >
-                                <thead>
-                                    <tr>
-                                        <th>Date</th>
-                                        <th class="text-right">Amount</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="invoice_tbody">
-                                    <tr t-foreach="o.cash_record_ids" t-as="l">
-                                        <td>
-                                            <span t-field="l.date" />
-                                        </td>
-                                        <td class="text-right" id="subtotal">
-                                            <span t-field="l.balance" />
-                                        </td>
-                                    </tr>
-                                    <tr
-                                        t-foreach="range(max(5-len(o.cash_record_ids),0))"
-                                        t-as="l"
-                                    >
-                                        <td t-translation="off">&amp;nbsp;</td>
-                                        <td />
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </t>
-                    </t>
-                    <t t-if="o.real_estate_transmissions_amount">
-                        <h2>Real State Transmissions</h2>
-                        <div class="row mt32 mb32">
-                            <div class="col-xs-4">
-                                <strong class="text-right">Amount:</strong>
-                                <p
-                                    class="text-right"
-                                    t-field="o.real_estate_transmissions_amount"
-                                />
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount 2Q:</strong>
+                            <p class="m-0" t-field="o.second_quarter" />
                         </div>
-                        <div class="col-xs-2">
-                            <strong class="text-right">Amount 1Q: <span
-                                        t-field="o.first_quarter"
-                                    />
-            </strong>
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount 3Q:</strong>
+                            <p class="m-0" t-field="o.third_quarter" />
                         </div>
-                        <div class="col-xs-2">
-                            <strong class="text-right">Amount 2Q: <span
-                                        t-field="o.second_quarter"
-                                    />
-            </strong>
-                        </div>
-                        <div class="col-xs-2">
-                            <strong class="text-right">Amount 3Q: <span
-                                        t-field="o.third_quarter"
-                                    />
-            </strong>
-                        </div>
-                        <div class="col-xs-2">
-                            <strong class="text-right">Amount 4Q:  <span
-                                        t-field="o.fourth_quarter"
-                                    />
-            </strong>
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount 4Q:</strong>
+                            <p class="m-0" t-field="o.fourth_quarter" />
                         </div>
                     </div>
                     <t t-if="o.move_record_ids">
@@ -185,13 +65,13 @@
                                         <span t-field="l.move_id.date" />
                                     </td>
                                     <td class="text-right" id="subtotal">
-                                        <span t-field="l.amount_signed" />
+                                        <span t-field="l.amount" />
                                     </td>
                                 </tr>
                                 <tr
-                                        t-foreach="range(max(5-len(o.move_record_ids),0))"
-                                        t-as="l"
-                                    >
+                                    t-foreach="range(max(5-len(o.move_record_ids),0))"
+                                    t-as="l"
+                                >
                                     <td t-translation="off">&amp;nbsp;</td>
                                     <td />
                                     <td />
@@ -203,9 +83,9 @@
                 <t t-if="o.cash_amount">
                     <h2>Cash Register</h2>
                     <div class="row mt32 mb32">
-                        <div class="col-xs-4">
-                            <strong class="text-right">Amount:</strong>
-                            <p class="text-right" t-field="o.cash_amount" />
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount:</strong>
+                            <p class="m-0" t-field="o.cash_amount" />
                         </div>
                     </div>
                     <t t-if="o.cash_record_ids">
@@ -226,9 +106,9 @@
                                     </td>
                                 </tr>
                                 <tr
-                                        t-foreach="range(max(5-len(o.cash_record_ids),0))"
-                                        t-as="l"
-                                    >
+                                    t-foreach="range(max(5-len(o.cash_record_ids),0))"
+                                    t-as="l"
+                                >
                                     <td t-translation="off">&amp;nbsp;</td>
                                     <td />
                                 </tr>
@@ -239,45 +119,44 @@
                 <t t-if="o.real_estate_transmissions_amount">
                     <h2>Real State Transmissions</h2>
                     <div class="row mt32 mb32">
-                        <div class="col-xs-4">
-                            <strong class="text-right">Amount:</strong>
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount:</strong>
                             <p
-                                    class="text-right"
-                                    t-field="o.real_estate_transmissions_amount"
-                                />
+                                class="m-0"
+                                t-field="o.real_estate_transmissions_amount"
+                            />
                         </div>
-                        <div class="col-xs-2">
-                            <strong class="text-right">Amount 1Q:</strong>
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount 1Q:</strong>
                             <p
-                                    class="text-right"
-                                    t-field="o.first_quarter_real_estate_transmission"
-                                />
+                                class="m-0"
+                                t-field="o.first_quarter_real_estate_transmission"
+                            />
                         </div>
-                        <div class="col-xs-2">
-                            <strong class="text-right">Amount 2Q:</strong>
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount 2Q:</strong>
                             <p
-                                    class="text-right"
-                                    t-field="o.second_quarter_real_estate_transmission"
-                                />
+                                class="m-0"
+                                t-field="o.second_quarter_real_estate_transmission"
+                            />
                         </div>
-                        <div class="col-xs-2">
-                            <strong class="text-right">Amount 3Q:</strong>
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount 3Q:</strong>
                             <p
-                                    class="text-right"
-                                    t-field="o.third_quarter_real_estate_transmission"
-                                />
+                                class="m-0"
+                                t-field="o.third_quarter_real_estate_transmission"
+                            />
                         </div>
-                        <div class="col-xs-2">
-                            <strong class="text-right">Amount 4Q:</strong>
+                        <div class="col-auto col-3 mw-100 mb-2">
+                            <strong>Amount 4Q:</strong>
                             <p
-                                    class="text-right"
-                                    t-field="o.fourth_quarter_real_estate_transmission"
-                                />
+                                class="m-0"
+                                t-field="o.fourth_quarter_real_estate_transmission"
+                            />
                         </div>
                     </div>
                 </t>
             </div>
-        </div>
         </t>
     </template>
     <template id="report_347_partner">


### PR DESCRIPTION
Modificado Informe 347 en PDF según lo comentado aquí: #2732 

Los cambios realizados han sido:
 - Modificado el bloque de dirección utilizando el estándar de la factura
 - Modificado el bloque de encima de la tabla donde pone los importes utilizando el mismo formato estándar de la factura
 - Eliminadas secciones duplicadas (aparentemente introducidas en la migración a 15.0)

@OCA/local-spain-maintainers 