### PR TITLE
[13.0][FIX] l10n_es_ticketbai: Delete analytic lines when cancelling invoice

### DIFF
--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -423,6 +423,7 @@ class AccountMove(models.Model):
                 lambda x: x.tbai_enabled and "posted" == x.state and x.tbai_invoice_id
             )
             tbai_invoices._tbai_invoice_cancel()
+        self.mapped("line_ids.analytic_line_ids").unlink()
         return super().button_cancel()
 
     def post(self):


### PR DESCRIPTION
Al cancelarse las facturas directamente sin pasarlas a borrador las líneas analíticas no estaban siendo eliminadas