### PR TITLE
[16.0][IMP] l10n_es_aeat_sii_oca: show account registration date

### DIFF
--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -120,6 +120,10 @@
                                 <group>
                                     <field name="sii_state" />
                                     <field
+                                        name="sii_account_registration_date"
+                                        attrs="{'invisible': ['|',('sii_account_registration_date', '=', False),('move_type', 'not in', ['in_invoice', 'in_refund'])]}"
+                                    />
+                                    <field
                                         name="sii_send_failed"
                                         attrs="{'invisible': [('sii_send_failed', '=', False)]}"
                                     />


### PR DESCRIPTION
In v13 this field was removed from SII result tab, while merging invoice and vendor bill forms.

Fw-port of #3373 