### PR TITLE
[14.0][FIX] l10n_es_ticketbai_batuz: Corregido error al realizar pagos en facturas

### DIFF
--- a/l10n_es_ticketbai_batuz/models/account_move.py
+++ b/l10n_es_ticketbai_batuz/models/account_move.py
@@ -834,7 +834,6 @@ class AccountMove(models.Model):
         res = super(AccountMove, self)._post(soft)
         lroe_invoices = self.sudo().filtered(
             lambda x: x.tbai_enabled
-            and x.invoice_date >= x.journal_id.tbai_active_date
             and (
                 x.move_type == "in_invoice"
                 or (


### PR DESCRIPTION
Al intentar realizar el pago de facturas de proveedor Odoo muestra el siguiente error:

raise exception.with_traceback(None) from new_cause
TypeError: '>=' not supported between instances of 'bool' and 'datetime.date'

Creo que esa línea más arriba está bien pero que en este punto concreto no hace falta esa validación