### PR TITLE
[16.0][FIX] l10n_es_aeat_mod349: refund intermediate periods

### DIFF
--- a/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod349/readme/CONTRIBUTORS.rst
@@ -25,3 +25,7 @@
   * Manuel Regidor
 
 * Jairo Llopis (Moduon)
+
+* `Factor Libre <https://factorlibre.com>`_:
+
+    * Luis J. Salvatierra <luis.salvatierra@factorlibre.com>


### PR DESCRIPTION
Use case:
* Invoice January 2023: 1.000€
* Credit note February 2023: -200€
* credit note March 2023: -200€

Without the fix:
* 349 January total amount 1000€ (correct)
* 349 February total rectified amount 800€ (correct) and original amount 1000€ (correct)
* 349 March total rectified amount 800€ (incorrect) and original amount 1000€ (incorrect)

With the fix:
* 349 January total amount 1000€ (correct)
* 349 February total rectified amount 800€ (correct) and original amount 1000€ (correct)
* 349 March total rectified amount 600€ (correct) and original amount 800€ (correct)