### PR TITLE
[FIX] l10n_es_aeat_mod347: cáclulo importe entregas

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -230,6 +230,7 @@ class L10nEsAeatMod347Report(models.Model):
             }
 
     def _create_partner_records(self, key, map_ref, partner_record=None):
+        sign = -1 if key == "B" else 1
         partner_record_obj = self.env["l10n.es.aeat.mod347.partner_record"]
         partner_obj = self.env["res.partner"]
         map_line = self.env.ref(map_ref)
@@ -252,7 +253,7 @@ class L10nEsAeatMod347Report(models.Model):
                 "partner_id": partner.id,
                 "representative_vat": "",
                 "operation_key": key,
-                "amount": (-1 if key == "B" else 1) * group["balance"],
+                "amount": sign * group["balance"],
             }
             vals.update(self._get_partner_347_identification(partner))
             move_groups = self.env["account.move.line"].read_group(
@@ -266,7 +267,7 @@ class L10nEsAeatMod347Report(models.Model):
                     0,
                     {
                         "move_id": move_group["move_id"][0],
-                        "amount": move_group["balance"],
+                        "amount": sign * move_group["balance"],
                     },
                 )
                 for move_group in move_groups
@@ -557,28 +558,25 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
 
     @api.depends("move_record_ids.move_id.date", "report_id.year")
     def calculate_quarter_totals(self):
-        def calc_amount_by_quarter(records, sign, year, month_start):
+        def calc_amount_by_quarter(records, year, month_start):
             day_start = 1
             month_end = month_start + 2
             day_end = monthrange(year, month_end)[1]
             date_start = datetime.date(year, month_start, day_start)
             date_end = datetime.date(year, month_end, day_end)
-            return (
-                sum(
-                    records.filtered(
-                        lambda x: date_start <= x.move_id.date <= date_end
-                    ).mapped("amount")
-                )
-            ) * sign
+            return sum(
+                records.filtered(
+                    lambda x: date_start <= x.move_id.date <= date_end
+                ).mapped("amount")
+            )
 
         for record in self:
-            sign = -1 if record.operation_key == "B" else 1
             year = record.report_id.year
             moves = record.move_record_ids
-            record.first_quarter = calc_amount_by_quarter(moves, sign, year, 1)
-            record.second_quarter = calc_amount_by_quarter(moves, sign, year, 4)
-            record.third_quarter = calc_amount_by_quarter(moves, sign, year, 7)
-            record.fourth_quarter = calc_amount_by_quarter(moves, sign, year, 10)
+            record.first_quarter = calc_amount_by_quarter(moves, year, 1)
+            record.second_quarter = calc_amount_by_quarter(moves, year, 4)
+            record.third_quarter = calc_amount_by_quarter(moves, year, 7)
+            record.fourth_quarter = calc_amount_by_quarter(moves, year, 10)
 
     def action_exception(self):
         self.write({"state": "exception"})

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -166,7 +166,13 @@
                             </group>
                         </page>
                         <page string="Details">
-                            <div><strong>Color codes: </strong> <span
+                            <div attrs="{'invisible': [('operation_key', '!=', 'B')]}">
+                                <strong>Color codes: </strong> <span
+                                    class="text-info"
+                                >Normal invoices</span> - Refund invoices
+                            </div>
+                            <div attrs="{'invisible': [('operation_key', '=', 'B')]}">
+                                <strong>Color codes: </strong> <span
                                     class="text-info"
                                 >Refund invoices</span> - Normal invoices</div>
                             <field

--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -5,57 +5,47 @@
             <t t-call="web.external_layout">
                 <t t-set="o" t-value="o.with_context({'lang':o.partner_id.lang})" />
                 <div class="page">
-                    <div class="row">
-                        <div name="invoice_address" class="col-xs-5 col-xs-offset-7">
-                            <address
-                                t-field="o.partner_id"
-                                t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
+                    <t t-set="address">
+                        <address
+                            t-field="o.partner_id"
+                            t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
+                        />
+                        <div t-if="o.partner_id.vat" class="mt16">
+                            <t
+                                t-if="o.report_id.company_id.country_id.vat_label"
+                                t-esc="o.report_id.company_id.country_id.vat_label"
                             />
