### PR TITLE
[14.0][FIX] l10n_es_aeat: Convert COM countries to France

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -48,7 +48,19 @@ class ResPartner(models.Model):
         """
         country_code_map = {"EL": "GR"}
         if extended:
-            country_code_map.update({"RE": "FR", "GP": "FR", "MQ": "FR", "GF": "FR"})
+            country_code_map.update(
+                {
+                    "RE": "FR",
+                    "GP": "FR",
+                    "MQ": "FR",
+                    "GF": "FR",
+                    "PF": "FR",
+                    "BL": "FR",
+                    "MF": "FR",
+                    "PM": "FR",
+                    "WF": "FR",
+                }
+            )
         return country_code_map.get(country_code, country_code)
 
     @ormcache("self.env")


### PR DESCRIPTION
Backport of #3350 

COM (collectivité d'outre-mer - https://es.wikipedia.org/wiki/Colectividad_de_ultramar) are also considered France for the AEAT, so we need to map the existing countries to FR.

@Tecnativa TT46789