### PR TITLE
[15.0][MIG][FIX] l10n_es_aeat_sii_oca: Comprobar si existe la columna sii_tax_agency_id en la base de datos

### DIFF
--- a/l10n_es_aeat_sii_oca/migrations/15.0.2.1.0/post-migration.py
+++ b/l10n_es_aeat_sii_oca/migrations/15.0.2.1.0/post-migration.py
@@ -61,5 +61,6 @@ def _set_agency_in_company(env, agency_map):
 
 @openupgrade.migrate()
 def migrate(env, version):
-    agency_map = _get_tax_agency_map(env)
-    _set_agency_in_company(env, agency_map)
+    if openupgrade.column_exists(env.cr, "res_company", "sii_tax_agency_id"):
+        agency_map = _get_tax_agency_map(env)
+        _set_agency_in_company(env, agency_map)

--- a/l10n_es_aeat_sii_oca/migrations/15.0.2.1.0/pre-migration.py
+++ b/l10n_es_aeat_sii_oca/migrations/15.0.2.1.0/pre-migration.py
@@ -7,7 +7,9 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     column_name = openupgrade.get_legacy_name("sii_tax_agency_id")
-    if not openupgrade.column_exists(env.cr, "res_company", column_name):
+    if openupgrade.column_exists(
+        env.cr, "res_company", "sii_tax_agency_id"
+    ) and not openupgrade.column_exists(env.cr, "res_company", column_name):
         openupgrade.rename_columns(
             env.cr, {"res_company": [("sii_tax_agency_id", column_name)]}
         )


### PR DESCRIPTION
cc @Tecnativa

Si ya se ha ejecutado el script de migración de v14 donde se renombra la columna fallará en el script de migración de v15

ping @LoisRForgeFlow 