### PR TITLE
[16.0][FIX] l10n_es_igic: Sujeto Pasivo, factor -100

### DIFF
--- a/l10n_es_igic/data/account_tax_data.xml
+++ b/l10n_es_igic/data/account_tax_data.xml
@@ -1164,7 +1164,8 @@
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4727'),
                           }),
-                   (0, 0, {'repartition_type': 'tax',
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4777'),
                           }),
@@ -1178,7 +1179,8 @@
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4727'),
                           }),
-                   (0, 0, {'repartition_type': 'tax',
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4777'),
                           }),
@@ -1200,7 +1202,8 @@
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4727'),
                           }),
-                   (0, 0, {'repartition_type': 'tax',
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4777'),
                           }),
@@ -1214,7 +1217,8 @@
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4727'),
                           }),
-                   (0, 0, {'repartition_type': 'tax',
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4777'),
                           }),
@@ -1236,7 +1240,8 @@
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4727'),
                           }),
-                   (0, 0, {'repartition_type': 'tax',
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4777'),
                           }),
@@ -1250,7 +1255,8 @@
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4727'),
                           }),
-                   (0, 0, {'repartition_type': 'tax',
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4777'),
                           }),
@@ -1272,7 +1278,8 @@
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4727'),
                           }),
-                   (0, 0, {'repartition_type': 'tax',
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4777'),
                           }),
@@ -1286,7 +1293,8 @@
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4727'),
                           }),
-                   (0, 0, {'repartition_type': 'tax',
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4777'),
                           }),
@@ -1308,7 +1316,8 @@
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4727'),
                           }),
-                   (0, 0, {'repartition_type': 'tax',
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4777'),
                           }),
@@ -1322,7 +1331,8 @@
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4727'),
                           }),
-                   (0, 0, {'repartition_type': 'tax',
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
                            'account_id':
                            ref('l10n_es_igic.account_common_canary_4777'),
                           }),


### PR DESCRIPTION
Hemos detectado que para los impuestos de Sujeto Pasivo no se había colocado el factor -100 causando que en ambas cuentas el impuesto calculado salga en débito.