### PR TITLE
[IMP] l10n_es_ticketbai l10n_es_ticketbai_api: Autofacturas - Facturas emitidas por terceros o por destinatario

### DIFF
--- a/l10n_es_ticketbai/i18n/es.po
+++ b/l10n_es_ticketbai/i18n/es.po
@@ -297,6 +297,24 @@ msgid "Invoice Serial"
 msgstr "Serie de factura"
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_journal__tbai_invoice_issuer__t
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_invoice_issuer__t
+msgid "Invoice issued by a third party"
+msgstr "Factura emitida por tercero"
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_journal__tbai_invoice_issuer__d
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_invoice_issuer__d
+msgid "Invoice issued by recipient"
+msgstr "Factura emitida por destinatario"
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_journal__tbai_invoice_issuer__n
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_invoice_issuer__n
+msgid "Invoice issued by the issuer itself"
+msgstr "Factura emitida por el propio emisor"
+
+#. module: l10n_es_ticketbai
 #: model:ir.ui.menu,name:l10n_es_ticketbai.menu_tbai_invoice
 msgid "Invoices"
 msgstr "Facturas"
@@ -839,6 +857,14 @@ msgid ""
 msgstr ""
 "TicketBAI: No es posible cancelar y recrear una factura cuyo estado no sea "
 "'Error'."
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_line__tbai_invoice_issuer
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_invoice_issuer
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_move__tbai_invoice_issuer
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_payment__tbai_invoice_issuer
+msgid "TicketBai: Invoice issuer"
+msgstr "TicketBai: Emisor de la factura"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_fp_tbai_tax__tbai_vat_exemption_key

--- a/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
+++ b/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-11-14 14:03+0000\n"
+"PO-Revision-Date: 2023-11-14 14:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -288,6 +290,24 @@ msgstr ""
 #. module: l10n_es_ticketbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.view_move_form_inherit
 msgid "Invoice Serial"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_journal__tbai_invoice_issuer__t
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_invoice_issuer__t
+msgid "Invoice issued by a third party"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_journal__tbai_invoice_issuer__d
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_invoice_issuer__d
+msgid "Invoice issued by recipient"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_journal__tbai_invoice_issuer__n
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_invoice_issuer__n
+msgid "Invoice issued by the issuer itself"
 msgstr ""
 
 #. module: l10n_es_ticketbai
@@ -800,6 +820,14 @@ msgstr ""
 msgid ""
 "TicketBAI: You cannot cancel and recreate an Invoice with a state different "
 "than 'Error'."
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_line__tbai_invoice_issuer
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_invoice_issuer
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_move__tbai_invoice_issuer
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_payment__tbai_invoice_issuer
+msgid "TicketBai: Invoice issuer"
 msgstr ""
 
 #. module: l10n_es_ticketbai

--- a/l10n_es_ticketbai/models/account_journal.py
+++ b/l10n_es_ticketbai/models/account_journal.py
@@ -17,6 +17,21 @@ class AccountJournal(models.Model):
         help="Start date for sending invoices to the tax authorities",
         default=fields.Date.to_date("2022-01-01"),
     )
+    tbai_invoice_issuer = fields.Selection(
+        selection=[
+            ("N", "Invoice issued by the issuer itself"),
+            # Factura emitida por el propio emisor
+            ("T", "Invoice issued by a third party"),
+            # Factura emitida por tercero
+            ("D", "Invoice issued by recipient"),
+            # Factura emitida por destinatario
+        ],
+        default="N",
+        string="TicketBai: Invoice issuer",
+        # TicketBai: Emisor de la factura
+        copy=False,
+        required=True,
+    )
 
     @api.onchange("refund_sequence")
     def onchange_refund_sequence(self):

--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -101,6 +101,9 @@ class AccountMove(models.Model):
         inverse_name="account_refund_invoice_id",
         string="TicketBAI Refund Origin References",
     )
