### PR TITLE
[15.0][FIX] l10n_es_aeat_sii_oca: rename method confirm_one_invoice

### DIFF
--- a/l10n_es_aeat_sii_oca/data/aeat_sii_queue_job.xml
+++ b/l10n_es_aeat_sii_oca/data/aeat_sii_queue_job.xml
@@ -14,4 +14,9 @@
         <field name="method">cancel_one_invoice</field>
         <field name="channel_id" ref="invoice_validate_sii" />
     </record>
+    <record id="job_function_confirm_one_document" model="queue.job.function">
+        <field name="model_id" ref="account.model_account_move" />
+        <field name="method">confirm_one_document</field>
+        <field name="channel_id" ref="invoice_validate_sii" />
+    </record>
 </odoo>

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -911,3 +911,6 @@ class SiiMixin(models.AbstractModel):
 
     def confirm_one_document(self):
         self.sudo()._send_document_to_sii()
+
+    def confirm_one_invoice(self):
+        return self.confirm_one_document()


### PR DESCRIPTION
Debido a que se ha renombrado el método confirm_one_invoice por confirm_one_document añadido en PR: https://github.com/OCA/l10n-spain/pull/3088 si había trabajos en colas previos a la modificación se puede bloquear la cola https://github.com/OCA/l10n-spain/pull/3088#pullrequestreview-1550069266

@moduon MT-3433