### PR TITLE
[14.0][FIX] l10n_es_aeat: Manages Nothern Ireland intracommunity code 'XI'

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -58,7 +58,7 @@ class ResPartner(models.Model):
             europe = self.env["res.country.group"].search(
                 [("name", "=", "Europe")], limit=1
             )
-        return europe.country_ids.mapped("code")
+        return europe.country_ids.mapped("code") + ["XI"]  # Nothern Ireland
 
     @ormcache(
         "self.vat, self.country_id, self.aeat_identification, self.aeat_identification_type"


### PR DESCRIPTION
Hola,

Irlanda del Norte tras el Brexit sigue manteniendose en el mercado intracomunitario, no como Escocia o Inglaterra, para poder gestionar esto la Unión Europea y Reino Unido crearon un nuevo código para los VAT de Irlanda del Norte (https://sede.agenciatributaria.gob.es/Sede/iva/iva-operaciones-comercio-exterior/consecuencias-brexit-iva-partir-1-2021/nif-iva-modelo-349.html), se substituía GB por XI en este caso, Odoo valida corectamente ambos prefijos.

Añadiendo XI a los códigos europeos, que es lo que hace este PR, se consigue enviar correctamente al SII este caso como intracomunitario, ya que compone el NIF correctamenet XI + identificador, sin el PR lo intenta enviar como si fuera extracomunitario y con GB, lo cual falla.

Revisando más código donde se utiliza esta función, he encontrado el 347, no he podido probarlo subiendo fichero, pero probando a crear un 347 a mano, creo que no va a funcionar, ya que como código de país no existe XI, sólo GB, pero el NIF intracomutario si debería de ser XI + identificador, con el PR entiendo que se enviaría código de país XI y el identificador intracomunitario sin prefijo, tal y como está el código del 347.

@pedrobaeza  ¿se te ocurre alguna forma para no hacerlo para todos los casos sólo para el SII por ahora? o quizás devolver un resultado más en "_parse_aeat_vat_info", código de país por un lado y prefijo por otro, por si pudiera estar fallando en otros modelos, se usa esta función también en ticketbai y libro de iva