### PR TITLE
[FIX] l10n_es_aeat_mod190: allow partner access for non-accounting users

### DIFF
--- a/l10n_es_aeat_mod190/views/partner_view.xml
+++ b/l10n_es_aeat_mod190/views/partner_view.xml
@@ -13,6 +13,7 @@
                 </group>
                 <group>
                     <group
+                        groups="account.group_account_invoice,l10n_es_aeat.group_account_aeat"
                         string="Performance key"
                         name="acc_sale"
                         attrs="{'invisible':[('incluir_190', '=', False)]}"
@@ -59,6 +60,7 @@
                         <field name="hijos_y_descendientes_entero" />
                     </group>
                     <group
+                        groups="account.group_account_invoice,l10n_es_aeat.group_account_aeat"
                         string="First 3 compute"
                         attrs="{'invisible': [('is_aeat_perception_subkey_visible', '=', False)]}"
                     >


### PR DESCRIPTION
Fixes an access error when users without accounting permissions want to open partners form view.

The permissions for demo user:
![flameshot_2024-01-24_09-21](https://github.com/OCA/l10n-spain/assets/973709/1d95ae67-23c6-48ff-8dc7-83f23074e053)

The error without this patch:
![imagen](https://github.com/OCA/l10n-spain/assets/973709/c63acf8a-ec80-41bb-ac04-b085a06f1e5b)



@moduon MT-4878