+    tbai_invoice_issuer = fields.Selection(
+        related="journal_id.tbai_invoice_issuer", store=True
+    )
 
     @api.constrains("state")
     def _check_cancel_number_invoice(self):
@@ -263,6 +266,7 @@ class AccountMove(models.Model):
             "vat_regime_key": self.tbai_vat_regime_key.code,
             "vat_regime_key2": self.tbai_vat_regime_key2.code,
             "vat_regime_key3": self.tbai_vat_regime_key3.code,
+            "tbai_invoice_issuer": self.tbai_invoice_issuer,
         }
         if partner and not partner.aeat_anonymous_cash_customer:
             vals["tbai_customer_ids"] = [

--- a/l10n_es_ticketbai/views/account_journal_views.xml
+++ b/l10n_es_ticketbai/views/account_journal_views.xml
@@ -18,6 +18,10 @@
                     name="tbai_active_date"
                     attrs="{'invisible': [('tbai_send_invoice', '=', False)]}"
                 />
+                <field
+                    name="tbai_invoice_issuer"
+                    attrs="{'invisible': ['|', '|', ('type', '!=', 'sale'), ('tbai_enabled', '=', False), ('tbai_send_invoice', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>

--- a/l10n_es_ticketbai/views/account_move_views.xml
+++ b/l10n_es_ticketbai/views/account_move_views.xml
@@ -21,6 +21,7 @@
                         <group name="ticketbai" colspan="2" col="2">
                             <field name="tbai_enabled" invisible="1" />
                             <field name="tbai_send_invoice" invisible="1" />
+                            <field name="tbai_invoice_issuer" invisible="1" />
                             <field
                                 name="tbai_invoice_id"
                                 readonly="1"

--- a/l10n_es_ticketbai_api/i18n/es.po
+++ b/l10n_es_ticketbai_api/i18n/es.po
@@ -273,11 +273,6 @@ msgid "Company %s TicketBAI Tax Agency is required."
 msgstr "La hacienda de TicketBAI en la compañía %s es requerida."
 
 #. module: l10n_es_ticketbai_api
-#: model:ir.model,name:l10n_es_ticketbai_api.model_res_config_settings
-msgid "Config Settings"
-msgstr "Opciones de configuración"
-
-#. module: l10n_es_ticketbai_api
 #: model:ir.model,name:l10n_es_ticketbai_api.model_res_partner
 msgid "Contact"
 msgstr "Contacto"
@@ -512,6 +507,21 @@ msgid "Invoice Tax Retention Total Amount"
 msgstr "Retención soportada"
 
 #. module: l10n_es_ticketbai_api
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai_api.selection__tbai_invoice__tbai_invoice_issuer__t
+msgid "Invoice issued by a third party"
+msgstr "Factura emitida por tercero"
+
+#. module: l10n_es_ticketbai_api
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai_api.selection__tbai_invoice__tbai_invoice_issuer__d
+msgid "Invoice issued by recipient"
+msgstr "Factura emitida por destinatario"
+
+#. module: l10n_es_ticketbai_api
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai_api.selection__tbai_invoice__tbai_invoice_issuer__n
+msgid "Invoice issued by the issuer itself"
+msgstr "Factura emitida por el propio emisor"
+
+#. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_tax__is_exempted
 msgid "Is Exempted"
 msgstr "Es exenta"
@@ -697,6 +707,11 @@ msgstr "Factura previa TicketBAI"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_line__price_unit
 msgid "Price Unit"
 msgstr "Precio unidad"
+
+#. module: l10n_es_ticketbai_api
+#: model:ir.model,name:l10n_es_ticketbai_api.model_res_config_settings
+msgid "Procurement purchase grouping settings"
+msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai_api.selection__tbai_invoice_tax__type__goods
@@ -1772,6 +1787,11 @@ msgid "TicketBai"
 msgstr "TicketBai"
 
 #. module: l10n_es_ticketbai_api
+#: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice__tbai_invoice_issuer
+msgid "TicketBai: Invoice issuer"
+msgstr "TicketBai: Emisor de la factura"
+
+#. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_tax__type
 msgid "Type"
 msgstr "Tipo"
@@ -1820,6 +1840,9 @@ msgstr "XML Respuesta"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_customer__zip
 msgid "ZIP Code"
 msgstr "Código postal"
+
+#~ msgid "Config Settings"
+#~ msgstr "Opciones de configuración"
 
 #~ msgid "Name %s too long. Should be 120 characters max.!"
 #~ msgstr ""

--- a/l10n_es_ticketbai_api/i18n/l10n_es_ticketbai_api.pot
+++ b/l10n_es_ticketbai_api/i18n/l10n_es_ticketbai_api.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-11-14 14:08+0000\n"
+"PO-Revision-Date: 2023-11-14 14:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -219,11 +221,6 @@ msgstr ""
 #: code:addons/l10n_es_ticketbai_api/models/res_company.py:0
 #, python-format
 msgid "Company %s TicketBAI Tax Agency is required."
-msgstr ""
-
-#. module: l10n_es_ticketbai_api
-#: model:ir.model,name:l10n_es_ticketbai_api.model_res_config_settings
-msgid "Config Settings"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
@@ -463,6 +460,21 @@ msgid "Invoice Tax Retention Total Amount"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai_api.selection__tbai_invoice__tbai_invoice_issuer__t
+msgid "Invoice issued by a third party"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai_api.selection__tbai_invoice__tbai_invoice_issuer__d
+msgid "Invoice issued by recipient"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: model:ir.model.fields.selection,name:l10n_es_ticketbai_api.selection__tbai_invoice__tbai_invoice_issuer__n
+msgid "Invoice issued by the issuer itself"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_tax__is_exempted
 msgid "Is Exempted"
 msgstr ""
@@ -643,6 +655,11 @@ msgstr ""
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_line__price_unit
 msgid "Price Unit"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: model:ir.model,name:l10n_es_ticketbai_api.model_res_config_settings
+msgid "Procurement purchase grouping settings"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
@@ -1609,6 +1626,11 @@ msgstr ""
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai_api.selection__tbai_invoice__schema__ticketbai
 msgid "TicketBai"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice__tbai_invoice_issuer
+msgid "TicketBai: Invoice issuer"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api

--- a/l10n_es_ticketbai_api/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice.py
@@ -219,6 +219,18 @@ class TicketBAIInvoice(models.Model):
     tax_retention_amount_total = fields.Char(
         "Invoice Tax Retention Total Amount", default=""
     )
+    tbai_invoice_issuer = fields.Selection(
+        selection=[
+            ("N", "Invoice issued by the issuer itself"),
+            # Factura emitida por el propio emisor
+            ("T", "Invoice issued by a third party"),
+            # Factura emitida por tercero
+            ("D", "Invoice issued by recipient"),
+            # Factura emitida por destinatario
+        ],
+        default="N",
+        string="TicketBai: Invoice issuer",
+    )
 
     @api.constrains("previous_tbai_invoice_id")
     def _check_previous_tbai_invoice_id(self):
@@ -1325,6 +1337,8 @@ class TicketBAIInvoice(models.Model):
         customers = self.build_destinatarios()
         if customers:
             res["Destinatarios"] = customers
+        if self.tbai_invoice_issuer != "N":
+            res["EmitidaPorTercerosODestinatario"] = self.tbai_invoice_issuer
         return res
 
     def build_tipo_desglose(self):


### PR DESCRIPTION
Se añade una opción en los diarios de facturas de venta para poder indicar si el emisor de las facturas de ese diario/serie es el emisor, un tercero o el destinatario. Cuando es un tercero o destinatario, en el XML que se genera para enviar a TicketBai se añade el dato “EmisorPorTercerosODestinatario”.