### PR TITLE
[16.0][FIX] l10n_es_facturae_face: facturae check in commercial_partner_id

### DIFF
--- a/l10n_es_facturae_face/components/account_move_l10n_es_facturae_listener.py
+++ b/l10n_es_facturae_face/components/account_move_l10n_es_facturae_listener.py
@@ -23,7 +23,7 @@ class AccountMoveL10nEsFacturaeListener(Component):
         for record in records:
             if record.edi_disable_auto:
                 continue
-            partner = record.partner_id
+            partner = record.commercial_partner_id
             if record.move_type not in ["out_invoice", "out_refund"]:
                 continue
             if not partner.facturae or not partner.l10n_es_facturae_sending_code:

--- a/l10n_es_facturae_face/data/edi.xml
+++ b/l10n_es_facturae_face/data/edi.xml
@@ -19,7 +19,7 @@
         <field name="model_id" ref="account.model_account_move" />
         <field
             name="enable_domain"
-        >[('state', '!=', 'draft'), ('partner_id', '!=', False), ('partner_id.l10n_es_facturae_sending_code', '=', "face"),('move_type', 'in', ['out_invoice', 'out_refund'])]</field>
+        >[('state', '!=', 'draft'), ('commercial_partner_id', '!=', False), ('commercial_partner_id.l10n_es_facturae_sending_code', '=', "face"),('move_type', 'in', ['out_invoice', 'out_refund'])]</field>
         <field
             name="enable_snippet"
         >result = not record._has_exchange_record(exchange_type)</field>

--- a/l10n_es_facturae_face/models/res_partner.py
+++ b/l10n_es_facturae_face/models/res_partner.py
@@ -28,7 +28,7 @@ class ResPartner(models.Model):
                 or record.l10n_es_facturae_sending_code != "face"
             ):
                 continue
-            if not record.facturae:
+            if not record.facturae and not record.parent_facturae:
                 raise exceptions.ValidationError(
                     _("Facturae must be selected in order to send to FACe")
                 )


### PR DESCRIPTION
Hola,

Cuando se migró el módulo de facturae a la 16.0 se le incluyeron los cambios de este PR de la 14: https://github.com/OCA/l10n-spain/pull/2691 pero no los cambios en el módulo de FACe asociados

Un saludo