### PR TITLE
[FIX] add report_template_facturae to avoid error when generate report unsigned

### DIFF
--- a/l10n_es_facturae/reports/__init__.py
+++ b/l10n_es_facturae/reports/__init__.py
@@ -1,1 +1,2 @@
 from . import report_facturae
+from . import report_template_facturae

--- a/l10n_es_facturae/reports/report_template_facturae.py
+++ b/l10n_es_facturae/reports/report_template_facturae.py
@@ -1,0 +1,64 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import logging
+from lxml import etree
+
+from odoo import _, api, models, tools
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class ReportTemplateFacturae(models.AbstractModel):
+    _name = "report.l10n_es_facturae.template_facturae"
+    _inherit = "report.report_xml.abstract"
+    _description = "Account Move Facturae unsigned"
+
+    def _get_report_values(self, docids, data=None):
+        result = super()._get_report_values(docids, data=data)
+        result["docs"] = self.env["account.move"].browse(docids)
+        return result
+
+    @api.model
+    def generate_report(self, ir_report, docids, data=None):
+        move = self.env["account.move"].browse(docids)
+        move.ensure_one()
+        move.validate_facturae_fields()
+        xml_facturae, content_type = super().generate_report(
+            ir_report, docids, data=data
+        )
+        # Quitamos espacios en blanco, para asegurar que el XML final quede
+        # totalmente libre de ellos.
+        tree = etree.fromstring(xml_facturae, etree.XMLParser(remove_blank_text=True))
+        xml_facturae = etree.tostring(tree, xml_declaration=True, encoding="UTF-8")
+        self._validate_facturae(move, xml_facturae)
+        return xml_facturae, content_type
+
+    def _get_facturae_schema_file(self, move):
+        return tools.file_open(
+            "addons/l10n_es_facturae/data/Facturaev%s.xsd"
+            % move.get_facturae_version(),
+        )
+
+    def _validate_facturae(self, move, xml_string):
+        facturae_schema = etree.XMLSchema(
+            etree.parse(self._get_facturae_schema_file(move))
+        )
+        try:
+
+            facturae_schema.assertValid(etree.fromstring(xml_string))
+        except Exception as e:
+            _logger.warning("The XML file is invalid against the XML Schema Definition")
+            _logger.warning(xml_string)
+            _logger.warning(e)
+            raise UserError(
+                _(
+                    "The generated XML file is not valid against the official "
+                    "XML Schema Definition. The generated XML file and the "
+                    "full error have been written in the server logs. Here "
+                    "is the error, which may give you an idea on the cause "
+                    "of the problem : %s"
+                )
+                % str(e)
+            ) from e
+        return True


### PR DESCRIPTION
Hola,
En el asistente para generar el archivo facturae si desmarcamos la opción de firmar sale un error al generar el PDF.
Se puede probar en runboat.
![image](https://github.com/OCA/l10n-spain/assets/43784849/3da9e3bf-4cd8-401d-8475-cb764b9fbc60)

Ademas hay un issue, ya cerrada, en en el que explican los pasos para reproducirlo:
https://github.com/OCA/l10n-spain/issues/2664

Cuando no se marca la opción de firma se llama directamente al action del informe y al no haber validaciones previas da error.

https://github.com/OCA/l10n-spain/blob/f9f25a7801d9f7080c248c6655765997ea631d73/l10n_es_facturae/wizard/create_facturae.py#L59-L67

Se me ha ocurrido replicar el comportamiento que se hace con el report actual facturae_signed, pero sin firmarlo, solamente validando los campos y la estructura. Ahora comprueba los campos y si falta alguno da un legible para el usuario.
Se genera correctamente y he validado el resultado con esta herramienta en línea: https://sedeaplicaciones2.minetur.gob.es/FacturaE/
