### PR TITLE
[15.0][IMP] l10n_es_aeat_sii_oca: Includes new taxes 0%, 0.62% and 5%

### DIFF
--- a/l10n_es_aeat_sii_oca/__manifest__.py
+++ b/l10n_es_aeat_sii_oca/__manifest__.py
@@ -11,7 +11,7 @@
 # Copyright 2020 Sygel Technology - Valentín Vinagre <valentin.vinagre@sygel.es>
 # Copyright 2021 Tecnativa - João Marques
 # Copyright 2022 ForgeFlow - Lois Rilo
-# Copyright 2022 Moduon - Eduardo de Miguel
+# Copyright 2022-2023 Moduon - Eduardo de Miguel
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
@@ -9,7 +9,9 @@
             name="taxes"
             eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_s_iva21b'),
+                ref('l10n_es.account_tax_template_s_iva0b'),
                 ref('l10n_es.account_tax_template_s_iva4b'),
+                ref('l10n_es.account_tax_template_s_iva5b'),
                 ref('l10n_es.account_tax_template_s_iva10b'),
             ])]"
         />
@@ -58,8 +60,9 @@
             eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_s_iva21s'),
                 ref('l10n_es.account_tax_template_s_iva10s'),
-                ref('l10n_es.account_tax_template_s_iva5s'),
+                ref('l10n_es.account_tax_template_s_iva0s'),
                 ref('l10n_es.account_tax_template_s_iva4s'),
+                ref('l10n_es.account_tax_template_s_iva5s'),
             ])]"
         />
         <field name="sii_map_id" ref="aeat_sii_map" />
@@ -98,10 +101,16 @@
                 ref('l10n_es.account_tax_template_p_iva21_sc'),
                 ref('l10n_es.account_tax_template_p_iva10_bc'),
                 ref('l10n_es.account_tax_template_p_iva10_sc'),
+                ref('l10n_es.account_tax_template_p_iva5_bc'),
                 ref('l10n_es.account_tax_template_p_iva5_sc'),
                 ref('l10n_es.account_tax_template_p_iva4_bc'),
                 ref('l10n_es.account_tax_template_p_iva4_sc'),
                 ref('l10n_es.account_tax_template_p_iva0_bc'),
+                ref('l10n_es.account_tax_template_p_iva0_s_bc'),
+                ref('l10n_es.account_tax_template_p_iva0_ic_bc'),
+                ref('l10n_es.account_tax_template_p_iva0_ic_sc'),
+                ref('l10n_es.account_tax_template_p_iva0_ibc'),
+                ref('l10n_es.account_tax_template_p_iva0_isc'),
                 ref('l10n_es.account_tax_template_p_iva4_bi'),
                 ref('l10n_es.account_tax_template_p_iva10_bi'),
                 ref('l10n_es.account_tax_template_p_iva21_bi'),
@@ -111,10 +120,14 @@
                 ref('l10n_es.account_tax_template_p_iva4_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva10_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva21_ic_bc'),
+                ref('l10n_es.account_tax_template_p_iva5_ic_bc'),
+                ref('l10n_es.account_tax_template_p_iva5_ic_sc'),
                 ref('l10n_es.account_tax_template_p_iva4_ic_bi'),
                 ref('l10n_es.account_tax_template_p_iva10_ic_bi'),
                 ref('l10n_es.account_tax_template_p_iva21_ic_bi'),
                 ref('l10n_es.account_tax_template_p_iva4_ibc'),
+                ref('l10n_es.account_tax_template_p_iva5_ibc'),
+                ref('l10n_es.account_tax_template_p_iva5_isc'),
                 ref('l10n_es.account_tax_template_p_iva10_ibc'),
                 ref('l10n_es.account_tax_template_p_iva21_ibc'),
                 ref('l10n_es.account_tax_template_p_iva4_ibi'),
@@ -186,6 +199,8 @@
                 ref('l10n_es.account_tax_template_s_req52'),
                 ref('l10n_es.account_tax_template_p_req014'),
                 ref('l10n_es.account_tax_template_s_req014'),
+                ref('l10n_es.account_tax_template_p_req062'),
+                ref('l10n_es.account_tax_template_s_req062'),
                 ref('l10n_es.account_tax_template_p_req05'),
                 ref('l10n_es.account_tax_template_s_req05'),
             ])]"


### PR DESCRIPTION
Idéntico al PR de Pedro (me he basado en ese PR exclusivamente), pero cambiando los impuestos que no había nombrado Odoo por los external ids que ha decidido poner.

PR de Pedro con el mapeo de impuestos: https://github.com/OCA/l10n-spain/pull/2717

PR a Odoo (v13) no mergeado: https://github.com/odoo/odoo/pull/108868
PR de Odoo: https://github.com/odoo/odoo/pull/110592

Adjunto el mapeo que me hecho en excel para cambiarlo por si se me ha colado algo:
[mapeo_nuevos_impuestos_con_viejos_nombres.xls](https://github.com/OCA/l10n-spain/files/10499034/mapeo_nuevos_impuestos_con_viejos_nombres.xls)


MT-2127 @moduon @pedrobaeza @rafaelbn @omar7r 