### PR TITLE
[14.0][FIX] l10n_es_aeat_sii_oca: wrong job channel name

### DIFF
--- a/l10n_es_aeat_sii_oca/data/aeat_sii_queue_job.xml
+++ b/l10n_es_aeat_sii_oca/data/aeat_sii_queue_job.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="invoice_validate_sii" model="queue.job.channel">
-        <field name="name">root.invoice_validate_sii</field>
+        <field name="name">invoice_validate_sii</field>
         <field name="parent_id" ref="queue_job.channel_root" />
     </record>
     <record id="job_function_confirm_one_invoice" model="queue.job.function">


### PR DESCRIPTION
A partir de v14, ya no es necesario el prefijo `root.` para el nombre del canal del envío de las facturas al SII

Soluciona #3147