### PR TITLE
[16.0][FIX] payment_redsys: Error processing redsys response

### DIFF
--- a/payment_redsys/controllers/main.py
+++ b/payment_redsys/controllers/main.py
@@ -48,4 +48,8 @@ class RedsysController(http.Controller):
         website=True,
     )
     def redsys_result(self, page, **vals):
+        if vals:
+            request.env["payment.transaction"].sudo()._handle_notification_data(
+                "redsys", vals
+            )
         return request.redirect("/payment/status")


### PR DESCRIPTION
- /payment/redsys/result/<page> controller now process Redsys response and updates related transaction.

**Steps to reproduce:**
- Install payment_redsys module
- Configure payment method with test values from https://pagosonline.redsys.es/entornosPruebas.html as "Test mode" and publish.
- Login into portal with "portal" user
- Buy something and go to checkout screen, pay with Redsys.
- Use an Autenticación Frictionless card numbres (4918019160034602,Expiration:12/34, CVV:123)
- The payment will end with success message.
- Press "Continuar" and you'll won't see the "Success message", instead you'll see a pending confirmation message.

The endpoint that retrieves Redsys response doesn't process it and redirects the browser and losts the response information.

All other payment modules call __handle_notification_data_ before the redirection.