### PR TITLE
[15.0][IMP] l10n_es_facturae: campos de facturae en inglés

### DIFF
--- a/l10n_es_facturae/models/res_partner.py
+++ b/l10n_es_facturae/models/res_partner.py
@@ -12,10 +12,10 @@ class ResPartner(models.Model):
     facturae_version = fields.Selection(
         [("3_2", "3.2"), ("3_2_1", "3.2.1"), ("3_2_2", "3.2.2")]
     )
-    organo_gestor = fields.Char(size=10)
-    unidad_tramitadora = fields.Char(size=10)
-    oficina_contable = fields.Char(size=10)
-    organo_proponente = fields.Char("Órgano proponente", size=10)
+    facturae_managing_body = fields.Char(size=10)
+    facturae_processing_unit = fields.Char(size=10)
+    facturae_accounting_office = fields.Char(size=10)
+    facturae_proponent_body = fields.Char(size=10)
     attach_invoice_as_annex = fields.Boolean()
 
     def get_facturae_residence(self):

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -76,29 +76,29 @@
             <t t-call="l10n_es_facturae.administrative_center">
                 <t
                     t-set="centre_code"
-                    t-value="administrative_partner.oficina_contable or partner.oficina_contable"
+                    t-value="administrative_partner.facturae_accounting_office or partner.facturae_accounting_office"
                 />
                 <t t-set="role_type_code" t-value="'01'" />
             </t>
             <t t-call="l10n_es_facturae.administrative_center">
                 <t
                     t-set="centre_code"
-                    t-value="administrative_partner.organo_gestor or partner.organo_gestor"
+                    t-value="administrative_partner.facturae_managing_body or partner.facturae_managing_body"
                 />
                 <t t-set="role_type_code" t-value="'02'" />
             </t>
             <t t-call="l10n_es_facturae.administrative_center">
                 <t
                     t-set="centre_code"
-                    t-value="administrative_partner.unidad_tramitadora or partner.unidad_tramitadora"
+                    t-value="administrative_partner.facturae_processing_unit or partner.facturae_processing_unit"
                 />
                 <t t-set="role_type_code" t-value="'03'" />
             </t>
             <t
                 t-call="l10n_es_facturae.administrative_center"
-                t-if="partner.organo_proponente"
+                t-if="partner.facturae_proponent_body"
             >
-                <t t-set="centre_code" t-value="partner.organo_proponente" />
+                <t t-set="centre_code" t-value="partner.facturae_proponent_body" />
                 <t t-set="role_type_code" t-value="'04'" />
             </t>
         </AdministrativeCentres>

--- a/l10n_es_facturae/views/res_partner_view.xml
+++ b/l10n_es_facturae/views/res_partner_view.xml
@@ -15,12 +15,31 @@
                         attrs="{'invisible': ['|', ('parent.facturae', '=', False), ('type', '!=', 'invoice')]}"
                         colspan="5"
                     >
-                        <field name="facturae_version" />
-                        <field name="organo_gestor" />
-                        <field name="unidad_tramitadora" />
-                        <field name="oficina_contable" />
-                        <field name="organo_proponente" />
-                        <field name="attach_invoice_as_annex" />
+                        <field name="facturae"/>
+                        <field name="facturae_version" attrs="{'invisible': [('facturae', '=', False)]}"/>
+                        <field
+                            name="facturae_managing_body"
+                            attrs="{
+                                'required': [('facturae', '=', True)],
+                                'invisible': [('facturae', '=', False)]
+                            }"
+                        />
+                        <field
+                            name="facturae_processing_unit"
+                            attrs="{
+                                'required': [('facturae', '=', True)],
+                                'invisible': [('facturae', '=', False)]
+                            }"
+                        />
+                        <field
+                            name="facturae_accounting_office"
+                            attrs="{
+                                'required': [('facturae', '=', True)],
+                                'invisible': [('facturae', '=', False)]
+                            }"
+                        />
+                        <field name="facturae_proponent_body" attrs="{'invisible': [('facturae', '=', False)]}"/>
+                        <field name="attach_invoice_as_annex" attrs="{'invisible': [('facturae', '=', False)]}"/>
                     </group>
                 </group>
             </xpath>
@@ -35,18 +54,18 @@
                 >
                     <field name="facturae_version" />
                     <field
-                        name="organo_gestor"
+                        name="facturae_managing_body"
                         attrs="{'required': [('facturae', '=', True)]}"
                     />
                     <field
-                        name="unidad_tramitadora"
+                        name="facturae_processing_unit"
                         attrs="{'required': [('facturae', '=', True)]}"
                     />
                     <field
-                        name="oficina_contable"
+                        name="facturae_accounting_office"
                         attrs="{'required': [('facturae', '=', True)]}"
                     />
-                    <field name="organo_proponente" />
+                    <field name="facturae_proponent_body" />
                     <field name="attach_invoice_as_annex" />
                 </group>
             </group>


### PR DESCRIPTION
Los campos de facturae ahora están en inglés.

También se ha mejorado el formulario de la dirección de facturación haciendo que si el facturae está activado, los campos sean obligatorios