### PR TITLE
[15.0][IMP] l10n_es_ticketbai_batuz: LROE modelo 140 implementar grupo de cuenta contable L20 e importe gasto IRPF

### DIFF
--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -478,8 +478,10 @@ class AccountMove(models.Model):
         refund_invoices = self.sudo().filtered(
             lambda x: x.tbai_enabled
             and "out_refund" == x.move_type
-            and not x.tbai_refund_type
-            or x.tbai_refund_type == RefundType.differences.value
+            and (
+                not x.tbai_refund_type
+                or x.tbai_refund_type == RefundType.differences.value
+            )
             and x.tbai_send_invoice
         )
 

--- a/l10n_es_ticketbai_batuz/models/account_move.py
+++ b/l10n_es_ticketbai_batuz/models/account_move.py
@@ -371,6 +371,18 @@ class AccountMove(models.Model):
             )
         return re_tax
 
+    def _get_lroe_concept_group_account(self, tax_line):
+        concepto = ""
+        lines_with_tax = self.line_ids.filtered(
+            lambda l: tax_line["tax"].id in l.tax_ids.ids
+        )
+        if lines_with_tax:
+            for line in lines_with_tax:
+                concepto = line.account_id.group_id.code_prefix_start
+                if concepto:
+                    break
+        return concepto
+
     @api.model
     def _get_lroe_tax_dict(self, tax_line, tax_lines, deductible=True):
         """Get the LROE tax dictionary for the passed tax line.
@@ -400,11 +412,12 @@ class AccountMove(models.Model):
                 ]
             )
         else:
+            concept = self._get_lroe_concept_group_account(tax_line)
             tax_dict = OrderedDict(
                 [
                     ("Epigrafe", self.company_id.main_activity_iae),
                     # TODO: 140 - BienAfectoIRPFYOIVA --> valor por defecto "N"
-                    # TODO: 140 - Concepto --> grupo de cuenta contable L20
+                    ("Concepto", concept),
                     # TODO: 140 - ReferenciaBien
                     ("InversionSujetoPasivo", "N"),
                     # TODO: 140 - OperacionEnRecargoDeEquivalenciaORegimenSimplificado
@@ -412,7 +425,7 @@ class AccountMove(models.Model):
                     ("TipoImpositivo", str(tax_type)),
                     ("CuotaIVASoportada", cuota),
                     ("CuotaIVADeducible", cuota * int(deductible)),
-                    # TODO: 140 - ImporteGastoIRPF
+                    ("ImporteGastoIRPF", base),
                     # TODO: 140 - CriterioCobrosYPagos
                 ]
             )


### PR DESCRIPTION
En las facturas recibidas del LROE 140 para personas físicas hay algunos valores informativos que están pendientes de implementar. Estos valores dentro del apartado “DetalleRentaIVA” son:
 
1. Valor que llaman “Concepto”. En este campo debe ir indicada la raíz de la cuenta contable por la que se origina el gasto a efectos del IRPF. 
2. "ImporteGastoIRP" es el importe del gasto en el IRPF 

Esta imagen muestra el esquema según la documentación de Hacienda de Bizkaia 

![image](https://github.com/OCA/l10n-spain/assets/8178160/1b366233-618f-495a-a224-d0f58cf7b100)

Este PR hace una aproximación seguramente mejorable para implementar la inclusión de estos datos en el LROE 140. 
Hasta ahora no se rellenan y a efectos de IVA toda cuadra, pero a efectos de IRPF no se marca ninguna factura recibida como deducible en IRPF. 

2º Commit [l10n_es_ticketbai]
Al realizar una factura rectificativa de proveedor se está enviando una factura emitida Ticketbai.
Este error solo afecta a la v15.0