### PR TITLE
[15.0][FIX] l10n_es_aeat_mod190: BOE format + chatter in report

### DIFF
--- a/l10n_es_aeat_mod190/data/aeat_export_mod190_data.xml
+++ b/l10n_es_aeat_mod190/data/aeat_export_mod190_data.xml
@@ -166,6 +166,8 @@
         <field name="expression">${object.casilla_02}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
+        <field name="positive_sign"> </field>
+        <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -203,7 +205,7 @@
         >Reservado para la Administración. Rellenar con blancos</field>
         <field name="fixed_value" />
         <field name="export_type">string</field>
-        <field name="size">261</field>
+        <field name="size">262</field>
         <field name="alignment">left</field>
     </record>
     <!-- SELLO ELECTRONICO (13) -->

--- a/l10n_es_aeat_mod190/data/aeat_export_mod190_partner_data.xml
+++ b/l10n_es_aeat_mod190/data/aeat_export_mod190_partner_data.xml
@@ -133,7 +133,9 @@
         <field name="sequence">10</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field name="name">Subclave</field>
-        <field name="expression">${object.aeat_perception_subkey_id.name}</field>
+        <field
+            name="expression"
+        >${object.aeat_perception_subkey_id.name or '00'}</field>
         <field name="export_type">string</field>
         <field name="size">2</field>
         <field name="alignment">left</field>
@@ -147,10 +149,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Percepciones dinerarias no derivadas de incapacidad laboral</field>
+        >Percepciones dinerarias no derivadas de incapacidad laboral (signo)</field>
         <field
             name="expression"
-        >${'N' if object.percepciones_dinerarias &lt; 0 else ''}</field>
+        >${'N' if object.percepciones_dinerarias &lt; 0 else ' '}</field>
         <field name="export_type">string</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
@@ -163,10 +165,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Percepciones dinerarias no derivadas de incapacidad laboral</field>
+        >Percepciones dinerarias no derivadas de incapacidad laboral (base)</field>
         <field name="expression">${object.percepciones_dinerarias}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -179,10 +181,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Percepciones dinerarias no derivadas de incapacidad laboral</field>
+        >Percepciones dinerarias no derivadas de incapacidad laboral (retención)</field>
         <field name="expression">${object.retenciones_dinerarias}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -196,10 +198,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Signo de las percepciones en especie no derivadas de incapacidad laboral</field>
+        >Percepciones en especie no derivadas de incapacidad laboral (signo)</field>
         <field
             name="expression"
-        >${'N' if object.percepciones_en_especie &lt; 0 else ''}</field>
+        >${'N' if object.percepciones_en_especie &lt; 0 else ' '}</field>
         <field name="export_type">string</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
@@ -212,10 +214,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Percepciones en especie no derivadas de incapacidad laboral</field>
+        >Percepciones en especie no derivadas de incapacidad laboral (base)</field>
         <field name="expression">${object.percepciones_en_especie}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -231,7 +233,7 @@
         >Ingresos a cuenta efectuados no derivados de incapacidad laboral</field>
         <field name="expression">${object.ingresos_a_cuenta_efectuados}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -247,7 +249,7 @@
         >Ingresos a cuenta repercutidos no derivados de incapacidad laboral</field>
         <field name="expression">${object.ingresos_a_cuenta_repercutidos}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -261,7 +263,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field name="name">Ejercicio devengo</field>
         <field name="expression">${object.ejercicio_devengo}</field>
-        <field name="export_type">string</field>
+        <field name="export_type">integer</field>
         <field name="size">4</field>
         <field name="alignment">right</field>
     </record>
@@ -273,11 +275,9 @@
         <field name="sequence">19</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field name="name">Ceuta y Melilla</field>
-        <field name="expression">${object.ceuta_melilla == True}</field>
-        <field name="export_type">boolean</field>
+        <field name="expression">${object.ceuta_melilla}</field>
+        <field name="export_type">integer</field>
         <field name="size">1</field>
-        <field name="bool_yes">1</field>
-        <field name="bool_no">0</field>
         <field name="alignment">left</field>
     </record>
     <!-- (153-254) DATOS ADICIONALES (102) -->
