### PR TITLE
[FIX][16.0] payment_redsys: Missing parameter in method override

### DIFF
--- a/payment_redsys/models/payment_provider.py
+++ b/payment_redsys/models/payment_provider.py
@@ -194,8 +194,8 @@ class PaymentProvider(models.Model):
             res = description[:125]
         return res
 
-    def _get_default_payment_method_id(self):
+    def _get_default_payment_method_id(self, code):
         self.ensure_one()
         if self.code != "redsys":
-            return super()._get_default_payment_method_id()
+            return super()._get_default_payment_method_id(code)
         return self.env.ref("payment_redsys.payment_method_redsys").id

--- a/payment_redsys/readme/CONTRIBUTORS.rst
+++ b/payment_redsys/readme/CONTRIBUTORS.rst
@@ -18,3 +18,7 @@
 * `Studio73 <https://www.studio73.es/>`_:
 
   * Rafa Ferri <rafa.ferri@studio73.es>
+
+* `Factor Libre <https://factorlibre.com/>`_:
+
+  * Pablo De Andrés <pablo.deandres@factorlibre.com>


### PR DESCRIPTION
`_get_default_payment_method_id` has an extra argument: "code".

Original in account_payment:
![image](https://github.com/OCA/l10n-spain/assets/712821/7677a8b2-7130-4d52-b84b-d756938a052d)

Inherited in payment_redsys:
![image](https://github.com/OCA/l10n-spain/assets/712821/837fca74-f6c1-4378-94ef-1fe45debe592)
