### PR TITLE
[12.0][FIX] l10n_es_aeat390:Mapeo impuestos

### DIFF
--- a/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
+++ b/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
@@ -147,7 +147,7 @@
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="True"/>
-        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva21_ic_bc_2'), ref('l10n_es.1_account_tax_template_p_iva21_ic_bi_2'), ])]"/>
+        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva21_ic_bc_2'), ref('l10n_es.account_tax_template_p_iva21_ic_bi_2'), ])]"/>
     </record>
 
     <record id="aeat_mod390_map_line_26" model="l10n.es.aeat.map.tax.line">
@@ -158,7 +158,7 @@
         <field name="field_type">amount</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="False"/>
-        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva21_ic_bc_2'),  ref('l10n_es.1_account_tax_template_p_iva21_ic_bi_2'),])]"/>
+        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva21_ic_bc_2'),  ref('l10n_es.account_tax_template_p_iva21_ic_bi_2'),])]"/>
     </record>
 
     <record id="aeat_mod390_map_line_545" model="l10n.es.aeat.map.tax.line">

--- a/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
+++ b/l10n_es_aeat_mod390/data/tax_code_map_mod390_data.xml
@@ -147,7 +147,7 @@
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="True"/>
-        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva21_ic_bc_2'), ])]"/>
+        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva21_ic_bc_2'), ref('l10n_es.1_account_tax_template_p_iva21_ic_bi_2'), ])]"/>
     </record>
 
     <record id="aeat_mod390_map_line_26" model="l10n.es.aeat.map.tax.line">
@@ -158,7 +158,7 @@
         <field name="field_type">amount</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="False"/>
-        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva21_ic_bc_2'), ])]"/>
+        <field name="tax_ids" eval="[(6, False, [ref('l10n_es.account_tax_template_p_iva21_ic_bc_2'),  ref('l10n_es.1_account_tax_template_p_iva21_ic_bi_2'),])]"/>
     </record>
 
     <record id="aeat_mod390_map_line_545" model="l10n.es.aeat.map.tax.line">


### PR DESCRIPTION
Cuando hay adquisiciones de bienes de inversión, la parte deducible sí tiene sus casillas pero se les debió olvidar la parte devengada. Para que se calcule bien, hay que ponerla en algún sitio. Creo que junto a la compra de bienes corrientes es lo más parecido.