@@ -290,7 +290,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field name="name">Datos adicionales: Año de nacimiento</field>
         <field name="expression">${object.a_nacimiento}</field>
-        <field name="export_type">string</field>
+        <field name="export_type">integer</field>
         <field name="size">4</field>
         <field name="alignment">left</field>
     </record>
@@ -303,7 +303,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field name="name">Datos adicionales: Situación familiar</field>
         <field name="expression">${object.situacion_familiar}</field>
-        <field name="export_type">string</field>
+        <field name="export_type">integer</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
     </record>
@@ -329,7 +329,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field name="name">Datos adicionales: Discapacidad</field>
         <field name="expression">${object.discapacidad}</field>
-        <field name="export_type">string</field>
+        <field name="export_type">integer</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
     </record>
@@ -342,7 +342,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field name="name">Datos adicionales: Contrato o relación</field>
         <field name="expression">${object.contrato_o_relacion}</field>
-        <field name="export_type">string</field>
+        <field name="export_type">integer</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
     </record>
@@ -353,9 +353,9 @@
     >
         <field name="sequence">25</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: - </field>
-        <field name="fixed_value" />
-        <field name="export_type">string</field>
+        <field name="name">Datos adicionales: Titular unidad de convivencia</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">integer</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
     </record>
@@ -368,7 +368,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field name="name">Datos adicionales: Movilidad geográfica</field>
         <field name="expression">${object.movilidad_geografica}</field>
-        <field name="export_type">string</field>
+        <field name="export_type">integer</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
     </record>
@@ -382,7 +382,7 @@
         <field name="name">Datos adicionales: Reducciones aplicables</field>
         <field name="expression">${object.reduccion_aplicable}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -397,7 +397,7 @@
         <field name="name">Datos adicionales: Gastos deducibles</field>
         <field name="expression">${object.gastos_deducibles}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -412,7 +412,7 @@
         <field name="name">Datos adicionales: Pensiones compensatorias</field>
         <field name="expression">${object.pensiones_compensatorias}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -427,7 +427,7 @@
         <field name="name">Datos adicionales: Anualidades por alimentos</field>
         <field name="expression">${object.anualidades_por_alimentos}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -439,7 +439,9 @@
     >
         <field name="sequence">31</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Hijos y otros descendientes</field>
+        <field
+            name="name"
+        >Datos adicionales: Hijos y otros descendientes (&lt; 3 años. Nº total)</field>
         <field name="expression">${object.hijos_y_descendientes_m}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -451,7 +453,9 @@
     >
         <field name="sequence">32</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Hijos y otros descendientes</field>
+        <field
+            name="name"
+        >Datos adicionales: Hijos y otros descendientes (&lt; 3 años. Por entero)</field>
         <field name="expression">${object.hijos_y_descendientes_m_entero}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -463,7 +467,9 @@
     >
         <field name="sequence">33</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Hijos y otros descendientes</field>
+        <field
+            name="name"
+        >Datos adicionales: Hijos y otros descendientes (Resto. Nº total)</field>
         <field name="expression">${object.hijos_y_descendientes}</field>
         <field name="export_type">integer</field>
         <field name="size">2</field>
@@ -475,7 +481,9 @@
     >
         <field name="sequence">34</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Hijos y otros descendientes</field>
+        <field
+            name="name"
+        >Datos adicionales: Hijos y otros descendientes (Resto. Por entero)</field>
         <field name="expression">${object.hijos_y_descendientes_entero}</field>
         <field name="export_type">integer</field>
         <field name="size">2</field>
@@ -490,7 +498,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Datos adicionales: Hijos y otros descendientes con discapacidad</field>
+        >Datos adicionales: Hijos y otros descendientes con discapacidad (≥ 33% y &lt; 65%. Nº total)</field>
         <field name="expression">${object.hijos_y_desc_discapacidad_33}</field>
         <field name="export_type">integer</field>
         <field name="size">2</field>
@@ -504,7 +512,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Datos adicionales: Hijos y otros descendientes con discapacidad</field>
+        >Datos adicionales: Hijos y otros descendientes con discapacidad (≥ 33% y &lt; 65%. Por entero)</field>
         <field name="expression">${object.hijos_y_desc_discapacidad_entero_33}</field>
         <field name="export_type">integer</field>
         <field name="size">2</field>
