### PR TITLE
[15.0][FIX] l10n_es_account_statement_import_n43: Avoid partner mismatch

### DIFF
--- a/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py
+++ b/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py
@@ -285,7 +285,7 @@ class AccountStatementImport(models.TransientModel):
             # Try to match from partner name
             if conceptos.get("01"):
                 name = conceptos["01"][0][4:] + conceptos["01"][1]
-                if name:
+                if name and len(name) > 7:
                     partner = partner_obj.search([("name", "ilike", name)], limit=1)
         return partner
 
@@ -302,7 +302,7 @@ class AccountStatementImport(models.TransientModel):
             # Try to match from partner name
             if conceptos.get("01"):
                 name = conceptos["01"][0]
-                if name:
+                if name and len(name) > 7:
                     partner = partner_obj.search([("name", "ilike", name)], limit=1)
         return partner
 
@@ -322,7 +322,7 @@ class AccountStatementImport(models.TransientModel):
         # Try to match from partner name
         if conceptos.get("01"):
             name = conceptos["01"][1]
-            if name and len(name) > 5:
+            if name and len(name) > 7:
                 partner = partner_obj.search([("name", "ilike", name)], limit=1)
         return partner
 


### PR DESCRIPTION
Forward-port of #3199

If we have very short concepts, there's a chance that the stripped text on the subsequent bank patterns matches with a partner, without the concept being really a partner.

Example: "2301IMPUESTOS", taking "ESTOS" as name to match, which can match with "GESTOS S.L.".

For avoiding this, we put a minimal string length of 8 chars for making the match.

@Tecnativa TT44038