### PR TITLE
[16.0][FIX] l10n_es_ticketbai_api_batuz: Adapt LROE Operation view to V16

### DIFF
--- a/l10n_es_ticketbai_api_batuz/views/lroe_operation_views.xml
+++ b/l10n_es_ticketbai_api_batuz/views/lroe_operation_views.xml
@@ -56,8 +56,17 @@
                         />
                         <field name="trx_gzip_fsize" invisible="1" />
                     </group>
-                    <group name="customer_invoices" string="TBAI Customer Invoices">
-                        <field name="tbai_invoice_ids" nolabel="1" readonly="1">
+                    <group
+                        name="customer_invoices"
+                        string="TBAI Customer Invoices"
+                        cols="4"
+                    >
+                        <field
+                            name="tbai_invoice_ids"
+                            nolabel="1"
+                            readonly="1"
+                            colspan="2"
+                        >
                             <form
                                 string="Customer Invoice"
                                 create="false"


### PR DESCRIPTION
Adapta la vista form de las operaciones LROE a la V16 correctamente, una tabla O2M no se visualizaba correctamente.