### PR TITLE
[15.0][FIX] l10n_es_ticketbai: 'Recargo' fiscal position TBAI regime key

### DIFF
--- a/l10n_es_ticketbai/__manifest__.py
+++ b/l10n_es_ticketbai/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "TicketBAI",
     "summary": "Declaración de todas las operaciones de venta realizadas por las "
     "personas y entidades que desarrollan actividades económicas",
-    "version": "15.0.1.4.6",
+    "version": "15.0.1.4.7",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/l10n-spain",
     "author": "Binovo, Odoo Community Association (OCA)",

--- a/l10n_es_ticketbai/data/account_fiscal_position_template.xml
+++ b/l10n_es_ticketbai/data/account_fiscal_position_template.xml
@@ -17,10 +17,10 @@
         <field name="tbai_vat_regime_key" ref="tbai_vat_regime_08" />
     </record>
     <record id="l10n_es.fp_recargo" model="account.fiscal.position.template">
-        <field name="tbai_vat_regime_key" ref="tbai_vat_regime_51" />
+        <field name="tbai_vat_regime_key" ref="tbai_vat_regime_01" />
     </record>
     <record id="l10n_es.fp_recargo_isp" model="account.fiscal.position.template">
-        <field name="tbai_vat_regime_key" ref="tbai_vat_regime_51" />
+        <field name="tbai_vat_regime_key" ref="tbai_vat_regime_01" />
     </record>
     <record id="l10n_es.fp_irpf1" model="account.fiscal.position.template">
         <field name="tbai_vat_regime_key" ref="tbai_vat_regime_01" />

--- a/l10n_es_ticketbai/migrations/15.0.1.4.7/post-migration.py
+++ b/l10n_es_ticketbai/migrations/15.0.1.4.7/post-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Landoo Sistemas de Informacion SL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+    companies = env["res.company"].search([])
+    fps = env["account.fiscal.position"]
+    for company in companies:
+        fps |= company.get_fps_from_templates(
+            env.ref("l10n_es.fp_recargo") + env.ref("l10n_es.fp_recargo_isp")
+        )
+    fps.write(
+        {"tbai_vat_regime_key": env.ref("l10n_es_ticketbai.tbai_vat_regime_01").id}
+    )


### PR DESCRIPTION
Fix de clave de régimen en posiciones fiscales de recargo equivalencia. 51 y 52 se utilizan en caso de que la compañía de Odoo esté asociada a los regímenes de "Recargo de Equivalencia" o "Régimen Simplificado"  (pendiente de incorporación al módulo, solución propuesta en el PR #2295).