### PR TITLE
[16.0][IMP] l10n_es_aeat: Add country ISO code mapper function

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -50,6 +50,12 @@ class ResPartner(models.Model):
             country_code_map.update({"RE": "FR", "GP": "FR", "MQ": "FR", "GF": "FR"})
         return country_code_map.get(country_code, country_code)
 
+    def _map_aeat_country_iso_code(self, country_id):
+        """Map country ISO code according to AEAT code"""
+        code = country_id.code
+        country_iso_code_map = {"GR": "EL"}
+        return country_iso_code_map.get(code, code)
+
     @ormcache("self.env")
     def _get_aeat_europe_codes(self):
         europe = self.env.ref("base.europe", raise_if_not_found=False)

--- a/l10n_es_aeat/tests/test_l10n_es_aeat.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat.py
@@ -109,3 +109,17 @@ class TestL10nEsAeat(TransactionCase):
             self.env["l10n.es.aeat.map.tax"].create(
                 {"date_to": "2021-01-01", "model": 303}
             )
+
+    def test_map_aeat_iso_code_greece(self):
+        res_partner_obj = self.env["res.partner"]
+        greece_country = self.env.ref("base.gr")
+        iso_code = "EL"
+        mapping_return = res_partner_obj._map_aeat_country_iso_code(greece_country)
+        self.assertEqual(iso_code, mapping_return)
+
+    def test_map_aeat_iso_code_no_mapping(self):
+        res_partner_obj = self.env["res.partner"]
+        spain_country = self.env.ref("base.es")
+        iso_code = "ES"
+        mapping_return = res_partner_obj._map_aeat_country_iso_code(spain_country)
+        self.assertEqual(iso_code, mapping_return)


### PR DESCRIPTION
Se ve la necesidad (modulo `l10n_es_aeat_mod369`) de obtener el código ISO de un país partiendo del código de país almacenado en Odoo (caso Grecia, en Odoo se almacena GR pero necesito EL). 

He visto que la función `_map_aeat_country_code` hace justo lo inverso, pero he pensado dejar la función implementada en `l10n_es_aeat` para poder utilizarlo en `l10n_es_aeat_mod369` o futuras ocasiones.

Que opinas @pedrobaeza ?