### PR TITLE
[16.0][IMP] l10n_es_aeat: Show public key from frontend

### DIFF
--- a/l10n_es_aeat/views/aeat_certificate_view.xml
+++ b/l10n_es_aeat/views/aeat_certificate_view.xml
@@ -33,7 +33,13 @@
                 <group>
                     <field name="private_key" />
                     <field name="public_key" />
+                    <field
+                        name="show_public_key"
+                        widget="boolean_toggle"
+                        options="{'autosave': False}"
+                    />
                 </group>
+                <field name="public_key_data" />
             </form>
         </field>
     </record>


### PR DESCRIPTION
Este cambio nos permite mostrar la clave pública desde el frontend (sólo la pública) Esto lo hacemos por que en algunas situaciones (FACe) necesitamos esta clave y es mejor mostrar-lo al usuario que hacerles extraer el dato desde terminal.

![image](https://github.com/OCA/l10n-spain/assets/28590170/f55269a0-d040-496e-991e-a86895c90512)

Por defecto, este campo no se rellenará y lo haremos solo cuando el usuario solicite acceder a la información.