### PR TITLE
[16.0][FIX] l10n_es_igic: Move accounts 4707,4757 out of common

### DIFF
--- a/l10n_es_igic/data/account.account.template-common-canary.csv
+++ b/l10n_es_igic/data/account.account.template-common-canary.csv
@@ -1,9 +1,7 @@
 id,name,code,account_type,chart_template_id/id,reconcile
-account_common_canary_4707,"Hacienda Pública, deudora por IGIC",4707,asset_current,account_chart_template_common_canary,False
 account_common_canary_47071,"Hacienda Pública, deudora por IGIC régimen transitorio circulante",47071,asset_current,account_chart_template_common_canary,False
 account_common_canary_47072,"Hacienda Pública, deudora por IGIC régimen transitorio inversión",47072,asset_current,account_chart_template_common_canary,False
 account_common_canary_4727,"Hacienda Pública. IGIC Soportado",4727,asset_current,account_chart_template_common_canary,False
-account_common_canary_4757,"Hacienda Pública, acreedora por IGIC",4757,asset_current,account_chart_template_common_canary,False
 account_common_canary_4777,"Hacienda Pública. IGIC Repercutido",4777,liability_current,account_chart_template_common_canary,False
 account_common_canary_6343,"Ajustes negativos en IGIC de circulante",6343,expense,account_chart_template_common_canary,False
 account_common_canary_6344,"Ajustes negativos en IGIC de inversión",6344,expense,account_chart_template_common_canary,False

--- a/l10n_es_igic/data/account.account.template-full-canary.csv
+++ b/l10n_es_igic/data/account.account.template-full-canary.csv
@@ -36,6 +36,8 @@
 "account_full_canary_2553","Activos por derivados financieros, instrumentos de cobertura","2553","asset_fixed","account_chart_template_full_canary","False"
 "account_full_canary_257","Derechos de reembolso derivados de contratos de seguro relativos a retribuciones al personal","257","asset_fixed","account_chart_template_full_canary","False"
 "account_full_canary_466","Remuneraciones mediante sistemas de aportación definida pendientes de pago","466","liability_payable","account_chart_template_full_canary","True"
+"account_full_canary_4707","Hacienda Pública, deudora por IGIC","4707","asset_current","account_chart_template_full_canary","False"
+"account_full_canary_4757","Hacienda Pública, acreedora por IGIC","4757","asset_current","account_chart_template_full_canary","False"
 "account_full_canary_490","Deterioro de valor de créditos por operaciones comerciales","490","liability_current","account_chart_template_full_canary","False"
 "account_full_canary_501","Obligaciones y bonos convertibles a corto plazo","501","liability_current","account_chart_template_full_canary","False"
 "account_full_canary_5091","Obligaciones y bonos convertibles amortizados","5091","liability_current","account_chart_template_full_canary","True"

--- a/l10n_es_igic/data/account.account.template-pymes-canary.csv
+++ b/l10n_es_igic/data/account.account.template-pymes-canary.csv
@@ -18,6 +18,8 @@
 "account_pymes_canary_255","Activos por derivados financieros","255","asset_fixed","account_chart_template_pymes_canary"
 "account_pymes_canary_2935","Deterioro de valor de participaciones a largo plazo en otras partes vinculadas","2935","asset_fixed","account_chart_template_pymes_canary"
 "account_pymes_canary_296","Deterioro de  valor de participaciones en el patrimonio neto a largo plazo","296","asset_fixed","account_chart_template_pymes_canary"
+"account_pymes_canary_4707","Hacienda Pública, deudora por IGIC","4707","asset_current","account_chart_template_pymes_canary",False
+"account_pymes_canary_4757","Hacienda Pública, acreedora por IGIC","4757","asset_current","account_chart_template_pymes_canary",False
 "account_pymes_canary_490","Deterioro de valor de créditos por operaciones comerciales","490","liability_current","account_chart_template_pymes_canary"
 "account_pymes_canary_551","Cuenta corriente con socios y administradores","551","asset_current","account_chart_template_pymes_canary"
 "account_pymes_canary_5935","Deterioro de valor de participaciones a corto plazo en otras partes vinculadas","5935","asset_current","account_chart_template_pymes_canary"


### PR DESCRIPTION
Al elegir el plan "PGCE entidades sin ánimo de lucro 2008 - Islas Canarias" carga dos veces las cuentas 4707,4757