### PR TITLE
[14.0][FIX] l10n_es_aeat:  error en los reports al generar un número de sequencia en un entorno multicompañía

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -371,7 +371,7 @@ class L10nEsAeatReport(models.AbstractModel):
     @api.model
     def _report_identifier_get(self, vals):
         seq_name = "aeat%s-sequence" % self._aeat_number
-        company_id = vals.get("company_id", self.env.user.company_id.id)
+        company_id = vals.get("company_id", self.env.company.id)
         seq = self.env["ir.sequence"].search(
             [("name", "=", seq_name), ("company_id", "=", company_id)], limit=1
         )

--- a/l10n_es_aeat/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat/readme/CONTRIBUTORS.rst
@@ -15,3 +15,4 @@
 * Digital5 S.L.
 * Manuel Regidor <manuel.regidor@sygel.es>
 * Eric Antones <eantones@nuobit.com>
+* kilian Niubo <kniubo@nuobit.com>


### PR DESCRIPTION
El campo sequencia se determina a partir de la compañía por defecto del usuario y no por la compañia activa.