### PR TITLE
[15.0][IMP] l10n_es_facturae: improvements view facturae

### DIFF
--- a/l10n_es_facturae/wizard/create_facturae_view.xml
+++ b/l10n_es_facturae/wizard/create_facturae_view.xml
@@ -14,7 +14,7 @@
                 <group attrs="{'invisible': [('state', '=', 'first')]}" colspan="4">
                     <field name="facturae" filename="facturae_fname" />
                     <field name="facturae_fname" invisible="1" />
-                    <field name="note" colspan="4" nolabel="1" />
+                    <field name="note" colspan="4" nolabel="1" readonly="1" />
                 </group>
                 <footer>
                     <button


### PR DESCRIPTION
Mejoras en la vista.

En la vista `views/account_move_view.xml` se estaba poniendo como `invisible` el `field l10n_es_facturae_attachment_ids,` cuando es mejor poner como invisible el `group facturae_attachment`.

En la vista `wizard/create_facturae_view` el campo informativo `note` era editable y lo he puesto como `readonly`.