### PR TITLE
[16.0][IMP] l10n_es_aeat_mod_190: Retenciones IRPF Consejeros y Administradores

### DIFF
--- a/l10n_es_aeat_mod190/data/tax_code_map_mod190_data.xml
+++ b/l10n_es_aeat_mod190/data/tax_code_map_mod190_data.xml
@@ -16,7 +16,12 @@
              P_IRPFT, P_IRPFTD -->
         <field
             name="tax_ids"
-            eval="[(6, False, [ref('l10n_es.account_tax_template_p_irpf21t'), ref('l10n_es.account_tax_template_p_irpf21td')])]"
+            eval="[(6, False, [
+             ref('l10n_es.account_tax_template_p_irpf21t'),
+             ref('l10n_es.account_tax_template_p_irpf21td'),
+             ref('l10n_es.account_tax_template_p_irpf19ca'),
+             ref('l10n_es.account_tax_template_p_irpf35cya'),
+        ])]"
         />
     </record>
     <record id="aeat_mod190_map_line_12" model="l10n.es.aeat.map.tax.line">
@@ -32,7 +37,12 @@
              P_IRPFT, P_IRPFTD -->
         <field
             name="tax_ids"
-            eval="[(6, False, [ref('l10n_es.account_tax_template_p_irpf21t'), ref('l10n_es.account_tax_template_p_irpf21td')])]"
+            eval="[(6, False, [
+             ref('l10n_es.account_tax_template_p_irpf21t'),
+             ref('l10n_es.account_tax_template_p_irpf21td'),
+             ref('l10n_es.account_tax_template_p_irpf19ca'),
+             ref('l10n_es.account_tax_template_p_irpf35cya'),
+        ])]"
         />
     </record>
     <record id="aeat_mod190_map_line_13" model="l10n.es.aeat.map.tax.line">


### PR DESCRIPTION
Añade impuestos Retenciones IRPF del 35% y 19% Consejeros y Administradores al mapeo de impuestos del modelo 190.

Issue: https://github.com/OCA/l10n-spain/issues/3174

![image](https://github.com/OCA/l10n-spain/assets/53056345/204dd456-8a5f-41c6-9525-ab9b0f8ad619)


MT-2835 @moduon