### PR TITLE
[FIX] l10n_es_aeat_mod390: missing dependency

### DIFF
--- a/l10n_es_aeat_mod390/__manifest__.py
+++ b/l10n_es_aeat_mod390/__manifest__.py
@@ -10,7 +10,7 @@
     'website': "https://github.com/OCA/l10n-spain",
     'license': 'AGPL-3',
     'depends': [
-        'l10n_es_aeat_mod303'
+        'l10n_es_aeat_mod303_extra_data',
     ],
     'data': [
         # 2017


### PR DESCRIPTION
Soluciona https://github.com/OCA/l10n-spain/issues/2808