### PR TITLE
[16.0][FIX] l10n_es_*: Fix minimum models read permissions for readonly acc…

### DIFF
--- a/l10n_es_aeat_mod190/views/account_invoice_view.xml
+++ b/l10n_es_aeat_mod190/views/account_invoice_view.xml
@@ -11,7 +11,11 @@
                     groups="l10n_es_aeat.group_account_aeat"
                 />
                 <field name="aeat_perception_subkey_id" invisible="1" />
-                <field name="is_aeat_perception_subkey_visible" invisible="1" />
+                <field
+                    name="is_aeat_perception_subkey_visible"
+                    groups="l10n_es_aeat.group_account_aeat"
+                    invisible="1"
+                />
                 <field
                     name="aeat_perception_subkey_id"
                     groups="l10n_es_aeat.group_account_aeat"

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -63,25 +63,33 @@
                         <field name="sii_registration_key_domain" invisible="1" />
                         <field
                             name="sii_registration_key"
+                            groups="account.group_account_invoice"
                             domain="[('type', '=', sii_registration_key_domain)]"
                             attrs="{'required': [('sii_enabled', '=', True)]}"
                             widget="selection"
                         />
                         <field
                             name="sii_registration_key_additional1"
+                            groups="account.group_account_invoice"
                             domain="[('type', '=', sii_registration_key_domain)]"
                             widget="selection"
                         />
                         <field
                             name="sii_registration_key_additional2"
+                            groups="account.group_account_invoice"
                             domain="[('type', '=', sii_registration_key_domain)]"
                             widget="selection"
                         />
-                        <field name="sii_registration_key_code" invisible="1" />
+                        <field
+                            name="sii_registration_key_code"
+                            groups="account.group_account_invoice"
+                            invisible="1"
+                        />
                         <field name="sii_enabled" invisible="1" />
                         <field name="sii_lc_operation" />
                         <field
                             name="sii_property_location"
+                            groups="account.group_account_invoice"
                             attrs="{
                                 'invisible': [
                                     '|',
@@ -96,6 +104,7 @@
                         />
                         <field
                             name="sii_property_cadastrial_code"
+                            groups="account.group_account_invoice"
                             attrs="{
                                 'invisible': [
                                     '|',

--- a/l10n_es_ticketbai/views/account_move_views.xml
+++ b/l10n_es_ticketbai/views/account_move_views.xml
@@ -49,6 +49,7 @@
                     >
                           <group
                             name="tbai_reversed_entry_id"
+                            groups="account.group_account_invoice"
                             attrs="{'invisible': ['|', '|', ('tbai_enabled', '!=', True), ('tbai_refund_origin_ids', '!=', []), ('move_type', '!=', 'out_refund')]}"
                         >
                               <field
@@ -76,6 +77,7 @@
                             name="tbai_refund_origin_invoices_data"
                             string="Origin Invoices Data"
                             cols="4"
+                            groups="account.group_account_invoice"
                             attrs="{'invisible': ['|', '|', ('tbai_enabled', '!=', True), ('reversed_entry_id', '!=', False), ('move_type', '!=', 'out_refund')]}"
                         >
                             <field

--- a/l10n_es_ticketbai_batuz/views/account_move_views.xml
+++ b/l10n_es_ticketbai_batuz/views/account_move_views.xml
@@ -77,6 +77,7 @@
                     <field name="tbai_enabled" invisible="1" />
                     <group
                         name="lroe_refund"
+                        groups="account.group_account_invoice"
                         string="Refund"
                         attrs="{'invisible': ['|', '|', ('tbai_enabled', '!=', True), ('tbai_refund_origin_ids', '!=', []), ('move_type', '!=', 'in_refund')]}"
                     >
@@ -108,6 +109,7 @@
                         name="tbai_refund_origin_invoices_data"
                         string="Origin Invoices Data"
                         cols="4"
+                        groups="account.group_account_invoice"
                         attrs="{'invisible': ['|', '|', ('tbai_enabled', '!=', True), ('reversed_entry_id', '!=', False), ('move_type', '!=', 'in_refund')]}"
                     >
                             <field


### PR DESCRIPTION
…ounting group

El usuario con el permiso `Mostrar funciones de contabilidad: solo lectura` no puede acceder a las facturas porque hay unos registros sobre los que no tiene acceso de lectura.

Se agregan los permisos que faltan, para que el usuario con estos permisos pueda acceder a las facturas sin problema.