### PR TITLE
[FIX] l10n_es_aeat_mod347: remove taxes not required

### DIFF
--- a/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
+++ b/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
@@ -38,9 +38,6 @@
         ref('l10n_es.account_tax_template_p_req014'),
         ref('l10n_es.account_tax_template_p_req05'),
         ref('l10n_es.account_tax_template_p_req52'),
-        ref('l10n_es.account_tax_template_p_iva4_isp_1'),
-        ref('l10n_es.account_tax_template_p_iva10_isp_1'),
-        ref('l10n_es.account_tax_template_p_iva21_isp_1'),
         ref('l10n_es.account_tax_template_p_iva105_gan'),
         ])]"/>
   </record>


### PR DESCRIPTION
Estos impuestos no deben estar incluidos para calcular el 347. Si no, incluye el impuesto en el resultado.

De hecho en las versiones superiores ya no están.

cc @AlbertCabedo 