### PR TITLE
[16.0][FIX] l10n_es_dua_sii: Add 2 taxes to SII DUA map

### DIFF
--- a/l10n_es_dua_sii/data/tax_code_map_dua_sii_data.xml
+++ b/l10n_es_dua_sii/data/tax_code_map_dua_sii_data.xml
@@ -10,7 +10,9 @@
             eval="[(6, 0, [
         ref('l10n_es.account_tax_template_p_iva21_ibc'),
         ref('l10n_es.account_tax_template_p_iva10_ibc'),
+        ref('l10n_es.account_tax_template_p_iva5_ibc'),
         ref('l10n_es.account_tax_template_p_iva4_ibc'),
+        ref('l10n_es.account_tax_template_p_iva0_ibc'),
         ref('l10n_es.account_tax_template_p_iva21_ibi'),
         ref('l10n_es.account_tax_template_p_iva10_ibi'),
         ref('l10n_es.account_tax_template_p_iva4_ibi'),


### PR DESCRIPTION
Added taxes to DUA map from SII:
- IVA 5% Importaciones bienes corrientes.
- IVA 0% Importaciones bienes corrientes.

MT-2319 @moduon https://github.com/OCA/l10n-spain/issues/2816