### PR TITLE
[14.0][FIX] l10n_es_ticketbai_batuz: Corrección mapeo impuestos

### DIFF
--- a/l10n_es_ticketbai_batuz/data/tbai_tax_map_data.xml
+++ b/l10n_es_ticketbai_batuz/data/tbai_tax_map_data.xml
@@ -21,6 +21,7 @@
             ref('l10n_es.account_tax_template_p_iva0_ns'),
             ref('l10n_es.account_tax_template_p_iva0_ns_b'),
             ref('l10n_es.account_tax_template_p_iva5_sc'),
+            ref('l10n_es.account_tax_template_p_iva0_isc'),
         ])]"
         />
         <field name="name">Facturas Recibidas Servicios</field>
@@ -42,6 +43,7 @@
             ref('l10n_es.account_tax_template_p_iva21_ibc'),
             ref('l10n_es.account_tax_template_p_iva10_ibc'),
             ref('l10n_es.account_tax_template_p_iva4_ibc'),
+            ref('l10n_es.account_tax_template_p_iva0_ibc'),
         ])]"
         />
         <field name="name">Facturas Recibidas Bienes Corrientes</field>


### PR DESCRIPTION
Se ha añadido al mapeo de Facturas Recibidas Servicios (FRS) el impuesto "IVA 0% Adquisición de servicios extracomunitarios" y al mapeo de Facturas Recibidas Bienes Corrientes (FRBC) el impuesto "IVA 0% Importaciones bienes corrientes"