### PR TITLE
[16.0][FIX] l10n_es_payment_order_confirming_aef: Put processing date as today

### DIFF
--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -109,7 +109,7 @@ class ConfirmingAEF(object):
             vat = vat.replace(self.partner_bank.country_id.code, "")
         text += self._aef_convert_text(vat, 15, "left")
         # 67 - 74 Fecha proceso
-        fecha_proceso = fields.first(self.record.payment_line_ids).date
+        fecha_proceso = fields.Date.today()
         text += self._aef_convert_text(str(fecha_proceso).replace("-", ""), 8)
         # 75 - 82 Fecha remesa
         if self.record.date_prefered == "due":


### PR DESCRIPTION
[FIX] l10n_es_payment_order_confirming_aef: Put processing date as today

Bankinter is actually using the processing date indicated in the file for their
planning and using the first line payment date causes that the files generated
don't work with that bank.

As harmless for the rest of the banks, let's use the date where the file is generated
for this data.

 #3425 Related
