### PR TITLE
[12.0][IMP] l10n_es_ticketbai*: Facturas emitidas por terceros o por destinatario

### DIFF
--- a/l10n_es_ticketbai/i18n/es.po
+++ b/l10n_es_ticketbai/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-11 09:01+0000\n"
-"PO-Revision-Date: 2022-08-09 09:43+0000\n"
+"POT-Creation-Date: 2024-01-10 10:10+0000\n"
+"PO-Revision-Date: 2024-01-10 11:14+0100\n"
 "Last-Translator: olatzavanzosc <olatzaranguren@avanzosc.es>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_l10n_es_aeat_certificate
@@ -84,6 +84,7 @@ msgstr "Cancelar y recrear"
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:326
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:352
 #, python-format
 msgid "Cancellation"
 msgstr "Anulación factura"
@@ -186,6 +187,12 @@ msgid "Display Name"
 msgstr "Nombre mostrado"
 
 #. module: l10n_es_ticketbai
+#: sql_constraint:account.fp.tbai.tax:0
+#: sql_constraint:account.fp.tbai.tax_template:0
+msgid "El impuesto debe ser único por posición fiscal!"
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_import_journal_creation__tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_enabled
@@ -286,6 +293,24 @@ msgstr "Serie de factura"
 #: model:ir.model,name:l10n_es_ticketbai.model_account_invoice_tax
 msgid "Invoice Tax"
 msgstr "Impuesto de factura"
+
+#. module: l10n_es_ticketbai
+#: selection:account.invoice,tbai_invoice_issuer:0
+#: selection:account.journal,tbai_invoice_issuer:0
+msgid "Invoice issued by a third party"
+msgstr "Factura emitida por tercero"
+
+#. module: l10n_es_ticketbai
+#: selection:account.invoice,tbai_invoice_issuer:0
+#: selection:account.journal,tbai_invoice_issuer:0
+msgid "Invoice issued by recipient"
+msgstr "Factura emitida por destinatario"
+
+#. module: l10n_es_ticketbai
+#: selection:account.invoice,tbai_invoice_issuer:0
+#: selection:account.journal,tbai_invoice_issuer:0
+msgid "Invoice issued by the issuer itself"
+msgstr "Factura emitida por el propio emisor"
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/ticketbai_invoice.py:120
@@ -421,6 +446,7 @@ msgstr "Datos facturas origen"
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:371
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:397
 #, python-format
 msgid ""
 "Please, specify data for the original invoices that are going to be refunded"
@@ -444,6 +470,7 @@ msgstr "Rectificativa"
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:349
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:375
 #, python-format
 msgid ""
 "Refund invoices must be cancelled in order to cancel the original invoice."
@@ -480,7 +507,7 @@ msgstr ""
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_tax__tbai_vat_regime_simplified
 msgid "Regime Simplified"
-msgstr ""
+msgstr "Régimen Simplificado"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_response_ids
@@ -503,7 +530,7 @@ msgstr "Secuencia"
 #. module: l10n_es_ticketbai
 #: selection:account.invoice,tbai_refund_key:0
 msgid "Simplified Invoice"
-msgstr ""
+msgstr "Factura Simplificada"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_info__software
@@ -512,6 +539,7 @@ msgstr "Software"
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:385
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:411
 #, python-format
 msgid "Some of the original invoices have related tbai cancelled invoices"
 msgstr ""
@@ -520,6 +548,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:380
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:406
 #, python-format
 msgid ""
 "Some of the original invoices have related tbai invoices in inconsistent "
@@ -552,8 +581,6 @@ msgid "Tax"
 msgstr "Impuesto"
 
 #. module: l10n_es_ticketbai
-#: sql_constraint:account.fp.tbai.tax:0
-#: sql_constraint:account.fp.tbai.tax_template:0
 #: code:addons/l10n_es_ticketbai/models/account_fiscal_position.py:35
 #: code:addons/l10n_es_ticketbai/models/chart_template.py:37
 #, python-format
@@ -806,6 +833,13 @@ msgstr ""
 "'Error'."
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_import_journal_creation__tbai_invoice_issuer
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_invoice_issuer
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_invoice_issuer
+msgid "TicketBai: Invoice issuer"
+msgstr "TicketBai: Emisor de la factura"
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_fp_tbai_tax__tbai_vat_exemption_key
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_fp_tbai_tax_template__tbai_vat_exemption_key
 msgid "VAT Exemption Key"
