### PR TITLE
[16.0][IMP] l10n_es_aeat_sii_oca: Add neutralize.sql file for test enabling

### DIFF
--- a/l10n_es_aeat_sii_oca/data/neutralize.sql
+++ b/l10n_es_aeat_sii_oca/data/neutralize.sql
@@ -1,0 +1,2 @@
+-- DISABLE SII ON COMPANIES
+UPDATE res_company SET sii_test = true;


### PR DESCRIPTION
Se agrega fichero neutralize para que al recuperar una base de datos con el SII activado se active el check de entorno de pruebas para el SII en caso de que se haya decidido neutralizar.