### PR TITLE
[11.0][IMP] l10n_es_vat_book_extra_data: include 2023 map taxes.

### DIFF
--- a/l10n_es_vat_book_extra_data/data/aeat_vat_book_map_data.xml
+++ b/l10n_es_vat_book_extra_data/data/aeat_vat_book_map_data.xml
@@ -11,6 +11,8 @@
 
     <record id="l10n_es_vat_book.aeat_vat_book_map_line_p_iva" model="aeat.vat.book.map.line">
         <field name="tax_tmpl_ids" eval="[
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_a')),
+            (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_a')),
             (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_sc')),
             (4, ref('l10n_es_extra_data.account_tax_template_p_iva5_ic_a_1')),
             (4, ref('l10n_es_extra_data.account_tax_template_p_iva0_ic_a_1')),


### PR DESCRIPTION
Añadimos los impuestos 5% soportado (Alimentos) y 0% Soportado (Alimentos)

Depende de de https://github.com/OCA/l10n-spain/pull/2880