### PR TITLE
[IMP] l10n_es_mis_report: Add a new template for normal plan

### DIFF
--- a/l10n_es_mis_report/__manifest__.py
+++ b/l10n_es_mis_report/__manifest__.py
@@ -19,6 +19,7 @@
         "data/mis_report_balance_sme_sfl.xml",
         "data/mis_report_pyg_abreviated.xml",
         "data/mis_report_pyg_normal.xml",
+        "data/mis_report_pyg_normal_2022.xml",
         "data/mis_report_pyg_sme.xml",
         "data/mis_report_pyg_sme_sfl.xml",
         "data/mis_report_revenues_expenses_normal.xml",

--- a/l10n_es_mis_report/data/mis_report_pyg_normal_2022.xml
+++ b/l10n_es_mis_report/data/mis_report_pyg_normal_2022.xml
@@ -1,0 +1,1069 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <record id="mis_report_es_pyg_normal_2022" model="mis.report">
+            <field
+                name="name"
+            >Pérdidas y ganancias completo (PGCE 2008) - Edición 2022</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_base"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_a" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">10</field>
+            <field name="name">es2022_A</field>
+            <field name="description">A) OPERACIONES CONTINUADAS</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1"
+            />
+            <field
+                name="expression"
+            > +es2022_0100 +es2022_0200 +es2022_0300 +es2022_0400 +es2022_0500 +es2022_0600 +es2022_0700 +es2022_0800 +es2022_0900 +es2022_1000 +es2022_1100 +es2022_1200 +es2022_1300 +es2022_1400 +es2022_1500 +es2022_1600 +es2022_1700 +es2022_1800 +es2022_1900</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_100" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">20</field>
+            <field name="name">es2022_0100</field>
+            <field name="description">1. Importe neto de la cifra de negocios</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field name="expression"> +es2022_0110 +es2022_0120</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_110" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">30</field>
+            <field name="name">es2022_0110</field>
+            <field name="description">a) Ventas</field>
+            <field
+                name="expression"
+            >-balp[700%,701%,702%,703%,704%,706%,708%,709%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_120" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">40</field>
+            <field name="name">es2022_0120</field>
+            <field name="description">b) Prestación de servicios</field>
+            <field name="expression">-balp[705%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0200" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">50</field>
+            <field name="name">es2022_0200</field>
+            <field
+                name="description"
+            >2. Variación de existencias de productos terminados y en curso de fabricación</field>
+            <field name="expression">-balp[6930%,71%,7930%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0300" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">60</field>
+            <field name="name">es2022_0300</field>
+            <field
+                name="description"
+            >3. Trabajos realizados por la empresa para su activo</field>
+            <field name="expression">-balp[73%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0400" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">70</field>
+            <field name="name">es2022_0400</field>
+            <field name="description">4. Aprovisionamientos</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field
+                name="expression"
+            > +es2022_0410 +es2022_0420 +es2022_0430 +es2022_0440</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0410" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">80</field>
+            <field name="name">es2022_0410</field>
+            <field name="description">a) Consumo de mercaderías</field>
+            <field name="expression">-balp[600%,6060%,6080%,6090%,610%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0420" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">90</field>
+            <field name="name">es2022_0420</field>
+            <field
+                name="description"
+            >b) Consumo de materias primas y otras materias consumibles</field>
+            <field
+                name="expression"
+            >-balp[601%,602%,6061%,6062%,6081%,6082%,6091%,6092%,611%,612%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0430" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">100</field>
+            <field name="name">es2022_0430</field>
+            <field name="description">c) Trabajos realizados por otras empresas</field>
+            <field name="expression">-balp[607%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0440" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">110</field>
+            <field name="name">es2022_0440</field>
+            <field
+                name="description"
+            >d) Deterioro de mercaderías, materias primas y otros aprovisionamientos</field>
+            <field name="expression">-balp[6931%,6932%,6933%,7931%,7932%,7933%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0500" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">120</field>
+            <field name="name">es2022_0500</field>
+            <field name="description">5. Otros ingresos de explotación</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field name="expression"> +es2022_0510 +es2022_0520</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0510" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">130</field>
+            <field name="name">es2022_0510</field>
+            <field
+                name="description"
+            >a) Ingresos accesorios y otros de gestión corriente</field>
+            <field name="expression">-balp[75%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0520" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">140</field>
+            <field name="name">es2022_0520</field>
+            <field
+                name="description"
+            >b) Subvenciones de explotación incorporadas al resultado del ejercicio</field>
+            <field name="expression">-balp[740%,747%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0600" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">150</field>
+            <field name="name">es2022_0600</field>
+            <field name="description">6. Gastos de personal</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field name="expression"> +es2022_0610 +es2022_0620 +es2022_0630</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0610" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">160</field>
+            <field name="name">es2022_0610</field>
+            <field name="description">a) Sueldos, salarios y asimilados</field>
+            <field name="expression">-balp[640%,641%,6450%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0620" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">170</field>
+            <field name="name">es2022_0620</field>
+            <field name="description">b) Cargas sociales</field>
+            <field name="expression">-balp[642%,643%,649%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0630" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">180</field>
+            <field name="name">es2022_0630</field>
+            <field name="description">c) Provisiones</field>
+            <field name="expression">-balp[644%,6457%,7950%,7957%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0700" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">190</field>
+            <field name="name">es2022_0700</field>
+            <field name="description">7. Otros gastos de explotación</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field
+                name="expression"
+            > +es2022_0710 +es2022_0720 +es2022_0730 +es2022_0740</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0710" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">200</field>
+            <field name="name">es2022_0710</field>
+            <field name="description">a) Servicios exteriores</field>
+            <field name="expression">-balp[62%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0720" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">210</field>
+            <field name="name">es2022_0720</field>
+            <field name="description">b) Tributos</field>
+            <field name="expression">-balp[631%,634%,636%,639%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0730" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">220</field>
+            <field name="name">es2022_0730</field>
+            <field
+                name="description"
+            >c) Pérdidas, deterioro y variación de provisiones por operaciones comerciales</field>
+            <field name="expression">-balp[650%,694%,695%,794%,7954%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0740" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">230</field>
+            <field name="name">es2022_0740</field>
+            <field name="description">d) Otros gastos de gestión corriente </field>
+            <field name="expression">-balp[651%,659%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0800" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">240</field>
+            <field name="name">es2022_0800</field>
+            <field name="description">8. Amortización del inmovilizado</field>
+            <field name="expression">-balp[68%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_0900" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">250</field>
+            <field name="name">es2022_0900</field>
+            <field
+                name="description"
+            >9. Imputación de subvenciones de inmovilizado no financiero y otras</field>
+            <field name="expression">-balp[7460%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1000" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">260</field>
+            <field name="name">es2022_1000</field>
+            <field name="description">10. Excesos de provisiones </field>
+            <field name="expression">-balp[7951%,7952%,7955%,7956%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1100" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">270</field>
+            <field name="name">es2022_1100</field>
+            <field
+                name="description"
+            >11. Deterioro y resultado por enajenaciones del inmovilizado</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field name="expression"> +es2022_1110 +es2022_1120</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1110" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">280</field>
+            <field name="name">es2022_1110</field>
+            <field name="description">a) Deterioro y pérdidas</field>
+            <field name="expression">-balp[690%,691%,692%,790%,791%,792%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1120" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">290</field>
+            <field name="name">es2022_1120</field>
+            <field name="description">b) Resultados por enajenaciones y otras</field>
+            <field name="expression">-balp[670%,671%,672%,770%,771%,772%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1200" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">300</field>
+            <field name="name">es2022_1200</field>
+            <field
+                name="description"
+            >12. Diferencia negativa de combinaciones de negocio</field>
+            <field name="expression">-balp[774%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1300" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">310</field>
+            <field name="name">es2022_1300</field>
+            <field name="description">13. Otros resultados</field>
+            <field name="expression">-balp[678%,778%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_a1" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">320</field>
+            <field name="name">es2022_A1</field>
+            <field
+                name="description"
+            >A.1)  RESULTADO DE EXPLOTACIÓN (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12 + 13)</field>
+            <field
+                name="expression"
+            >+es2022_0100+es2022_0200+es2022_0300+es2022_0400+es2022_0500+es2022_0600+es2022_0700+es2022_0800+es2022_0900+es2022_1000+es2022_1100+es2022_1200+es2022_1300</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1400" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">330</field>
+            <field name="name">es2022_1400</field>
+            <field name="description">14. Ingresos financieros</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field name="expression"> +es2022_1410 +es2022_1420 +es2022_1430</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1410" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">340</field>
+            <field name="name">es2022_1410</field>
+            <field
+                name="description"
+            >a) De participaciones en instrumentos de patrimonio</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+            <field name="expression"> +es2022_1411 +es2022_1412</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1411" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">350</field>
+            <field name="name">es2022_1411</field>
+            <field name="description">a 1) En empresas del grupo y asociadas</field>
+            <field name="expression">-balp[7600%,7601%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l5"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1412" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">360</field>
+            <field name="name">es2022_1412</field>
+            <field name="description">a 2) En terceros</field>
+            <field name="expression">-balp[7602%,7603%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l5"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1420" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">370</field>
+            <field name="name">es2022_1420</field>
+            <field
+                name="description"
+            >b) De valores negociables y otros instrumentos financieros</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+            <field name="expression"> +es2022_1421 +es2022_1422</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1421" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">380</field>
+            <field name="name">es2022_1421</field>
+            <field name="description">b 1) De empresas del grupo y asociadas</field>
+            <field
+                name="expression"
+            >-balp[7610%,7611%,76200%,76201%,76210%,76211%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l5"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1422" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">390</field>
+            <field name="name">es2022_1422</field>
+            <field name="description">b 2) De terceros</field>
+            <field
+                name="expression"
+            >-balp[7612%,7613%,76202%,76203%,76212%,76213%,767%,769%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l5i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l5"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1430" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">400</field>
+            <field name="name">es2022_1430</field>
+            <field
+                name="description"
+            >c) Imputación de subvenciones, donaciones y legados de carácter financiero</field>
+            <field name="expression">-balp[7461%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1500" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">410</field>
+            <field name="name">es2022_1500</field>
+            <field name="description">15. Gastos financieros</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field name="expression"> +es2022_1510 +es2022_1520 +es2022_1530</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1510" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">420</field>
+            <field name="name">es2022_1510</field>
+            <field
+                name="description"
+            >a) Por deudas con empresas del grupo y asociadas</field>
+            <field
+                name="expression"
+            >-balp[6610%,6611%,6615%,6616%,6620%,6621%,6640%,6641%,6650%,6651%,6654%,6655%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1520" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">430</field>
+            <field name="name">es2022_1520</field>
+            <field name="description">b) Por deudas con terceros</field>
+            <field
+                name="expression"
+            >-balp[6612%,6613%,6617%,6618%,6622%,6623%,6624%,6642%,6643%,6652%,6653%,6656%,6657%,669%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1530" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">440</field>
+            <field name="name">es2022_1530</field>
+            <field name="description">c) Por actualización de provisiones</field>
+            <field name="expression">-balp[660%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1600" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">450</field>
+            <field name="name">es2022_1600</field>
+            <field
+                name="description"
+            >16. Variación de valor razonable en instrumentos financieros</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field name="expression"> +es2022_1610 +es2022_1620</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1610" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">460</field>
+            <field name="name">es2022_1610</field>
+            <field
+                name="description"
+            >a) Valor razonable con cabios en pérdidas y ganancias </field>
+            <field
+                name="expression"
+            >-balp[6630%,6631%,6633%,6634%,7630%,7631%,7633%,7634%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1620" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">470</field>
+            <field name="name">es2022_1620</field>
+            <field
+                name="description"
+            >b) Transferencia de ajustes de valor razonable con cambios en el patrimonio neto</field>
+            <field name="expression">-balp[6632%,7632%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1700" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">480</field>
+            <field name="name">es2022_1700</field>
+            <field name="description">17. Diferencias de cambio</field>
+            <field name="expression">-balp[668%,768%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1800" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">490</field>
+            <field name="name">es2022_1800</field>
+            <field
+                name="description"
+            >18. Deterioro y resultado por enajenaciones de instrumentos financieros</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field name="expression"> +es2022_1810 +es2022_1820</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1810" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">500</field>
+            <field name="name">es2022_1810</field>
+            <field name="description">a) Deterioros y pérdidas</field>
+            <field
+                name="expression"
+            >-balp[696%,697%,698%,699%,796%,797%,798%,799%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1820" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">510</field>
+            <field name="name">es2022_1820</field>
+            <field name="description">b) Resultados por enajenaciones y otras</field>
+            <field name="expression">-balp[666%,667%,673%,675%,766%,773%,775%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l4"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_1900" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">515</field>
+            <field name="name">es2022_1900</field>
+            <field
+                name="description"
+            >19. Otros ingresos y gastos de carácter financiero</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+            <field name="expression"> 0 </field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_a2" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">520</field>
+            <field name="name">es2022_A2</field>
+            <field
+                name="description"
+            >A.2) RESULTADO FINANCIERO (14 + 15 + 16 + 17 + 18 + 19)</field>
+            <field
+                name="expression"
+            >+es2022_1400+es2022_1500+es2022_1600+es2022_1700+es2022_1800 + es2022_1900</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_a3" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">530</field>
+            <field name="name">es2022_A3</field>
+            <field
+                name="description"
+            >A.3) RESULTADO ANTES DE IMPUESTOS (A.1 + A.2)</field>
+            <field name="expression">+es2022_A1+es2022_A2</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_2000" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">540</field>
+            <field name="name">es2022_2000</field>
+            <field name="description">20. Impuestos sobre beneficios</field>
+            <field name="expression">-balp[6300%,6301%,633%,638%]</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_a4" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">550</field>
+            <field name="name">es2022_A4</field>
+            <field
+                name="description"
+            >A.4) RESULTADO DEL EJERCICIO PROCEDENTE DE OPERACIONES CONTINUADAS (A.3 + 20)</field>
+            <field name="expression">+es2022_A3+es2022_2000</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_b" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">560</field>
+            <field name="name">esB</field>
+            <field name="description">B) OPERACIONES INTERRUMPIDAS</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1"
+            />
+            <field name="expression"> +es2022_2100</field>
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_2100" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">570</field>
+            <field name="name">es2022_2100</field>
+            <field
+                name="description"
+            >21. Resultado del ejercicio procedente de operaciones interrumpidas neto de impuestos</field>
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l3"
+            />
+        </record>
+        <record id="mis_report_kpi_es_pyg_normal_2022_a5" model="mis.report.kpi">
+            <field name="report_id" ref="mis_report_es_pyg_normal_2022" />
+            <field name="type">num</field>
+            <field name="compare_method">pct</field>
+            <field name="sequence">580</field>
+            <field name="name">es2022_A5</field>
+            <field name="description">A.5) RESULTADO DEL EJERCICIO (A.4 + 20)</field>
+            <field name="expression">+es2022_A4+es2022_2100</field>
+            <field name="auto_expand_accounts">True</field>
+            <field
+                name="auto_expand_accounts_style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1i"
+            />
+            <field
+                name="style_id"
+                ref="l10n_es_mis_report.mis_report_style_l10n_es_l1"
+            />
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Hemos detectado que el perdidas y ganancias normal ha sido modificado. como cambian referencias y número hemos preferido hacer una nueva plantilla. Si queréis toda la información, podéis consultarla aquí

https://www.boe.es/diario_boe/txt.php?id=BOE-A-2022-10975
[Cuenta de Pérdidas y Ganancias Normal - Disposición 10975 del BOE núm.pdf](https://github.com/OCA/l10n-spain/files/11734074/Cuenta.de.Perdidas.y.Ganancias.Normal.-.Disposicion.10975.del.BOE.num.pdf)
