### PR TITLE
[16.0][IMP] l10n_es_facturae: rename field parent_facturae

### DIFF
--- a/l10n_es_facturae/models/res_partner.py
+++ b/l10n_es_facturae/models/res_partner.py
@@ -9,7 +9,9 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     facturae = fields.Boolean("Factura electrónica")
-    parent_facturae = fields.Boolean(related="commercial_partner_id.facturae")
+    parent_facturae = fields.Boolean(
+        related="commercial_partner_id.facturae", string="Parent Facturae"
+    )
     facturae_version = fields.Selection(
         [("3_2", "3.2"), ("3_2_1", "3.2.1"), ("3_2_2", "3.2.2")]
     )


### PR DESCRIPTION
Si os parece bien renombro el campo `parent_facturae` pare evitar el warning:

`odoo.addons.base.models.ir_model: Two fields (parent_facturae, facturae) of res.partner() have the same label: Factura electrónica. [Modules: l10n_es_facturae and l10n_es_facturae]`
Ya que no es un campo que se muestre en ninguna vista, entiendo que es indiferente el nombre.