### PR TITLE
[15.0][FIX] l10n_es_aeat_sii_oca: Proper places for some food taxes reduction

### DIFF
--- a/l10n_es_aeat_sii_oca/__manifest__.py
+++ b/l10n_es_aeat_sii_oca/__manifest__.py
@@ -5,13 +5,13 @@
 # Copyright 2017 Studio73 - Jordi Tolsà <jordi@studio73.es>
 # Copyright 2017 Factor Libre - Ismael Calvo
 # Copyright 2017 Otherway - Pedro Rodríguez Gil
-# Copyright 2017-2021 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Javi Melendez <javimelex@gmail.com>
 # Copyright 2018 Angel Moya <angel.moya@pesol.es>
 # Copyright 2020 Sygel Technology - Valentín Vinagre <valentin.vinagre@sygel.es>
 # Copyright 2021 Tecnativa - João Marques
 # Copyright 2022 ForgeFlow - Lois Rilo
 # Copyright 2022-2023 Moduon - Eduardo de Miguel
+# Copyright 2017-2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2017 Acysos
+    Copyright 2017 Studio 73 - Jordi Ortolsa
+    Copyright 2021 Iván Antón
+    Copyright 2021 Comunitea - Omar Castiñeira
+    Copyright 2021 Planeta Huerto - Juanjo Algaz
+    Copyright 2021 Sygel - Valentín Vinagre
+    Copyright 2022 Punt Sistemes S.L.U - Rafa Martínez
+    Copyright 2022 Solvos - David Alonso
+    Copyright 2022 Moduon - Eduardo de Miguel
+    Copyright 2017-2023 Tecnativa - Pedro M. Baeza
+-->
 <odoo>
     <record id="aeat_sii_map" model="aeat.sii.map">
         <field name="name">SII</field>
@@ -107,10 +119,10 @@
                 ref('l10n_es.account_tax_template_p_iva4_sc'),
                 ref('l10n_es.account_tax_template_p_iva0_bc'),
                 ref('l10n_es.account_tax_template_p_iva0_s_bc'),
+                ref('l10n_es.account_tax_template_p_iva0_s_sc'),
                 ref('l10n_es.account_tax_template_p_iva0_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva0_ic_sc'),
                 ref('l10n_es.account_tax_template_p_iva0_ibc'),
-                ref('l10n_es.account_tax_template_p_iva0_isc'),
                 ref('l10n_es.account_tax_template_p_iva4_bi'),
                 ref('l10n_es.account_tax_template_p_iva10_bi'),
                 ref('l10n_es.account_tax_template_p_iva21_bi'),
@@ -127,7 +139,6 @@
                 ref('l10n_es.account_tax_template_p_iva21_ic_bi'),
                 ref('l10n_es.account_tax_template_p_iva4_ibc'),
                 ref('l10n_es.account_tax_template_p_iva5_ibc'),
-                ref('l10n_es.account_tax_template_p_iva5_isc'),
                 ref('l10n_es.account_tax_template_p_iva10_ibc'),
                 ref('l10n_es.account_tax_template_p_iva21_ibc'),
                 ref('l10n_es.account_tax_template_p_iva4_ibi'),
@@ -159,7 +170,9 @@
                 ref('l10n_es.account_tax_template_p_iva4_isp'),
                 ref('l10n_es.account_tax_template_p_iva21_sp_ex'),
                 ref('l10n_es.account_tax_template_p_iva10_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva5_isc'),
                 ref('l10n_es.account_tax_template_p_iva4_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva0_isc'),
             ])]"
         />
         <field name="sii_map_id" ref="aeat_sii_map" />
@@ -203,6 +216,8 @@
                 ref('l10n_es.account_tax_template_s_req062'),
                 ref('l10n_es.account_tax_template_p_req05'),
                 ref('l10n_es.account_tax_template_s_req05'),
+                ref('l10n_es.account_tax_template_p_req0'),
+                ref('l10n_es.account_tax_template_s_req0'),
             ])]"
         />
         <field name="sii_map_id" ref="aeat_sii_map" />
@@ -272,11 +287,15 @@
             eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_p_iva21_sp_ex'),
                 ref('l10n_es.account_tax_template_p_iva10_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva5_isc'),
                 ref('l10n_es.account_tax_template_p_iva4_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva0_isc'),
                 ref('l10n_es.account_tax_template_p_iva4_sp_in'),
                 ref('l10n_es.account_tax_template_p_iva10_sp_in'),
                 ref('l10n_es.account_tax_template_p_iva21_sp_in'),
+                ref('l10n_es.account_tax_template_p_iva0_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva4_ic_bc'),
+                ref('l10n_es.account_tax_template_p_iva5_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva10_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva21_ic_bc'),
                 ref('l10n_es.account_tax_template_p_iva4_ic_bi'),


### PR DESCRIPTION
Refinement of #2836

- Missing tax "0% IVA soportado (servicios corrientes)"
- Bad tax group for taxes "Importaciones servicios corrientes"
- Missing "Recargo equivalencia 0%" taxes
- Missing new taxes in NotIncludeInTotalNegative

@Tecnativa 