@@ -853,12 +887,14 @@ msgstr "Asistente para cargar el certificado AEAT"
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:89
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:114
 #, python-format
 msgid "You cannot change to draft a TicketBAI invoice!"
 msgstr "No es posible cambiar el estado a borrador de una factura TicketBAI!"
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_journal.py:39
+#: code:addons/l10n_es_ticketbai/models/account_journal.py:54
 #, python-format
 msgid ""
 "You cannot stop sending invoices from this journal, an invoice has already "

--- a/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
+++ b/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-10 10:10+0000\n"
+"PO-Revision-Date: 2024-01-10 10:10+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -76,6 +78,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:326
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:352
 #, python-format
 msgid "Cancellation"
 msgstr ""
@@ -178,6 +181,12 @@ msgid "Display Name"
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: sql_constraint:account.fp.tbai.tax:0
+#: sql_constraint:account.fp.tbai.tax_template:0
+msgid "El impuesto debe ser único por posición fiscal!"
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_import_journal_creation__tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_enabled
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_enabled
@@ -277,6 +286,24 @@ msgstr ""
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_account_invoice_tax
 msgid "Invoice Tax"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: selection:account.invoice,tbai_invoice_issuer:0
+#: selection:account.journal,tbai_invoice_issuer:0
+msgid "Invoice issued by a third party"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: selection:account.invoice,tbai_invoice_issuer:0
+#: selection:account.journal,tbai_invoice_issuer:0
+msgid "Invoice issued by recipient"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: selection:account.invoice,tbai_invoice_issuer:0
+#: selection:account.journal,tbai_invoice_issuer:0
+msgid "Invoice issued by the issuer itself"
 msgstr ""
 
 #. module: l10n_es_ticketbai
@@ -395,6 +422,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:371
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:397
 #, python-format
 msgid "Please, specify data for the original invoices that are going to be refunded"
 msgstr ""
@@ -416,6 +444,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:349
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:375
 #, python-format
 msgid "Refund invoices must be cancelled in order to cancel the original invoice."
 msgstr ""
@@ -473,12 +502,14 @@ msgstr ""
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:385
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:411
 #, python-format
 msgid "Some of the original invoices have related tbai cancelled invoices"
 msgstr ""
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:380
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:406
 #, python-format
 msgid "Some of the original invoices have related tbai invoices in inconsistent state please fix them beforehand."
 msgstr ""
@@ -507,8 +538,6 @@ msgid "Tax"
 msgstr ""
 
 #. module: l10n_es_ticketbai
-#: sql_constraint:account.fp.tbai.tax:0
-#: sql_constraint:account.fp.tbai.tax_template:0
 #: code:addons/l10n_es_ticketbai/models/account_fiscal_position.py:35
 #: code:addons/l10n_es_ticketbai/models/chart_template.py:37
 #, python-format
@@ -742,6 +771,13 @@ msgid "TicketBAI: You cannot cancel and recreate an Invoice with a state differe
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_import_journal_creation__tbai_invoice_issuer
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_invoice__tbai_invoice_issuer
+#: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_journal__tbai_invoice_issuer
+msgid "TicketBai: Invoice issuer"
+msgstr ""
+
+#. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_fp_tbai_tax__tbai_vat_exemption_key
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_fp_tbai_tax_template__tbai_vat_exemption_key
 msgid "VAT Exemption Key"
@@ -789,12 +825,14 @@ msgstr ""
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_invoice.py:89
+#: code:addons/l10n_es_ticketbai/models/account_invoice.py:114
 #, python-format
 msgid "You cannot change to draft a TicketBAI invoice!"
 msgstr ""
 
 #. module: l10n_es_ticketbai
 #: code:addons/l10n_es_ticketbai/models/account_journal.py:39
+#: code:addons/l10n_es_ticketbai/models/account_journal.py:54
 #, python-format
 msgid "You cannot stop sending invoices from this journal, an invoice has already been sent."
 msgstr ""

--- a/l10n_es_ticketbai/models/account_journal.py
+++ b/l10n_es_ticketbai/models/account_journal.py
@@ -18,6 +18,21 @@ class AccountJournal(models.Model):
         help="Start date for sending invoices to the tax authorities",
         default=fields.Date.from_string("2022-01-01"))
 
