### PR TITLE
[14.0][FIX] l10n_es_payment_order_confirming_aef: Fecha de proceso no es obligatoria pero Bankinter si la pide

### DIFF
--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -112,7 +112,8 @@ class ConfirmingAEF(object):
             )
         text += self._aef_convert_text(vat, 15, "left")
         # 67 - 74 Fecha proceso
-        text += self._aef_convert_text("", 8)
+        fecha_proceso = fields.first(self.record.payment_line_ids).date
+        text += self._aef_convert_text(str(fecha_proceso).replace("-", ""), 8)
         # 75 - 82 Fecha remesa
         if self.record.date_prefered == "due":
             fecha_planificada = fields.first(


### PR DESCRIPTION
Prueba del delito:

![image](https://github.com/OCA/l10n-spain/assets/45542433/a3ccd255-8bc3-4894-8cc4-e9824b7c6f0a)


EDIT: falta probar y quito el draft.