### PR TITLE
[16.0][FIX] l10n_es_aeat_sii_oca: Inherit proper view

### DIFF
--- a/l10n_es_aeat_sii_oca/views/product_view.xml
+++ b/l10n_es_aeat_sii_oca/views/product_view.xml
@@ -5,7 +5,7 @@
         <field name="name">product.template.form.inherit.sii</field>
         <field name="model">product.template</field>
         <field name="priority">6</field>
-        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="inherit_id" ref="account.product_template_form_view" />
         <field name="arch" type="xml">
             <group name="properties" position="after">
                 <separator string="SII" />


### PR DESCRIPTION
Esta vista realmente debería heredar de la vista declarada en `account` https://github.com/odoo/odoo/blob/16.0/addons/account/views/product_view.xml#L59 que es donde se crea el `<group name="properties">`
Ahora mismo está funcionado "por casualidad" porque el `priority` es posterior al de `account`, pero personalmente me está dando problemas a la hora de recrear esta vista.

```
odoo.tools.convert.ParseError: while parsing /opt/odoo/src/oca/l10n-spain/l10n_es_aeat_sii_oca/views/product_view.xml:4
Element '<group name="properties">' cannot be located in parent view
```

Afecta a la 12.0+, personalmente haré cherry-pick a 14 y 15 una vez se fusione