### PR TITLE
[16.0][FIX] l10n_es_facturae: Precio unitario

### DIFF
--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -317,6 +317,24 @@ class AccountMoveLine(models.Model):
         else:
             return subtotal
 
+    def _facturae_get_price_unit(self):
+        # Se añade esta funcionalidad para el caso en el cual algún impuesto de la
+        # factura sea con el precio incluido. De esta forma se obtiene siemrpe el
+        # precio sin impuestos. Como es el precio unitario lo que se calcula, no se
+        # deben tener en cuenta los descuentos que pueda tener la factura
+        self.ensure_one()
+        if any(tax.price_include for tax in self.tax_ids):
+            taxes_res = self.tax_ids.compute_all(
+                self.price_unit,
+                quantity=1.0,
+                currency=self.currency_id,
+                product=self.product_id,
+                partner=self.partner_id,
+                is_refund=self.is_refund,
+            )
+            return taxes_res["total_excluded"]
+        return self.price_unit
+
 
 class L10nEsFacturaeAttachment(models.Model):
     _name = "l10n.es.facturae.attachment"

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -566,7 +566,7 @@
                             <Quantity t-esc="line_sign * line.quantity" />
                             <UnitOfMeasure t-if="False" />
                             <UnitPriceWithoutTax
-                                t-out="('%.6f' if version == '3_2' else '%.8f') % line.price_unit"
+                                t-out="('%.6f' if version == '3_2' else '%.8f') % line._facturae_get_price_unit()"
                             />
                             <t
                                 t-set="subtotal_gross"


### PR DESCRIPTION
Se corrige el problema de generar el archivo xsig cuando alguno de los impuestos es con precio incluido que la administración lo rechaza.