### PR TITLE
[14.0][FIX] l10n_es_aeat_mod303: Add new result_types to domain

### DIFF
--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -26,7 +26,7 @@
             <field name="partner_bank_id" position="attributes">
                 <attribute
                     name="attrs"
-                >{'invisible': [('result_type', 'not in', ('D', 'B', 'I'))], 'required': [('result_type', '=', 'D')]}</attribute>
+                >{'invisible': [('result_type', 'not in', ('D', 'V', 'X', 'I', 'G', 'U'))], 'required': [('result_type', 'in', ('D', 'V', 'X'))]}</attribute>
             </field>
             <field name="previous_number" position="after">
                 <field name="devolucion_mensual" />


### PR DESCRIPTION
- Ajustar el domain de `partner_bank_id` para los tipos de resultado nuevos añadidos en https://github.com/OCA/l10n-spain/pull/2897
- He quitado el `B` porque no veo de dónde sale e asumo que es algo antiguo que no creo que importe tenerlo en un domain de invisible a día de hoy

El caso de uso para necesitar el cambio era una declaración mensual que se ponía en Cuenta extranjera porque el campo de `marca_sepa` se calculaba a 0 al no tener cuenta bancaria, ya que el campo estaba invisible