-                            <div t-if="o.partner_id.vat" class="mt16"><t
-                                    t-esc="o.report_id.company_id.country_id.vat_label or 'TIN'"
-                                />:
-                <span t-field="o.partner_id.vat" /></div>
+                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat" />
                         </div>
-                    </div>
+                    </t>
                     <div class="row mt32 mb32">
-                        <div class="col-xs-12" t-if="o.operation_key">
+                        <div class="col-auto col-3 mw-100 mb-2" t-if="o.operation_key">
                             <strong>Operation Key:</strong>
-                            <p t-field="o.operation_key" />
+                            <p class="m-0" t-field="o.operation_key" />
                         </div>
-                        <!-- TODO -->
                     </div>
                     <t t-if="o.amount">
                         <h2>Invoices</h2>
                         <div class="row mt32 mb32">
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount: <span
-                                        t-field="o.amount"
-                                    />
-                </strong>
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount:</strong>
+                                <p class="m-0" t-field="o.amount" />
                             </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 1Q: <span
-                                        t-field="o.first_quarter"
-                                    />
-                </strong>
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount 1Q:</strong>
+                                <p class="m-0" t-field="o.first_quarter" />
                             </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 2Q: <span
-                                        t-field="o.second_quarter"
-                                    />
-                </strong>
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount 2Q:</strong>
+                                <p class="m-0" t-field="o.second_quarter" />
                             </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 3Q: <span
-                                        t-field="o.third_quarter"
-                                    />
-                </strong>
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount 3Q:</strong>
+                                <p class="m-0" t-field="o.third_quarter" />
                             </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 4Q:  <span
-                                        t-field="o.fourth_quarter"
-                                    />
-                </strong>
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount 4Q:</strong>
+                                <p class="m-0" t-field="o.fourth_quarter" />
                             </div>
                         </div>
                         <t t-if="o.move_record_ids">
@@ -99,9 +89,9 @@
                     <t t-if="o.cash_amount">
                         <h2>Cash Register</h2>
                         <div class="row mt32 mb32">
-                            <div class="col-xs-4">
-                                <strong class="text-right">Amount:</strong>
-                                <p class="text-right" t-field="o.cash_amount" />
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount:</strong>
+                                <p class="m-0" t-field="o.cash_amount" />
                             </div>
                         </div>
                         <t t-if="o.cash_record_ids">
@@ -138,38 +128,38 @@
                     <t t-if="o.real_estate_transmissions_amount">
                         <h2>Real State Transmissions</h2>
                         <div class="row mt32 mb32">
-                            <div class="col-xs-4">
-                                <strong class="text-right">Amount:</strong>
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount:</strong>
                                 <p
-                                    class="text-right"
+                                    class="m-0"
                                     t-field="o.real_estate_transmissions_amount"
                                 />
                             </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 1Q:</strong>
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount 1Q:</strong>
                                 <p
-                                    class="text-right"
+                                    class="m-0"
                                     t-field="o.first_quarter_real_estate_transmission"
                                 />
                             </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 2Q:</strong>
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount 2Q:</strong>
                                 <p
-                                    class="text-right"
+                                    class="m-0"
                                     t-field="o.second_quarter_real_estate_transmission"
                                 />
                             </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 3Q:</strong>
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount 3Q:</strong>
                                 <p
-                                    class="text-right"
+                                    class="m-0"
                                     t-field="o.third_quarter_real_estate_transmission"
                                 />
                             </div>
-                            <div class="col-xs-2">
-                                <strong class="text-right">Amount 4Q:</strong>
+                            <div class="col-auto col-3 mw-100 mb-2">
+                                <strong>Amount 4Q:</strong>
                                 <p
-                                    class="text-right"
+                                    class="m-0"
                                     t-field="o.fourth_quarter_real_estate_transmission"
                                 />
                             </div>


### PR DESCRIPTION
Aplico a la versión 14.0 los problemas reportados en https://github.com/OCA/l10n-spain/issues/2732

En lugar de modificar el signo para los registros de tipo B entregas en el cáclulo de los importes por trimestre y para el total se hace para cada línea con lo cual se calculan directamente con el signo correcto los importes por trimestre y para el informe.

Aprovecho también para corregir como se muestran los datos de importes por trimestre en el informe ya que salían como en v15.0

![imagen](https://user-images.githubusercontent.com/79899255/214026734-0ce8fc8d-f55a-496b-b22e-3ed8190c7f04.png)
