### PR TITLE
[FIX] l10n_es_aeat_mod296,l10n_es_aeat_mod347,l10n_es_aeat_mod349: Add newline separator for export file

### DIFF
--- a/l10n_es_aeat_mod296/data/aeat_export_mod296_data.xml
+++ b/l10n_es_aeat_mod296/data/aeat_export_mod296_data.xml
@@ -207,9 +207,18 @@
         <field name="size">13</field>
         <field name="alignment">left</field>
     </record>
-    <!-- Tipo de Registro 2 – Registro de perceptor -->
-    <record id="aeat_mod296_main_export_line_21" model="aeat.model.export.config.line">
+    <record id="aeat_mod296_main_export_line_21_2" model="aeat.model.export.config.line">
         <field name="sequence">21</field>
+        <field name="export_config_id" ref="aeat_mod296_main_export_config" />
+        <field name="name">Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
+        <field name="expression">${"\r\n".encode("ascii")}</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+    <!-- Tipo de Registro 2 – Registro de perceptor -->
+    <record id="aeat_mod296_main_export_line_22_2" model="aeat.model.export.config.line">
+        <field name="sequence">22</field>
         <field name="export_config_id" ref="aeat_mod296_main_export_config" />
         <field name="name">Tipo de Registro 2 – Registro de perceptor</field>
         <field name="subconfig_id" ref="aeat_mod296_sub01_export_config" />

--- a/l10n_es_aeat_mod296/data/aeat_export_mod296_line_data.xml
+++ b/l10n_es_aeat_mod296/data/aeat_export_mod296_line_data.xml
@@ -435,4 +435,13 @@
         <field name="size">1</field>
         <field name="alignment">left</field>
     </record>
+    <record id="aeat_mod296_sub01_export_line_47" model="aeat.model.export.config.line">
+        <field name="sequence">47</field>
+        <field name="export_config_id" ref="aeat_mod296_sub01_export_config" />
+        <field name="name">Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
+        <field name="expression">${"\r\n".encode("ascii")}</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
 </odoo>

--- a/l10n_es_aeat_mod347/data/aeat_export_mod347_data.xml
+++ b/l10n_es_aeat_mod347/data/aeat_export_mod347_data.xml
@@ -215,9 +215,18 @@
         <field name="size">13</field>
         <field name="alignment">left</field>
     </record>
-    <!-- Tipo de Registro 2 – Registro de declarado: -->
-    <record id="aeat_mod347_main_export_line_20" model="aeat.model.export.config.line">
+    <record id="aeat_mod347_main_export_line_20_2" model="aeat.model.export.config.line">
         <field name="sequence">20</field>
+        <field name="export_config_id" ref="aeat_mod347_main_export_config" />
+        <field name="name">Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
+        <field name="expression">${"\r\n".encode("ascii")}</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+    <!-- Tipo de Registro 2 – Registro de declarado: -->
+    <record id="aeat_mod347_main_export_line_21_2" model="aeat.model.export.config.line">
+        <field name="sequence">21</field>
         <field name="export_config_id" ref="aeat_mod347_main_export_config" />
         <field name="name">Tipo de Registro 2 – Registro de declarado</field>
         <field name="subconfig_id" ref="aeat_mod347_partner_export_config" />
@@ -225,8 +234,8 @@
         <field name="repeat_expression">object.partner_record_ids</field>
     </record>
     <!-- Tipo registro 2 – Registro de inmueble: -->
-    <record id="aeat_mod347_main_export_line_21" model="aeat.model.export.config.line">
-        <field name="sequence">21</field>
+    <record id="aeat_mod347_main_export_line_22_2" model="aeat.model.export.config.line">
+        <field name="sequence">22</field>
         <field name="export_config_id" ref="aeat_mod347_main_export_config" />
         <field name="name">Tipo de Registro 2 – Registro de inmueble</field>
         <field name="subconfig_id" ref="aeat_mod347_real_state_export_config" />

--- a/l10n_es_aeat_mod347/data/aeat_export_mod347_partner_data.xml
+++ b/l10n_es_aeat_mod347/data/aeat_export_mod347_partner_data.xml
@@ -494,4 +494,13 @@
         <field name="size">201</field>
         <field name="alignment">left</field>
     </record>
