### PR TITLE
[16.0][FIX] l10n_es_aeat_mod303_oss: Make sure company's country is set

### DIFF
--- a/l10n_es_aeat_mod303_oss/tests/test_l10n_es_aeat_mod303_oss.py
+++ b/l10n_es_aeat_mod303_oss/tests/test_l10n_es_aeat_mod303_oss.py
@@ -23,6 +23,8 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
             )
         )
         cls.oss_country = cls.env.ref("base.fr")
+        cls.company.country_id = cls.env.ref("base.es").id
+        cls.company.account_fiscal_country_id = cls.env.ref("base.es").id
         general_tax = cls.env.ref(
             "l10n_es.%s_account_tax_template_s_iva21b" % cls.company.id
         )


### PR DESCRIPTION
For proper OSS taxes creation after the fix in https://github.com/OCA/account-fiscal-rule/pull/399.

@Tecnativa 