### PR TITLE
[14.0][IMP] delivery_dhl_parcel: Cash on delivery

### DIFF
--- a/delivery_dhl_parcel/i18n/delivery_dhl_parcel.pot
+++ b/delivery_dhl_parcel/i18n/delivery_dhl_parcel.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-07-15 08:57+0000\n"
+"PO-Revision-Date: 2022-07-15 08:57+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -31,6 +33,11 @@ msgstr ""
 #. module: delivery_dhl_parcel
 #: model_terms:ir.ui.view,arch_db:delivery_dhl_parcel.delivery_endday_wizard_form
 msgid "Cancel"
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_cash_on_delivery
+msgid "Cash on delivery"
 msgstr ""
 
 #. module: delivery_dhl_parcel
@@ -189,6 +196,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__id
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_stock_picking__id
 msgid "ID"
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_cash_on_delivery
+msgid ""
+"If checked, it means that the carrier is paid with cash. It assumes there is"
+" a sale order linked and it will use that total amount as the value to be "
+"paid. It will also exclude this carrier from the e-commerce checkout."
 msgstr ""
 
 #. module: delivery_dhl_parcel

--- a/delivery_dhl_parcel/i18n/es.po
+++ b/delivery_dhl_parcel/i18n/es.po
@@ -6,11 +6,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-30 10:29+0000\n"
-"PO-Revision-Date: 2021-10-30 10:29+0000\n"
+"POT-Creation-Date: 2022-07-15 08:58+0000\n"
+"PO-Revision-Date: 2022-07-15 08:58+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -37,6 +36,11 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_cash_on_delivery
+msgid "Cash on delivery"
+msgstr "Contra reembolso"
+
+#. module: delivery_dhl_parcel
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__create_uid
 msgid "Created by"
 msgstr "Creado por"
@@ -57,6 +61,7 @@ msgid "DHL Parcel"
 msgstr "DHL Parcel"
 
 #. module: delivery_dhl_parcel
+#: code:addons/delivery_dhl_parcel/models/delivery_carrier.py:0
 #: code:addons/delivery_dhl_parcel/models/delivery_carrier.py:0
 #, python-format
 msgid ""
@@ -201,6 +206,16 @@ msgid "ID"
 msgstr "ID"
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_cash_on_delivery
+msgid ""
+"If checked, it means that the carrier is paid with cash. It assumes there is"
+" a sale order linked and it will use that total amount as the value to be "
+"paid. It will also exclude this carrier from the e-commerce checkout."
+msgstr "Si está marcado, significa que el transportista se paga a la hora de entregar. Asume que hay un pedido"
+" de venta relacionado del cual usará la cantidad total como el valor a pagar."
+" También excluirá este método de envío de los disponibles en la web."
+
+#. module: delivery_dhl_parcel
 #: model:ir.model.fields,help:delivery_dhl_parcel.field_dhl_parcel_endday_wizard__customer_accounts
 msgid ""
 "If doing multiple, input them separated by commas without spaces.\n"
@@ -222,6 +237,7 @@ msgid "Label format"
 msgstr "Formato de etiqueta"
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier____last_update
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_dhl_parcel_endday_wizard____last_update
 #: model:ir.model.fields,field_description:delivery_dhl_parcel.field_stock_picking____last_update
 msgid "Last Modified on"

--- a/delivery_dhl_parcel/models/__init__.py
+++ b/delivery_dhl_parcel/models/__init__.py
@@ -1,3 +1,4 @@
 from . import delivery_carrier
 from . import dhl_parcel_request
+from . import sale_order
 from . import stock_picking

--- a/delivery_dhl_parcel/models/sale_order.py
+++ b/delivery_dhl_parcel/models/sale_order.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Studio73 - Ethan Hildick <ethan@studio73.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _get_delivery_methods(self):
+        # Exclude CoD delivery methods when getting methods for checkout in the
+        # website_sale_delivery module
+        return (
+            super()
+            ._get_delivery_methods()
+            .filtered(lambda c: not c.dhl_parcel_cash_on_delivery)
+        )

--- a/delivery_dhl_parcel/readme/USAGE.rst
+++ b/delivery_dhl_parcel/readme/USAGE.rst
@@ -52,3 +52,10 @@ Depuración de errores
      España (por lo menos para el consignatario).
   #. También puede activar Odoo con `--log-level=debug` para registrar las
      peticiones y las respuestas en el log.
+
+Contrareembolso
+~~~~~~~~~~~~~~~
+
+  #. Al crear un envío con un método que tiene marcado el check de contrareembolso, asumirá que hay un pedido
+     vinculado al albarán y usará el importe total del pedido como importe del contrareembolso.
+     Métodos de envío con este check no se encontrarán disponibles en la web si se está usando.

--- a/delivery_dhl_parcel/views/delivery_carrier_view.xml
+++ b/delivery_dhl_parcel/views/delivery_carrier_view.xml
@@ -36,6 +36,9 @@
                                 name="dhl_parcel_label_format"
                                 attrs="{'required': [('delivery_type', '=', 'dhl_parcel')]}"
                             />
+                        </group>
+                        <group>
+                            <field name="dhl_parcel_cash_on_delivery" />
                             <field
                                 name="dhl_parcel_last_end_day_report"
                                 filename="dhl_parcel_last_end_day_report_name"


### PR DESCRIPTION
- Reabrir https://github.com/OCA/l10n-spain/pull/2411, se me ha pasado agilizarlo tras el comentario de github
- Se lleva usando en entorno producción sin problemas desde la creación del PR anterior
* Opción para el contra-reembolso, usa el valor del pedido de venta
* Separa los campos de configuración en 2 campos, por no alargarlo todo en 1 lado