### PR TITLE
[16.0][IMP] l10n_es_aeat_report: Aeat reports sorted by date start

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -18,6 +18,7 @@ class L10nEsAeatReport(models.AbstractModel):
     _name = "l10n.es.aeat.report"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "AEAT report base module"
+    _order = "date_start"
     _rec_name = "name"
     _aeat_number = False
     _period_quarterly = True

--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -18,7 +18,7 @@ class L10nEsAeatReport(models.AbstractModel):
     _name = "l10n.es.aeat.report"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "AEAT report base module"
-    _order = "date_start"
+    _order = "date_start,id"
     _rec_name = "name"
     _aeat_number = False
     _period_quarterly = True

--- a/l10n_es_aeat/views/aeat_report_view.xml
+++ b/l10n_es_aeat/views/aeat_report_view.xml
@@ -10,6 +10,8 @@
                 <field name="name" />
                 <field name="year" />
                 <field name="period_type" />
+                <field name="date_start" optional="show" />
+                <field name="date_end" optional="hide" />
                 <field name="state" />
                 <field name="company_id" groups="base.group_multi_company" />
             </tree>


### PR DESCRIPTION
A veces es muy molesto que si no se han creado los reportes de AEAT de manera secuencial los tienes desordenados y no  hay nada que te permita ordenarlos.
Puedes ordernar por año pero eso no te ordena por período y si ordenas por período, tendrás todos mezclados sin importar el año.
Con esta mejora se ordenan todos por fecha de inicio

@rafaelbn @yajo @loida-vm @ArantxaSudon @pedrobaeza @HaraldPanten  ¿podéis revisarlo por favor?

@moduon MT-4519