### PR TITLE
[14.0][FIX] l10n_es_dua_ticketbai_batuz: Correción desglose impuestos

### DIFF
--- a/l10n_es_dua_ticketbai_batuz/models/account_move.py
+++ b/l10n_es_dua_ticketbai_batuz/models/account_move.py
@@ -58,6 +58,7 @@ class AccountMove(models.Model):
         dua_fiscal_position_id = self._get_dua_fiscal_position_id(self.company_id)
         if (
             self.move_type == "in_invoice"
+            and dua_fiscal_position_id
             and self.fiscal_position_id.id == dua_fiscal_position_id
             and not self.tbai_dua_invoice
         ):


### PR DESCRIPTION
Corrección que evita que en el "DetalleIVA" se dupliquen los impuestos.

El caso se produce cuando una factura de compra no tiene posición fiscal asociada y la posición fiscal de dua no se encuentras entre las posiciones fiscales de la compañía al no haberse actualizado su plan contable.