### PR TITLE
[12.0][IMP] l10n_es_aeat_mod216: IRPF No residentes exento por convenio

### DIFF
--- a/l10n_es_aeat_mod216/__manifest__.py
+++ b/l10n_es_aeat_mod216/__manifest__.py
@@ -1,11 +1,12 @@
 # Copyright 2015 AvanzOSC - Ainara Galdona
 # Copyright 2016 Tecnativa - Antonio Espinosa
 # Copyright 2015-2019 Tecnativa - Pedro M. Baeza
+# Copyright 2024 Trey - Roberto Lizana
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     'name': 'AEAT modelo 216',
-    'version': '12.0.2.4.0',
+    'version': '12.0.2.5.0',
     'category': "Localisation/Accounting",
     'author': "AvanzOSC,"
               "Tecnativa,"

--- a/l10n_es_aeat_mod216/data/tax_code_map_mod216_data.xml
+++ b/l10n_es_aeat_mod216/data/tax_code_map_mod216_data.xml
@@ -14,7 +14,7 @@
         <field name="field_type">base</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="True"/>
-        <field name="tax_ids" eval="[(6, False, [ref('l10n_es_irnr.account_tax_template_p_irpfnrnue24p'),ref('l10n_es_irnr.account_tax_template_p_irpfnrue19p')])]"/>
+        <field name="tax_ids" eval="[(6, False, [ref('l10n_es_irnr.account_tax_template_p_irpfnrnue24p'),ref('l10n_es_irnr.account_tax_template_p_irpfnrue19p'),ref('l10n_es_irnr.account_tax_template_p_irpfnrnue0p'),ref('l10n_es_irnr.account_tax_template_p_irpfnrue0p')])]"/>
     </record>
 
     <record id="aeat_mod216_map_line_03" model="l10n.es.aeat.map.tax.line">
@@ -24,7 +24,7 @@
         <field name="field_type">amount</field>
         <field name="sum_type">both</field>
         <field name="inverse" eval="False"/>
-        <field name="tax_ids" eval="[(6, False, [ref('l10n_es_irnr.account_tax_template_p_irpfnrnue24p'),ref('l10n_es_irnr.account_tax_template_p_irpfnrue19p')])]"/>
+        <field name="tax_ids" eval="[(6, False, [ref('l10n_es_irnr.account_tax_template_p_irpfnrnue24p'),ref('l10n_es_irnr.account_tax_template_p_irpfnrue19p'),ref('l10n_es_irnr.account_tax_template_p_irpfnrnue0p'),ref('l10n_es_irnr.account_tax_template_p_irpfnrue0p')])]"/>
     </record>
 
 </odoo>

--- a/l10n_es_aeat_mod216/tests/test_l10n_es_aeat_mod216.py
+++ b/l10n_es_aeat_mod216/tests/test_l10n_es_aeat_mod216.py
@@ -17,12 +17,13 @@ class TestL10nEsAeatMod216Base(TestL10nEsAeatModBase):
         # tax code: (base, tax_amount)
         'l10n_es_irnr.account_tax_template_p_irpfnrnue24p': (1000, 240),
         'l10n_es_irnr.account_tax_template_p_irpfnrue19p': (2000, 380),
+        'l10n_es_irnr.account_tax_template_p_irpfnrnue0p': (3000, 0),
     }
     taxes_result = {
         # Rendimientos del trabajo (dinerarios) - Base
-        '2': 6000,
+        '2': 12000,
         # Rendimientos del trabajo (dinerarios) - Retenciones
-        '3': 1240,  # (2 * 240) + (2 * 380)
+        '3': 1240,  # (2 * 240) + (2 * 380) + (2 * 0)
     }
 
     def test_model_216(self):

