### PR TITLE
[16.0][IMP] l10n_es_vat_book: Prevent sections and notes when return move lines

### DIFF
--- a/l10n_es_aeat/tests/test_l10n_es_aeat_map_tax.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_map_tax.py
@@ -4,7 +4,7 @@
 import logging
 
 from odoo import exceptions
-from odoo.tests.common import SavepointCase
+from odoo.tests.common import TransactionCase
 
 _logger = logging.getLogger("aeat")
 _DATES_MAPPING = [
@@ -49,7 +49,7 @@ _DATES_MAPPING = [
 ]
 
 
-class TestL10nEsAeat(SavepointCase):
+class TestL10nEsAeat(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -323,6 +323,7 @@ class L10nEsVatBook(models.Model):
             ("date", ">=", self.date_start),
             ("date", "<=", self.date_end),
             ("parent_state", "=", "posted"),
+            ("display_type", "not in", ("line_section", "line_note")),
         ]
         if taxes:
             domain.append(("tax_ids", "in", taxes.ids))


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/l10n-spain/pull/2909

Prevent sections and notes when return move lines

Please @pedrobaeza can you review it?

@Tecnativa TT41951