### PR TITLE
[14.0][FIX] l10n_es_vat_prorate: Handle properly prorate refund account

### DIFF
--- a/l10n_es_vat_prorate/README.rst
+++ b/l10n_es_vat_prorate/README.rst
@@ -62,6 +62,9 @@ Contributors
 ~~~~~~~~~~~~
 
 * Enric Tobella
+* `Tecnativa <https://www.tecnativa.com/>`_:
+
+  * Pedro M. Baeza
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_vat_prorate/models/account_move.py
+++ b/l10n_es_vat_prorate/models/account_move.py
@@ -63,6 +63,20 @@ class AccountMove(models.Model):
             )
         return super()._onchange_invoice_line_ids()
 
+    def _reverse_move_vals(self, default_values, cancel=True):
+        """Reassign again the proper field name on prorate lines after avoiding the
+        account reassignation in super (in combination with `copy_data` method in
+        account.move.line).
+        """
+        vals = super()._reverse_move_vals(default_values, cancel=cancel)
+        for command in vals["line_ids"]:
+            line_vals = command[2]
+            if line_vals.get("prorate_tax_repartition_line_id"):
+                line_vals["tax_repartition_line_id"] = line_vals.pop(
+                    "prorate_tax_repartition_line_id"
+                )
+        return vals
+
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
@@ -73,3 +87,15 @@ class AccountMoveLine(models.Model):
         super()._process_aeat_tax_fee_info(res, tax, sign)
         if self.vat_prorate:
             res[tax]["deductible_amount"] -= self.balance * sign
+
+    def copy_data(self, default=None):
+        """Move `tax_repartition_line_id` value to other field name for avoiding the
+        `account_id` reassignation due to the code inside `_reverse_move_vals`, which
+        calls this one. We will put it again after, overwriting the other method.
+        """
+        res = super().copy_data(default=default)
+        for vals in res:
+            if vals.get("vat_prorate") and vals.get("tax_repartition_line_id"):
+                repartition_line_id = vals.pop("tax_repartition_line_id")
+                vals["prorate_tax_repartition_line_id"] = repartition_line_id
+        return res

--- a/l10n_es_vat_prorate/readme/CONTRIBUTORS.rst
+++ b/l10n_es_vat_prorate/readme/CONTRIBUTORS.rst
@@ -1,1 +1,4 @@
 * Enric Tobella
+* `Tecnativa <https://www.tecnativa.com/>`_:
+
+  * Pedro M. Baeza

--- a/l10n_es_vat_prorate/static/description/index.html
+++ b/l10n_es_vat_prorate/static/description/index.html
@@ -410,6 +410,10 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
 <li>Enric Tobella</li>
+<li><a class="reference external" href="https://www.tecnativa.com/">Tecnativa</a>:<ul>
+<li>Pedro M. Baeza</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
When doing a refund, the account of the prorate line is changed to the tax repartition line default one (472). 

That's because there's some code on the method `_reverse_move_vals` that is checking `tax_repartition_line_id` value in the returned dictionary for ignoring the copied value. See https://github.com/odoo/odoo/blob/82b1e68b60eb14896666adfd3ad1f753e944d393/addons/account/models/account_move.py#L2515-L2533

What we do for tricking it (as it's atomic and can't be intercepted in other part) is:

- When copying values, we move the `tax_repartition_line_id` into another field name.
- Thus, `_reverse_move_vals` is not modifying the account.
- Immediately after returning from `_reverse_move_vals`, we restored the field value.

@Tecnativa TT44656