--- a/l10n_es_irnr/__manifest__.py
+++ b/l10n_es_irnr/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Retenciones IRNR (No residentes)",
-    'version': '12.0.2.2.0',
+    'version': '12.0.2.3.0',
     'category': 'Localization',
     'depends': [
         'l10n_es',

--- a/l10n_es_irnr/data/fiscal_position_taxes_irnr.xml
+++ b/l10n_es_irnr/data/fiscal_position_taxes_irnr.xml
@@ -309,4 +309,310 @@
     <field name="tax_dest_id" ref="account_tax_template_p_irpfnrue19p"/>
 </record>
 
+<!-- Retención IRPF No residentes UE exento -->
+
+<record id="fptt_fp_irpfnrue0sale_21b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21b"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva21b"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_21b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21b"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrue0"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_21isp" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21isp"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva21isp"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_21isp_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21isp"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrue0"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_21s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21s"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva21s"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_21s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21s"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrue0"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_10b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva10b"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva10b"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_10b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva10b"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrue0"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_10s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva10s"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva10s"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_10s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva10s"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrue0"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_4b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva4b"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva4b"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_4b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva4b"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrue0"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_4s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva4s"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva4s"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_4s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva4s"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrue0"/>
+</record>
+<record id="fptt_fp_irpfnrue0_21b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva21_bc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva21_bc"/>
+</record>
+<record id="fptt_fp_irpfnrue0_21b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva21_bc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrue0p"/>
+</record>
+<record id="fptt_fp_irpfnrue0_21s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva21_sc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva21_sc"/>
+</record>
+<record id="fptt_fp_irpfnrue0_21s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva21_sc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrue0p"/>
+</record>
+<record id="fptt_fp_irpfnrue0_10b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva10_bc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva10_bc"/>
+</record>
+<record id="fptt_fp_irpfnrue0_10b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva10_bc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrue0p"/>
+</record>
+<record id="fptt_fp_irpfnrue0_10s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva10_sc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva10_sc"/>
+</record>
+<record id="fptt_fp_irpfnrue0_10s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva10_sc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrue0p"/>
+</record>
+<record id="fptt_fp_irpfnrue0_4b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_bc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva4_bc"/>
+</record>
+<record id="fptt_fp_irpfnrue0_4b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_bc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrue0p"/>
+</record>
+<record id="fptt_fp_irpfnrue0_4s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_sc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva4_sc"/>
+</record>
+<record id="fptt_fp_irpfnrue0_4s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_sc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrue0p"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_ex" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva0"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva0"/>
+</record>
+<record id="fptt_fp_irpfnrue0sale_ex_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva0"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrue0"/>
+</record>
+<record id="fptt_fp_irpfnrue0_0" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva0_bc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva0_bc"/>
+</record>
+<record id="fptt_fp_irpfnrue0_0_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva0_bc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrue0p"/>
+</record>
+
+<!-- Retención IRPF No residentes no-UE exento -->
+
+<record id="fptt_fp_irpfnrue0sale_21b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21b"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva21b"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_21b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21b"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrnue0"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_21isp" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21isp"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva21isp"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_21isp_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21isp"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrnue0"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_21s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21s"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva21s"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_21s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva21s"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrnue0"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_10b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva10b"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva10b"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_10b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva10b"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrnue0"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_10s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva10s"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva10s"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_10s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva10s"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrnue0"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_4b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva4b"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva4b"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_4b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva4b"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrnue0"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_4s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva4s"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva4s"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_4s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva4s"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrnue0"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_21b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva21_bc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva21_bc"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_21b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva21_bc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrnue0p"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_21s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva21_sc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva21_sc"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_21s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva21_sc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrnue0p"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_10b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva10_bc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva10_bc"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_10b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva10_bc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrnue0p"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_10s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva10_sc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva10_sc"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_10s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva10_sc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrnue0p"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_4b" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_bc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva4_bc"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_4b_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_bc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrnue0p"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_4s" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_sc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva4_sc"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_4s_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva4_sc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrnue0p"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_ex" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva0"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_iva0"/>
+</record>
+<record id="fptt_fp_irpfnrnue0sale_ex_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_s_iva0"/>
+    <field name="tax_dest_id" ref="account_tax_template_s_irpfnrnue0"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_0" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva0_bc"/>
+    <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_iva0_bc"/>
+</record>
+<record id="fptt_fp_irpfnrnue0_0_2" model="account.fiscal.position.tax.template">
+    <field name="position_id" ref="fp_irpfnrnue0"/>
+    <field name="tax_src_id" ref="l10n_es.account_tax_template_p_iva0_bc"/>
+    <field name="tax_dest_id" ref="account_tax_template_p_irpfnrnue0p"/>
+</record>
+
 </odoo>

--- a/l10n_es_irnr/data/fiscal_positions_irnr.xml
+++ b/l10n_es_irnr/data/fiscal_positions_irnr.xml
@@ -13,4 +13,14 @@
     <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
 </record>
 
+<record id="fp_irpfnrue0" model="account.fiscal.position.template">
+    <field name="name">Retención IRPF No residentes UE exento por convenio</field>
+    <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+</record>
+
+<record id="fp_irpfnrnue0" model="account.fiscal.position.template">
+    <field name="name">Retención IRPF No residentes no-UE exento por convenio</field>
+    <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+</record>
+
 </odoo>

--- a/l10n_es_irnr/data/taxes_irnr.xml
+++ b/l10n_es_irnr/data/taxes_irnr.xml
@@ -34,6 +34,32 @@
     <field name="tax_group_id" ref="tax_group_irnr_no_ue"/>
 </record>
 
+<!-- Retenciones IRPF No residentes no-UE Exento -->
+
+<record id="account_tax_template_s_irpfnrnue0" model="account.tax.template">
+    <field name="description">IRPF no-UE exento</field>
+    <field name="type_tax_use">sale</field>
+    <field name="account_id" ref="l10n_es.account_common_473"/>
+    <field name="name">Retenciones a cuenta IRPF No residentes no-UE exento por convenio</field>
+    <field name="refund_account_id" ref="l10n_es.account_common_473"/>
+    <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+    <field name="amount" eval="0"/>
+    <field name="tax_group_id" ref="tax_group_irnr_no_ue"/>
+    <field name="amount_type">percent</field>
+</record>
+
+<record id="account_tax_template_p_irpfnrnue0p" model="account.tax.template">
+    <field name="description">IRPF no-UE exento</field>
+    <field name="type_tax_use">purchase</field>
+    <field name="account_id" ref="l10n_es.account_common_4751"/>
+    <field name="name">Retenciones IRPF No residentes no-UE exento por convenio</field>
+    <field name="refund_account_id" ref="l10n_es.account_common_4751"/>
+    <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+    <field name="amount" eval="0"/>
+    <field name="amount_type">percent</field>
+    <field name="tax_group_id" ref="tax_group_irnr_no_ue"/>
+</record>
+
 <!-- Retenciones IRPF No residentes UE 19% -->
 
 
@@ -61,6 +87,31 @@
     <field name="refund_account_id" ref="l10n_es.account_common_4751"/>
     <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
     <field name="amount" eval="-19"/>
+    <field name="tax_group_id" ref="tax_group_irnr_ue"/>
+    <field name="amount_type">percent</field>
+</record>
+
+<!-- Retenciones IRPF No residentes no-UE Exento -->
+<record id="account_tax_template_s_irpfnrue0" model="account.tax.template">
+    <field name="description">IRPF UE exento</field>
+    <field name="type_tax_use">sale</field>
+    <field name="account_id" ref="l10n_es.account_common_473"/>
+    <field name="name">Retenciones a cuenta IRPF No residentes UE exento por convenio</field>
+    <field name="refund_account_id" ref="l10n_es.account_common_473"/>
+    <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+    <field name="amount" eval="0"/>
+    <field name="tax_group_id" ref="tax_group_irnr_ue"/>
+    <field name="amount_type">percent</field>
+</record>
+
+<record id="account_tax_template_p_irpfnrue0p" model="account.tax.template">
+    <field name="description">IRPF UE exento</field>
+    <field name="type_tax_use">purchase</field>
+    <field name="account_id" ref="l10n_es.account_common_4751"/>
+    <field name="name">Retenciones IRPF No residentes UE exento por convenio</field>
+    <field name="refund_account_id" ref="l10n_es.account_common_4751"/>
+    <field name="chart_template_id" ref="l10n_es.account_chart_template_common"/>
+    <field name="amount" eval="0"/>
     <field name="tax_group_id" ref="tax_group_irnr_ue"/>
     <field name="amount_type">percent</field>
 </record>


### PR DESCRIPTION
En el modelo 216 se presentan las retenciones a No Residentes tanto de la UE como de fuera de ella.
 
Actualmente hay uno al 19% para No Residentes de la UE y otro al 24% para los de fuera de UE.

Hay países tanto de la UE como de fuera de ella, que tienen convenios por los cuales están exentos. Y estas bases hay que declararlas en el 216.

Se crea plantillas de impuestos para compras y ventas:
- Retenciones a cuenta IRPF No residentes UE exento por convenio
- Retenciones a cuenta IRPF No residentes no-UE exento por convenio

Se crea nuevas posiciones fiscales:
- Retención IRPF No residentes UE exento por convenio
- Retención IRPF No residentes no-UE exento por convenio

Y modifica el mapeo del modelo 216 para añadir las plantillas de impuestos para su correcto cálculo.