### PR TITLE
[16.0][FIX] l10n_es_ticketbai_api_batuz: Fix model field definition on lroe…

### DIFF
--- a/l10n_es_ticketbai_api_batuz/models/lroe_operation.py
+++ b/l10n_es_ticketbai_api_batuz/models/lroe_operation.py
@@ -172,7 +172,7 @@ class LROEOperation(models.Model):
         default=LROEOperationEnum.create.value,
     )
     model = fields.Selection(
-        "Model", related="company_id.lroe_model", readonly=True, required=True
+        related="company_id.lroe_model", readonly=True, required=True
     )
     state = fields.Selection(
         selection=[


### PR DESCRIPTION
….operation model

Se estaba asignando un valor incorrecto como selection, que hacía que saliese un warning