### PR TITLE
[FIX] l10n_es_ticketbai: emplear el commercial_partner_id para recoger los datos de TicketBAI

### DIFF
--- a/l10n_es_ticketbai/models/account_move.py
+++ b/l10n_es_ticketbai/models/account_move.py
@@ -244,7 +244,7 @@ class AccountMove(models.Model):
                     )
 
         self.ensure_one()
-        partner = self.partner_id
+        partner = self.commercial_partner_id
         vals = {
             "invoice_id": self.id,
             "schema": TicketBaiSchema.TicketBai.value,


### PR DESCRIPTION
Entre otros el tipo de identificación y el número de identificación: son campos que NO son commercial_fields, por lo que pueden estar des-coordinados entre la compañía y el contacto de facturación, y el usuario no tiene forma de ver el dato que se envía.