### PR TITLE
[14.0][OU-ADD] l10n_es_intrastat_report: Add migration script

### DIFF
--- a/l10n_es_intrastat_report/migrations/14.0.1.0.0/pre-migration.py
+++ b/l10n_es_intrastat_report/migrations/14.0.1.0.0/pre-migration.py
@@ -1,0 +1,18 @@
+# Copyright 2023 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+_field_renames = [
+    (
+        "l10n.es.intrastat.product.declaration",
+        "l10n_es_intrastat_product_declaration",
+        "type",
+        "declaration_type",
+    ),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_fields(env, _field_renames)


### PR DESCRIPTION
Relacionado con https://github.com/OCA/l10n-spain/pull/3111#issuecomment-1710048213

Cambios realizados:
- [x] Renombrar `type` por `declaration_type` en `l10n_es_intrastat_product_declaration` (similar a https://github.com/OCA/intrastat-extrastat/blob/14.0/intrastat_product/migrations/14.0.1.0.0/pre-migration.py)

@Tecnativa