### PR TITLE
[14.0][FIX] l10n_es_pos: Remove unnecessary function inheritance

### DIFF
--- a/l10n_es_pos/models/pos_order.py
+++ b/l10n_es_pos/models/pos_order.py
@@ -60,12 +60,6 @@ class PosOrder(models.Model):
             self._update_sequence_number(pos)
         return super()._process_order(pos_order, draft, existing_order)
 
-    def _get_fields_for_order_line(self):
-        fields = super()._get_fields_for_order_line()
-
-        fields += ["l10n_es_unique_id"]
-        return fields
-
     def _export_for_ui(self, order):
         res = super()._export_for_ui(order)
 


### PR DESCRIPTION
He visto que en el commit 8cf467afca9d5c444a0b82a76f66cc304b07c170 se heredó la función `_get_fields_for_order_line` para agregar el campo `l10n_es_unique_id`. Estoy obteniendo un error diciendo que este campo no existe en el modelo `pos.order.line`, cosa es que cierta.

¿Alguien sabe para que se heredó esta función y se agregó este campo en el return de la función?

@AntoniRomera te menciono a ti, ya que eres el autor del commit.