### PR TITLE
[16.0][IMP] l10n_es_intrastat_report: Set the fiscal position "Régimen Intracomunitario" with Intrastat flag

### DIFF
--- a/l10n_es_intrastat_report/data/account_fiscal_position_template.xml
+++ b/l10n_es_intrastat_report/data/account_fiscal_position_template.xml
@@ -6,4 +6,8 @@
         <field name="intrastat">b2b</field>
         <field name="vat_required" eval="False" />
     </record>
+    <record id="l10n_es.fp_intra" model="account.fiscal.position.template">
+        <field name="intrastat">b2b</field>
+        <field name="vat_required" eval="False" />
+    </record>
 </odoo>

--- a/l10n_es_intrastat_report/hooks.py
+++ b/l10n_es_intrastat_report/hooks.py
@@ -12,7 +12,7 @@ def post_init_hook(cr, registry):
     items = env["ir.model.data"].search(
         [
             ("model", "=", "account.fiscal.position"),
-            ("name", "like", "%_fp_intra_private"),
+            ("name", "like", "%_fp_intra%"),
             ("module", "=", "l10n_es"),
         ]
     )


### PR DESCRIPTION
FWP de 15.0: https://github.com/OCA/l10n-spain/pull/3272

Definir también la posición fiscal "Régimen Intracomunitario" con Intrastat.

Por favor @pedrobaeza, ¿puedes revisarlo?

@Tecnativa TT45420