### PR TITLE
[11.0][FIX] l10n_es_aeat: improve report.tax.mapping performance

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -434,7 +434,7 @@ class L10nEsAeatMod303Report(models.Model):
         if 79 <= map_line.field_number <= 99 or map_line.field_number == 125:
             if (self.exonerated_390 == '2' or not self.has_operation_volume
                     or self.period_type not in ('4T', '12')):
-                return self.env['account.move.line']
+                return {}
         return super(L10nEsAeatMod303Report, self)._get_tax_lines(
             codes, date_start, date_end, map_line,
         )

--- a/l10n_es_aeat_mod303_oss/models/mod303.py
+++ b/l10n_es_aeat_mod303_oss/models/mod303.py
@@ -33,7 +33,7 @@ class L10nEsAeatMod303Report(models.Model):
         if 126 <= map_line.field_number <= 127:
             if (self.exonerated_390 == '2' or not self.has_operation_volume
                     or self.period_type not in ('4T', '12')):
-                return self.env['account.move.line']
+                return {}
         return res
 
     def _get_move_line_domain(self, codes, date_start, date_end, map_line):


### PR DESCRIPTION
Evitar iterar a través de la misma lista de elementos en el método `calculate` durante la creación de líneas de impuestos.

Rompe compatibilidad en método `_get_tax_lines` cambiando el valor de retorno, solo se necesitan los campos `ID`, `credit` y `debit`.

Se realiza una búsqueda de apuntes contables en lotes con un nuevo cursor cada vez para evitar alcanzar límites de memoria.

Caso de uso real (en producción):

* Al obtener los apuntes contables para los códigos y periodos asociados, encontramos unos 2 millones de filas en una sola búsqueda, consumiendo más de 1.6GB de memoria RAM. Al realizar cada búsqueda en una misma transacción/entorno, la memoria RAM se va llenando hasta que alcanza el límite, en nuestro caso fueron más de 3.5GB.
* Utilizando la búsqueda por lotes (100k de límite en cada query) y en un entorno y cursor distinto, el máximo de RAM ocupado nos llegó a 700MB.
