### PR TITLE
[FIX] l10n_es_dua_sii: compute dua invoice

### DIFF
--- a/l10n_es_dua_sii/models/account_move.py
+++ b/l10n_es_dua_sii/models/account_move.py
@@ -37,7 +37,7 @@ class AccountMove(models.Model):
     def _compute_dua_invoice(self):
         for invoice in self:
             taxes = invoice._get_sii_taxes_map(
-                ["DUA"], self._get_document_fiscal_date()
+                ["DUA"], invoice._get_document_fiscal_date()
             )
             invoice.sii_dua_invoice = invoice.invoice_line_ids.filtered(
                 lambda x: any([tax in taxes for tax in x.tax_ids])


### PR DESCRIPTION
This fix is ​​to solve the following error if two invoices are merged.
![image](https://github.com/OCA/l10n-spain/assets/147067396/e40dcfe3-d436-427b-856f-e060e704d22b)
