### PR TITLE
[16.0][IMP] l10n_es_aeat_mod_111: Retenciones IRPF Consejeros y Administradores

### DIFF
--- a/l10n_es_aeat_mod111/data/tax_code_map_mod111_data.xml
+++ b/l10n_es_aeat_mod111/data/tax_code_map_mod111_data.xml
@@ -19,7 +19,12 @@
              P_IRPFT, P_IRPFTD -->
         <field
             name="tax_ids"
-            eval="[(6, False, [ref('l10n_es.account_tax_template_p_irpf21t'), ref('l10n_es.account_tax_template_p_irpf21td')])]"
+            eval="[(6, False, [
+             ref('l10n_es.account_tax_template_p_irpf21t'),
+             ref('l10n_es.account_tax_template_p_irpf21td'),
+             ref('l10n_es.account_tax_template_p_irpf19ca'),
+             ref('l10n_es.account_tax_template_p_irpf35cya'),
+        ])]"
         />
     </record>
     <record id="aeat_mod111_map_line_03" model="l10n.es.aeat.map.tax.line">
@@ -35,7 +40,12 @@
              P_IRPFT, P_IRPFTD -->
         <field
             name="tax_ids"
-            eval="[(6, False, [ref('l10n_es.account_tax_template_p_irpf21t'), ref('l10n_es.account_tax_template_p_irpf21td')])]"
+            eval="[(6, False, [
+             ref('l10n_es.account_tax_template_p_irpf21t'),
+             ref('l10n_es.account_tax_template_p_irpf21td'),
+             ref('l10n_es.account_tax_template_p_irpf19ca'),
+             ref('l10n_es.account_tax_template_p_irpf35cya'),
+        ])]"
         />
     </record>
     <record id="aeat_mod111_map_line_05" model="l10n.es.aeat.map.tax.line">


### PR DESCRIPTION
Añade impuestos Retenciones IRPF del 35% y 19% Consejeros y Administradores al mapeo del modelo 111.

Issue: https://github.com/OCA/l10n-spain/issues/3174

![image](https://github.com/OCA/l10n-spain/assets/53056345/5db05efc-b438-47f2-8ed7-7f9fd1a5116f)


@rafaelbn please review

MT-2835