### PR TITLE
[14.0][FIX] l10n_es_payment_order_sabadell: Missing string cast

### DIFF
--- a/l10n_es_payment_order_confirming_sabadell/models/confirming_sabadell.py
+++ b/l10n_es_payment_order_confirming_sabadell/models/confirming_sabadell.py
@@ -140,12 +140,15 @@ class ConfirmingSabadell(object):
             self.record.company_partner_bank_id.partner_id.name, 40, "left"
         )
         # 44 - 51 Fecha de proceso
-        fecha_planificada = (
-            str(fields.first(self.record.payment_line_ids).ml_maturity_date)
-            if self.record.date_prefered == "due"
-            else self.record.date_scheduled
-        )
-        text += fecha_planificada.replace("-", "")
+        if self.record.date_prefered == "due":
+            fecha_planificada = fields.first(
+                self.record.payment_line_ids
+            ).ml_maturity_date
+        elif self.record.date_prefered == "now":
+            fecha_planificada = fields.Date.today()
+        else:
+            fecha_planificada = self.record.date_scheduled
+        text += str(fecha_planificada).replace("-", "")
         # 52 - 60 NIF
         vat = self.record.company_partner_bank_id.partner_id.vat
         if self.record.company_partner_bank_id.partner_id.country_id.code in vat:


### PR DESCRIPTION
Corregir un error de tipos al usar un tipo de fecha que no es vencimiento
```
text += fecha_planificada.replace("-", "")

TypeError: an integer is required (got type str)
```

- Cubrir el caso `else` con `str` igual que se hace para el case `due`
- Añadir el caso para el `now` para que ponga la fecha actual como hacía originalmente https://github.com/OCA/l10n-spain/pull/2119/commits/904b6ea77f01a073e2a9ce1199cce5894e6610ee#diff-ea7eb8fe353625d22048a0d3824693523dea62a6d1a75782ce915c64e3aea1efR35-R47