@@ -518,7 +526,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Datos adicionales: Hijos y otros descendientes con discapacidad</field>
+        >Datos adicionales: Hijos y otros descendientes con discapacidad (Movilidad Reducida. Nº total)</field>
         <field name="expression">${object.hijos_y_desc_discapacidad_mr}</field>
         <field name="export_type">integer</field>
         <field name="size">2</field>
@@ -532,7 +540,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Datos adicionales: Hijos y otros descendientes con discapacidad</field>
+        >Datos adicionales: Hijos y otros descendientes con discapacidad (Movilidad Reducida. Por entero)</field>
         <field name="expression">${object.hijos_y_desc_discapacidad_entero_mr}</field>
         <field name="export_type">integer</field>
         <field name="size">2</field>
@@ -546,7 +554,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Datos adicionales: Hijos y otros descendientes con discapacidad</field>
+        >Datos adicionales: Hijos y otros descendientes con discapacidad (≥ 65%. Nº total)</field>
         <field name="expression">${object.hijos_y_desc_discapacidad_66}</field>
         <field name="export_type">integer</field>
         <field name="size">2</field>
@@ -560,7 +568,7 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Datos adicionales: Hijos y otros descendientes con discapacidad</field>
+        >Datos adicionales: Hijos y otros descendientes con discapacidad (≥ 65%. Por entero)</field>
         <field name="expression">${object.hijos_y_desc_discapacidad_entero_66}</field>
         <field name="export_type">integer</field>
         <field name="size">2</field>
@@ -573,7 +581,9 @@
     >
         <field name="sequence">41</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Ascendientes</field>
+        <field
+            name="name"
+        >Datos adicionales: Ascendientes (&lt; 75 años. Nº total)</field>
         <field name="expression">${object.ascendientes}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -585,7 +595,9 @@
     >
         <field name="sequence">42</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Ascendientes</field>
+        <field
+            name="name"
+        >Datos adicionales: Ascendientes (&lt; 75 años. Por entero)</field>
         <field name="expression">${object.ascendientes_entero}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -597,7 +609,7 @@
     >
         <field name="sequence">43</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Ascendientes</field>
+        <field name="name">Datos adicionales: Ascendientes (≥ 75 años. Nº total)</field>
         <field name="expression">${object.ascendientes_m75}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -609,7 +621,9 @@
     >
         <field name="sequence">44</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Ascendientes</field>
+        <field
+            name="name"
+        >Datos adicionales: Ascendientes (≥ 75 años. Por entero)</field>
         <field name="expression">${object.ascendientes_entero_m75}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -622,7 +636,9 @@
     >
         <field name="sequence">45</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Ascendientes con discapacidad</field>
+        <field
+            name="name"
+        >Datos adicionales: Ascendientes con discapacidad (≥ 33% y &lt; 65%. Nº total)</field>
         <field name="expression">${object.ascendientes_discapacidad_33}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -634,7 +650,9 @@
     >
         <field name="sequence">46</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Ascendientes con discapacidad</field>
+        <field
+            name="name"
+        >Datos adicionales: Ascendientes con discapacidad (≥ 33% y &lt; 65%. Por entero)</field>
         <field name="expression">${object.ascendientes_discapacidad_entero_33}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -646,7 +664,9 @@
     >
         <field name="sequence">47</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Ascendientes con discapacidad</field>
+        <field
+            name="name"
+        >Datos adicionales: Ascendientes con discapacidad (Movilidad Reducida. Nº total)</field>
         <field name="expression">${object.ascendientes_discapacidad_mr}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -658,7 +678,9 @@
     >
         <field name="sequence">48</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Ascendientes con discapacidad</field>
+        <field
+            name="name"
+        >Datos adicionales: Ascendientes con discapacidad (Movilidad Reducida. Por entero)</field>
         <field name="expression">${object.ascendientes_discapacidad_entero_mr}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -670,7 +692,9 @@
     >
         <field name="sequence">49</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Ascendientes con discapacidad</field>
