### PR TITLE
[15.0][IMP] l10n_es_aeat_sii_oca: añadir solo la parte deducible al campo CuotaDeducible

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -7,6 +7,7 @@
 # Copyright 2020 Valentin Vinagre <valent.vinagre@sygel.es>
 # Copyright 2021 Tecnativa - João Marques
 # Copyright 2022 ForgeFlow - Lois Rilo
+# Copyright 2023 QubiQ - Jan Tugores <jan.tugores@qubiq.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import json

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -490,9 +490,9 @@ class AccountMove(models.Model):
         for line in self.line_ids:
             sign = -1 if self.move_type[:3] == "out" else 1
             for tax in line.tax_ids:
-                res.setdefault(tax, {
-                    "tax": tax, "base": 0, "amount": 0, "deductible_amount": 0
-                })
+                res.setdefault(
+                    tax, {"tax": tax, "base": 0, "amount": 0, "deductible_amount": 0}
+                )
                 res[tax]["base"] += line.balance * sign
             if line.tax_line_id:
                 tax = line.tax_line_id
@@ -506,9 +506,9 @@ class AccountMove(models.Model):
                 ):
                     # taxes with more than one "tax" repartition line must be discarded
                     continue
-                res.setdefault(tax, {
-                    "tax": tax, "base": 0, "amount": 0, "deductible_amount": 0
-                })
+                res.setdefault(
+                    tax, {"tax": tax, "base": 0, "amount": 0, "deductible_amount": 0}
+                )
                 res[tax]["amount"] += line.balance * sign
                 # We will only take into account as deductible amount the lines
                 # with 472 accounts


### PR DESCRIPTION
Hasta ahora, el campo de CuotaDeducible del SII contenía la suma del importe correspondiente al impuesto de cada línea. Esto es erróneo, ya que si un impuesto tiene varias repartition lines y una de ellas no corresponde al grupo de cuentas 472, querrá decir que esa parte no es deducible.

Por ejemplo, tenemos un impuesto de 21% de IVA, el cual tiene dos repartition lines de tipo 'tax' con un 50% de factor en cada una. Una de ellas va a la cuenta 472000 (parte deducible) y la otra a la cuenta 600000 (cuenta de gastos, parte no deducible). Si tenemos una línea con un precio de 100 y el impuesto descrito, tendremos 21 de impuestos, pero el campo CuotaDeducible solo deberá contener 10.5, que es la parte deducible.

Así pues, el cálculo de la parte deducible se deberá hacer teniendo en cuenta solamente aquellas repartition lines que tengan asociada una cuenta empezada por 472.