### PR TITLE
[14.0][FIX] l10n_es_ticketbai: Convert line data from other currencies

### DIFF
--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -664,6 +664,14 @@ class AccountMoveLine(models.Model):
             partner=self.move_id.partner_id,
         )
         price_total = taxes["total_included"] if taxes else self.price_subtotal
+        invoice_id = self.move_id
+        if invoice_id.currency_id.id != invoice_id.company_id.currency_id.id:
+            price_total = currency._convert(
+                price_total,
+                invoice_id.company_id.currency_id,
+                invoice_id.company_id,
+                invoice_id.date or invoice_id.invoice_date,
+            )
         if RefundType.differences.value == self.move_id.tbai_refund_type:
             sign = -1
         else:
@@ -675,6 +683,15 @@ class AccountMoveLine(models.Model):
         for tax in self.tax_ids.filtered(lambda t: t.price_include):
             price_unit = price_unit - (
                 self.price_unit * tax.amount / (100 + tax.amount)
+            )
+        currency = self.move_id and self.move_id.currency_id or None
+        invoice_id = self.move_id
+        if invoice_id.currency_id.id != invoice_id.company_id.currency_id.id:
+            price_unit = currency._convert(
+                price_unit,
+                invoice_id.company_id.currency_id,
+                invoice_id.company_id,
+                invoice_id.date or invoice_id.invoice_date,
             )
         return price_unit
 


### PR DESCRIPTION
Al enviar la factura a TicketBAI el total si que se pasa a Euros, pero no los detalles de las líneas, con lo que hacienda devuelve warning diciendo que no cuadra la suma.