### PR TITLE
[16.0][IMP] l10n_es_vat_book: Add tax agency

### DIFF
--- a/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
+++ b/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
@@ -7,6 +7,10 @@
         <field name="fee_type_xlsx_column">N</field>
         <field name="fee_amount_xlsx_column">O</field>
         <field
+            name="tax_agency_ids"
+            eval="[ Command.link(ref('l10n_es_aeat.aeat_tax_agency_spain')) ]"
+        />
+        <field
             name="tax_tmpl_ids"
             eval="[
             (4, ref('l10n_es.account_tax_template_s_iva0b')),
@@ -36,6 +40,10 @@
         <field name="special_tax_group" eval="False" />
         <field name="fee_type_xlsx_column">O</field>
         <field name="fee_amount_xlsx_column">P</field>
+        <field
+            name="tax_agency_ids"
+            eval="[ Command.link(ref('l10n_es_aeat.aeat_tax_agency_spain')) ]"
+        />
         <field name="tax_account_id" ref="l10n_es.account_common_472" />
         <field
             name="tax_tmpl_ids"
@@ -97,6 +105,10 @@
         <field name="book_type">received</field>
         <field name="special_tax_group" eval="False" />
         <field
+            name="tax_agency_ids"
+            eval="[ Command.link(ref('l10n_es_aeat.aeat_tax_agency_spain')) ]"
+        />
+        <field
             name="tax_tmpl_ids"
             eval="[
             (4, ref('l10n_es.account_tax_template_p_iva0_nd')),
@@ -111,6 +123,10 @@
         <field name="special_tax_group">req</field>
         <field name="fee_type_xlsx_column">P</field>
         <field name="fee_amount_xlsx_column">Q</field>
+        <field
+            name="tax_agency_ids"
+            eval="[ Command.link(ref('l10n_es_aeat.aeat_tax_agency_spain')) ]"
+        />
         <field
             name="tax_tmpl_ids"
             eval="[
@@ -128,6 +144,10 @@
         <field name="special_tax_group">req</field>
         <field name="fee_type_xlsx_column">R</field>
         <field name="fee_amount_xlsx_column">S</field>
+        <field
+            name="tax_agency_ids"
+            eval="[ Command.link(ref('l10n_es_aeat.aeat_tax_agency_spain')) ]"
+        />
         <field
             name="tax_tmpl_ids"
             eval="[

--- a/l10n_es_vat_book/models/aeat_vat_book_map_line.py
+++ b/l10n_es_vat_book/models/aeat_vat_book_map_line.py
@@ -32,6 +32,7 @@ class AeatVatBookMapLines(models.Model):
         comodel_name="account.account.template",
         string="Tax Account Restriction",
     )
+    tax_agency_ids = fields.Many2many("aeat.tax.agency", string="Tax Agency")
 
     def get_taxes(self, report):
         self.ensure_one()

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -98,3 +98,15 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatModBase):
         )
         self.assertGreaterEqual(len(report_xlsx[0]), 1)
         self.assertEqual(report_xlsx[1], "xlsx")
+        # Check empty Vat Book
+        vat_book.write(
+            {
+                "tax_agency_ids": [
+                    (4, self.env.ref("l10n_es_aeat.aeat_tax_agency_araba").id)
+                ],
+            }
+        )
+        vat_book.button_calculate()
+        self.assertEqual(len(vat_book.issued_line_ids), 0)
+        self.assertEqual(len(vat_book.rectification_issued_line_ids), 0)
+        self.assertEqual(len(vat_book.issued_tax_summary_ids), 0)

--- a/l10n_es_vat_book/views/aeat_vat_book_map_view.xml
+++ b/l10n_es_vat_book/views/aeat_vat_book_map_view.xml
@@ -23,6 +23,7 @@
                 <field name="fee_amount_xlsx_column" />
                 <field name="tax_tmpl_ids" widget="many2many_tags" />
                 <field name="tax_account_id" />
+                <field name="tax_agency_ids" widget="many2many_tags" />
             </tree>
         </field>
     </record>

--- a/l10n_es_vat_book/views/l10n_es_vat_book.xml
+++ b/l10n_es_vat_book/views/l10n_es_vat_book.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <record id="view_l10n_es_vat_book_tree" model="ir.ui.view">
+        <field name="name">l10n_es.vat.book.tree</field>
+        <field name="model">l10n.es.vat.book</field>
+        <field name="inherit_id" ref="l10n_es_aeat.view_l10n_es_aeat_report_tree" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <field name="period_type" position="after">
+                <field name="tax_agency_ids" widget="many2many_tags" />
+            </field>
+        </field>
+    </record>
     <record id="view_l10n_es_vat_book_form" model="ir.ui.view">
         <field name="name">l10n_es.vat.book.form</field>
         <field name="model">l10n.es.vat.book</field>
@@ -44,6 +55,7 @@
             </field>
             <group name="group_other_parameters" position="inside">
                 <field name="auto_renumber" />
+                <field name="tax_agency_ids" widget="many2many_tags" />
             </group>
             <xpath expr="//group[@name='group_declaration']" position="after">
                 <notebook>
@@ -96,7 +108,7 @@
     <record model="ir.actions.act_window.view" id="action_l10n_vat_book_report_tree">
         <field name="sequence" eval="2" />
         <field name="view_mode">tree</field>
-        <field name="view_id" ref="l10n_es_aeat.view_l10n_es_aeat_report_tree" />
+        <field name="view_id" ref="view_l10n_es_vat_book_tree" />
         <field name="act_window_id" ref="l10n_es_vat_book_action" />
     </record>
     <record model="ir.actions.act_window.view" id="action_l10n_vat_book_report_form">


### PR DESCRIPTION
Continuando con el cambio propuesto en https://github.com/OCA/l10n-spain/pull/3082#issuecomment-1587114368 una vez aceptado haré los cambios necesarios en https://github.com/OCA/l10n-spain/pull/3082 para adaptarlo al nuevo campo `tax_agency_ids`