### PR TITLE
[15.0][FIX] l10n_es_aeat_sii_oca: Avoid singleton error on invoice posting

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -591,7 +591,7 @@ class AccountMove(models.Model):
             invoice._sii_check_exceptions()
             if (
                 invoice.sii_state in ["sent_modified", "sent"]
-                and self._sii_invoice_dict_not_modified()
+                and invoice._sii_invoice_dict_not_modified()
             ):
                 if invoice.sii_state == "sent_modified":
                     invoice.sii_state = "sent"


### PR DESCRIPTION
If you post more than one invoice at a time (using the action in the list), and one of them is already sent to SII, there's a singleton error because a typo in the code using `self` instead of `invoice`.

@Tecnativa 