### PR TITLE
[14.0][IMP] l10n_es_vat_prorate: Manage intracommunity and extracommunity taxes

### DIFF
--- a/l10n_es_vat_prorate/data/account_template_tax.xml
+++ b/l10n_es_vat_prorate/data/account_template_tax.xml
@@ -50,5 +50,190 @@
     </record>
     <record id="l10n_es.account_tax_template_p_iva10_ibi" model="account.tax.template">
         <field name="template_with_vat_prorate" eval="True" />
+        </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva21_sp_in"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva21_ic_bc"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva21_ic_bi"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva4_sp_ex" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva10_sp_ex"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva21_sp_ex"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva4_ic_bc" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva4_ic_bi" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva10_ic_bc"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva10_ic_bi"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva5_ic_bc" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva5_ic_sc" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva5_ibc" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva5_isc" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva5_bc" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva5_sc" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+    </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva10_sp_in"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva4_sp_in" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva4_isp" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva10_isp" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record id="l10n_es.account_tax_template_p_iva21_isp" model="account.tax.template">
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva4_isp_bi"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva10_isp_bi"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
+    </record>
+    <record
+        id="l10n_es.account_tax_template_p_iva21_isp_bi"
+        model="account.tax.template"
+    >
+        <field name="template_with_vat_prorate" eval="True" />
+        <field
+            name="prorate_account_template_ids"
+            eval="[(5,0,0), (4, ref('l10n_es.account_common_472'))]"
+        />
     </record>
 </odoo>

--- a/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva21_sp_ex_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_in_invoice_p_iva21_sp_ex_dict.json
@@ -18,7 +18,7 @@
         ]
       }
     },
-    "CuotaDeducible": 21.0
+    "CuotaDeducible": 4.2
   },
   "PeriodoLiquidacion": {"Periodo": "01", "Ejercicio": 2020}
 }

--- a/l10n_es_vat_prorate/tests/json/sii_in_refund_p_iva21_sp_in_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_in_refund_p_iva21_sp_in_dict.json
@@ -19,7 +19,7 @@
         ]
       }
     },
-    "CuotaDeducible": -21.0
+    "CuotaDeducible": -4.2
   },
   "PeriodoLiquidacion": {"Periodo": "01", "Ejercicio": 2020}
 }

--- a/l10n_es_vat_prorate/tests/test_prorate_sii.py
+++ b/l10n_es_vat_prorate/tests/test_prorate_sii.py
@@ -19,8 +19,8 @@ class TestSIIVatProrate(test_l10n_es_aeat_sii.TestL10nEsAeatSiiBase):
             {
                 "with_vat_prorate": True,
                 "vat_prorate_ids": [
-                    (0, 0, {"date": date(2000, 1, 1), "vat_prorate": 10}),
-                    (0, 0, {"date": date(2001, 1, 1), "vat_prorate": 20}),
+                    (0, 0, {"date": date(2020, 1, 1), "vat_prorate": 20}),
+                    (0, 0, {"date": date(2021, 1, 1), "vat_prorate": 10}),
                 ],
             }
         )

--- a/l10n_es_vat_prorate/views/account_tax_views.xml
+++ b/l10n_es_vat_prorate/views/account_tax_views.xml
@@ -13,6 +13,11 @@
                     attrs="{'invisible': [('company_with_vat_prorate', '=', False)]}"
                 />
                 <field name="company_with_vat_prorate" invisible="1" />
+                <field
+                    name="prorate_account_ids"
+                    widget="many2many_tags"
+                    attrs="{'invisible': [('company_with_vat_prorate', '=', False)]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Con el cambio, solo se aplican a las líneas con la cuenta concreta.

Estaria bien revisar el fichero de los impuestos.

A nivel de código, no sé si es lo más limpio, pero funciona.

@pedrobaeza 