### PR TITLE
[16.0][FIX] l10n_es_payment_order_confirming_aef: Make test resilient

### DIFF
--- a/l10n_es_payment_order_confirming_aef/tests/test_payment_order_confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/tests/test_payment_order_confirming_aef.py
@@ -104,4 +104,5 @@ class TestPaymentOrderOutboundBaseAEF(TestPaymentOrderOutboundBase):
                 ],
             }
         )
+        self.invoice.partner_bank_id = self.partner.bank_ids[-1].id
         self.order_creation(False)


### PR DESCRIPTION
Forward-port of #3464 #3465 

Force the invoice to use the partner bank account indicated for the test for having a correct result no matter the upstream code.

@Tecnativa 