### PR TITLE
[15.0][IMP] l10n_es_aeat: Change Warning to UserError exception to prevent warning log

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_map_tax.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_map_tax.py
@@ -40,7 +40,7 @@ class L10nEsAeatMapTax(models.Model):
             if self.date_to:
                 domain.append(("date_from_search", "<=", map_tax.date_to))
             if map_tax.search(domain):
-                raise exceptions.Warning(
+                raise exceptions.UserError(
                     _(
                         "Error! The dates of the record overlap with an "
                         "existing record."


### PR DESCRIPTION
Change Warning to UserError exception to prevent warning log

`warnings.warn("Warning is a deprecated alias to UserError.", DeprecationWarning)`

Please @pedrobaeza can you review it?

@Tecnativa