### PR TITLE
[16.0][IMP] l10n_es_aeat_mod303: Return last period

### DIFF
--- a/l10n_es_aeat_mod303/README.rst
+++ b/l10n_es_aeat_mod303/README.rst
@@ -137,7 +137,10 @@ Contributors
 
   * Iván Antón
 
-* Arantxa Sudón (`Moduon <https://www.moduon.team/>`__)
+* `Moduon <https://www.moduon.team/>`__:
+
+  * Arantxa Sudón
+  * Rafael Blasco
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -48,6 +48,14 @@ class L10nEsAeatMod303Report(models.Model):
         states=NON_EDITABLE_ON_DONE,
         help="Registered in the Register of Monthly Return",
     )
+    return_last_period = fields.Boolean(
+        string="Last Period Return",
+        states=NON_EDITABLE_ON_DONE,
+        help="Check if you are submitting the last period return",
+        compute="_compute_return_last_period",
+        store=True,
+        readonly=False,
+    )
     total_devengado = fields.Float(
         string="[27] VAT payable",
         readonly=True,
@@ -358,6 +366,12 @@ class L10nEsAeatMod303Report(models.Model):
             if record.period_type not in ("4T", "12"):
                 record.exonerated_390 = "2"
 
+    @api.depends("period_type")
+    def _compute_return_last_period(self):
+        for record in self:
+            if record.period_type not in ("4T", "12"):
+                record.return_last_period = False
+
     @api.depends("tax_line_ids", "tax_line_ids.amount")
     def _compute_total_devengado(self):
         casillas_devengado = (152, 3, 155, 6, 9, 11, 13, 15, 158, 18, 21, 24, 26)
@@ -448,6 +462,7 @@ class L10nEsAeatMod303Report(models.Model):
         "devolucion_mensual",
         "marca_sepa",
         "use_aeat_account",
+        "return_last_period",
     )
     def _compute_result_type(self):
         for report in self:
@@ -470,8 +485,10 @@ class L10nEsAeatMod303Report(models.Model):
                 if report.devolucion_mensual or report.period_type in ("4T", "12"):
                     if report.use_aeat_account:
                         report.result_type = "V"
-                    else:
+                    elif report.return_last_period:
                         report.result_type = "D" if report.marca_sepa == "1" else "X"
+                    else:
+                        report.result_type = "C"
                 else:
                     report.result_type = "C"
 
@@ -495,7 +512,7 @@ class L10nEsAeatMod303Report(models.Model):
                         - fields.Date.to_date(mod303.date_start)
                     ),
                 )
-                if (
+                if prev_report and (
                     prev_report.remaining_cuota_compensar > 0
                     or prev_report.result_type == "C"
                 ):
@@ -507,7 +524,9 @@ class L10nEsAeatMod303Report(models.Model):
                             ),
                         }
                     )
-            if (
+            if mod303.return_last_period:
+                cuota_compensar = mod303.potential_cuota_compensar
+            elif (
                 float_compare(
                     mod303.resultado_liquidacion,
                     0,

--- a/l10n_es_aeat_mod303/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod303/readme/CONTRIBUTORS.rst
@@ -15,4 +15,7 @@
 
   * Iván Antón
 
-* Arantxa Sudón (`Moduon <https://www.moduon.team/>`__)
+* `Moduon <https://www.moduon.team/>`__:
+
+  * Arantxa Sudón
+  * Rafael Blasco

--- a/l10n_es_aeat_mod303/static/description/index.html
+++ b/l10n_es_aeat_mod303/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -494,13 +495,19 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Iván Antón</li>
 </ul>
 </li>
-<li>Arantxa Sudón (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
+<li><a class="reference external" href="https://www.moduon.team/">Moduon</a>:<ul>
+<li>Arantxa Sudón</li>
+<li>Rafael Blasco</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -34,6 +34,10 @@
             <field name="previous_number" position="after">
                 <field name="devolucion_mensual" />
                 <field
+                    name="return_last_period"
+                    attrs="{'invisible': [('period_type', 'not in', ('4T', '12'))]}"
+                />
+                <field
                     name="exonerated_390"
                     attrs="{'invisible': [('period_type', 'not in', ('4T', '12'))]}"
                 />


### PR DESCRIPTION
En Odoo en el último período del 303 antes no se podía compensar en el último período del año. Con este cambio se incluye un check para que los cálculos se hagan teniendo en cuenta que se solicita la devolución y que por defecto siempre quede a compensar.

Proveniente del PR https://github.com/OCA/l10n-spain/pull/3359 en el que se pide separar este comportamiento.

@pedrobaeza

@moduon MT-4519