### PR TITLE
[15.0][FIX] l10n_es_aeat_mod303: The remaining fee to compensate from previous declarations are not taken into account.

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -477,7 +477,10 @@ class L10nEsAeatMod303Report(models.Model):
                 ),
             )
             if prev_report.result_type == "C":
-                amount = abs(prev_report.resultado_liquidacion)
+                amount = (
+                    abs(prev_report.resultado_liquidacion)
+                    + prev_report.remaining_cuota_compensar
+                )
                 mod303.write(
                     {"cuota_compensar": amount, "potential_cuota_compensar": amount}
                 )


### PR DESCRIPTION
cc @Tecnativa

ping @carlosdauden @victoralmau 