### PR TITLE
[16.0][FIX] l10n_es_pos_sii: Set auto_install correctly on manifest

### DIFF
--- a/l10n_es_pos_sii/__manifest__.py
+++ b/l10n_es_pos_sii/__manifest__.py
@@ -23,5 +23,5 @@
         ],
     },
     "installable": True,
-    "autoinstall": True,
+    "auto_install": True,
 }


### PR DESCRIPTION
Se corrige auto_install en el manifest, no estaba funcionando bien al no estar bien escrito.