### PR TITLE
[14.0][FIX] l10n_es_aeat_mod347: Corrección de la exportación a BOE del NIF operador comunitario.

### DIFF
--- a/l10n_es_aeat_mod347/data/aeat_export_mod347_partner_data.xml
+++ b/l10n_es_aeat_mod347/data/aeat_export_mod347_partner_data.xml
@@ -413,21 +413,37 @@
         <field name="alignment">right</field>
     </record>
     <!--             264-280     NIF del operador comunitario -->
+    <!--             264-265     Código país -->
     <record
         id="aeat_mod347_partner_export_line_27"
         model="aeat.model.export.config.line"
     >
         <field name="sequence">27</field>
         <field name="export_config_id" ref="aeat_mod347_partner_export_config" />
+        <field name="name">NIF operador comunitario - Código país</field>
+        <field
+            name="expression"
+        >${object.partner_country_code if object.community_vat and object.partner_state_code == '99' else ''}</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+    <!--             266-280     Código país -->
+    <record
+        id="aeat_mod347_partner_export_line_28"
+        model="aeat.model.export.config.line"
+    >
+        <field name="sequence">28</field>
+        <field name="export_config_id" ref="aeat_mod347_partner_export_config" />
         <field name="name">NIF operador comunitario</field>
         <field name="expression">${object.community_vat}</field>
         <field name="export_type">string</field>
-        <field name="size">17</field>
+        <field name="size">15</field>
         <field name="alignment">left</field>
     </record>
     <!--             281         'X' si aplica el régimen especial de criterio de caja -->
-    <record id="aeat_mod349_main_export_line_28" model="aeat.model.export.config.line">
-        <field name="sequence">28</field>
+    <record id="aeat_mod349_main_export_line_29" model="aeat.model.export.config.line">
+        <field name="sequence">29</field>
         <field name="export_config_id" ref="aeat_mod347_partner_export_config" />
         <field name="name">Régimen especial de criterio de caja</field>
         <field name="expression">${object.cash_basis_operation}</field>
@@ -438,8 +454,8 @@
         <field name="alignment">left</field>
     </record>
     <!--             282         'X' si son operaciones con inversión de sujeto pasivo -->
-    <record id="aeat_mod349_main_export_line_29" model="aeat.model.export.config.line">
-        <field name="sequence">29</field>
+    <record id="aeat_mod349_main_export_line_30" model="aeat.model.export.config.line">
+        <field name="sequence">30</field>
         <field name="export_config_id" ref="aeat_mod347_partner_export_config" />
         <field name="name">Operaciones con inversión de sujeto pasivo</field>
         <field name="expression">${object.tax_person_operation}</field>
@@ -451,8 +467,8 @@
     </record>
     <!--             283         'X' si son operaciones vinculadas al régimen de -->
     <!--                         depósito distinto del aduanero -->
-    <record id="aeat_mod349_main_export_line_30" model="aeat.model.export.config.line">
-        <field name="sequence">30</field>
+    <record id="aeat_mod349_main_export_line_31" model="aeat.model.export.config.line">
+        <field name="sequence">31</field>
         <field name="export_config_id" ref="aeat_mod347_partner_export_config" />
         <field
             name="name"
@@ -466,10 +482,10 @@
     </record>
     <!--             284-299     Importe de la operaciones anuales de criterio de caja -->
     <record
-        id="aeat_mod347_partner_export_line_31"
+        id="aeat_mod347_partner_export_line_32"
         model="aeat.model.export.config.line"
     >
-        <field name="sequence">31</field>
+        <field name="sequence">32</field>
         <field name="export_config_id" ref="aeat_mod347_partner_export_config" />
         <field name="name">Importe de la operaciones anuales de criterio de caja</field>
         <field name="fixed_value">0</field>
@@ -483,10 +499,10 @@
     </record>
     <!--             300-500     Blancos -->
     <record
-        id="aeat_mod347_partner_export_line_32"
+        id="aeat_mod347_partner_export_line_33"
         model="aeat.model.export.config.line"
     >
-        <field name="sequence">32</field>
+        <field name="sequence">33</field>
         <field name="export_config_id" ref="aeat_mod347_partner_export_config" />
         <field name="name">Blancos</field>
         <field name="fixed_value" />


### PR DESCRIPTION
Según el diseño de registro debe especificarse primero los dos códigos del país, y seguidamente 15 dígitos que deberán 
contener el número de NIF.

![image](https://user-images.githubusercontent.com/7683926/221565315-bb7c169c-8521-4d8e-8a15-deef00693d73.png)
