### PR TITLE
[14.0][FIX] l10n_es_facturae: The "global" tax calculation rounding method …

### DIFF
--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -204,21 +204,23 @@ class AccountMove(models.Model):
 
     def _get_facturae_tax_info(self):
         self.ensure_one()
+        sign = -1 if self.move_type[:3] == "out" else 1
         output_taxes = defaultdict(lambda: {"base": 0, "amount": 0})
         withheld_taxes = defaultdict(lambda: {"base": 0, "amount": 0})
         for line in self.line_ids:
-            sign = -1 if self.move_type[:3] == "out" else 1
+            base = line.balance * sign
             for tax in line.tax_ids:
+                tax_amount = base * tax.amount / 100
+                if self.company_id.tax_calculation_rounding_method == "round_per_line":
+                    tax_amount = tools.float_round(
+                        tax_amount, precision_rounding=self.currency_id.rounding
+                    )
                 if tools.float_compare(tax.amount, 0, precision_digits=2) >= 0:
-                    output_taxes[tax]["base"] += line.balance * sign
+                    output_taxes[tax]["base"] += base
+                    output_taxes[tax]["amount"] += tax_amount
                 else:
-                    withheld_taxes[tax]["base"] += line.balance * sign
-        for tax in output_taxes:
-            output_taxes[tax]["amount"] = output_taxes[tax]["base"] * tax.amount / 100
-        for tax in withheld_taxes:
-            withheld_taxes[tax]["amount"] = (
-                withheld_taxes[tax]["base"] * tax.amount / 100
-            )
+                    withheld_taxes[tax]["base"] += base
+                    withheld_taxes[tax]["amount"] += tax_amount
         return output_taxes, withheld_taxes
 
 


### PR DESCRIPTION
…is always used to compute the tax amounts even if the company has the tax rounding method set to "per line"

This commit fixes an issue in the l10n_es_facturae module where the "global" tax calculation rounding method was always used, regardless of the company's tax rounding method setting. Before the fix, even if the company had the tax rounding method set to "per line", the module incorrectly applied the "global" method when generating the XML file.

The changes implemented in this commit ensure that the correct tax rounding method, as defined by the company's settings, is used for tax calculations.