+        <field
+            name="name"
+        >Datos adicionales: Ascendientes con discapacidad (≥ 65%. Nº total)</field>
         <field name="expression">${object.ascendientes_discapacidad_66}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -682,7 +706,9 @@
     >
         <field name="sequence">50</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Datos adicionales: Ascendientes con discapacidad</field>
+        <field
+            name="name"
+        >Datos adicionales: Ascendientes con discapacidad (≥ 65%. Por entero)</field>
         <field name="expression">${object.ascendientes_discapacidad_entero_66}</field>
         <field name="export_type">integer</field>
         <field name="size">1</field>
@@ -755,10 +781,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Percepciones dinerarias derivadas de incapacidad laboral</field>
+        >Percepciones dinerarias derivadas de incapacidad laboral (signo)</field>
         <field
             name="expression"
-        >${'N' if object.percepciones_dinerarias_incap &lt; 0 else ''}</field>
+        >${'N' if object.percepciones_dinerarias_incap &lt; 0 else ' '}</field>
         <field name="export_type">string</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
@@ -771,10 +797,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Percepciones dinerarias no derivadas de incapacidad laboral</field>
+        >Percepciones dinerarias derivadas de incapacidad laboral (base)</field>
         <field name="expression">${object.percepciones_dinerarias_incap}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -787,10 +813,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Percepciones dinerarias no derivadas de incapacidad laboral</field>
+        >Percepciones dinerarias derivadas de incapacidad laboral (retención)</field>
         <field name="expression">${object.retenciones_dinerarias_incap}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -804,10 +830,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Signo de las percepciones en especie no derivadas de incapacidad laboral</field>
+        >Percepciones en especie derivadas de incapacidad laboral (signo)</field>
         <field
             name="expression"
-        >${'N' if object.percepciones_en_especie &lt; 0 else ''}</field>
+        >${'N' if object.percepciones_en_especie &lt; 0 else ' '}</field>
         <field name="export_type">string</field>
         <field name="size">1</field>
         <field name="alignment">left</field>
@@ -820,10 +846,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Percepciones en especie no derivadas de incapacidad laboral</field>
+        >Percepciones en especie derivadas de incapacidad laboral (base)</field>
         <field name="expression">${object.percepciones_en_especie}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -836,10 +862,10 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Ingresos a cuenta efectuados no derivados de incapacidad laboral</field>
+        >Ingresos a cuenta efectuados por prestaciones en especie derivadas de incapacidad laboral</field>
         <field name="expression">${object.ingresos_a_cuenta_efectuados_incap}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
@@ -852,34 +878,52 @@
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field
             name="name"
-        >Ingresos a cuenta repercutidos no derivados de incapacidad laboral</field>
+        >Ingresos a cuenta repercutidos por prestaciones en especia derivadas de incapacidad laboral</field>
         <field name="expression">${object.ingresos_a_cuenta_repercutidos_incap}</field>
         <field name="export_type">float</field>
-        <field name="apply_sign" eval="True" />
+        <field name="apply_sign" eval="False" />
         <field name="size">13</field>
         <field name="decimal_size">2</field>
         <field name="alignment">right</field>
     </record>
-    <!-- (322-500) BLANCOS (179) -->
+    <!-- (322-387) COMPLEMENTO AYUDA PARA LA INFANCIA + RETENCIONES E INGRESOS A CUENTA
+        INGRESADOS EN EL ESTADO, EN LAS DIPUTACIONES FORALES DEL PAIS VASCO Y
+        EN LA COMUNIDAD FORAL DE NAVARRA (66) -->
     <record
         id="aeat_mod190_partner_export_line_62"
         model="aeat.model.export.config.line"
     >
         <field name="sequence">62</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
-        <field name="name">Espacios en blanco</field>
-        <field name="fixed_value" />
-        <field name="export_type">string</field>
-        <field name="size">179</field>
+        <field
+            name="name"
+        >Complemento ayuda infancia + diputaciones forales (forzado a 0s)</field>
+        <field name="fixed_value">0</field>
+        <field name="export_type">integer</field>
+        <field name="size">66</field>
         <field name="alignment">left</field>
     </record>
