### PR TITLE
[14.0][IMP] l10n_es_aeat_sii_oca: Includes new food taxes reduction

### DIFF
--- a/l10n_es_aeat_sii_oca/__manifest__.py
+++ b/l10n_es_aeat_sii_oca/__manifest__.py
@@ -5,7 +5,6 @@
 # Copyright 2017 Studio73 - Jordi Tolsà <jordi@studio73.es>
 # Copyright 2017 Factor Libre - Ismael Calvo
 # Copyright 2017 Otherway - Pedro Rodríguez Gil
-# Copyright 2017-2021 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Javi Melendez <javimelex@gmail.com>
 # Copyright 2018 Angel Moya <angel.moya@pesol.es>
 # Copyright 2020 Sygel Technology - Valentín Vinagre <valentin.vinagre@sygel.es>
@@ -13,6 +12,7 @@
 # Copyright 2022 ForgeFlow - Lois Rilo
 # Copyright 2022 Moduon - Eduardo de Miguel
 # Copyright 2022 NuoBiT - Eric Antones <eantones@nuobit.com>
+# Copyright 2017-2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2017 Acysos
+    Copyright 2017 Studio 73 - Jordi Ortolsa
+    Copyright 2021 Iván Antón
+    Copyright 2021 Comunitea - Omar Castiñeira
+    Copyright 2021 Planeta Huerto - Juanjo Algaz
+    Copyright 2021 Sygel - Valentín Vinagre
+    Copyright 2022 Punt Sistemes S.L.U - Rafa Martínez
+    Copyright 2022 Solvos - David Alonso
+    Copyright 2017-2023 Tecnativa - Pedro M. Baeza
+-->
 <odoo>
     <record id="aeat_sii_map" model="aeat.sii.map">
         <field name="name">SII</field>
@@ -9,7 +20,9 @@
             name="taxes"
             eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_s_iva21b'),
+                ref('l10n_es.account_tax_template_s_iva0b'),
                 ref('l10n_es.account_tax_template_s_iva4b'),
+                ref('l10n_es.account_tax_template_s_iva5b'),
                 ref('l10n_es.account_tax_template_s_iva10b'),
             ])]"
         />
@@ -60,6 +73,7 @@
                 ref('l10n_es.account_tax_template_s_iva10s'),
                 ref('l10n_es.account_tax_template_s_iva5s'),
                 ref('l10n_es.account_tax_template_s_iva4s'),
+                ref('l10n_es.account_tax_template_s_iva0s'),
             ])]"
         />
         <field name="sii_map_id" ref="aeat_sii_map" />
@@ -98,23 +112,32 @@
                 ref('l10n_es.account_tax_template_p_iva21_sc'),
                 ref('l10n_es.account_tax_template_p_iva10_bc'),
                 ref('l10n_es.account_tax_template_p_iva10_sc'),
+                ref('l10n_es.account_tax_template_p_iva5_bc'),
                 ref('l10n_es.account_tax_template_p_iva5_sc'),
                 ref('l10n_es.account_tax_template_p_iva4_bc'),
                 ref('l10n_es.account_tax_template_p_iva4_sc'),
                 ref('l10n_es.account_tax_template_p_iva0_bc'),
+                ref('l10n_es.account_tax_template_p_iva0_s_bc'),
+                ref('l10n_es.account_tax_template_p_iva0_s_sc'),
+                ref('l10n_es.account_tax_template_p_iva0_ibc'),
                 ref('l10n_es.account_tax_template_p_iva4_bi'),
                 ref('l10n_es.account_tax_template_p_iva10_bi'),
                 ref('l10n_es.account_tax_template_p_iva21_bi'),
+                ref('l10n_es.account_tax_template_p_iva0_ic_sc'),
                 ref('l10n_es.account_tax_template_p_iva4_sp_in'),
+                ref('l10n_es.account_tax_template_p_iva5_ic_sc'),
                 ref('l10n_es.account_tax_template_p_iva10_sp_in'),
                 ref('l10n_es.account_tax_template_p_iva21_sp_in'),
+                ref('l10n_es.account_tax_template_p_iva0_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva4_ic_bc'),
+                ref('l10n_es.account_tax_template_p_iva5_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva10_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva21_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva4_ic_bi'),
                 ref('l10n_es.account_tax_template_p_iva10_ic_bi'),
                 ref('l10n_es.account_tax_template_p_iva21_ic_bi'),
                 ref('l10n_es.account_tax_template_p_iva4_ibc'),
+                ref('l10n_es.account_tax_template_p_iva5_ibc'),
                 ref('l10n_es.account_tax_template_p_iva10_ibc'),
                 ref('l10n_es.account_tax_template_p_iva21_ibc'),
                 ref('l10n_es.account_tax_template_p_iva4_ibi'),
@@ -146,7 +169,9 @@
                 ref('l10n_es.account_tax_template_p_iva4_isp'),
                 ref('l10n_es.account_tax_template_p_iva21_sp_ex'),
                 ref('l10n_es.account_tax_template_p_iva10_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva5_isc'),
                 ref('l10n_es.account_tax_template_p_iva4_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva0_isc'),
             ])]"
         />
         <field name="sii_map_id" ref="aeat_sii_map" />
@@ -186,8 +211,12 @@
                 ref('l10n_es.account_tax_template_s_req52'),
                 ref('l10n_es.account_tax_template_p_req014'),
                 ref('l10n_es.account_tax_template_s_req014'),
+                ref('l10n_es.account_tax_template_p_req062'),
+                ref('l10n_es.account_tax_template_s_req062'),
                 ref('l10n_es.account_tax_template_p_req05'),
                 ref('l10n_es.account_tax_template_s_req05'),
+                ref('l10n_es.account_tax_template_p_req0'),
+                ref('l10n_es.account_tax_template_s_req0'),
             ])]"
         />
         <field name="sii_map_id" ref="aeat_sii_map" />
@@ -257,11 +286,15 @@
             eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_p_iva21_sp_ex'),
                 ref('l10n_es.account_tax_template_p_iva10_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva5_isc'),
                 ref('l10n_es.account_tax_template_p_iva4_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva0_isc'),
                 ref('l10n_es.account_tax_template_p_iva4_sp_in'),
                 ref('l10n_es.account_tax_template_p_iva10_sp_in'),
                 ref('l10n_es.account_tax_template_p_iva21_sp_in'),
+                ref('l10n_es.account_tax_template_p_iva0_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva4_ic_bc'),
+                ref('l10n_es.account_tax_template_p_iva5_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva10_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva21_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva4_ic_bi'),


### PR DESCRIPTION
BOE-A-2022-22685 Real Decreto-ley 20/2022, de 27 de diciembre:

https://www.boe.es/buscar/doc.php?id=BOE-A-2022-22685

Adaptation of the SII mappings to the new taxes introduced in https://github.com/odoo/odoo/pull/103361 for the temporal reduction of the food taxes.

@Tecnativa TT41625