### PR TITLE
[12.0][FIX] l10n_es_aeat_mod347: add missing taxes

### DIFF
--- a/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
+++ b/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
@@ -38,6 +38,9 @@
         ref('l10n_es.account_tax_template_p_req014'),
         ref('l10n_es.account_tax_template_p_req05'),
         ref('l10n_es.account_tax_template_p_req52'),
+        ref('l10n_es.account_tax_template_p_iva4_isp'),
+        ref('l10n_es.account_tax_template_p_iva10_isp'),
+        ref('l10n_es.account_tax_template_p_iva21_isp'),
         ref('l10n_es.account_tax_template_p_iva105_gan'),
         ])]"/>
   </record>


### PR DESCRIPTION
No me había dado cuenta que faltaban los impuestos padres.

Relacionado: https://github.com/OCA/l10n-spain/pull/2863