### PR TITLE
[11.0][FIX] l10n_es_ticketbai: Error DesgloseTipoOperacion 

### DIFF
--- a/l10n_es_dua_ticketbai_batuz/models/account_invoice.py
+++ b/l10n_es_dua_ticketbai_batuz/models/account_invoice.py
@@ -26,7 +26,9 @@ class AccountInvoice(models.Model):
             tbai_dua_map = self.env['tbai.tax.map'].search(
                 [('code', '=', 'DUA')]
             )
-            dua_taxes = self.env['l10n.es.aeat.report'].get_taxes_from_templates(
+            dua_taxes = self.env["l10n.es.aeat.report"].new(
+                {'company_id': invoice.company_id.id}
+            ).get_taxes_from_templates(
                 tbai_dua_map.mapped("tax_template_ids")
             )
             invoice.tbai_dua_invoice = (

--- a/l10n_es_ticketbai/hooks.py
+++ b/l10n_es_ticketbai/hooks.py
@@ -31,8 +31,9 @@ def post_init_hook(cr, registry):
             if 0 < len(fiscal_position_template.tbai_vat_exemption_ids):
                 tbai_vat_exemptions = []
                 for exemption in fiscal_position_template.tbai_vat_exemption_ids:
-                    tax = env['l10n.es.aeat.report']\
-                        .get_taxes_from_templates(exemption.tax_id)
+                    tax = env['l10n.es.aeat.report'].new(
+                        {'company_id': position.company_id.id}
+                    ).get_taxes_from_templates(exemption.tax_id)
                     if 1 == len(tax):
                         tbai_vat_exemptions.append((0, 0, {
                             'tax_id': tax.id,

--- a/l10n_es_ticketbai/models/account_invoice.py
+++ b/l10n_es_ticketbai/models/account_invoice.py
@@ -265,7 +265,9 @@ class AccountInvoice(models.Model):
         tbai_maps = self.env["tbai.tax.map"].search(
             [('code', 'in', ("RE", "IRPF"))]
         )
-        exclude_taxes = self.env['l10n.es.aeat.report'].get_taxes_from_templates(
+        exclude_taxes = self.env["l10n.es.aeat.report"].new(
+            {'company_id': self.company_id.id}
+        ).get_taxes_from_templates(
             tbai_maps.mapped("tax_template_ids")
         )
         for tax in self.tax_line_ids.filtered(
@@ -487,7 +489,9 @@ class AccountInvoice(models.Model):
         tbai_maps = self.env["tbai.tax.map"].search(
             [('code', '=', "IRPF")]
         )
-        irpf_taxes = self.env['l10n.es.aeat.report'].get_taxes_from_templates(
+        irpf_taxes = self.env["l10n.es.aeat.report"].new(
+            {'company_id': self.company_id.id}
+        ).get_taxes_from_templates(
             tbai_maps.mapped("tax_template_ids")
         )
         taxes = self.tax_line_ids.filtered(
@@ -532,7 +536,9 @@ class AccountInvoiceLine(models.Model):
 
     def tbai_get_value_importe_total(self):
         tbai_maps = self.env["tbai.tax.map"].search([('code', '=', "IRPF")])
-        irpf_taxes = self.env['l10n.es.aeat.report'].get_taxes_from_templates(
+        irpf_taxes = self.env["l10n.es.aeat.report"].new(
+            {'company_id': self.company_id.id}
+        ).get_taxes_from_templates(
             tbai_maps.mapped("tax_template_ids")
         )
         currency = self.invoice_id and self.invoice_id.currency_id or None

--- a/l10n_es_ticketbai/models/account_invoice_tax.py
+++ b/l10n_es_ticketbai/models/account_invoice_tax.py
@@ -30,7 +30,9 @@ class AccountInvoiceTax(models.Model):
         tbai_maps = self.env["tbai.tax.map"].search(
             [('code', '=', "RE")]
         )
-        s_iva_re_taxes = self.env['l10n.es.aeat.report'].get_taxes_from_templates(
+        s_iva_re_taxes = self.env["l10n.es.aeat.report"].new(
+            {'company_id': self.company_id.id}
+        ).get_taxes_from_templates(
             tbai_maps.mapped("tax_template_ids")
         )
         lines = self.invoice_id.invoice_line_ids.filtered(
@@ -69,7 +71,9 @@ class AccountInvoiceTax(models.Model):
         tbai_maps = self.env["tbai.tax.map"].search(
             [("code", "in", ("SNS", "SIE", "S", "SER"))]
         )
-        taxes = self.env['l10n.es.aeat.report'].get_taxes_from_templates(
+        taxes = self.env["l10n.es.aeat.report"].new(
+            {'company_id': self.company_id.id}
+        ).get_taxes_from_templates(
             tbai_maps.mapped("tax_template_ids")
         )
         return self.tax_id in taxes
@@ -82,7 +86,9 @@ class AccountInvoiceTax(models.Model):
         tbai_maps = self.env["tbai.tax.map"].search(
             [("code", "in", ("B", "BNS", "IEE", "SER"))]
         )
-        taxes = self.env['l10n.es.aeat.report'].get_taxes_from_templates(
+        taxes = self.env["l10n.es.aeat.report"].new(
+            {'company_id': self.company_id.id}
+        ).get_taxes_from_templates(
             tbai_maps.mapped("tax_template_ids")
         )
         return self.tax_id in taxes
@@ -124,7 +130,9 @@ class AccountInvoiceTax(models.Model):
         tbai_maps = self.env["tbai.tax.map"].search(
             [("code", "=", "ISP")]
         )
-        isp_taxes = self.env['l10n.es.aeat.report'].get_taxes_from_templates(
+        isp_taxes = self.env["l10n.es.aeat.report"].new(
+            {'company_id': self.company_id.id}
+        ).get_taxes_from_templates(
             tbai_maps.mapped("tax_template_ids")
         )
         if self.tax_id in isp_taxes:

--- a/l10n_es_ticketbai/models/chart_template.py
+++ b/l10n_es_ticketbai/models/chart_template.py
@@ -57,7 +57,9 @@ class AccountChartTemplate(models.Model):
             fiscal_position = self.env['account.fiscal.position'].browse(res_id)
             tbai_vat_exemptions = []
             for exemption in template.tbai_vat_exemption_ids:
-                Report = self.env['l10n.es.aeat.report']
+                Report = self.env["l10n.es.aeat.report"].new(
+                    {'company_id': company.id}
+                )
                 tax = Report.get_taxes_from_templates(exemption.tax_id)
                 if 1 == len(tax):
                     tbai_vat_exemptions.append((0, 0, {


### PR DESCRIPTION
Corrección del error "DesgloseTipoOperacion" en entorno multicompañía.

La llamada al método "_tbai_build_invoice" se hace con sudo, lo que provoca que en el método "get_taxes_from_templates" del modelo "l10n.es.aeat.report" se tome como compañía la del superusuario. Esto provoca que "get_taxes_from_templates " no devuelva los impuestos correctos si el usuario que valida la factura no se encuentra en la misma compañía que el superusuario. Al no ser lo impuestos correctos no se realiza el desglose de iva.