### PR TITLE
[16.0][FIX] l10n_es_facturae: Facturae field visibility for all the childrens

### DIFF
--- a/l10n_es_facturae/views/res_partner_view.xml
+++ b/l10n_es_facturae/views/res_partner_view.xml
@@ -11,7 +11,7 @@
                 <group groups="account.group_account_invoice">
                     <group
                         string="Facturae"
-                        attrs="{'invisible': ['|', ('parent.facturae', '=', False), ('type', '!=', 'invoice')]}"
+                        attrs="{'invisible': [('parent.facturae', '=', False)]}"
                         colspan="5"
                     >
                         <field name="facturae_version" />
@@ -58,7 +58,7 @@
                 <group
                     name="group_facturae"
                     string="Facturae"
-                    attrs="{'invisible': ['|', ('type', '!=', 'invoice'), ('parent_facturae', '=', False)]}"
+                    attrs="{'invisible': [('parent_facturae', '=', False)]}"
                     groups="account.group_account_invoice"
                 >
                     <field name="facturae_version" />


### PR DESCRIPTION
You can invoice to any contact, so there's no reason to hide Facturae fields for childrens that are not invoice addresses.

@Tecnativa TT45821