+    tbai_invoice_issuer = fields.Selection(
+        selection=[
+            ("N", "Invoice issued by the issuer itself"),
+            # Factura emitida por el propio emisor
+            ("T", "Invoice issued by a third party"),
+            # Factura emitida por tercero
+            ("D", "Invoice issued by recipient"),
+            # Factura emitida por destinatario
+        ],
+        default="N",
+        string="TicketBai: Invoice issuer",
+        # TicketBai: Emisor de la factura
+        copy=False,
+    )
+
     @api.onchange('refund_sequence')
     def onchange_refund_sequence(self):
         if not self.refund_sequence and self.type == 'sale':

--- a/l10n_es_ticketbai/views/account_invoice_views.xml
+++ b/l10n_es_ticketbai/views/account_invoice_views.xml
@@ -19,6 +19,7 @@
                             <group name="ticketbai" colspan="2" col="2">
                                 <field name="tbai_enabled" invisible="1"/>
                                 <field name="tbai_send_invoice" invisible="1"/>
+                                <field name="tbai_invoice_issuer" invisible="1"/>
                                 <field name="tbai_invoice_id" readonly="1" options="{'no_create':True}"
                                        attrs="{'invisible': [('tbai_invoice_id', '=', False)]}"/>
                                 <field name="tbai_cancellation_id" readonly="1" options="{'no_create':True}"

--- a/l10n_es_ticketbai/views/account_journal_views.xml
+++ b/l10n_es_ticketbai/views/account_journal_views.xml
@@ -10,6 +10,9 @@
                 <xpath expr="//field[@name='refund_sequence']" position="before">
                     <field name="tbai_enabled" invisible="1" />
                     <field name="tbai_active_date" attrs="{'invisible': ['|', ('type', '!=', 'sale'), ('tbai_enabled', '=', False)]}"/>
+                    <field name="tbai_invoice_issuer"
+                           attrs="{'invisible': ['|', '|', ('type', '!=', 'sale'), ('tbai_enabled', '=', False), ('tbai_send_invoice', '=', False)]}"
+                    />
                 </xpath>
                 <xpath expr="//field[@name='type']" position="after">
                     <field name="tbai_send_invoice" attrs="{'invisible': ['|', ('type', '!=', 'sale'), ('tbai_enabled', '=', False)]}" />

--- a/l10n_es_ticketbai_api/i18n/es.po
+++ b/l10n_es_ticketbai_api/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-10 13:17+0000\n"
-"PO-Revision-Date: 2022-08-23 13:07+0000\n"
+"POT-Creation-Date: 2024-01-10 10:02+0000\n"
+"PO-Revision-Date: 2024-01-10 11:09+0100\n"
 "Last-Translator: olatzavanzosc <olatzaranguren@avanzosc.es>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,help:l10n_es_ticketbai_api.field_tbai_invoice__schema
@@ -388,7 +388,6 @@ msgstr "Entidad desarrolladora"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_installation.py:21
-#: sql_constraint:tbai.installation:0
 #, python-format
 msgid "Developer must be unique!"
 msgstr "¡La entidad desarrolladora debe ser única!"
@@ -544,6 +543,21 @@ msgid "Invoice Tax Retention Total Amount"
 msgstr "Retención soportada"
 
 #. module: l10n_es_ticketbai_api
+#: selection:tbai.invoice,tbai_invoice_issuer:0
+msgid "Invoice issued by a third party"
+msgstr "Factura emitida por tercero"
+
+#. module: l10n_es_ticketbai_api
+#: selection:tbai.invoice,tbai_invoice_issuer:0
+msgid "Invoice issued by recipient"
+msgstr "Factura emitida por destinatario"
+
+#. module: l10n_es_ticketbai_api
+#: selection:tbai.invoice,tbai_invoice_issuer:0
+msgid "Invoice issued by the issuer itself"
+msgstr "Factura emitida por el propio emisor"
+
+#. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_tax__is_exempted
 msgid "Is Exempted"
 msgstr "Es exenta"
@@ -616,7 +630,6 @@ msgstr "Licencia TBAI"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_installation.py:22
-#: sql_constraint:tbai.installation:0
 #, python-format
 msgid "License Key must be unique!"
 msgstr "¡La licencia TicketBAI debe ser única!"
@@ -898,7 +911,6 @@ msgstr "Nombre del software"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_installation.py:20
-#: sql_constraint:tbai.installation:0
 #, python-format
 msgid "Software Name must be unique!"
 msgstr "¡El nombre de Software TicketBAI debe ser único!"
@@ -1057,6 +1069,7 @@ msgstr "URL base del QR test"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:630
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:642
 #, python-format
 msgid "The Company %s VAT Number is required."
 msgstr "La compañía %s debe tener establecido un NIF válido."
