### PR TITLE
[12.0][FIX] l10n_es_aeat_vat_prorrate: exportar casilla 44 en fichero 2022

### DIFF
--- a/l10n_es_aeat_vat_prorrate/data/aeat_export_mod303_data.xml
+++ b/l10n_es_aeat_vat_prorrate/data/aeat_export_mod303_data.xml
@@ -10,6 +10,10 @@
             <field name="fixed_value"/>
             <field name="expression">${object.casilla_44}</field>
         </record>
+        <record id="l10n_es_aeat_mod303.aeat_mod303_2022_sub01_export_line_68" model="aeat.model.export.config.line">
+            <field name="fixed_value"/>
+            <field name="expression">${object.casilla_44}</field>
+        </record>
 
     </data>
 </openerp>

--- a/l10n_es_aeat_vat_prorrate/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_vat_prorrate/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Pedro M. Baeza
+* Rafael Blasco (https://www.moduon.team/)


### PR DESCRIPTION
@moduon MT-2174 fixes https://github.com/OCA/l10n-spain/issues/2784