### PR TITLE
[14.0][IMP] l10n_es_ticketbai: Support for rappel invoices

### DIFF
--- a/l10n_es_ticketbai/i18n/es.po
+++ b/l10n_es_ticketbai/i18n/es.po
@@ -6,16 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-03 15:25+0000\n"
-"PO-Revision-Date: 2022-08-29 13:07+0000\n"
-"Last-Translator: olatzavanzosc <olatzaranguren@avanzosc.es>\n"
+"POT-Creation-Date: 2023-03-08 09:11+0000\n"
+"PO-Revision-Date: 2023-03-08 10:13+0100\n"
+"Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 3.2.2\n"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_l10n_es_aeat_certificate
@@ -26,7 +26,7 @@ msgstr "Certificados AEAT"
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_account_chart_template
 msgid "Account Chart Template"
-msgstr "Plantilla de Plan de Cuentas"
+msgstr "Plantilla de gráfico de cuentas"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_account_move_reversal
@@ -41,7 +41,7 @@ msgstr "Factura rectificativa"
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_l10n_es_aeat_certificate__tbai_p12_friendlyname
 msgid "Alias"
-msgstr "Alias"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_refund_key__r4
@@ -56,12 +56,12 @@ msgstr "Art. 80.1, 80.2, 80.6 y errores fundados de derecho"
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_refund_key__r2
 msgid "Art. 80.3"
-msgstr "Art. 80.3"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_refund_key__r3
 msgid "Art. 80.4"
-msgstr "Art. 80.4"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__res_company__tbai_description_method__auto
@@ -76,8 +76,6 @@ msgid ""
 "BOE-A-1992-28740. Ley 37/1992, de 28 de diciembre, del Impuesto sobre el "
 "Valor Añadido. Artículo 80. Modificación de la base imponible."
 msgstr ""
-"BOE-A-1992-28740. Ley 37/1992, de 28 de diciembre, del Impuesto sobre el "
-"Valor Añadido. Artículo 80. Modificación de la base imponible."
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_refund_type__i
@@ -194,7 +192,13 @@ msgstr "Número de serie de dispositivo"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_exemption_key__display_name
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_regime_key__display_name
 msgid "Display Name"
-msgstr "Mostrar nombre"
+msgstr "Nombre mostrado"
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.constraint,message:l10n_es_ticketbai.constraint_account_fp_tbai_tax_position_tax_uniq
+#: model:ir.model.constraint,message:l10n_es_ticketbai.constraint_account_fp_tbai_tax_template_position_tax_uniq
+msgid "El impuesto debe ser único por posición fiscal!"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_line__tbai_enabled
@@ -280,6 +284,17 @@ msgstr "Agrupar por"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_regime_key__id
 msgid "ID"
 msgstr "Identificador"
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_account_bank_statement_line__tbai_rappel_invoice
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_account_move__tbai_rappel_invoice
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_account_payment__tbai_rappel_invoice
+msgid ""
+"If rappel invoice check this field, and insert first and last invoices from "
+"period."
+msgstr ""
+"Si factura de bonificación o rappel activa el campo e inserta la primera y "
+"última factura del periodo."
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_invoice__invoice_id
@@ -394,7 +409,7 @@ msgstr "Enlace entre la factura del cliente y su sustituta."
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__res_company__tbai_description_method__manual
 msgid "Manual"
-msgstr "Manual"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.view_move_form_inherit
@@ -483,6 +498,13 @@ msgid "QR Code"
 msgstr "Código QR"
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_line__tbai_rappel_invoice
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_move__tbai_rappel_invoice
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_payment__tbai_rappel_invoice
+msgid "Rappel invoice"
+msgstr "Factura bonificación o rappel"
+
+#. module: l10n_es_ticketbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.view_move_form_inherit
 msgid "Refund"
 msgstr "Rectificativa"
@@ -551,7 +573,7 @@ msgstr "Secuencia"
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_info__software
 msgid "Software"
-msgstr "Software"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_move.py:0
@@ -574,7 +596,7 @@ msgstr ""
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,help:l10n_es_ticketbai.field_account_journal__tbai_active_date
 msgid "Start date for sending invoices to the tax authorities"
-msgstr ""
+msgstr "Fecha inicio para enviar las facturas a hacienda"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_line__tbai_substitute_simplified_invoice
@@ -598,8 +620,6 @@ msgstr "Impuesto"
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_fiscal_position.py:0
 #: code:addons/l10n_es_ticketbai/models/chart_template.py:0
-#: model:ir.model.constraint,message:l10n_es_ticketbai.constraint_account_fp_tbai_tax_position_tax_uniq
-#: model:ir.model.constraint,message:l10n_es_ticketbai.constraint_account_fp_tbai_tax_template_position_tax_uniq
 #, python-format
 msgid "Tax must be unique per fiscal position!"
 msgstr "El impuesto debe ser único por posición fiscal!"
@@ -684,7 +704,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.view_move_form_inherit
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.view_partner_property_form_inherit
 msgid "TicketBAI"
