### PR TITLE
[16.0][FIX] l10n_es_facturae: Allow invoicing users to set Facturae

### DIFF
--- a/l10n_es_facturae/views/res_partner_view.xml
+++ b/l10n_es_facturae/views/res_partner_view.xml
@@ -27,9 +27,6 @@
                 <field name="parent_facturae" invisible="1" />
                 <field name="facturae" invisible="1" />
             </xpath>
-            <group name='accounting_entries' position="inside">
-                <field name="facturae" groups="account.group_account_invoice" />
-            </group>
             <group name="accounting_entries" position="after">
                 <group
                     name="group_facturae"
@@ -37,45 +34,65 @@
                     attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)]}"
                     groups="account.group_account_invoice"
                 >
-                    <field name="facturae_version" />
+                    <field name="facturae" />
+                    <field
+                        name="facturae_version"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)]}"
+                    />
                     <field
                         name="organo_gestor"
-                        attrs="{'required': [('facturae', '=', True)]}"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)], 'required': [('facturae', '=', True)]}"
                     />
                     <field
                         name="unidad_tramitadora"
-                        attrs="{'required': [('facturae', '=', True)]}"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)], 'required': [('facturae', '=', True)]}"
                     />
                     <field
                         name="oficina_contable"
-                        attrs="{'required': [('facturae', '=', True)]}"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)], 'required': [('facturae', '=', True)]}"
                     />
-                    <field name="organo_proponente" />
-                    <field name="attach_invoice_as_annex" />
+                    <field
+                        name="organo_proponente"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)]}"
+                    />
+                    <field
+                        name="attach_invoice_as_annex"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)]}"
+                    />
                 </group>
             </group>
             <page name="accounting_disabled" position="inside">
                 <group
-                    name="group_facturae"
+                    name="group_facturae_wo_accounting"
                     string="Facturae"
-                    attrs="{'invisible': [('parent_facturae', '=', False)]}"
+                    attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)]}"
                     groups="account.group_account_invoice"
                 >
-                    <field name="facturae_version" />
+                    <field name="facturae" />
+                    <field
+                        name="facturae_version"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)]}"
+                    />
                     <field
                         name="organo_gestor"
-                        attrs="{'required': [('facturae', '=', True)]}"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)], 'required': [('facturae', '=', True)]}"
                     />
                     <field
                         name="unidad_tramitadora"
-                        attrs="{'required': [('facturae', '=', True)]}"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)], 'required': [('facturae', '=', True)]}"
                     />
                     <field
                         name="oficina_contable"
-                        attrs="{'required': [('facturae', '=', True)]}"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)], 'required': [('facturae', '=', True)]}"
                     />
-                    <field name="organo_proponente" />
-                    <field name="attach_invoice_as_annex" />
+                    <field
+                        name="organo_proponente"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)]}"
+                    />
+                    <field
+                        name="attach_invoice_as_annex"
+                        attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)]}"
+                    />
                 </group>
             </page>
         </field>

--- a/l10n_es_facturae_face/views/res_partner.xml
+++ b/l10n_es_facturae_face/views/res_partner.xml
@@ -17,7 +17,10 @@
                 expr="//group[@name='group_facturae']/field[@name='facturae_version']"
                 position="before"
             >
-                <field name="l10n_es_facturae_sending_code" />
+                <field
+                    name="l10n_es_facturae_sending_code"
+                    attrs="{'invisible': [('facturae', '=', False), ('parent_facturae', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
As it was, only accountant users can set Facturae check, as the field was inside a group with such restriction. It doesn't matter that the field itself has another less restricting group.

Thus, we put the initial check in the same group as the rest, and move the visibility attributes to each field.

@Tecnativa TT47097