### PR TITLE
[16.0][FIX] l10n_es_aeat_sii_oca: cliente intracomunitario, entrega extracomunitaria

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -1320,6 +1320,11 @@ class AccountMove(models.Model):
         elif gen_type == 2:
             return {"IDOtro": {"IDType": "02", "ID": country_code + identifier}}
         elif gen_type == 3 and identifier_type:
+            # Si usamos identificador tipo 02 en exportaciones, el envío falla con:
+            #   {'CodigoErrorRegistro': 1104,
+            #    'DescripcionErrorRegistro': 'Valor del campo ID incorrecto'}
+            if identifier_type == "02":
+                identifier_type = "06"
             return {
                 "IDOtro": {
                     "CodigoPais": country_code,


### PR DESCRIPTION

Una venta a un cliente intracomunitario enviada al extranjero es exportación.

Nunca se puede informar el tipo de identificador 02 para estos envíos porque la AEAT los rechaza siempre. Al poner identificador 06, funciona bien.

Fix https://github.com/OCA/l10n-spain/issues/2969

@moduon MT-2407 forward-port-of https://github.com/OCA/l10n-spain/pull/2979