+    <record id="aeat_mod347_partner_export_line_33" model="aeat.model.export.config.line">
+        <field name="sequence">33</field>
+        <field name="export_config_id" ref="aeat_mod347_partner_export_config" />
+        <field name="name">Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
+        <field name="expression">${"\r\n".encode("ascii")}</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
 </odoo>

--- a/l10n_es_aeat_mod347/data/aeat_export_mod347_real_state_data.xml
+++ b/l10n_es_aeat_mod347/data/aeat_export_mod347_real_state_data.xml
@@ -396,4 +396,13 @@
         <field name="size">167</field>
         <field name="alignment">left</field>
     </record>
+    <record id="aeat_mod347_real_state_export_line_30" model="aeat.model.export.config.line">
+        <field name="sequence">30</field>
+        <field name="export_config_id" ref="aeat_mod347_real_state_export_config" />
+        <field name="name">Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
+        <field name="expression">${"\r\n".encode("ascii")}</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
 </odoo>

--- a/l10n_es_aeat_mod349/data/aeat_export_mod349_data.xml
+++ b/l10n_es_aeat_mod349/data/aeat_export_mod349_data.xml
@@ -238,9 +238,18 @@
         <field name="size">13</field>
         <field name="alignment">left</field>
     </record>
-    <!-- Tipo registro 2: -->
-    <record id="aeat_mod349_main_export_line_22" model="aeat.model.export.config.line">
+    <record id="aeat_mod349_main_export_line_22_2" model="aeat.model.export.config.line">
         <field name="sequence">22</field>
+        <field name="export_config_id" ref="aeat_mod349_main_export_config" />
+        <field name="name">Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
+        <field name="expression">${"\r\n".encode("ascii")}</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
+    <!-- Tipo registro 2: -->
+    <record id="aeat_mod349_main_export_line_23_2" model="aeat.model.export.config.line">
+        <field name="sequence">23</field>
         <field name="export_config_id" ref="aeat_mod349_main_export_config" />
         <field
             name="name"
@@ -250,8 +259,8 @@
         <field name="repeat_expression">object.partner_record_ids</field>
     </record>
     <!-- Tipo registro 2: -->
-    <record id="aeat_mod349_main_export_line_23" model="aeat.model.export.config.line">
-        <field name="sequence">23</field>
+    <record id="aeat_mod349_main_export_line_24_2" model="aeat.model.export.config.line">
+        <field name="sequence">24</field>
         <field name="export_config_id" ref="aeat_mod349_main_export_config" />
         <field
             name="name"

--- a/l10n_es_aeat_mod349/data/aeat_export_mod349_partner_data.xml
+++ b/l10n_es_aeat_mod349/data/aeat_export_mod349_partner_data.xml
@@ -142,4 +142,13 @@
         <field name="size">354</field>
         <field name="alignment">left</field>
     </record>
+    <record id="aeat_mod349_partner_export_line_11" model="aeat.model.export.config.line">
+        <field name="sequence">11</field>
+        <field name="export_config_id" ref="aeat_mod349_partner_export_config" />
+        <field name="name">Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
+        <field name="expression">${"\r\n".encode("ascii")}</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
 </odoo>

--- a/l10n_es_aeat_mod349/data/aeat_export_mod349_partner_refund_data.xml
+++ b/l10n_es_aeat_mod349/data/aeat_export_mod349_partner_refund_data.xml
@@ -204,4 +204,13 @@
         <field name="size">322</field>
         <field name="alignment">left</field>
     </record>
+    <record id="aeat_mod349_partner_refund_export_line_15" model="aeat.model.export.config.line">
+        <field name="sequence">15</field>
+        <field name="export_config_id" ref="aeat_mod349_partner_refund_export_config" />
+        <field name="name">Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
+        <field name="expression">${"\r\n".encode("ascii")}</field>
+        <field name="export_type">string</field>
+        <field name="size">2</field>
+        <field name="alignment">left</field>
+    </record>
 </odoo>


### PR DESCRIPTION
This MR adds newline separators data for different types of AEAT exports.

Originally, I had this error reported on 347, but looking through supported OCA AEAT Export Models and [AEAT Models](https://sede.agenciatributaria.gob.es/Sede/ayuda/disenos-registro/modelos.html) I could see that the problematic ones were those informed on a "PDF" file.

Model 190 correctly adds the newline separator, and I extended the fix to 296 and 349.

The client gave me the 👍🏼 with this new file format, as it imports correctly into the tax authorities software.

Closes #3442 