### PR TITLE
[15.0][IMP] l10n_es_intrastat_report: Set the fiscal position "Régimen Intracomunitario" with Intrastat flag

### DIFF
--- a/l10n_es_intrastat_report/data/account_fiscal_position_template.xml
+++ b/l10n_es_intrastat_report/data/account_fiscal_position_template.xml
@@ -5,4 +5,7 @@
     <record id="l10n_es.fp_intra_private" model="account.fiscal.position.template">
         <field name="intrastat" eval="True" />
     </record>
+    <record id="l10n_es.fp_intra" model="account.fiscal.position.template">
+        <field name="intrastat" eval="True" />
+    </record>
 </odoo>

--- a/l10n_es_intrastat_report/hooks.py
+++ b/l10n_es_intrastat_report/hooks.py
@@ -12,7 +12,7 @@ def post_init_hook(cr, registry):
     items = env["ir.model.data"].search(
         [
             ("model", "=", "account.fiscal.position"),
-            ("name", "like", "%_fp_intra_private"),
+            ("name", "like", "%_fp_intra%"),
             ("module", "=", "l10n_es"),
         ]
     )


### PR DESCRIPTION
FWP de 14.0: https://github.com/OCA/l10n-spain/pull/3266

Definir también la posición fiscal "Régimen Intracomunitario" con Intrastat.

Por favor @pedrobaeza, ¿puedes revisarlo?

@Tecnativ TT45420