@@ -1142,6 +1155,7 @@ msgstr "TicketBAI Instalaciones"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:807
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:819
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1152,6 +1166,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1172
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1186
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1162,6 +1177,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:197
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:209
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1251,6 +1267,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:292
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:304
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1261,6 +1278,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:351
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:363
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1272,6 +1290,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:341
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:353
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1283,6 +1302,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:281
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:293
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1293,6 +1313,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:361
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:373
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1303,6 +1324,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:296
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:308
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1314,6 +1336,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:939
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:951
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1324,6 +1347,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:779
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:791
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1334,6 +1358,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1057
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1069
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1344,6 +1369,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:960
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:972
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1354,6 +1380,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1240
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1254
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1364,6 +1391,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1230
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1244
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1376,6 +1404,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1219
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1233
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1399,6 +1428,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:271
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:283
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1409,6 +1439,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:266
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:278
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1419,6 +1450,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:254
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:266
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1429,6 +1461,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:249
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:261
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1439,6 +1472,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:385
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:397
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1449,6 +1483,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:376
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:388
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1469,6 +1504,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:800
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:812
 #, python-format
 msgid ""
 "TicketBAI Invoice %s:\n"
@@ -1479,6 +1515,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:332
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:344
 #, python-format
 msgid "TicketBAI Invoice %s: Amount Total"
 msgstr "TicketBAI Factura %s: Importe total"
@@ -1503,12 +1540,14 @@ msgstr "TicketBAI Factura %s: Los impuestos exentos son sujetos."
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:305
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:317
 #, python-format
 msgid "TicketBAI Invoice %s: Expedition Date"
 msgstr "TicketBAI Factura %s: Fecha expedición"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:314
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:326
 #, python-format
 msgid "TicketBAI Invoice %s: Expedition Hour"
 msgstr "TicketBAI Factura %s: Hora expedición"
@@ -1539,6 +1578,7 @@ msgstr "TicketBAI Factura %s: Línea %s cantidad"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:832
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:844
 #, python-format
 msgid "TicketBAI Invoice %s: Max. number of exempted taxes is 7!"
 msgstr ""
@@ -1546,6 +1586,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:918
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:930
 #, python-format
 msgid "TicketBAI Invoice %s: Max. number of not subject to taxes is 2!"
 msgstr ""
@@ -1554,12 +1595,14 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:323
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:335
 #, python-format
 msgid "TicketBAI Invoice %s: Operation Date"
 msgstr "TicketBAI Factura %s: Fecha operación"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:238
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:250
 #, python-format
 msgid "TicketBAI Invoice %s: Refund Code and Type are required."
 msgstr ""
@@ -1567,6 +1610,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:218
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:230
 #, python-format
 msgid "TicketBAI Invoice %s: Second VAT Regime Key not valid."
 msgstr "TicketBAI Factura %s: Segunda clave de regímenes de IVA no válida."
@@ -1621,24 +1665,28 @@ msgstr "TicketBAI Factura %s: Cuota recargo de equivalencia"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:228
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:240
 #, python-format
 msgid "TicketBAI Invoice %s: Third VAT Regime Key not valid."
 msgstr "TicketBAI Factura %s: Tercera clave de regímenes de IVA no válida."
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:209
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:221
 #, python-format
 msgid "TicketBAI Invoice %s: VAT Regime Key not valid."
 msgstr "TicketBAI Factura %s: Primera clave de regímenes de IVA no válida."
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:454
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:466
 #, python-format
 msgid "TicketBAI Invoice %s: XML Invoice schema not supported!"
 msgstr "TicketBAI Factura %s: Esquema XML de factura no soportado!"
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:670
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:682
 #, python-format
 msgid "TicketBAI Invoice %s: XML schema not supported!"
 msgstr "TicketBAI Factura %s: Esquema XML de factura no soportado!"
@@ -1752,6 +1800,11 @@ msgid "TicketBai"
 msgstr "TicketBai"
 
 #. module: l10n_es_ticketbai_api
+#: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice__tbai_invoice_issuer
+msgid "TicketBai: Invoice issuer"
+msgstr "TicketBai: Emisor de la factura"
+
+#. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_tax__type
 msgid "Type"
 msgstr "Tipo"
@@ -1794,3 +1847,18 @@ msgstr "XML Respuesta"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_customer__zip
 msgid "ZIP Code"
 msgstr "Código postal"
