### PR TITLE
[13.0][FIX] l10n_es_aeat_mod347: incorrect company in reports and email template with multicompany.

### DIFF
--- a/l10n_es_aeat_mod347/data/mail_template_data.xml
+++ b/l10n_es_aeat_mod347/data/mail_template_data.xml
@@ -7,7 +7,7 @@
         >${(user.email and '&quot;%s&quot; &lt;%s&gt;' % (user.name, user.email) or '')|safe}</field>
         <field
             name="subject"
-        >Comprobación datos de modelo 347 año ${object.report_id.year} de ${user.company_id.name}</field>
+        >Comprobación datos de modelo 347 año ${object.report_id.year} de ${object.report_id.company_id.name}</field>
         <field
             name="partner_to"
         >${object.partner_id.address_get(['invoice'])['invoice']}</field>

--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -181,6 +181,7 @@
         <template id="report_347_partner">
             <t t-call="web.html_container">
                 <t t-foreach="docs" t-as="o">
+                    <t t-set="company" t-value="o.report_id.company_id" />
                     <t
                         t-call="l10n_es_aeat_mod347.report_347_partner_document"
                         t-lang="o.partner_id.lang"


### PR DESCRIPTION
There is a bug in reports and mail templates of Mod347 when there are multiple companies. 

If there are multiple companies configured, the subject of the message template and the company data of the report are those of the company assigned by default to the user who does the send/print action instead of being the company of the 347 report.
 
**To reproduce the error:**

- Log in with the admin user (Default company: My Company (San Francisco)).
- Change company -> My company (Chicago)
- Go to the Invoicing module -> AEAT reports -> AEAT 347 Model
- Create a new report -> Calculate -> From the partner records tab click on print -> the footer and header data is My Company (San Francisco) instead of My Company (Chicago)
- Click on Submit -> the subject is 'My Company (San Francisco) Model Year 2024 347 Data Check' instead of 'My Company (Chicago) Model Year 2024 347 Data Check'.
