### PR TITLE
[15.0][FIX] l10n_es_ticketbai: Display TBAI ID and QR always on same page

### DIFF
--- a/l10n_es_ticketbai/views/report_invoice.xml
+++ b/l10n_es_ticketbai/views/report_invoice.xml
@@ -11,7 +11,7 @@
         <div class="page" position="inside">
             <div
                 id="ticketbai"
-                style="padding-top:50px;"
+                style="padding-top:50px;page-break-inside:avoid;"
                 class="text-center"
                 t-if="o.tbai_enabled and o.tbai_invoice_id.tbai_identifier and o.tbai_invoice_id.qr"
             >


### PR DESCRIPTION
Nos comentan de hacienda (via mail) que el identificador TBAI y el QR deben ir siempre en la misma página del impreso de la factura. 

Se especifica en la factura vía CSS que no se corte el div que contiene el identificador y el QR en caso de que haya un salto de página.