-msgstr "TicketBAI"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_account_fp_tbai_tax
@@ -839,7 +859,7 @@ msgstr "TicketBAI Mapeo claves de regímenes de IVA"
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_active_date
 msgid "TicketBAI active date"
-msgstr ""
+msgstr "TicketBAI Fecha inicio"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_tbai_info

--- a/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
+++ b/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 14.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-03-08 09:11+0000\n"
+"PO-Revision-Date: 2023-03-08 09:11+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -191,6 +193,12 @@ msgid "Display Name"
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.constraint,message:l10n_es_ticketbai.constraint_account_fp_tbai_tax_position_tax_uniq
+#: model:ir.model.constraint,message:l10n_es_ticketbai.constraint_account_fp_tbai_tax_template_position_tax_uniq
+msgid "El impuesto debe ser único por posición fiscal!"
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_line__tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_move__tbai_enabled
@@ -273,6 +281,15 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_exemption_key__id
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_regime_key__id
 msgid "ID"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_account_bank_statement_line__tbai_rappel_invoice
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_account_move__tbai_rappel_invoice
+#: model:ir.model.fields,help:l10n_es_ticketbai.field_account_payment__tbai_rappel_invoice
+msgid ""
+"If rappel invoice check this field, and insert first and last invoices from "
+"period."
 msgstr ""
 
 #. module: l10n_es_ticketbai
@@ -463,6 +480,13 @@ msgid "QR Code"
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_line__tbai_rappel_invoice
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_move__tbai_rappel_invoice
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_payment__tbai_rappel_invoice
+msgid "Rappel invoice"
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.view_move_form_inherit
 msgid "Refund"
 msgstr ""
@@ -568,8 +592,6 @@ msgstr ""
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_fiscal_position.py:0
 #: code:addons/l10n_es_ticketbai/models/chart_template.py:0
-#: model:ir.model.constraint,message:l10n_es_ticketbai.constraint_account_fp_tbai_tax_position_tax_uniq
-#: model:ir.model.constraint,message:l10n_es_ticketbai.constraint_account_fp_tbai_tax_template_position_tax_uniq
 #, python-format
 msgid "Tax must be unique per fiscal position!"
 msgstr ""

--- a/l10n_es_ticketbai/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai/models/ticketbai_invoice.py
@@ -114,6 +114,8 @@ class TicketBAIInvoiceRefundOrigin(models.Model):
     @api.constrains("number", "number_prefix", "expedition_date")
     def _check_account_invoice_exists(self):
         for record in self:
+            if record.account_refund_invoice_id.tbai_rappel_invoice:
+                continue
             invoice_number = ""
             if record.number_prefix:
                 invoice_number = record.number_prefix

--- a/l10n_es_ticketbai/views/account_move_views.xml
+++ b/l10n_es_ticketbai/views/account_move_views.xml
@@ -78,6 +78,7 @@
                                 colspan="4"
                                 attrs="{'invisible': ['|', '|', ('tbai_enabled', '!=', True), ('reversed_entry_id', '!=', False), ('move_type', '!=', 'out_refund')]}"
                             >
+                                <field name="tbai_rappel_invoice" />
                                 <field
                                     name="tbai_refund_origin_ids"
                                     nolabel="1"


### PR DESCRIPTION
En caso de querer crear una factura rectificativas por la concesión de descuentos o bonificaciones por volumen de operaciones (rappel) TicketBAI permite especificar la primera y última factura del periodo de bonificación.

El problema es que Odoo no permite seleccionar mas de una factura que se esté rectificando. Por esa razón, se hace uso de la tabla de rectificación de facturas que no existen en Odoo. Se agrega un checkbox para especificar que se trata de una factura rappel, y desde ese momento se permite introducir datos de facturas existentes en la tabla.

También se agrega el texto `(rappel)` el final de la descripción de la factura.

Adjunto el FAQ de hacienda hablando del tema, y la respuesta copiada:
https://www.gipuzkoa.eus/documents/2456431/13761128/1-FAQ-TEXTO+UNIFICADO+19-05-2021.pdf/029ebb00-0fb1-aefe-cfde-2bae0eef4dd6

> **¿Cómo deben informarse las facturas rectificativas por la concesión de descuentos o bonificaciones por volumen de operaciones?** 
> 
> Para el caso de facturas rectificativas en las que la modificación de la base imponible
> tenga su origen en la concesión de descuentos o bonificaciones por volumen de
> operaciones, se deberá actuar de la siguiente forma:
> Se hará una factura rectificativa, por sustitución “S” o por diferencias “I”, según lo
> indicado para las facturas rectificativas, con las siguientes especialidades:
> • Código de factura rectificativa: R1.
> En el bloque de “Facturas Rectificadas Sustituidas”, “ID Factura Rectificada Sustituida”,
> se identificarán la primera y la última factura a las que afecta la modificación, para indicar
> el periodo del descuento o bonificación al que se refieren.
> •En el bloque “Datos Factura”, en el campo “Descripción Factura”, deberá aparecer
> dentro de la descripción general las palabras “rappel”, “descuento” o “bonificación”.