### PR TITLE
[16.0][FIX] l10n_es_aeat: No ir.model forbidden access, missing sudo in field domain

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -176,7 +176,7 @@ class L10nEsAeatReport(models.AbstractModel):
             (
                 "model_id",
                 "=",
-                self.env["ir.model"].search([("model", "=", self._name)]).id,
+                self.env["ir.model"].sudo().search([("model", "=", self._name)]).id,
             )
         ],
         compute="_compute_export_config_id",


### PR DESCRIPTION
Fixes one more remaining unauthorized access to ir.model 

On export_config_id field, domain calculation searched on ir.model 
Added sudo() to avoid unauthorized access.

fixes #3016