### PR TITLE
[14.0][FIX] l10n_es_dua_sii: error sending a DUA refund - (1135) "Si la fact…

### DIFF
--- a/l10n_es_dua_sii/models/account_move.py
+++ b/l10n_es_dua_sii/models/account_move.py
@@ -70,7 +70,10 @@ class AccountMove(models.Model):
         res = super()._get_sii_invoice_dict_in(cancel=cancel)
         if res.get("FacturaRecibida") and self.sii_dua_invoice:
             if not self.sii_lc_operation:
-                res["FacturaRecibida"]["TipoFactura"] = "F5"
+                res["FacturaRecibida"]["TipoFactura"] = (
+                    "F5" if self.move_type == "in_invoice" else "R4"
+                )
+
             res["FacturaRecibida"].pop("FechaOperacion", None)
             nif = self.company_id.partner_id._parse_aeat_vat_info()[2]
             res["FacturaRecibida"]["IDEmisorFactura"] = {"NIF": nif}


### PR DESCRIPTION
…ura no es de tipo rectificativa, el campo TipoRectificativa no debe tener valor"

Al enviar al SII una factura rectificativa DUA, por un lado, al ser rectificativa, se asigna el valor "I" en el campo TipoRectificativa; y por otro lado, al ser DUA, se asigna el valor "F5" en el campo TipoFactura. El problema es que el valor "F5" se asigna siempre, independientemente de si la factura es de cargo o de abono. Esto genera efectivamente la inconsistencia que el SII detecta, ya que el TipoFactura "F5" no es una factura rectificativa.

Dado que no existe un valor específico para el campo `TipoFactura` en las rectificaciones DUA, propongo utilizar el valor "R4", que entre las opciones disponibles, parece ser el más genérico.

Aprovecho para abrir el debate sobre si es adecuado usar el valor "R4" o si deberíamos optar por otro valor disponible. 

¿Qué opináis @pedrobaeza y @rafaelbn?