### PR TITLE
[14.0][FIX] l10n_es_payment_order_confirming_aef: Use move ref for invoice number

### DIFF
--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -38,13 +38,13 @@ class ConfirmingAEF(object):
                     % line.partner_id.name
                 )
             # Num Factura
-            if line.move_line_id.ref and len(line.move_line_id.ref) > 15:
+            if len(line.move_line_id.move_id.ref or "") > 15:
                 validation_errors.append(
                     _(
                         "- La referencia de factura %s de proveedor no puede ocupar "
                         "más de 15 caracteres."
                     )
-                    % line.move_line_id.ref
+                    % line.move_line_id.move_id.ref
                 )
             # Ciudad
             if not line.partner_id.city:
@@ -239,11 +239,7 @@ class ConfirmingAEF(object):
         # 1 Valor fijo
         text = "6"
         # 2 - 21 Num factura
-        referencia_factura = (
-            str(line.move_line_id.move_id.name)
-            if line.move_line_id.move_id.name
-            else line.communication
-        )
+        referencia_factura = line.move_line_id.move_id.ref or line.communication
         text += self._aef_convert_text(referencia_factura.replace("-", ""), 20, "left")
         # 22 - 22 signo
         signo_factura = "+" if line.amount_currency >= 0 else "-"


### PR DESCRIPTION
The field `ref` in the account.move.line doesn't always contain the same value as the account.move, and what we want is the invoice number, so let's use the move one in any case.

Basically  #3245 adapted for AEF format. Might be cherry-picked to newer versions?