### PR TITLE
[13.0][IMP] l10n_es_ticketbai_*: Make TBAI software version visible and e…

### DIFF
--- a/l10n_es_ticketbai_api/__manifest__.py
+++ b/l10n_es_ticketbai_api/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "TicketBAI - API",
-    "version": "13.0.1.5.6",
+    "version": "13.0.1.5.7",
     "category": "Accounting & Finance",
     "website": "https://github.com/OCA/l10n-spain",
     "author": "Binovo," "Odoo Community Association (OCA)",

--- a/l10n_es_ticketbai_api/migrations/13.0.1.5.7/post-migrate.py
+++ b/l10n_es_ticketbai_api/migrations/13.0.1.5.7/post-migrate.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Landoo Sistemas de Informacion SL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import odoo
+from odoo import release
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+    installations = env["tbai.installation"].search([])
+    for installation in installations:
+        installation.version = release.version

--- a/l10n_es_ticketbai_api/models/res_company.py
+++ b/l10n_es_ticketbai_api/models/res_company.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from collections import OrderedDict
 
-from odoo import _, api, exceptions, fields, models, release
+from odoo import _, api, exceptions, fields, models
 
 
 class ResCompany(models.Model):
@@ -34,6 +34,12 @@ class ResCompany(models.Model):
         related="tbai_installation_id.name",
         readonly=True,
         help="Registered name at the Tax Agency.",
+    )
+    tbai_software_version = fields.Char(
+        string="Software Version",
+        related="tbai_installation_id.version",
+        copy=False,
+        help="Version of the software.",
     )
     tbai_device_serial_number = fields.Char(
         "Device Serial Number", default="", copy=False
@@ -163,6 +169,6 @@ class ResCompany(models.Model):
                 ("LicenciaTBAI", self.tbai_license_key),
                 ("EntidadDesarrolladora", self._tbai_build_entidad_desarrolladora()),
                 ("Nombre", self.tbai_software_name),
-                ("Version", release.version),
+                ("Version", self.tbai_software_version),
             ]
         )

--- a/l10n_es_ticketbai_api/models/ticketbai_installation.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_installation.py
@@ -19,6 +19,12 @@ class TicketBaiInstallation(models.Model):
     )
     vat = fields.Char("TIN", related="developer_id.vat")
     license_key = fields.Char("License Key", required=True, copy=False)
+    version = fields.Char(
+        string="Software Version",
+        required=True,
+        copy=False,
+        help="Version of the software.",
+    )
 
     _sql_constraints = [
         ("name_ref_uniq", "UNIQUE(name)", _("Software Name must be unique!")),

--- a/l10n_es_ticketbai_api/tests/common.py
+++ b/l10n_es_ticketbai_api/tests/common.py
@@ -706,6 +706,7 @@ class TestL10nEsTicketBAIAPI(common.TransactionCase):
         installation = self.env["tbai.installation"].create(
             {
                 "name": vals.pop("tbai_software_name"),
+                "version": vals.pop("tbai_software_version"),
                 "developer_id": self.env.ref(
                     "l10n_es_ticketbai_api.res_partner_binovo"
                 ).id,

--- a/l10n_es_ticketbai_api/tests/company.json
+++ b/l10n_es_ticketbai_api/tests/company.json
@@ -1,6 +1,7 @@
 {
   "tbai_license_key": "TBAIGIPRE00000000003",
   "tbai_software_name": "Odoo",
+  "tbai_software_version": "0.1",
   "tbai_p12_certificate_path": "./certs/ciudadano_act.p12",
   "tbai_p12_certificate_password": "IZProd2021",
   "vat": "ESA12345674",

--- a/l10n_es_ticketbai_api/views/ticketbai_installation_views.xml
+++ b/l10n_es_ticketbai_api/views/ticketbai_installation_views.xml
@@ -11,6 +11,7 @@
                 <form string="TicketBAI Installations">
                     <group>
                         <field name="name" />
+                        <field name="version" />
                         <field
                             name="developer_id"
                             options="{'no_open':True,'no_create':True}"

--- a/l10n_es_ticketbai_pos/static/src/js/models.js
+++ b/l10n_es_ticketbai_pos/static/src/js/models.js
@@ -23,6 +23,7 @@ odoo.define("l10n_es_ticketbai_pos.models", function(require) {
         "tbai_license_key",
         "tbai_developer_id",
         "tbai_software_name",
+        "tbai_software_version",
         "tbai_tax_agency_id",
         "tbai_protected_data",
         "tbai_protected_data_txt",

--- a/l10n_es_ticketbai_pos/static/src/js/tbai_models.js
+++ b/l10n_es_ticketbai_pos/static/src/js/tbai_models.js
@@ -240,7 +240,7 @@ odoo.define("l10n_es_ticketbai_pos.tbai_models", function(require) {
                         company.tbai_developer_id[0]
                     ),
                     name: company.tbai_software_name,
-                    version: this.pos.tbai_version,
+                    version: company.tbai_software_version,
                 };
             }
             return tbai_json;


### PR DESCRIPTION
…ditable field

Se usaba como versión de instalación TicketBAI la versión de Odoo. Esto hacía que diferentes instalaciones compartieran versión, y después en los informes que envía hacienda es imposible distinguir de que cliente son los errores.