### PR TITLE
[11.0][IMP] l10n_es_ticketbai - fecha expedición en origen rectificativa a tipo fecha

### DIFF
--- a/l10n_es_ticketbai/__manifest__.py
+++ b/l10n_es_ticketbai/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "TicketBAI - "
             "declaración de todas las operaciones de venta realizadas por las personas "
             "y entidades que desarrollan actividades económicas",
-    "version": "11.0.1.4.5",
+    "version": "11.0.1.4.6",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/l10n-spain",
     "author": "Binovo,"

--- a/l10n_es_ticketbai/migrations/11.0.1.4.6/post-migration.py
+++ b/l10n_es_ticketbai/migrations/11.0.1.4.6/post-migration.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Digital5 - Enrique Martin
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+from psycopg2 import sql
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr, sql.SQL("""
+        UPDATE tbai_invoice_refund_origin
+        SET expedition_date = TO_DATE({}, 'DD-MM-YYYY')
+        """).format(
+            sql.Identifier(openupgrade.get_legacy_name("expedition_date"))
+        )
+    )

--- a/l10n_es_ticketbai/migrations/11.0.1.4.6/pre-migration.py
+++ b/l10n_es_ticketbai/migrations/11.0.1.4.6/pre-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Digital5 - Enrique Martin
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_columns(
+        env.cr, {"tbai_invoice_refund_origin": [("expedition_date", None)]}
+    )

--- a/l10n_es_ticketbai/models/account_invoice.py
+++ b/l10n_es_ticketbai/models/account_invoice.py
@@ -186,11 +186,13 @@ class AccountInvoice(models.Model):
                 if self.tbai_refund_origin_ids:
                     refund_id_dicts = []
                     for refund_origin_id in self.tbai_refund_origin_ids:
+                        expedition_date = fields.Date.from_string(
+                            refund_origin_id.expedition_date).strftime("%d-%m-%Y")
                         refund_id_dicts.append(
                             (0, 0, {
                                 'number_prefix': refund_origin_id.number_prefix,
                                 'number': refund_origin_id.number,
-                                'expedition_date': refund_origin_id.expedition_date
+                                'expedition_date': expedition_date
                             }))
                     vals.update({
                         'is_invoice_refund': True,

--- a/l10n_es_ticketbai/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai/models/ticketbai_invoice.py
@@ -3,9 +3,7 @@
 from odoo.addons.l10n_es_ticketbai_api.models.ticketbai_invoice import \
     TicketBaiInvoiceState
 from odoo.addons.l10n_es_ticketbai_api.ticketbai.xml_schema import TicketBaiSchema
-from odoo.addons.l10n_es_ticketbai_api.utils import utils as tbai_utils
 from odoo import models, fields, api, exceptions, _
-from datetime import datetime
 
 
 class TicketBAIInvoice(models.Model):
@@ -64,9 +62,8 @@ class TicketBAIInvoiceRefundOrigin(models.Model):
         help='Number prefix of this invoice name e.g. if the invoice name is'
         ' INV/2021/00001 then the prefix is INV/2021/, '
         'ending back slash included')
-    expedition_date = fields.Char(
-        required=True,
-        help="Expected string date format: %dd-%mm-%yyyy")
+    expedition_date = fields.Date(
+        required=True)
 
     @api.multi
     @api.constrains('number')
@@ -87,36 +84,3 @@ class TicketBAIInvoiceRefundOrigin(models.Model):
                     "Refunded Invoice %s Number Prefix %s longer than expected. "
                     "Should be 20 characters max.!"
                 ) % (record.number, record.number_prefix))
