### PR TITLE
[13.0][FIX] l10n_es_aeat_mod347: Multicompany report and mail

### DIFF
--- a/l10n_es_aeat_mod347/__manifest__.py
+++ b/l10n_es_aeat_mod347/__manifest__.py
@@ -10,7 +10,7 @@
 
 {
     "name": "AEAT modelo 347",
-    "version": "13.0.2.4.0",
+    "version": "13.0.2.5.0",
     "author": "Tecnativa,PESOL,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "category": "Accounting",

--- a/l10n_es_aeat_mod347/migrations/13.0.2.5.0/post-migration.py
+++ b/l10n_es_aeat_mod347/migrations/13.0.2.5.0/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Ángel García de la Chica Herrera <angel.garcia@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    template = env.ref("l10n_es_aeat_mod347.email_template_347")
+    for lang_code, _ in env["res.lang"].get_installed():
+        translated_subject = template.with_context(lang=lang_code).subject
+        new_subject = translated_subject.replace(
+            "${user.company_id.name}", "${object.report_id.company_id.name}"
+        )
+        template.with_context(lang=lang_code).write({"subject": new_subject})

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -347,6 +347,11 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
         default=lambda self: self.env.user,
         copy=False,
     )
+    # Needed for having the field in the external layout rendering scope for catching
+    # the proper company for the header/footer
+    company_id = fields.Many2one(
+        comodel_name="res.company", string="Company", related="report_id.company_id",
+    )
     state = fields.Selection(
         selection=[
             ("pending", "Pending"),


### PR DESCRIPTION
Este PR pretende arreglar que al imprimir el pdf con el informe que se envía a clientes/proveedores aparece la compañía con id más bajo (pues no existe company_id en el modelo que genera el informe) y al enviar el email (en el asunto) aparece la compañía por defecto del usuario que está enviando el email, pudiendo tener permitidas varias y estando operando desde otra.