### PR TITLE
[16.0][FIX] l10n_es_aeat_partner_check: permitir a todos escribir en res.partner

### DIFF
--- a/l10n_es_aeat_partner_check/models/res_partner.py
+++ b/l10n_es_aeat_partner_check/models/res_partner.py
@@ -64,7 +64,7 @@ class ResPartner(models.Model):
             if country_code != "ES":
                 continue
             request = {"Nif": vat_number, "Nombre": partner.name}
-            res = soap_obj.send_soap(
+            res = soap_obj.sudo().send_soap(
                 service, wsdl, port_name, partner, operation, request
             )
             vals = {
@@ -84,7 +84,7 @@ class ResPartner(models.Model):
                 )
                 if partner_name != partner.name:
                     vals.update({"aeat_data_diff": True})
-            partner.write(vals)
+            partner.sudo().write(vals)
         self.aeat_check_re()
 
     def write(self, vals):
@@ -120,13 +120,15 @@ class ResPartner(models.Model):
             if country_code != "ES":
                 continue
             if "company_id" in partner._fields:
-                public_crt, private_key = self.env[
-                    "l10n.es.aeat.certificate"
-                ].get_certificates(partner.company_id)
+                public_crt, private_key = (
+                    self.env["l10n.es.aeat.certificate"]
+                    .sudo()
+                    .get_certificates(partner.company_id)
+                )
             else:
-                public_crt, private_key = self.env[
-                    "l10n.es.aeat.certificate"
-                ].get_certificates()
+                public_crt, private_key = (
+                    self.env["l10n.es.aeat.certificate"].sudo().get_certificates()
+                )
             request = {"nif": vat_number, "apellido": partner.name}
             res = requests.post(
                 url, params=request, cert=(public_crt, private_key), timeout=20
@@ -136,4 +138,4 @@ class ResPartner(models.Model):
                 vals.update({"aeat_partner_type": "sales_equalization"})
             else:
                 vals.update({"aeat_partner_type": "standard"})
-            partner.write(vals)
+            partner.sudo().write(vals)


### PR DESCRIPTION
Sin esta corrección, los usuarios estaban teniendo este error al escribir en algunos partners:

> No puedes ingresar a los registros 'Certificados AEAT' (l10n.es.aeat.certificate)
>
> Se permite esta operación para los grupos siguientes:
> - Accounting/Advisor
>
> Ponte en contacto con tu administrador para pedirle acceso si es necesario

@moduon MT-2308
fw-port of https://github.com/OCA/l10n-spain/pull/2848