### PR TITLE
[16.0][FIX] l10n_es_partner: Wizard UI colspan

### DIFF
--- a/l10n_es_partner/wizard/l10n_es_partner_wizard.xml
+++ b/l10n_es_partner/wizard/l10n_es_partner_wizard.xml
@@ -17,9 +17,9 @@
                 <separator position="replace">
                     <group attrs="{'invisible': [('import_fail', '=', True)]}">
                         <p
-                            colspan="4"
+                            colspan="2"
                         >This wizard will import spanish bank data. You can choose to import it from:</p>
-                        <ul>
+                        <ul colspan="2">
                             <li
                             >Internet (from Bank of Spain). Maybe this source will be not available from certain moment in time. You will need xlrd Python library.</li>
                             <li
@@ -27,7 +27,7 @@
                         </ul>
                     </group>
                     <label
-                        colspan="4"
+                        colspan="2"
                         for="import_fail"
                         attrs="{'invisible': [('import_fail', '=', False)]}"
                         string="Something has failed importing data from Internet. You will need to import local data instead."


### PR DESCRIPTION
The elements are not shown correctly due to the styling changes in v16.

Before:

![Selección_043](https://github.com/OCA/l10n-spain/assets/7165771/1e319dfc-5f6e-4cea-a295-a10450996e01)

After:

![Selección_044](https://github.com/OCA/l10n-spain/assets/7165771/5e799e9e-aa33-4681-9941-101c0d44ab83)

@Tecnativa 