+
+#. module: l10n_es_ticketbai_api
+#: sql_constraint:tbai.installation:0
+msgid "¡El nombre de Software TicketBAI debe ser único!"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: sql_constraint:tbai.installation:0
+msgid "¡La entidad desarrolladora debe ser única!"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: sql_constraint:tbai.installation:0
+msgid "¡La licencia TicketBAI debe ser única!"
+msgstr ""

--- a/l10n_es_ticketbai_api/i18n/l10n_es_ticketbai_api.pot
+++ b/l10n_es_ticketbai_api/i18n/l10n_es_ticketbai_api.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-10 10:02+0000\n"
+"PO-Revision-Date: 2024-01-10 10:02+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -317,7 +319,6 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_installation.py:21
-#: sql_constraint:tbai.installation:0
 #, python-format
 msgid "Developer must be unique!"
 msgstr ""
@@ -473,6 +474,21 @@ msgid "Invoice Tax Retention Total Amount"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
+#: selection:tbai.invoice,tbai_invoice_issuer:0
+msgid "Invoice issued by a third party"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: selection:tbai.invoice,tbai_invoice_issuer:0
+msgid "Invoice issued by recipient"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: selection:tbai.invoice,tbai_invoice_issuer:0
+msgid "Invoice issued by the issuer itself"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_tax__is_exempted
 msgid "Is Exempted"
 msgstr ""
@@ -545,7 +561,6 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_installation.py:22
-#: sql_constraint:tbai.installation:0
 #, python-format
 msgid "License Key must be unique!"
 msgstr ""
@@ -819,7 +834,6 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_installation.py:20
-#: sql_constraint:tbai.installation:0
 #, python-format
 msgid "Software Name must be unique!"
 msgstr ""
@@ -969,6 +983,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:630
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:642
 #, python-format
 msgid "The Company %s VAT Number is required."
 msgstr ""
@@ -1045,6 +1060,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:807
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:819
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Address for %s is required for the Tax Agency %s!"
@@ -1052,6 +1068,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1172
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1186
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "All Invoice recipients must be from the same country."
@@ -1059,6 +1076,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:197
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:209
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Already exists a TicketBAI Invoice with the same link to its previous TicketBAI Invoice."
@@ -1115,6 +1133,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:292
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:304
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Invoice Description is required."
@@ -1122,6 +1141,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:351
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:363
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Invoice Number Prefix longer than expected. Should be 20 characters max.!"
@@ -1129,6 +1149,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:341
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:353
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Invoice Number longer than expected. Should be 20 characters max.!"
@@ -1136,6 +1157,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:281
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:293
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Invoice Refund Reason Code is required."
@@ -1143,6 +1165,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:361
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:373
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Invoice Tax Retention Total Amount"
@@ -1150,6 +1173,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:296
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:308
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Invoice description longer than expected. Should be 250 characters max.!"
@@ -1157,6 +1181,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:939
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:951
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Invoice lines are required for the Tax Agency %s!"
@@ -1164,6 +1189,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:779
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:791
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Maximum 100 recipients allowed for each Invoice!"
@@ -1171,6 +1197,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1057
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1069
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Maximum number of Invoice Lines allowed is 1000."
@@ -1178,6 +1205,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:960
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:972
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Previous Invoice signature value is required."
@@ -1185,6 +1213,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1240
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1254
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Refunded Invoice %s Expedition Date"
@@ -1192,6 +1221,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1230
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1244
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Refunded Invoice %s Number Prefix %s longer than expected. Should be 20 characters max.!"
@@ -1199,6 +1229,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1219
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:1233
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Refunded Invoice Number %s longer than expected. Should be 20 characters max.!"
@@ -1213,6 +1244,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:271
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:283
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Substituted Invoice Tax Amount Total"
@@ -1220,6 +1252,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:266
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:278
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Substituted Invoice Tax Amount Total is required."
@@ -1227,6 +1260,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:254
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:266
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Substituted Invoice amount total untaxed"
@@ -1234,6 +1268,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:249
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:261
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "Substituted Invoice amount total untaxed is required."
@@ -1241,6 +1276,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:385
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:397
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "TBAI identifier %s should be %d characters long with CRC-8!"
@@ -1248,6 +1284,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:376
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:388
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "TBAI identifier without CRC-8 %s should be %d characters long!"
@@ -1262,6 +1299,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:800
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:812
 #, python-format
 msgid "TicketBAI Invoice %s:\n"
 "ZIP code for %s is required for the Tax Agency %s!"
