### PR TITLE
[14.0][FIX] l10n_es_aeat: Consider financial_type="other" as regular operations

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
@@ -91,7 +91,11 @@ class L10nEsAeatReportTaxMapping(models.AbstractModel):
         ]
         if map_line.move_type == "regular":
             move_line_domain.append(
-                ("move_id.financial_type", "in", ("receivable", "payable", "liquidity"))
+                (
+                    "move_id.financial_type",
+                    "in",
+                    ("receivable", "payable", "liquidity", "other"),
+                )
             )
         elif map_line.move_type == "refund":
             move_line_domain.append(


### PR DESCRIPTION
Steps to reproduce the problem:

- PoS installed.
- Have a session with only payment methods with outstanding accounts (no cash payments received).
- Close and post session.
- The resulting journal entry is of type = "Other".

Such entries, even if having taxes, won't be included in the AEAT 303 model, as the type = "Other" is not considered till now. That's because it can't be deduced if the operation is regular or not.

Let's assume that such operations are always regular (as 99.9% of the times will be), for not having differences in the amounts of the report vs balances in the tax.

@Tecnativa TT44503