### PR TITLE
[16.0][FIX] l10n_es_partner: Python 3.8+ time.clock removed

### DIFF
--- a/l10n_es_partner/gen_src/gen_data_banks.py
+++ b/l10n_es_partner/gen_src/gen_data_banks.py
@@ -5,12 +5,12 @@
 import codecs
 import logging
 import os
+import time
 from datetime import datetime
 
-try:
-    import xlrd
-except ImportError:
-    xlrd = None
+import xlrd
+
+time.clock = time.time  # For Python 3.8+ compatibility
 
 STATES_REPLACE_LIST = {
     "01": "vi",


### PR DESCRIPTION
- https://github.com/OCA/l10n-spain/pull/2709#issuecomment-1484666510

---
EDIT:

La librería consultada inicialmente no era de la versión correcta, cierro PR ya que la librería `xlrd` utiliza `perf_counter` en vez de `clock` en las versiones más recientes.