### PR TITLE
[14.0][FIX] l10n_es_dua_ticketbai_batuz: Correción mapeo impuestos

### DIFF
--- a/l10n_es_dua_ticketbai_batuz/data/tax_code_map_dua_ticketbai_data.xml
+++ b/l10n_es_dua_ticketbai_batuz/data/tax_code_map_dua_ticketbai_data.xml
@@ -14,9 +14,7 @@
         ref('l10n_es.account_tax_template_p_iva21_ibi'),
         ref('l10n_es.account_tax_template_p_iva10_ibi'),
         ref('l10n_es.account_tax_template_p_iva4_ibi'),
-        ref('l10n_es.account_tax_template_p_iva21_sp_ex'),
-        ref('l10n_es.account_tax_template_p_iva10_sp_ex'),
-        ref('l10n_es.account_tax_template_p_iva4_sp_ex'),
+        ref('l10n_es.account_tax_template_p_iva0_ibc'),
       ])]"
         />
       <field name="name">Importaciones con DUA</field>


### PR DESCRIPTION
Se han eliminado los tres impuestos del tipo "Adquisición de servicios extracomunitarios" al no pasar por aduanas y se ha añadido el impuesto "IVA 0% Importaciones de bienes corrientes"