### PR TITLE
[14.0][FIX] l10n_es_partner: Orden incorrecto ignorando funcionalidad res_partner_search_mode

### DIFF
--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -1,7 +1,7 @@
 # Copyright 2009 Jordi Esteve <jesteve@zikzakmedia.com>
 # Copyright 2012-2014 Ignacio Ibeas <ignacio@acysos.com>
 # Copyright 2016-2017 Tecnativa - Pedro M. Baeza
-# Copyright 2016 Tecnativa - Carlos Dauden
+# Copyright 2016-2022 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3).
 
 from odoo import api, fields, models
@@ -12,25 +12,38 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     comercial = fields.Char("Trade name", size=128, index=True)
-    display_name = fields.Char(compute="_compute_display_name")
 
+    # Extend original depends with comercial field
     @api.depends("comercial")
     def _compute_display_name(self):
         super()._compute_display_name()
 
     @api.model
+    def _get_comercial_name_pattern(self):
+        return (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("l10n_es_partner.name_pattern", default="")
+        )
+
+    @api.model
     def search(self, args, offset=0, limit=None, order=None, count=False):
         """Include commercial name in direct name search."""
-        args = expression.normalize_domain(args)
-        for arg in args:
-            if isinstance(arg, (list, tuple)) and (
-                arg[0] == "name" or arg[0] == "display_name"
-            ):
-                index = args.index(arg)
-                args = (
-                    args[:index] + ["|", ("comercial", arg[1], arg[2])] + args[index:]
-                )
-                break
+        if "%(comercial_name)s" not in self._get_comercial_name_pattern():
+            args = expression.normalize_domain(args)
+            for arg in args:
+                if (
+                    isinstance(arg, (list, tuple))
+                    and (arg[0] == "name" or arg[0] == "display_name")
+                    and arg[2]
+                ):
+                    index = args.index(arg)
+                    args = (
+                        args[:index]
+                        + ["|", ("comercial", arg[1], arg[2])]
+                        + args[index:]
+                    )
+                    break
         return super().search(
             args, offset=offset, limit=limit, order=order, count=count
         )
@@ -40,10 +53,18 @@ class ResPartner(models.Model):
         """Give preference to commercial names on name search, appending
         the rest of the results after. This has to be done this way, as
         Odoo overwrites name_search on res.partner in a non inheritable way."""
+        if "%(comercial_name)s" in self._get_comercial_name_pattern():
+            return super().name_search(
+                name=name, args=args, operator=operator, limit=limit
+            )
         if not args:
             args = []
-        partners = self.search([("comercial", operator, name)] + args, limit=limit)
-        res = partners.name_get()
+        partner_search_mode = self.env.context.get("res_partner_search_mode")
+        order = "{}_rank".format(partner_search_mode) if partner_search_mode else None
+        partners = self.search(
+            [("comercial", operator, name)] + args, limit=limit, order=order
+        )
+        res = models.lazy_name_get(partners)
         if limit:
             limit_rest = limit - len(partners)
         else:  # pragma: no cover
@@ -57,11 +78,7 @@ class ResPartner(models.Model):
         return res
 
     def _get_name(self):
-        name_pattern = (
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param("l10n_es_partner.name_pattern", default="")
-        )
+        name_pattern = self._get_comercial_name_pattern()
         origin = super()._get_name()
         if (
             self.env.context.get("no_display_commercial", False)


### PR DESCRIPTION
FWP de 13.0: https://github.com/OCA/l10n-spain/pull/2189

Orden incorrecto cuando se encuentran coincidencias con nombre comercial.

Se condiciona la sobrecarga de los métodos, innecesaria cuando el nombre comercial está incluido en el patron que genera el display_name. https://github.com/odoo/odoo/blob/129f516c32d421418b48dbcd0ec5432cbc1b4666/odoo/addons/base/models/res_partner.py#L753 Se tiene en cuenta la funcionalidad incorporada por res_partner_search_mode.

Por favor @pedrobaeza y @carlosdauden podéis revisarlo?

@Tecnativa TT42883