@@ -1269,6 +1307,7 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:332
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:344
 #, python-format
 msgid "TicketBAI Invoice %s: Amount Total"
 msgstr ""
@@ -1293,12 +1332,14 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:305
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:317
 #, python-format
 msgid "TicketBAI Invoice %s: Expedition Date"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:314
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:326
 #, python-format
 msgid "TicketBAI Invoice %s: Expedition Hour"
 msgstr ""
@@ -1329,30 +1370,35 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:832
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:844
 #, python-format
 msgid "TicketBAI Invoice %s: Max. number of exempted taxes is 7!"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:918
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:930
 #, python-format
 msgid "TicketBAI Invoice %s: Max. number of not subject to taxes is 2!"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:323
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:335
 #, python-format
 msgid "TicketBAI Invoice %s: Operation Date"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:238
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:250
 #, python-format
 msgid "TicketBAI Invoice %s: Refund Code and Type are required."
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:218
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:230
 #, python-format
 msgid "TicketBAI Invoice %s: Second VAT Regime Key not valid."
 msgstr ""
@@ -1407,24 +1453,28 @@ msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:228
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:240
 #, python-format
 msgid "TicketBAI Invoice %s: Third VAT Regime Key not valid."
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:209
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:221
 #, python-format
 msgid "TicketBAI Invoice %s: VAT Regime Key not valid."
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:454
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:466
 #, python-format
 msgid "TicketBAI Invoice %s: XML Invoice schema not supported!"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
 #: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:670
+#: code:addons/l10n_es_ticketbai_api/models/ticketbai_invoice.py:682
 #, python-format
 msgid "TicketBAI Invoice %s: XML schema not supported!"
 msgstr ""
@@ -1532,6 +1582,11 @@ msgid "TicketBai"
 msgstr ""
 
 #. module: l10n_es_ticketbai_api
+#: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice__tbai_invoice_issuer
+msgid "TicketBai: Invoice issuer"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_tax__type
 msgid "Type"
 msgstr ""
@@ -1572,5 +1627,20 @@ msgstr ""
 #. module: l10n_es_ticketbai_api
 #: model:ir.model.fields,field_description:l10n_es_ticketbai_api.field_tbai_invoice_customer__zip
 msgid "ZIP Code"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: sql_constraint:tbai.installation:0
+msgid "¡El nombre de Software TicketBAI debe ser único!"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: sql_constraint:tbai.installation:0
+msgid "¡La entidad desarrolladora debe ser única!"
+msgstr ""
+
+#. module: l10n_es_ticketbai_api
+#: sql_constraint:tbai.installation:0
+msgid "¡La licencia TicketBAI debe ser única!"
 msgstr ""
 

--- a/l10n_es_ticketbai_api/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice.py
@@ -112,6 +112,18 @@ class TicketBAIInvoice(models.Model):
     tbai_invoice_refund_ids = fields.One2many(
         string='Refunded Invoices', copy=True,
         comodel_name='tbai.invoice.refund', inverse_name='tbai_invoice_id')
+    tbai_invoice_issuer = fields.Selection(
+        selection=[
+            ("N", "Invoice issued by the issuer itself"),
+            # Factura emitida por el propio emisor
+            ("T", "Invoice issued by a third party"),
+            # Factura emitida por tercero
+            ("D", "Invoice issued by recipient"),
+            # Factura emitida por destinatario
+        ],
+        default="N",
+        string="TicketBai: Invoice issuer",
+    )
     qr_url = fields.Char('URL', compute='_compute_tbai_qr', store=True, copy=False)
     qr = fields.Binary(string="QR", compute='_compute_tbai_qr', store=True,
                        copy=False, attachment=True)
@@ -1159,6 +1171,8 @@ class TicketBAIInvoice(models.Model):
         customers = self.build_destinatarios()
         if customers:
             res["Destinatarios"] = customers
+        if self.tbai_invoice_issuer and self.tbai_invoice_issuer != "N":
+            res["EmitidaPorTercerosODestinatario"] = self.tbai_invoice_issuer
         return res
 
     def build_tipo_desglose(self):


### PR DESCRIPTION
Se añade opción en los diarios de facturas de venta para poder indicar si el emisor de las facturas de ese diario/serie es el emisor, un tercero o el destinatario. Cuando es un tercero o destinatario, en el XML que se genera para enviar a TicketBai se añade el dato “EmisorPorTercerosODestinatario”.