### PR TITLE
[14.0] l10n_es_aeat_sii_oca: Nuevos impuestos de ISP bienes de inversión

### DIFF
--- a/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
@@ -167,6 +167,9 @@
                 ref('l10n_es.account_tax_template_p_iva21_isp'),
                 ref('l10n_es.account_tax_template_p_iva10_isp'),
                 ref('l10n_es.account_tax_template_p_iva4_isp'),
+                ref('l10n_es.account_tax_template_p_iva21_isp_bi'),
+                ref('l10n_es.account_tax_template_p_iva10_isp_bi'),
+                ref('l10n_es.account_tax_template_p_iva4_isp_bi'),
                 ref('l10n_es.account_tax_template_p_iva21_sp_ex'),
                 ref('l10n_es.account_tax_template_p_iva10_sp_ex'),
                 ref('l10n_es.account_tax_template_p_iva5_isc'),
@@ -185,6 +188,12 @@
                 ref('l10n_es.account_tax_template_p_iva4_bi'),
                 ref('l10n_es.account_tax_template_p_iva10_bi'),
                 ref('l10n_es.account_tax_template_p_iva21_bi'),
+                ref('l10n_es.account_tax_template_p_iva21_isp_bi'),
+                ref('l10n_es.account_tax_template_p_iva10_isp_bi'),
+                ref('l10n_es.account_tax_template_p_iva4_isp_bi'),
+                ref('l10n_es.account_tax_template_p_iva4_ic_bi'),
+                ref('l10n_es.account_tax_template_p_iva10_ic_bi'),
+                ref('l10n_es.account_tax_template_p_iva21_ic_bi'),
             ])]"
         />
         <field name="sii_map_id" ref="aeat_sii_map" />

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -626,6 +626,7 @@ class AccountMove(models.Model):
         taxes_sfrisp = self._get_sii_taxes_map(["SFRISP"])
         taxes_sfrns = self._get_sii_taxes_map(["SFRNS"])
         taxes_sfrnd = self._get_sii_taxes_map(["SFRND"])
+        taxes_sfrbi = self._get_sii_taxes_map(["SFRBI"])
         taxes_not_in_total = self._get_sii_taxes_map(["NotIncludedInTotal"])
         taxes_not_in_total_neg = self._get_sii_taxes_map(["NotIncludedInTotalNegative"])
         base_not_in_total = self._get_sii_taxes_map(["BaseNotIncludedInTotal"])
@@ -652,6 +653,8 @@ class AccountMove(models.Model):
             tax_dict = self._get_sii_tax_dict(tax_line, tax_lines)
             if tax in taxes_sfrisp + taxes_sfrs:
                 tax_amount += tax_line["deductible_amount"]
+            if tax in taxes_sfrbi:
+                tax_dict["BienInversion"] = "S"
             if tax in taxes_sfrns:
                 tax_dict.pop("TipoImpositivo")
                 tax_dict.pop("CuotaSoportada")


### PR DESCRIPTION
Nuevos impuestos de ISP bienes de inversión en el SII (https://github.com/odoo/odoo/pull/101863)
Se añade el atributo opcional BienesInversion que salió en la versión 1.1 del SII