### PR TITLE
[16.0][FIX] l10n_es_sigaus_stock_picking_report_valued: Show sigaus amount in picking lines without taxes

### DIFF
--- a/l10n_es_sigaus_stock_picking_report_valued/report/report_deliveryslip.xml
+++ b/l10n_es_sigaus_stock_picking_report_valued/report/report_deliveryslip.xml
@@ -62,7 +62,7 @@
                 <br /><span
                     style="font-size: 70%; opacity: 0.7;"
                 >Aportación SIGAUS (RD 679/2006): <span
-                        t-field="move_line.sigaus_amount_total"
+                        t-field="move_line.sigaus_amount_subtotal"
                         t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                     /></span>
             </t>


### PR DESCRIPTION
Before this fix, SIGAUS amount in picking lines PDFs was shown with taxes included. In other documents such as sale orders, the amount is shown without taxes, so the same rule should apply to pickings.

T-5943