### PR TITLE
[15.0][FIX] l10n_es_aeat_mod347: Add food taxes to the model

### DIFF
--- a/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
+++ b/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
@@ -52,6 +52,12 @@
         ref('l10n_es.account_tax_template_p_iva5_isc'),
         ref('l10n_es.account_tax_template_p_iva10_sp_ex'),
         ref('l10n_es.account_tax_template_p_iva21_sp_ex'),
+                ref('l10n_es.account_tax_template_p_iva5_bc'),
+                ref('l10n_es.account_tax_template_p_iva5_sc'),
+                ref('l10n_es.account_tax_template_p_iva0_s_bc'),
+                ref('l10n_es.account_tax_template_p_iva0_s_sc'),
+                ref('l10n_es.account_tax_template_p_req0'),
+                ref('l10n_es.account_tax_template_p_req062'),
         ])]"
         />
     </record>
@@ -84,6 +90,12 @@
         ref('l10n_es.account_tax_template_s_req014'),
         ref('l10n_es.account_tax_template_s_req52'),
         ref('l10n_es.account_tax_template_s_iva0_isp'),
+                ref('l10n_es.account_tax_template_s_iva0s'),
+                ref('l10n_es.account_tax_template_s_iva0b'),
+                ref('l10n_es.account_tax_template_s_iva5s'),
+                ref('l10n_es.account_tax_template_s_iva5b'),
+                ref('l10n_es.account_tax_template_s_req0'),
+                ref('l10n_es.account_tax_template_s_req062'),
         ])]"
         />
     </record>


### PR DESCRIPTION
We need to cover these new taxes for 2023 reports that are now being issued, as they apply during this year.

New lines added with the proper indentation, although seeming a bit weird in comparison with previous ones.

@Tecnativa TT47064