### PR TITLE
[15.0][FIX] l10n_es_aeat_sii_oca: Permitir eliminar facturas no enviadas al SII

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -159,13 +159,10 @@ class AccountMove(models.Model):
             vals["sii_refund_type"] = "I"
         return super().write(vals)
 
-    def unlink(self):
-        """A registered invoice at the SII cannot be deleted"""
-        if self.filtered(lambda x: x.is_invoice())._check_unlink_sii_sent():
-            raise exceptions.UserError(
-                _("You cannot delete an invoice already registered at the SII.")
-            )
-        return super().unlink()
+    def _filter_sii_unlink_not_possible(self):
+        """Filter records that we can delete to apply only to invoices."""
+        res = super()._filter_sii_unlink_not_possible()
+        return res.filtered(lambda x: x.is_invoice())
 
     def _get_sii_tax_req(self, tax):
         """Get the associated req tax for the specified tax.

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -9,7 +9,7 @@ import logging
 
 from requests import Session
 
-from odoo import _, api, fields, models
+from odoo import _, api, exceptions, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.modules.registry import Registry
 from odoo.tools.float_utils import float_compare
@@ -219,8 +219,18 @@ class SiiMixin(models.AbstractModel):
         self.ensure_one()
         return self._sii_get_partner()._parse_aeat_vat_info()[0]
 
-    def _check_unlink_sii_sent(self):
-        return self and not self.filtered(lambda rec: rec.sii_state != "not_sent")
+    def _filter_sii_unlink_not_possible(self):
+        """Filter records that we do not allow to be deleted, all those
+        that are not in not_sent sii status."""
+        return self.filtered(lambda rec: rec.sii_state != "not_sent")
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_sii(self):
+        """Do not allow the deletion of records already sent to the SII."""
+        if self._filter_sii_unlink_not_possible():
+            raise exceptions.UserError(
+                _("You cannot delete an invoice already registered at the SII.")
+            )
 
     @api.model
     def _get_sii_taxes_map(self, codes, date):

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -443,8 +443,14 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         with self.assertRaises(exceptions.UserError):
             invoice._sii_check_exceptions()
 
+    def test_unlink_draft_invoice_when_not_sent_to_sii(self):
+        draft_invoice = self.invoice.copy({})
+        draft_invoice.unlink()
+        self.assertFalse(draft_invoice.exists())
+
     def test_unlink_invoice_when_sent_to_sii(self):
         self.invoice.sii_state = "sent"
+        self.invoice.button_draft()  # Convert to draft to check only SII exception
         with self.assertRaises(exceptions.UserError):
             self.invoice.unlink()
 


### PR DESCRIPTION
Permitir eliminar facturas no enviadas al SII

Relacionado con https://github.com/OCA/l10n-spain/commit/f635bcafabbb15aaa90b6c5699e77fb44aad45df (anteriormente si se podía).

Por favor @pedrobaeza y @carlosdauden ¿podéis revisarlo?

@Tecnativa TT44504