### PR TITLE
[14.0][FIX] AEF: Santander pide IBAN entero, incluidos digitos de control

### DIFF
--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -129,8 +129,6 @@ class ConfirmingAEF(object):
         text += self._aef_convert_text(contract_cxb, 20, "left")
         # 103 - 136 Cuenta de cargo
         cuenta = self.record.company_partner_bank_id.acc_number.replace(" ", "")
-        if self.record.company_partner_bank_id.acc_type != "bank":
-            cuenta = cuenta[4:]
         text += self._aef_convert_text(cuenta, 34)
         # 137 - 139 Código divisa
         text += self._aef_convert_text(self.record.company_currency_id.name, 3)


### PR DESCRIPTION

![unnamed](https://github.com/OCA/l10n-spain/assets/45542433/8acbfbc2-b78e-453d-a653-1b4d5ddbca29)


Lo pongo en draft. Falta probar con Santander y los demás bancos... En la definición del AEF pone IBAN (alguna idea de por qué se descartan el codigo de pais y los 2 digitos de control actualmente? ESXX...)