### PR TITLE
[14.0][FIX] l10n_es_ticketbai: Save reversed entry on account move correctly

### DIFF
--- a/l10n_es_ticketbai/views/account_move_views.xml
+++ b/l10n_es_ticketbai/views/account_move_views.xml
@@ -9,6 +9,9 @@
             <field name="model">account.move</field>
             <field name="inherit_id" ref="account.view_move_form" />
             <field name="arch" type="xml">
+                <xpath expr="//field[@name='reversed_entry_id']" position="attributes">
+                    <attribute name="force_save">1</attribute>
+                </xpath>
                 <page name="other_info" position="after">
                     <page
                         name="ticketbai"


### PR DESCRIPTION
TicketBAI obliga especificar la factura a la que se está rectificando, pero al crear la rectificativa desde el botón de crear no se guardaba el valor del campo "Reversión de".