### PR TITLE
[FIX] l10n_es_ticketbai_batuz: Fecha factura rectificada se pasa a texto.

### DIFF
--- a/l10n_es_ticketbai_batuz/models/account_move.py
+++ b/l10n_es_ticketbai_batuz/models/account_move.py
@@ -311,7 +311,10 @@ class AccountMove(models.Model):
                         vals.append(("SerieFactura", refund_origin_id.number_prefix))
                     vals.append(("NumFactura", refund_origin_id.number))
                     vals.append(
-                        ("FechaExpedicionFactura", refund_origin_id.expedition_date)
+                        (
+                            "FechaExpedicionFactura",
+                            self._change_date_format(refund_origin_id.expedition_date),
+                        )
                     )
 
                     origins.append(


### PR DESCRIPTION
Al hacer una rectificativa de compras donde le indicabas que facturas rectificabas en el campo tbai_refund_origin_ids da un error porque no transforma la fecha a texto. Se arregla ese error.