### PR TITLE
[13.0][FIX] l10n_es_intrastat_report: Search archived records when importing codes.

### DIFF
--- a/l10n_es_intrastat_report/wizards/l10n_es_intrastat_code_import.py
+++ b/l10n_es_intrastat_report/wizards/l10n_es_intrastat_code_import.py
@@ -30,7 +30,7 @@ class L10nEsPartnerImportWizard(models.TransientModel):
         return self.env["intrastat.unit"].search([("name", "=", name)]).id
 
     def _import_hs_codes(self):
-        code_obj = self.env["hs.code"]
+        code_obj = self.env["hs.code"].with_context(active_test=False)
         path = os.path.join(
             os.path.dirname(os.path.dirname(__file__)), "data", "Estruc_NC2023.xlsx"
         )


### PR DESCRIPTION
Search archived records when importing codes.

If any code is archived, we need to find it as well to avoid the duplicate code error.

Please @pedrobaeza can you review it?

@Tecnativa TT41641