### PR TITLE
[13.0][FIX] l10n_es_aeat_mod349: Operation key not taken into account in refunds

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -198,14 +198,13 @@ class Mod349(models.Model):
         for refund_detail in self.partner_refund_detail_ids:
             move_line = refund_detail.refund_line_id
             origin_invoice = move_line.move_id.reversed_entry_id
-            groups.setdefault(origin_invoice, refund_detail_obj)
-            groups[origin_invoice] += refund_detail
-        for origin_invoice in groups:
-            refund_details = groups[origin_invoice]
+            key = (origin_invoice, move_line.l10n_es_aeat_349_operation_key)
+            groups.setdefault(key, refund_detail_obj)
+            groups[key] += refund_detail
+        for (origin_invoice, op_key), refund_details in groups.items():
             refund_detail = first(refund_details)
             move_line = refund_detail.refund_line_id
             partner = move_line.partner_id
-            op_key = move_line.l10n_es_aeat_349_operation_key
             if not origin_invoice:
                 # TODO: Instead continuing, generate an empty record and a msg
                 continue

--- a/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
@@ -20,3 +20,7 @@
   * Ignacio Ibeas
 
 * Manuel Regidor <manuel.regidor@sygel.es>
+
+* NuoBiT (http://www.nuobit.com)
+
+  * Eric Antones <eantones@nuobit.com>


### PR DESCRIPTION
Backport of #2774

Steps to reproduce the problem:

- Create an intra-community invoice on 2T with one service and one product, having 2 separate operation keys.
- Refund the invoice on 3T.
- Create a 349 declaration for 3T.
- On refund of others periods page, both refunded amounts are charged to the first operation key.

@Tecnativa