### PR TITLE
[16.0][IMP] l10n_es_aeat_mod347: extra EU taxes are added.

### DIFF
--- a/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
+++ b/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
@@ -47,6 +47,11 @@
         ref('l10n_es.account_tax_template_p_iva105_gan'),
         ref('l10n_es.account_tax_template_p_iva10_nd'),
         ref('l10n_es.account_tax_template_p_iva4_nd'),
+        ref('l10n_es.1_account_tax_template_p_iva0_isc'),
+        ref('l10n_es.1_account_tax_template_p_iva4_sp_ex'),
+        ref('l10n_es.1_account_tax_template_p_iva5_isc'),
+        ref('l10n_es.1_account_tax_template_p_iva10_sp_ex'),
+        ref('l10n_es.1_account_tax_template_p_iva21_sp_ex'),
         ])]"
         />
     </record>


### PR DESCRIPTION
Extra EU taxes are added to l10n_es_aeat_mod347 module.
Origin Issue https://github.com/OCA/l10n-spain/issues/2770
Same PR v14.0 https://github.com/OCA/l10n-spain/pull/3060