### PR TITLE
[16.0][FIX] l10n_es_aeat: replace deprecated method.

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
@@ -25,8 +25,7 @@ class L10nEsAeatReportTaxMapping(models.AbstractModel):
         res = super().calculate()
         for report in self:
             report.tax_line_ids.unlink()
-            report.flush()
-            report.invalidate_cache()
+            report.env.invalidate_all()
             # Buscar configuración de mapeo de impuestos
             tax_code_map = (
                 self.env["l10n.es.aeat.map.tax"]


### PR DESCRIPTION
Sustituir los métodos deprecados del modulo l10n_es_aeat:

- Quitar el método flush() deprecado.
- Remplazar el método invalidate_cache() deprecado por env.invalidate_all().

Para evitar los warning del log.

2023-05-30 20:32:47,970 255 WARNING odoo py.warnings: /__w/l10n-spain/l10n-spain/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py:28: DeprecationWarning: Deprecated method flush(), use flush_model(), flush_recordset() or env.flush_all() instead

2023-05-30 20:32:48,078 255 WARNING odoo py.warnings: /__w/l10n-spain/l10n-spain/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py:29: DeprecationWarning: Deprecated method invalidate_cache(), use invalidate_model(), invalidate_recordset() or env.invalidate_all() instead

Un saludo