### PR TITLE
[16.0][FIX] l10n_es_ticketbai: Send invoice line correctly when it has no name

### DIFF
--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -303,7 +303,7 @@ class AccountMove(models.Model):
             for line in self.invoice_line_ids.filtered(
                 lambda l: l.display_type not in ["line_note", "line_section"]
             ):
-                description_line = line.name[:250]
+                description_line = line.name[:250] if line.name else ""
                 if (
                     self.company_id.tbai_protected_data
                     and self.company_id.tbai_protected_data_txt


### PR DESCRIPTION
Hasta la versión 16 era requerido el campo de la descripción de la línea. Al no serlo para la 16, estaba saliendo un traceback ya que el código daba por hecho que no podía ser False.