### PR TITLE
[15.0][IMP] l10n_es_aeat_mod_111: Retenciones IRPF Consejeros y Administradores

### DIFF
--- a/l10n_es_aeat_mod111/data/tax_code_map_mod111_data.xml
+++ b/l10n_es_aeat_mod111/data/tax_code_map_mod111_data.xml
@@ -19,7 +19,12 @@
              P_IRPFT, P_IRPFTD -->
         <field
             name="tax_ids"
-            eval="[(6, False, [ref('l10n_es.account_tax_template_p_irpf21t'), ref('l10n_es.account_tax_template_p_irpf21td')])]"
+            eval="[(6, False, [
+             ref('l10n_es.account_tax_template_p_irpf21t'),
+             ref('l10n_es.account_tax_template_p_irpf21td'),
+             ref('l10n_es.account_tax_template_p_irpf19ca'),
+             ref('l10n_es.account_tax_template_p_irpf35cya'),
+        ])]"
         />
     </record>
     <record id="aeat_mod111_map_line_03" model="l10n.es.aeat.map.tax.line">
@@ -35,7 +40,12 @@
              P_IRPFT, P_IRPFTD -->
         <field
             name="tax_ids"
-            eval="[(6, False, [ref('l10n_es.account_tax_template_p_irpf21t'), ref('l10n_es.account_tax_template_p_irpf21td')])]"
+            eval="[(6, False, [
+             ref('l10n_es.account_tax_template_p_irpf21t'),
+             ref('l10n_es.account_tax_template_p_irpf21td'),
+             ref('l10n_es.account_tax_template_p_irpf19ca'),
+             ref('l10n_es.account_tax_template_p_irpf35cya'),
+        ])]"
         />
     </record>
     <record id="aeat_mod111_map_line_05" model="l10n.es.aeat.map.tax.line">


### PR DESCRIPTION
Añade impuestos Retenciones IRPF del 35% y 19% Consejeros y Administradores al mapeo de impuestos del modelo 111.

Backport: https://github.com/OCA/l10n-spain/pull/3334

Issue: https://github.com/OCA/l10n-spain/issues/3174

MT-2835