### PR TITLE
[FIX] l10n_es_ticketbai_batuz: usar el número de identificación si la identificación no es por NIF

### DIFF
--- a/l10n_es_ticketbai_batuz/models/account_move.py
+++ b/l10n_es_ticketbai_batuz/models/account_move.py
@@ -223,7 +223,11 @@ class AccountMove(models.Model):
                 res["NIF"] = vat[2:] if vat.startswith(country_code) else vat
         elif idtype:
             res["IDOtro"] = OrderedDict(
-                [("CodigoPais", country_code), ("IDType", idtype), ("ID", vat)]
+                [
+                    ("CodigoPais", country_code),
+                    ("IDType", idtype),
+                    ("ID", partner.tbai_partner_identification_number or vat),
+                ]
             )
         res[
             "ApellidosNombreRazonSocial"


### PR DESCRIPTION
En caso de opción de identificación distinta de NIF-VAT (02), emplear preferencialmente el número de identificación destinatario TicketBAI