### PR TITLE
[15.0][FIX]l10n_es_pos: Wrong customer info when reprinting receipt

### DIFF
--- a/l10n_es_pos/static/src/xml/pos.xml
+++ b/l10n_es_pos/static/src/xml/pos.xml
@@ -30,15 +30,15 @@
         </xpath>
         <xpath expr='//t[@t-if="receipt.cashier"]' position="after">
             <br />
-            <t t-if="env.pos.get_client()">
-                <div>Customer: <t t-esc="env.pos.get_client().name" /></div>
-                <t t-if="env.pos.get_client().vat">
+            <t t-if="receipt.client">
+                <div>Customer: <t t-esc="receipt.client.name" /></div>
+                <t t-if="receipt.client.vat">
                     <div><t t-esc="receipt.company.vat_label" />:<t
-                            t-esc="env.pos.get_client().vat"
+                            t-esc="receipt.client.vat"
                         /></div>
                 </t>
-                <t t-if="env.pos.get_client().address != ',  , '">
-                    <div><t t-esc="env.pos.get_client().address" /></div>
+                <t t-if="receipt.client.address != ',  , '">
+                    <div><t t-esc="receipt.client.address" /></div>
                 </t>
             </t>
         </xpath>


### PR DESCRIPTION
Cuando se reimprime un recibo, los datos de cliente que se muestran no son los de la venta que se selecciona sino los del cliente seleccionado en la centa en curso en el POS.

1. Tenemos un cliente determinado seleccionado en una venta.

![error_pos_1](https://user-images.githubusercontent.com/62256279/224646348-8661546d-b9ed-4c9c-a7b3-f26c724f96bb.png)

2. Desde pedidos, seleccionamos un pedido ya finalizado cuyo cliente es distinto al que tenemos seleccionado en el punto 1.
 
![error_pos_2](https://user-images.githubusercontent.com/62256279/224646546-992fb87d-436b-49f8-a516-e1cd439cfe6a.png)

3. Al reimprimir el recibo, los datos de cliente que se muestran son los del cliente seleccionado en el pedido en curso (punto 1) y no los del cliente al que realizamos la venta (punto 2).

![error_pos_3](https://user-images.githubusercontent.com/62256279/224646694-6666d500-1920-4f2b-a0c7-b426bd4a0477.png)