### PR TITLE
[16.0][IMP] l10n_es_sigaus_purchase: Calculate SIGAUS when using write/create methods in purchase.order.line

### DIFF
--- a/l10n_es_sigaus_purchase/models/purchase_order_line.py
+++ b/l10n_es_sigaus_purchase/models/purchase_order_line.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Manuel Regidor <manuel.regidor@sygel.es>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class PurchaseOrderLine(models.Model):
@@ -21,3 +21,38 @@ class PurchaseOrderLine(models.Model):
         res = super()._prepare_account_move_line(move)
         res["is_sigaus"] = self.is_sigaus
         return res
+
+    def recompute_sigaus_from_lines(self):
+        not_sigaus_lines = self.filtered(lambda a: not a.is_sigaus)
+        if not_sigaus_lines:
+            not_sigaus_lines.mapped("order_id").filtered(
+                lambda a: any(
+                    line.product_id.sigaus_has_amount
+                    for line in a.order_line.filtered("product_id")
+                )
+            ).apply_sigaus()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        recompute_sigaus = True
+        if self.env.context.get("avoid_recursion"):
+            recompute_sigaus = False
+        lines = super(
+            PurchaseOrderLine, self.with_context(avoid_recursion=True)
+        ).create(vals_list)
+        if recompute_sigaus:
+            lines.recompute_sigaus_from_lines()
+        return lines
+
+    def write(self, values):
+        recompute_sigaus = True
+        if self.env.context.get("avoid_recursion"):
+            recompute_sigaus = False
+        ret = super(PurchaseOrderLine, self.with_context(avoid_recursion=True)).write(
+            values
+        )
+        if recompute_sigaus and (
+            "product_id" in values or "product_qty" in values or "product_uom" in values
+        ):
+            self.recompute_sigaus_from_lines()
+        return ret


### PR DESCRIPTION
Se detectó a través de los pedidos de compra creados automáticamente a través de pedidos de venta con producto de MTO que la aportación SIGAUS no se calculaba en estos pedidos de compra creados. La razón era que el recálculo no se efectuaba con los métodos write y create de purchase.order.line.

Con este IMP, nos aseguramos de que la aportación SIGAUS se calcula al realizar un write o un create en purchase.order.line. Se controla asimismo que no se calcule desde purchase.order y purchase.order.line en una misma transacción, hecho que generaría errores cuando se intentara realizar cualquier operación sobre una línea SIGAUS que ha sido previamente eliminada a través del recálculo de la aportación.

T-5815