### PR TITLE
[16][FIX] l10n_es_aeat_sii_oca: broken view in Aeat SII Map Form

### DIFF
--- a/l10n_es_aeat_sii_oca/views/aeat_sii_map_view.xml
+++ b/l10n_es_aeat_sii_oca/views/aeat_sii_map_view.xml
@@ -17,14 +17,20 @@
         <field name="model">aeat.sii.map</field>
         <field name="arch" type="xml">
             <form string="Aeat SII Map">
-                <group col="4">
-                    <field name="name" />
-                    <field name="date_from" />
-                    <field name="date_to" />
-                </group>
-                <group string="Mapping Lines" col="4">
-                    <field name='map_lines' nolabel="1" />
-                </group>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name" />
+                        </group>
+                        <group>
+                            <field name="date_from" />
+                            <field name="date_to" />
+                        </group>
+                    </group>
+                    <group string="Mapping Lines" col="4">
+                        <field name="map_lines" nolabel="1" colspan="4" />
+                    </group>
+                </sheet>
             </form>
         </field>
     </record>


### PR DESCRIPTION
Fix the structure of the form and align the elements for its correct visualization.
@Tecnativa TT43941

Related with the issue: https://github.com/OCA/l10n-spain/issues/3096