-    <!-- FIN DE REGISTRO -->
-    <!-- (0) NUEVA LINEA -->
+    <!-- (388-500) BLANCOS (178) -->
     <record
         id="aeat_mod190_partner_export_line_63"
         model="aeat.model.export.config.line"
     >
         <field name="sequence">63</field>
+        <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
+        <field name="name">Espacios en blanco</field>
+        <field name="fixed_value" />
+        <field name="expression" />
+        <field name="export_type">string</field>
+        <field name="size">113</field>
+        <field name="alignment">left</field>
+    </record>
+    <!-- FIN DE REGISTRO -->
+    <!-- (0) NUEVA LINEA -->
+    <record
+        id="aeat_mod190_partner_export_line_64"
+        model="aeat.model.export.config.line"
+    >
+        <field name="sequence">64</field>
         <field name="export_config_id" ref="aeat_mod190_partner_export_config" />
         <field name="name">Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
         <field name="expression">${"\r\n".encode("ascii")}</field>

--- a/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
+++ b/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
@@ -221,7 +221,7 @@ class L10nEsAeatMod190Report(models.Model):
         vals = {
             "report_id": self.id,
             "partner_id": rp.id,
-            "partner_vat": rp.vat,
+            "partner_vat": rp._parse_aeat_vat_info()[2],
             "aeat_perception_key_id": key_id.id,
             "aeat_perception_subkey_id": subkey_id.id,
             "codigo_provincia": codigo_provincia,
@@ -504,7 +504,7 @@ class L10nEsAeatMod190ReportLine(models.Model):
             if not self.codigo_provincia:
                 self.codigo_provincia = "98"
 
-            self.partner_vat = partner.vat
+            self.partner_vat = partner._parse_aeat_vat_info()[2]
             # Cargamos valores establecidos en el tercero.
             self.aeat_perception_key_id = partner.aeat_perception_key_id
             self.aeat_perception_subkey_id = partner.aeat_perception_subkey_id

--- a/l10n_es_aeat_mod190/tests/test_mod190.py
+++ b/l10n_es_aeat_mod190/tests/test_mod190.py
@@ -112,7 +112,7 @@ class TestL10nEsAeatMod190Base(TestL10nEsAeatModBase):
         )
         record_new.partner_id = self.customer
         record_new.onchange_partner_id()
-        self.assertEqual(record_new.partner_vat, self.customer.vat)
+        self.assertEqual(record_new.partner_vat, "C2259530J")
         self.env["l10n.es.aeat.mod190.report.line"].create(
             record_new._convert_to_write(record_new._cache)
         )

--- a/l10n_es_aeat_mod190/views/mod190_line_view.xml
+++ b/l10n_es_aeat_mod190/views/mod190_line_view.xml
@@ -130,6 +130,7 @@
                                         string="Movilidad geográfica"
                                     />
                                 </group>
+                                <!-- TODO: Limitar a las claves A, B.01, B.03 y C-->
                                 <group>
                                     <field
                                         name="situacion_familiar"
@@ -174,6 +175,7 @@
                                 </group>
                             </group>
                         </page>
+                        <!-- TODO: Limitar a las claves A, B.01, B.03 y C-->
                         <page string="Decendents">
                             <group col="3">
                                 <group string="Lower than 3 years">

--- a/l10n_es_aeat_mod190/views/mod190_view.xml
+++ b/l10n_es_aeat_mod190/views/mod190_view.xml
@@ -67,6 +67,17 @@
                     </page>
                 </notebook>
             </group>
+            <form position="inside">
+                <div class="oe_chatter">
+                    <field
+                        name="message_follower_ids"
+                        widget="mail_followers"
+                        groups="base.group_user"
+                    />
+                    <field name="activity_ids" widget="mail_activity" />
+                    <field name="message_ids" widget="mail_thread" />
+                </div>
+            </form>
         </field>
     </record>
     <record id="action_l10n_es_aeat_mod190_report" model="ir.actions.act_window">


### PR DESCRIPTION
- Add the chatter in the report view.
- Fix problems in the BOE export.
- Extract the VAT number (without ES) through the generic helper method.

@Tecnativa TT47518