-
-    @api.multi
-    @api.constrains('expedition_date')
-    def _check_expedition_date(self):
-        for record in self:
-            tbai_utils.check_date(_(
-                "Refunded Invoice %s Expedition Date"
-            ) % record.number, record.expedition_date)
-
-    @api.multi
-    @api.constrains('number', 'number_prefix', 'expedition_date')
-    def _check_account_invoice_exists(self):
-        for record in self:
-            invoice_number = ''
-            if record.number_prefix:
-                invoice_number = record.number_prefix
-            if record.number:
-                invoice_number += record.number
-            if invoice_number and record.expedition_date:
-                record._check_expedition_date()
-                invoice_date = datetime.strptime(record.expedition_date, "%d-%m-%Y")
-                date_invoice = invoice_date.date().strftime('%Y-%m-%d')
-                domain_invoice = [('number', '=', invoice_number),
-                                  ('date_invoice', '=', date_invoice)
-                                  ]
-                account_invoice = self.sudo()\
-                    .env['account.invoice']\
-                    .search(domain_invoice)
-                if account_invoice:
-                    raise exceptions.ValidationError(_(
-                        "Invoice: number %s prefix %s invoice_date %s exists. Create a "
-                        "credit note from this invoice."
-                    ) % (record.number, record.number_prefix, record.expedition_date))

--- a/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
+++ b/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
@@ -376,7 +376,7 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
         invoice.sudo().tbai_refund_origin_ids = [
             (0, 0, {'number_prefix': 'INV_XYZ/2021/',
                     'number': '001',
-                    'expedition_date': '01-01-1901'})]
+                    'expedition_date': '1901-01-01'})]
         invoice.action_invoice_open()
         self.assertEqual(invoice.state, 'open')
         self.assertEqual(1, len(invoice.tbai_refund_origin_ids))
@@ -417,7 +417,7 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
             invoice.sudo().tbai_refund_origin_ids = [
                 (0, 0, {'number_prefix': 'INV_XYZ/2021/',
                         'number': '000000000000000000001',
-                        'expedition_date': '01-01-1901'})]
+                        'expedition_date': '1901-01-01'})]
 
     def test_invoice_out_refund_from_origin_prefix_too_long(self):
         ctx = {'type': 'out_refund'}
@@ -431,28 +431,7 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
             invoice.sudo().tbai_refund_origin_ids = [
                 (0, 0, {'number_prefix': 'S00000000000000000000',
                         'number': '01',
-                        'expedition_date': '01-01-1901'})]
-
-    def test_invoice_out_refund_from_origin_invoice_exists(self):
-        ctx = {'type': 'out_refund'}
-        invoice = self.create_draft_invoice(
-            self.account_billing.id,
-            self.fiscal_position_national)
-        invoice.onchange_fiscal_position_id_tbai_vat_regime_key()
-        invoice.date_invoice = '1901-01-01'
-        invoice.compute_taxes()
-        invoice.action_invoice_open()
-        number_prefix = '/'.join(invoice.number.split('/')[:-1]) + '/'
-        number = invoice.number.split('/')[-1]
-        refund = self.create_draft_invoice(self.account_billing.id,
-                                           self.fiscal_position_national,
-                                           invoice_type='out_refund',
-                                           context=ctx)
-        with self.assertRaises(exceptions.ValidationError):
-            refund.sudo().tbai_refund_origin_ids = [
-                (0, 0, {'number_prefix': number_prefix,
-                        'number': number,
-                        'expedition_date': '01-01-1901'})]
+                        'expedition_date': '1901-01-01'})]
 
     def test_invoice_lines_protected_data(self):
         invoice = self.create_draft_invoice(


### PR DESCRIPTION
Pasamos el campo `Fecha de la factura` del listado de `Datos facturas origen` en una rectificativa, a tipo fecha. Antes era de tipo texto y exigía un determinado formato de entrada distinto al usado en Odoo. Generaba bastante confusión/ruido en los usuarios y no aportaba nada a nivel técnico tenerlo como texto pudiendo formatearlo (como se hace con otros campos fecha).

También eliminamos constraint que comprueba que no se metan facturas existentes en Odoo en el campo `Datos facturas origen` de una rectificativa: para poder hacer facturas de rappel, es necesario poder identificar la primera y última factura a la que afecta, independientemente de si está o no en Odoo. Documentación a este respecto:

- Araba: [pregunta 11.9](https://web.araba.eus/es/hacienda/ticketbai/preguntas-frecuentes)
- Bizkaia: [batuz.eus](https://www.batuz.eus/es/preguntas-frecuentes?q=rappel#btz_pregunta_9154432)