### PR TITLE
[16.0][IMP] l10n_es_account_statement_import_n43: Define transaction reference (same as v13)

### DIFF
--- a/l10n_es_account_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
+++ b/l10n_es_account_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
@@ -98,6 +98,9 @@ class L10nEsAccountStatementImportN43(common.TransactionCase):
         self.assertAlmostEqual(statement.balance_start, 0, 2)
         self.assertAlmostEqual(statement.balance_end, 101.96, 2)
         self.assertEqual(statement_lines[2].partner_id, self.partner)
+        self.assertEqual(statement_lines[2].ref, "000975737917")
+        self.assertEqual(statement_lines[1].ref, "/")
+        self.assertEqual(statement_lines[0].ref, "5540014210128010")
 
     def test_import_n43_fecha_oper(self):
         self.journal.n43_date_type = "fecha_oper"

--- a/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py
+++ b/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py
@@ -381,6 +381,7 @@ class AccountStatementImport(models.TransientModel):
                     "payment_ref": " ".join(conceptos)
                     or self._get_n43_ref(line)
                     or "/",
+                    "ref": self._get_n43_ref(line),
                     "amount": line["importe"],
                     # inject raw parsed N43 dict for later use, that will be
                     # removed before passing final values to create the record


### PR DESCRIPTION
FWP de 15.0: https://github.com/OCA/l10n-spain/pull/3291

Definir la referencia (`ref`) de las transacciones (similar a v13).

En v13 (https://github.com/OCA/l10n-spain/blob/13.0/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py#L367) la referencia n43 se añadía a las transacciones y no queremos perder esa información ahora.

Por favor @pedrobaeza ¿puedes revisarlo?

@Tecnativa TT45629