### PR TITLE
[15.0][IMP] l10n_es_aeat_mod_190: Retenciones IRPF Consejeros y Administradores

### DIFF
--- a/l10n_es_aeat_mod190/data/tax_code_map_mod190_data.xml
+++ b/l10n_es_aeat_mod190/data/tax_code_map_mod190_data.xml
@@ -16,7 +16,12 @@
              P_IRPFT, P_IRPFTD -->
         <field
             name="tax_ids"
-            eval="[(6, False, [ref('l10n_es.account_tax_template_p_irpf21t'), ref('l10n_es.account_tax_template_p_irpf21td')])]"
+            eval="[(6, False, [
+             ref('l10n_es.account_tax_template_p_irpf21t'),
+             ref('l10n_es.account_tax_template_p_irpf21td'),
+             ref('l10n_es.account_tax_template_p_irpf19ca'),
+             ref('l10n_es.account_tax_template_p_irpf35cya'),
+        ])]"
         />
     </record>
     <record id="aeat_mod190_map_line_12" model="l10n.es.aeat.map.tax.line">
@@ -32,7 +37,12 @@
              P_IRPFT, P_IRPFTD -->
         <field
             name="tax_ids"
-            eval="[(6, False, [ref('l10n_es.account_tax_template_p_irpf21t'), ref('l10n_es.account_tax_template_p_irpf21td')])]"
+            eval="[(6, False, [
+             ref('l10n_es.account_tax_template_p_irpf21t'),
+             ref('l10n_es.account_tax_template_p_irpf21td'),
+             ref('l10n_es.account_tax_template_p_irpf19ca'),
+             ref('l10n_es.account_tax_template_p_irpf35cya'),
+        ])]"
         />
     </record>
     <record id="aeat_mod190_map_line_13" model="l10n.es.aeat.map.tax.line">


### PR DESCRIPTION
Añade impuestos Retenciones IRPF del 35% y 19% Consejeros y Administradores al mapeo de impuestos del modelo 190.

Backport: https://github.com/OCA/l10n-spain/pull/3342

Issue: https://github.com/OCA/l10n-spain/issues/3174

[Moduon - Task #2835](https://www.moduon.team/web#id=2835&model=project.task&view_type=form)

MT-2835 @moduon