### PR TITLE
[14.0][FIX] l10n_es_vat_book: Don't mix company / partner terminology

### DIFF
--- a/l10n_es_vat_book/i18n/ca.po
+++ b/l10n_es_vat_book/i18n/ca.po
@@ -143,11 +143,6 @@ msgid "Company"
 msgstr "Empresa"
 
 #. module: l10n_es_vat_book
-#: model_terms:ir.ui.view,arch_db:l10n_es_vat_book.vat_book_invoices_head
-msgid "Company Name"
-msgstr "Nom empresa"
-
-#. module: l10n_es_vat_book
 #: model:ir.model.fields,help:l10n_es_vat_book.field_l10n_es_vat_book__partner_bank_id
 msgid "Company bank account used for the presentation"
 msgstr "Compte bancari de l'empresa utilitzat per la presentació"
@@ -560,6 +555,11 @@ msgid "Partner"
 msgstr "Client"
 
 #. module: l10n_es_vat_book
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_book.vat_book_invoices_head
+msgid "Partner Name"
+msgstr "Nom empresa"
+
+#. module: l10n_es_vat_book
 #: model:ir.model.fields,field_description:l10n_es_vat_book.field_l10n_es_vat_book__period_type
 msgid "Period type"
 msgstr "Tipus de període"
@@ -811,8 +811,8 @@ msgstr "Aquest llibre té avisos. Corregiu-los abans de confirmar"
 #. module: l10n_es_vat_book
 #: code:addons/l10n_es_vat_book/models/l10n_es_vat_book.py:0
 #, python-format
-msgid "This company doesn't have VAT"
-msgstr "Aquesta companyia no té NIF"
+msgid "This partner doesn't have VAT"
+msgstr "Aquesta empresa no té NIF"
 
 #. module: l10n_es_vat_book
 #: model:ir.model.fields,field_description:l10n_es_vat_book.field_l10n_es_vat_book_line__total_amount

--- a/l10n_es_vat_book/i18n/es.po
+++ b/l10n_es_vat_book/i18n/es.po
@@ -141,11 +141,6 @@ msgid "Company"
 msgstr "Compañía"
 
 #. module: l10n_es_vat_book
-#: model_terms:ir.ui.view,arch_db:l10n_es_vat_book.vat_book_invoices_head
-msgid "Company Name"
-msgstr "Nombre Empresa"
-
-#. module: l10n_es_vat_book
 #: model:ir.model.fields,help:l10n_es_vat_book.field_l10n_es_vat_book__partner_bank_id
 msgid "Company bank account used for the presentation"
 msgstr "Cuenta bancaria de la compañía que se usará para la presentación"
@@ -557,6 +552,11 @@ msgid "Partner"
 msgstr "Empresa"
 
 #. module: l10n_es_vat_book
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_book.vat_book_invoices_head
+msgid "Partner Name"
+msgstr "Nombre Empresa"
+
+#. module: l10n_es_vat_book
 #: model:ir.model.fields,field_description:l10n_es_vat_book.field_l10n_es_vat_book__period_type
 msgid "Period type"
 msgstr "Tipo de periodo"
@@ -808,7 +808,7 @@ msgstr "Este libro contiene advertencias. Arréglelas antes de confirmar"
 #. module: l10n_es_vat_book
 #: code:addons/l10n_es_vat_book/models/l10n_es_vat_book.py:0
 #, python-format
-msgid "This company doesn't have VAT"
+msgid "This partner doesn't have VAT"
 msgstr "Esta empresa no tiene NIF"
 
 #. module: l10n_es_vat_book

--- a/l10n_es_vat_book/i18n/l10n_es_vat_book.pot
+++ b/l10n_es_vat_book/i18n/l10n_es_vat_book.pot
@@ -137,11 +137,6 @@ msgid "Company"
 msgstr ""
 
 #. module: l10n_es_vat_book
-#: model_terms:ir.ui.view,arch_db:l10n_es_vat_book.vat_book_invoices_head
-msgid "Company Name"
-msgstr ""
-
-#. module: l10n_es_vat_book
 #: model:ir.model.fields,help:l10n_es_vat_book.field_l10n_es_vat_book__partner_bank_id
 msgid "Company bank account used for the presentation"
 msgstr ""
@@ -553,6 +548,11 @@ msgid "Partner"
 msgstr ""
 
 #. module: l10n_es_vat_book
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_book.vat_book_invoices_head
+msgid "Partner Name"
+msgstr ""
+
+#. module: l10n_es_vat_book
 #: model:ir.model.fields,field_description:l10n_es_vat_book.field_l10n_es_vat_book__period_type
 msgid "Period type"
 msgstr ""
@@ -798,7 +798,7 @@ msgstr ""
 #. module: l10n_es_vat_book
 #: code:addons/l10n_es_vat_book/models/l10n_es_vat_book.py:0
 #, python-format
-msgid "This company doesn't have VAT"
+msgid "This partner doesn't have VAT"
 msgstr ""
 
 #. module: l10n_es_vat_book

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -437,7 +437,7 @@ class L10nEsVatBook(models.Model):
         """
         for rec in self:
             if not rec.company_id.partner_id.vat:
-                raise UserError(_("This company doesn't have VAT"))
+                raise UserError(_("This partner doesn't have VAT"))
             rec._clear_old_data()
             # Searches for all possible usable lines to report
             moves = rec._get_account_move_lines()

--- a/l10n_es_vat_book/report/common_templates.xml
+++ b/l10n_es_vat_book/report/common_templates.xml
@@ -71,7 +71,7 @@
             <tr>
                 <td id="detail_invoice_number">Number</td>
                 <td id="detail_invoice_date">Issue Date</td>
-                <td id="detail_company">Company Name</td>
+                <td id="detail_company">Partner Name</td>
                 <td id="detail_vat">VAT</td>
                 <td class="text-right" id="detail_base">Base</td>
                 <td id="detail_tax">Tax</td>


### PR DESCRIPTION
Menuda mezcla que hay a lo largo de todo Odoo 14+ de company / partner y traducciones unas veces como compañía y otras como empresa. En Transifex ya está solucionado lo segundo. Empiezo aquí a arreglar las cosas que voy detectando.

@Tecnativa