### PR TITLE
[14.0][FIX] l10n_es_aeat_sii_oca: cliente intracomunitario, entrega extracomunitaria

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -1263,6 +1263,11 @@ class AccountMove(models.Model):
         elif gen_type == 2:
             return {"IDOtro": {"IDType": "02", "ID": country_code + identifier}}
         elif gen_type == 3 and identifier_type:
+            # Si usamos identificador tipo 02 en exportaciones, el envío falla con:
+            #   {'CodigoErrorRegistro': 1104,
+            #    'DescripcionErrorRegistro': 'Valor del campo ID incorrecto'}
+            if identifier_type == "02":
+                identifier_type = "06"
             return {
                 "IDOtro": {
                     "CodigoPais": country_code,

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -181,6 +181,39 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
             [("sii_wsdl_out", "!=", False)]
         )
 
+    def test_intracomunitary_customer_extracomunitary_delivery(self):
+        """Comprobar venta a un cliente intracomunitario enviada al extranjero.
+
+        Este caso se puede dar cuando una asesoría contable contabiliza facturas
+        para otro cliente, en caso de que ese cliente le venda a otro cliente
+        intracomunitario pero envíe a una dirección extracomunitaria.
+
+        También se puede dar cuando se instala el módulo `sale` en Odoo. Al instalarlo,
+        se añade el campo `partner_shipping_id`, que permite indicar una dirección
+        de entrega extracomunitaria para clientes intracomunitarios.
+        """
+        self._activate_certificate(self.certificate_password)
+        eu_customer = self.env["res.partner"].create(
+            {
+                "name": "French Customer",
+                "country_id": self.ref("base.fr"),
+                "vat": "FR23334175221",
+            }
+        )
+        fp_extra = self.browse_ref(f"l10n_es.{self.company.id}_fp_extra")
+        fp_extra.sii_partner_identification_type = "3"
+        invoice = self.invoice.copy({"partner_id": eu_customer.id})
+        invoice.fiscal_position_id = fp_extra
+        invoice.action_post()
+        sii_info = invoice._get_sii_invoice_dict()
+        self.assertEqual(
+            sii_info["FacturaExpedida"]["Contraparte"],
+            {
+                "NombreRazon": "French Customer",
+                "IDOtro": {"CodigoPais": "FR", "IDType": "06", "ID": "23334175221"},
+            },
+        )
+
     def test_job_creation(self):
         self.assertTrue(self.invoice.invoice_jobs_ids)
 


### PR DESCRIPTION
Una venta a un cliente intracomunitario enviada al extranjero es exportación.

Nunca se puede informar el tipo de identificador 02 para estos envíos porque la AEAT los rechaza siempre. Al poner identificador 06, funciona bien.

Fix https://github.com/OCA/l10n-spain/issues/2969

@moduon MT-2407