### PR TITLE
[FIX] l10n_es_aeat_mod390: allow creating records

### DIFF
--- a/l10n_es_aeat_mod390/views/mod390_view.xml
+++ b/l10n_es_aeat_mod390/views/mod390_view.xml
@@ -27,11 +27,11 @@
                             <field name="main_activity" />
                             <field
                                 name="main_activity_code"
-                                attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&gt;', 2021)], 'required': [('year', '&lt;', 2022)]}"
+                                attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&gt;', 2021)], 'required': [('state', '!=', 'draft'), ('year', '&lt;', 2022)]}"
                             />
                             <field
                                 name="main_activity_code_id"
-                                attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&lt;', 2022)], 'required': [('year', '&gt;', 2021)]}"
+                                attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&lt;', 2022)], 'required': [('state', '!=', 'draft'), ('year', '&gt;', 2021)]}"
                             />
                             <field name="main_activity_iae" />
                         </group>


### PR DESCRIPTION
These fields are inside a notebook that is invisible in draft mode. Thus, making them required in draft mode makes the form impossible to save.

@moduon MT-2174