### PR TITLE
[15.0][FIX] l10n_es_pos_sii: default partner y roadmap.

### DIFF
--- a/l10n_es_pos_sii/models/pos_order.py
+++ b/l10n_es_pos_sii/models/pos_order.py
@@ -63,17 +63,7 @@ class PosOrder(models.Model):
         return SII_VALID_POS_ORDER_STATES
 
     def _sii_get_partner(self):
-        partner = (
-            self.partner_id.commercial_partner_id
-            or self.session_id.config_id.default_partner_id
-        )
-        if not partner:
-            raise UserError(
-                _("You must define a default partner for POS {}").format(
-                    self.session_id.config_id.display_name,
-                )
-            )
-        return partner
+        return self.env["res.partner"].new({"name": "Cliente contado"})
 
     def _is_sii_simplified_invoice(self):
         return True
@@ -114,7 +104,7 @@ class PosOrder(models.Model):
                 line.order_id.pricelist_id.currency_id or self.session_id.currency_id,
                 line.qty,
                 product=line.product_id,
-                partner=line.order_id.partner_id or False,
+                partner=self._sii_get_partner(),
             )
             for line_tax in line_taxes["taxes"]:
                 tax = self.env["account.tax"].browse(line_tax["id"])

--- a/l10n_es_pos_sii/readme/ROADMAP.rst
+++ b/l10n_es_pos_sii/readme/ROADMAP.rst
@@ -1,2 +1,4 @@
 * Anular envío al SII
 * Opción de envío de la sesión de forma resumida (desde pedido, hasta pedido)
+* Sólo se ha contemplado el caso en que se enviarán al SII los pedidos en estado 'done' como F2, y al ser factura simplificada, se envía al SII sin especificar la contraparte. Si un cliente se quiere desgravar un pedido, se deberá generar la factura desde el pos, y esa será la que se envíe al SII.
+* En cuanto a la fecha que se envía al SII, dado que no ha habido consenso, se envía la del pedido. Pero al estar modulado en un método, cada uno puede adaptarlo a sus necesidades.


### PR DESCRIPTION
https://github.com/OCA/l10n-spain/pull/3088

Los pedidos se enviarán siempre como F2, sin especificar la contraparte. Aún así, en el _sii_get_partner que también se utiliza en otros métodos del sii, hacemos que el partner que obtiene sea el default partner del pos, para no generar incongruencias. Respecto a la fecha, de momento seguimos enviado la del pedido.