### PR TITLE
[13.0][FIX] payment_redsys: feedback error string format

### DIFF
--- a/payment_redsys/models/redsys.py
+++ b/payment_redsys/models/redsys.py
@@ -356,6 +356,7 @@ class TxRedsys(models.Model):
             "date": fields.Datetime.now(),
         }
         state_message = ""
+        feedback_error = False
         if state == "done":
             vals["state_message"] = _("Ok: %s") % params.get("Ds_Response")
             self._set_transaction_done()
@@ -368,7 +369,7 @@ class TxRedsys(models.Model):
             self._set_transaction_cancel()
         else:
             state_message = _("Redsys: feedback error %s (%s)")
-            self._set_transaction_error(state_message)
+            feedback_error = True
         if state_message:
             vals["state_message"] = state_message % (
                 params.get("Ds_Response"),
@@ -376,6 +377,8 @@ class TxRedsys(models.Model):
             )
             if state == "error":
                 _logger.warning(vals["state_message"])
+            if feedback_error:
+                self._set_transaction_error(vals["state_message"])
         self.write(vals)
         return state != "error"
 


### PR DESCRIPTION
We're sending the string template without parameters to the method _set_transcation_error() so no info is shown.

cc @Tecnativa TT41589

please review @sergio-teruel 