### PR TITLE
[15.0] [FIX] l10n_es_aeat_sii_oca: Check for SII Exceptions when posting an invoice

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -9,6 +9,7 @@
 # Copyright 2011-2023 Tecnativa - Pedro M. Baeza
 # Copyright 2023 Aures Tic - Almudena de la Puente <almudena@aurestic.es>
 # Copyright 2023 Aures Tic - Jose Zambudio <jose@aurestic.es>
+# Copyright 2023 Moduon Team - Eduardo de Miguel
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import json
@@ -587,6 +588,7 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         res = super()._post(soft=soft)
         for invoice in self.filtered(lambda x: x.sii_enabled and x.is_invoice()):
+            invoice._sii_check_exceptions()
             if (
                 invoice.sii_state in ["sent_modified", "sent"]
                 and self._sii_invoice_dict_not_modified()

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -3,6 +3,7 @@
 # Copyright 2020 Valentin Vinagre <valent.vinagre@sygel.es>
 # Copyright 2021 Tecnativa - João Marques
 # Copyright 2017-2023 Tecnativa - Pedro M. Baeza
+# Copyright 2023 Moduon Team - Eduardo de Miguel
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import json
@@ -442,6 +443,35 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         )
         with self.assertRaises(exceptions.UserError):
             invoice._sii_check_exceptions()
+
+    def test_sii_check_exceptions_case_supplier_on_post(self):
+        """Check sii exceptions when posting supplier bills"""
+        supplier = self.supplier.copy()
+        supplier.country_id = self.env.ref("base.es")
+        supplier.vat = "A46180576"
+        # Extra data without `ref` field
+        extra_data_wo_ref = {
+            "partner_id": supplier.id,
+            "invoice_line_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Test line",
+                        "account_id": self.accounts["600000"].id,
+                        "price_unit": 100.0,
+                        "quantity": 1,
+                    },
+                )
+            ],
+        }
+        with self.assertRaises(exceptions.UserError):
+            self._invoice_purchase_create("2018-02-01", extra_vals=extra_data_wo_ref)
+        self.assertTrue(
+            self._invoice_purchase_create(
+                "2018-02-01", extra_vals=dict(extra_data_wo_ref, ref="TEST REF")
+            )
+        )
 
     def test_unlink_draft_invoice_when_not_sent_to_sii(self):
         draft_invoice = self.invoice.copy({})


### PR DESCRIPTION
## Contexto
Cuando el envío del SII está configurado en la compañía de manera _manual_ o en _diferido_ y la factura no está correctamente rellenada para el SII, saltan los errores de comprobación del SII en el `queue.job` (si está instalado).

## Cambios
Con este PR, la verificación se hace al validar una factura.
De esta manera, los errores son detectados in situ y se puede corregir para evitar los errores en la cola, que no suelen ser revisados tan a menudo.

---

closes https://github.com/OCA/l10n-spain/issues/3167

_Falta cherry-pick a v16_

---

MT-3718 @moduon @rafaelbn @pedrobaeza