### PR TITLE
Corrijo error de cálculo en el importe original de las rectificaciones de otros periodos del modelo aeat 349

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -303,7 +303,10 @@ class Mod349(models.Model):
             key_vals = data.setdefault(
                 key, {"original_amount": 0, "refund_details": refund_detail_obj}
             )
-            key_vals["original_amount"] += origin_amount
+
+            if not key_vals["original_amount"]:
+                key_vals["original_amount"] = origin_amount
+
             key_vals["refund_details"] += refund_details
         for key, key_vals in data.items():
             partner, op_key, period_type, year = key


### PR DESCRIPTION
… de otros periodos". El "Importe original" se está multiplicando por el nº de rectificativas que haya en el periodo de cómputo. El problema solo se hace visible cuando un mismo cliente tiene dos o más rectificativas en el periodo. Se puede ver en el código que anteriormente se computaba únicamente el importe original de las facturas afectadas que se iba sumando. Cuando se cambió para computar el periodo original al completo, se conservó la suma por cada factura rectificativa cuando solo debería incluirse una vez por cliente. Vendría bien un refactoring de la función pero en todo caso este pequeño cambio soluciona el problema.