### PR TITLE
[14.0][IMP]l10n_es_account_statement_import_n43: Usar partners de la compañía solamente

### DIFF
--- a/l10n_es_account_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
+++ b/l10n_es_account_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
@@ -12,6 +12,10 @@ class L10nEsAccountStatementImportN43(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.company_2 = cls.env["res.company"].create({"name": "New company"})
+        cls.partner_other_company = cls.env["res.partner"].create(
+            {"name": "Test partner N43", "company_id": cls.company_2.id}
+        )
         cls.partner = cls.env["res.partner"].create(
             {"name": "Test partner N43", "company_id": cls.env.company.id}
         )


### PR DESCRIPTION
Cuando se usa la importación con múltiples ficheros puede salir un error al estilo:

- '/' belongs to company 'YourCompany' and 'Partner' (partner_id: 'Test partner N43') belongs to another company.

Para evitarlo, lo mejor es forzar que use las compañías en la búsqueda de partner, ya que ya tenemos el diario.

Añado un detalle en el test para que se compruebe la decisión (sin el cambio salta el error comentado)

El error saldria si trabajamos con multicompañía pero hemos definido el mismo partner en las dos compañías