### PR TITLE
[16.0][FIX] l10n_es_vat_prorate: Restrict vat prorate value

### DIFF
--- a/l10n_es_vat_prorate/i18n/l10n_es_vat_prorate.pot
+++ b/l10n_es_vat_prorate/i18n/l10n_es_vat_prorate.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-09-11 11:28+0000\n"
+"PO-Revision-Date: 2023-09-11 11:28+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -76,6 +78,13 @@ msgstr ""
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#. odoo-python
+#: code:addons/l10n_es_vat_prorate/models/res_company.py:0
+#, python-format
+msgid "You must complete VAT prorate information"
 msgstr ""
 
 #. module: l10n_es_vat_prorate

--- a/l10n_es_vat_prorate/models/res_company.py
+++ b/l10n_es_vat_prorate/models/res_company.py
@@ -1,11 +1,12 @@
 # Copyright 2022 Creu Blanca
+# Copyright 2023 Tecnativa Carolina Fernandez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResCompany(models.Model):
-
     _inherit = "res.company"
 
     with_vat_prorate = fields.Boolean()
@@ -22,9 +23,14 @@ class ResCompany(models.Model):
         )
         return prorate.vat_prorate
 
+    @api.constrains("with_vat_prorate", "vat_prorate_ids")
+    def _check_vat_prorate_ids(self):
+        for rec in self.sudo():
+            if rec.with_vat_prorate and not rec.vat_prorate_ids:
+                raise ValidationError(_("You must complete VAT prorate information"))
+
 
 class ResCompanyVatProrate(models.Model):
-
     _name = "res.company.vat.prorate"
     _description = "VAT Prorate table"
     _rec_name = "date"
@@ -33,3 +39,11 @@ class ResCompanyVatProrate(models.Model):
     company_id = fields.Many2one("res.company", required=True)
     date = fields.Date(required=True, default=fields.Date.today())
     vat_prorate = fields.Float()
+
+    _sql_constraints = [
+        (
+            "vat_prorate_percent_amount",
+            "CHECK (vat_prorate > 0 and vat_prorate <= 100)",
+            "VAT prorate must be between 0.01 and 100!",
+        ),
+    ]

--- a/l10n_es_vat_prorate/readme/CONTRIBUTORS.rst
+++ b/l10n_es_vat_prorate/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * `Tecnativa <https://www.tecnativa.com/>`_:
 
   * Pedro M. Baeza
+  * Carolina Fernandez

--- a/l10n_es_vat_prorate/static/description/index.html
+++ b/l10n_es_vat_prorate/static/description/index.html
@@ -415,6 +415,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Enric Tobella</li>
 <li><a class="reference external" href="https://www.tecnativa.com/">Tecnativa</a>:<ul>
 <li>Pedro M. Baeza</li>
+<li>Carolina Fernandez</li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
- Add sql contraints to check vat prorate values
- If the company has "With Vat Prorate" checked, is mandatory to complete VAT Prorate tab.

This changes fixes error division by zero when company has not theoretical prorate 

@Tecnativa TT43231

@pedrobaeza 

