### PR TITLE
[16.0][FIX] l10n_es_aeat_sii_oca: fix error sii header

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -402,7 +402,7 @@ class AccountMove(models.Model):
             "IDVersionSii": SII_VERSION,
             "Titular": {
                 "NombreRazon": self.company_id.name[0:120],
-                "NIF": self.company_id.vat[2:],
+                "NIF": company.partner_id._parse_aeat_vat_info()[2],
             },
         }
         if not cancellation:
@@ -776,7 +776,9 @@ class AccountMove(models.Model):
             serial_number = self.thirdparty_number[0:60]
         inv_dict = {
             "IDFactura": {
-                "IDEmisorFactura": {"NIF": company.vat[2:]},
+                "IDEmisorFactura": {
+                    "NIF": company.partner_id._parse_aeat_vat_info()[2]
+                },
                 # On cancelled invoices, number is not filled
                 "NumSerieFacturaEmisor": serial_number,
                 "FechaExpedicionFacturaEmisor": invoice_date,


### PR DESCRIPTION
Forward-port of #2864

If the company VAT doesn't contain `ES`, the SII sending fails, as it was hardcoded to strip the first 2 characters.

Now it uses the standard AEAT function.

@Tecnativa 