### PR TITLE
[16.0][FIX] Campo company_id en vista l10n_es_aeat. Error al actualizar 303

### DIFF
--- a/l10n_es_aeat/views/aeat_report_view.xml
+++ b/l10n_es_aeat/views/aeat_report_view.xml
@@ -108,6 +108,10 @@
                     <field name="allow_posting" invisible="1" />
                     <field name="number" invisible="1" />
                     <field name="currency_id" invisible="1" />
+                    <!-- This company_id field as invisible is needed for use in domain
+                         for inherited views and to avoid error with company_id field
+                         with group defined -->
+                    <field name="company_id" invisible="1" />
                     <h1>
                         <label string="Report " for="name" />
                         <field name="name" class="oe_inline" readonly="1" />


### PR DESCRIPTION
Al actualizar el modulo l10n_es_aeat_mod303 está dando el siguiente error:

```
Field 'company_id' used in domain of field 'counterpart_account_id' ([('company_id', '=', company_id)]) is restricted to the group(s) base.group_multi_company.
```

Esto es debido a que se está usando el company_id en el dominio del counterpart_account_id que viene del l10n.es.aeat.report y que en esa vista está protegido por un grupo.

Para evitar este error es necesario volver a añadir el campo company_id como invisible en la vista para que pueda utilizarse como parámetro para otros campos que lo utilicen

