### PR TITLE
[12.0][FIX] l10n_es_aeat_mod347: Save proper real state fields

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -688,9 +688,10 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
             vals = self.report_id._get_partner_347_identification(
                 self.partner_id,
             )
-            vals.pop('community_vat', None)
-            del vals['partner_country_code']
-            self.update(vals)
+            self.update({
+                "partner_vat": vals.pop("partner_vat"),
+                "state_code": vals.pop("partner_state_code"),
+            })
 
 
 class L10nEsAeatMod347MoveRecord(models.Model):


### PR DESCRIPTION
Relacionado con https://github.com/OCA/l10n-spain/issues/2001