### PR TITLE
[16.0][FIX] l10n_es_aeat_sii_oca: Crash on sending cancellation to SII

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -444,6 +444,8 @@ class AccountMove(models.Model):
 
     def _get_sii_invoice_dict_out(self, cancel=False):
         inv_dict = super()._get_sii_invoice_dict_out(cancel=cancel)
+        if cancel:
+            return inv_dict
         if self.thirdparty_invoice:
             inv_dict["FacturaExpedida"]["EmitidaPorTercerosODestinatario"] = "S"
         if self.sii_registration_key_additional1:


### PR DESCRIPTION
Forward-port of #3363 

When sending a cancellation to SII, `FacturaExpedida` element in the data structure is not built and sent, so current override (after the mixin refactoring) is not taking into account this, crashing on modifying a missing element.

We avoid the problem not modifying such elements if cancelling.

@Tecnativa