### PR TITLE
[16.0][IMP] l10n_es_ticketbai_api: Limit tbai.invoice model compute registers

### DIFF
--- a/l10n_es_ticketbai_api/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice.py
@@ -449,7 +449,13 @@ class TicketBAIInvoice(models.Model):
 
     @api.depends("signature_value")
     def _compute_tbai_identifier(self):
-        for record in self:
+        for record in self.filtered(
+            lambda ti: ti.state
+            in (
+                TicketBaiInvoiceState.draft.value,
+                TicketBaiInvoiceState.pending.value,
+            )
+        ):
             if record.signature_value:
                 tbai_identifier_len_without_crc = 36
                 tbai_identifier_len_with_crc = 39
@@ -501,7 +507,13 @@ class TicketBAIInvoice(models.Model):
         El nivel de corrección de errores del QR será M.
         La codificación utilizada para la generación del código será UTF-8.
         """
-        for record in self:
+        for record in self.filtered(
+            lambda ti: ti.state
+            in (
+                TicketBaiInvoiceState.draft.value,
+                TicketBaiInvoiceState.pending.value,
+            )
+        ):
             if record.tbai_identifier:
                 if record.company_id.tbai_test_enabled:
                     qr_base_url = record.company_id.tbai_tax_agency_id.test_qr_base_url
@@ -539,7 +551,13 @@ class TicketBAIInvoice(models.Model):
         "company_id.tbai_tax_agency_id.test_rest_url_cancellation",
     )
     def _compute_api_url(self):
-        for record in self:
+        for record in self.filtered(
+            lambda ti: ti.state
+            in (
+                TicketBaiInvoiceState.draft.value,
+                TicketBaiInvoiceState.pending.value,
+            )
+        ):
             if record.schema == TicketBaiSchema.TicketBai.value:
                 if record.company_id.tbai_test_enabled:
                     url = record.company_id.tbai_tax_agency_id.test_rest_url_invoice


### PR DESCRIPTION
Los compute del modelo tbai.invoice modifican el QR, identificador, etc. no son necesarias si la factura ya ha sido enviada a hacienda. Estos compute se lanzan si se cambia a entorno de pruebas, si se cambia de hacienda, etc. o cuando se realiza un update all (por ejemplo en una migración).

Actualizando la BBDD de un cliente con muchísimas facturas TBAI creadas mediante TPV hemos visto que se tomaba un tiempo exagerado para realizar el update, y al ver la causa nos hemos encontrado con esto. No vemos sentido a que se actualicen estos campos si la factura TBAI está ya enviada, cancelada o con error.