### PR TITLE
[13.0][FIX] l10n_es_mod390: Set main_activity_code as required only for calculated state

### DIFF
--- a/l10n_es_aeat_mod390/views/mod390_view.xml
+++ b/l10n_es_aeat_mod390/views/mod390_view.xml
@@ -27,11 +27,11 @@
                             <field name="main_activity" />
                             <field
                                 name="main_activity_code"
-                                attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&gt;', 2021)], 'required': [('year', '&lt;', 2022)]}"
+                                attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&gt;', 2021)], 'required': [('state', '=', 'calculated'), ('year', '&lt;', 2022)]}"
                             />
                             <field
                                 name="main_activity_code_id"
-                                attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&lt;', 2022)], 'required': [('year', '&gt;', 2021)]}"
+                                attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&lt;', 2022)], 'required': [('state', '=', 'calculated'), ('year', '&gt;', 2021)]}"
                             />
                             <field name="main_activity_iae" />
                         </group>


### PR DESCRIPTION
Cherry-pick de #2794, permitiendo editar además los códigos de actividad en la etapa borrador, que es cuando naturalmente se pone la información.

@Tecnativa