### PR TITLE
[17.0][FIX] l10n_es_aeat_mod347: compañia incorrecta en plantilla de correo.

### DIFF
--- a/l10n_es_aeat_mod347/__manifest__.py
+++ b/l10n_es_aeat_mod347/__manifest__.py
@@ -10,7 +10,7 @@
 
 {
     "name": "AEAT modelo 347",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "author": "Tecnativa,PESOL,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "category": "Accounting",

--- a/l10n_es_aeat_mod347/data/mail_template_data.xml
+++ b/l10n_es_aeat_mod347/data/mail_template_data.xml
@@ -7,7 +7,7 @@
         >{{(user.email and '&quot;%s&quot; &lt;%s&gt;' % (user.name, user.email) or '')}}</field>
         <field
             name="subject"
-        >Comprobación datos de modelo 347 año {{object.report_id.year}} de {{user.company_id.name}}</field>
+        >Comprobación datos de modelo 347 año {{object.report_id.year}} de {{object.report_id.company_id.name}}</field>
         <field
             name="partner_to"
         >{{object.partner_id.address_get(['invoice'])['invoice']}}</field>

--- a/l10n_es_aeat_mod347/migrations/17.0.1.0.1/post-migration.py
+++ b/l10n_es_aeat_mod347/migrations/17.0.1.0.1/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Ángel García de la Chica Herrera <angel.garcia@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    template = env.ref("l10n_es_aeat_mod347.email_template_347")
+    for lang_code, _ in env["res.lang"].get_installed():
+        translated_subject = template.with_context(lang=lang_code).subject
+        new_subject = translated_subject.replace(
+            "{{user.company_id.name}}", "{{object.report_id.company_id.name}}"
+        )
+        template.with_context(lang=lang_code).write({"subject": new_subject})

--- a/l10n_es_aeat_mod347/static/description/index.html
+++ b/l10n_es_aeat_mod347/static/description/index.html
@@ -369,45 +369,48 @@ ul.auto-toc {
 !! source digest: sha256:5ccb38d25f4d418ebfc6b5862473c1a7a2c8f2891e31965c0403a6d9e0bc625c
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/l10n-spain/tree/17.0/l10n_es_aeat_mod347"><img alt="OCA/l10n-spain" src="https://img.shields.io/badge/github-OCA%2Fl10n--spain-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/l10n-spain-17-0/l10n-spain-17-0-l10n_es_aeat_mod347"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/l10n-spain&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>(Declaración Anual de Operaciones con Terceros)
-Basado en la Orden EHA/3012/2008, de 20 de Octubre, por el que se aprueban los
-diseños físicos y lógicos del 347.</p>
+<p>(Declaración Anual de Operaciones con Terceros) Basado en la Orden
+EHA/3012/2008, de 20 de Octubre, por el que se aprueban los diseños
+físicos y lógicos del 347.</p>
 <p>De acuerdo con la normativa de la Hacienda Española, están obligados a
 presentar el modelo 347:</p>
 <ul class="simple">
-<li>Todas aquellas personas físicas o jurídicas que no esten acogidas al régimen
-de módulos en el IRPF, de naturaleza pública o privada que desarrollen
-actividades empresariales o profesionales, siempre y cuando hayan realizado
-operaciones que, en su conjunto, respecto de otra persona o Entidad,
-cualquiera que sea su naturaleza o carácter, hayan superado la cifra de
-3.005,06 € durante el año natural al que se refiere la declaración. Para el
-cálculo de la cifra de 3.005,06 € se computan de forma separada las entregas
-de biene y servicios y las adquisiciones de los mismos.</li>
-<li>En el caso de Sociedades Irregulares, Sociedades Civiles y Comunidad de
-Bienes no acogidas el regimen de módulos en el IRPF, deben incluir las
-facturas sin incluir la cuantía del IRPF.</li>
-<li>En el caso de facturas de proveedor con IRPF, no deben ser presentadas en
-este modelo. Se presentan en el modelo 190. Desactivar en la ficha del
-proveedor la opción de “Incluir en el informe 347”.</li>
+<li>Todas aquellas personas físicas o jurídicas que no esten acogidas al
+régimen de módulos en el IRPF, de naturaleza pública o privada que
+desarrollen actividades empresariales o profesionales, siempre y
+cuando hayan realizado operaciones que, en su conjunto, respecto de
+otra persona o Entidad, cualquiera que sea su naturaleza o carácter,
+hayan superado la cifra de 3.005,06 € durante el año natural al que
+se refiere la declaración. Para el cálculo de la cifra de 3.005,06 €
+se computan de forma separada las entregas de biene y servicios y las
+adquisiciones de los mismos.</li>
+<li>En el caso de Sociedades Irregulares, Sociedades Civiles y Comunidad
+de Bienes no acogidas el regimen de módulos en el IRPF, deben incluir
+las facturas sin incluir la cuantía del IRPF.</li>
+<li>En el caso de facturas de proveedor con IRPF, no deben ser
+presentadas en este modelo. Se presentan en el modelo 190. Desactivar
+en la ficha del proveedor la opción de “Incluir en el informe 347”.</li>
 </ul>
-<p>De acuerdo con la normativa, no están obligados a presentar el modelo 347:</p>
+<p>De acuerdo con la normativa, no están obligados a presentar el modelo
+347:</p>
 <ul class="simple">
-<li>Quienes realicen en España actividades empresariales o profesionales sin
-tener en territorio español la sede de su actividad, un establecimiento
-permanente o su domicilio fiscal.</li>
-<li>Las personas físicas y entidades en régimen de atribución de rentas en
-el IRPF, por las actividades que tributen en dicho impuesto por el
+<li>Quienes realicen en España actividades empresariales o profesionales
+sin tener en territorio español la sede de su actividad, un
+establecimiento permanente o su domicilio fiscal.</li>
+<li>Las personas físicas y entidades en régimen de atribución de rentas
+en el IRPF, por las actividades que tributen en dicho impuesto por el
 régimen de estimación objetiva y, simultáneamente, en el IVA por los
-régimenes especiales simplificados o de la agricultura, ganadería
-y pesca o recargo de equivalencia, salvo las operaciones que estén
+régimenes especiales simplificados o de la agricultura, ganadería y
+pesca o recargo de equivalencia, salvo las operaciones que estén
 excluidas de la aplicación de los expresados regímenes.</li>
-<li>Los obligados tributarios que no hayan realizado operaciones que en su
-conjunto superen la cifra de 3.005,06 €.</li>
-<li>Los obligados tributarios que hayan realizado exclusivamente operaciones
-no declarables.</li>
+<li>Los obligados tributarios que no hayan realizado operaciones que en
+su conjunto superen la cifra de 3.005,06 €.</li>
+<li>Los obligados tributarios que hayan realizado exclusivamente
+operaciones no declarables.</li>
 <li>Los obligados tributarios que deban informar sobre las operaciones
-incluidas en los libros registro de IVA (modelo 340) salvo que realicen
-operaciones que expresamente deban incluirse en el modelo 347.</li>
+incluidas en los libros registro de IVA (modelo 340) salvo que
+realicen operaciones que expresamente deban incluirse en el modelo
+347.</li>
 </ul>
 <p>(<a class="reference external" href="http://www.boe.es/boe/dias/2008/10/23/pdfs/A42154-42190.pdf">http://www.boe.es/boe/dias/2008/10/23/pdfs/A42154-42190.pdf</a>)</p>
 <p><strong>Table of contents</strong></p>
@@ -439,60 +442,66 @@ disponible en:</p>
 <li>Pulse en el botón “Crear”.</li>
 <li>Seleccione el año para la declaración.</li>
 <li>Pulse en “Calcular”.</li>
-<li>Al cabo de un rato (dependerá de la cantidad de registros que tenga),
-aparecerá una nueva pestaña “Registros de empresas”, en la que se podrán
-revisar cada uno de los registros detectados.</li>
-<li>Si la línea del registro aparece en rojo, significa que falta algún dato
-que debe ser rellenado para poder realizar la declaración en la AEAT.</li>
-<li>Puede enviar masivamente los datos de todos los registros al primer contacto
-de facturación que esté establecido en la empresa pulsando el botón
-“Enviar correos electrónicos”. Esto realizará el envío masivo, dejando el
-mensaje enviado en el hilo de comunicación (chatter) de cada registro.
-En ese momento, todos los registros pasarán a estado “Enviado”</li>
-<li>Puede acceder a los detalles del registro y ver el hilo de comunicación
-pulsando sobre el smart-button “Registros” que aparece en la parte superior
-derecha de la pestaña “Registros de empresa”.</li>
-<li>También se pueden realizar envíos aislados de cada registro si todavía no
-está en estado “Enviado” (o pulsando previamente en el botón “Establecer a
-pendiente” de la vista de detalle), pulsando sobre el botón “Enviar” de la
-vista de detalle, o en el icono del sobre en la vista de listado.</li>
-<li>Puede registrar a mano la conformidad o disconformidad del registro pulsando
-sobre los botones del check de verificación o de la X en la vista de
-listado, o bien sobre los botones “Confirmar como válido” o
+<li>Al cabo de un rato (dependerá de la cantidad de registros que
+tenga), aparecerá una nueva pestaña “Registros de empresas”, en la
+que se podrán revisar cada uno de los registros detectados.</li>
+<li>Si la línea del registro aparece en rojo, significa que falta algún
+dato que debe ser rellenado para poder realizar la declaración en la
+AEAT.</li>
+<li>Puede enviar masivamente los datos de todos los registros al primer
+contacto de facturación que esté establecido en la empresa pulsando
+el botón “Enviar correos electrónicos”. Esto realizará el envío
+masivo, dejando el mensaje enviado en el hilo de comunicación
+(chatter) de cada registro. En ese momento, todos los registros
+pasarán a estado “Enviado”</li>
+<li>Puede acceder a los detalles del registro y ver el hilo de
+comunicación pulsando sobre el smart-button “Registros” que aparece
+en la parte superior derecha de la pestaña “Registros de empresa”.</li>
+<li>También se pueden realizar envíos aislados de cada registro si
+todavía no está en estado “Enviado” (o pulsando previamente en el
+botón “Establecer a pendiente” de la vista de detalle), pulsando
+sobre el botón “Enviar” de la vista de detalle, o en el icono del
+sobre en la vista de listado.</li>
+<li>Puede registrar a mano la conformidad o disconformidad del registro
+pulsando sobre los botones del check de verificación o de la X en la
+vista de listado, o bien sobre los botones “Confirmar como válido” o
 “Establecer a no válido” de la vista de detalle del registro.</li>
-<li>Cuando establezca como válido el registro, la línea aparecerá en un gris
-atenuado, y si por el contrario lo establece como no válido, aparecerá en
-un marrón claro.</li>
-<li>En la plantilla del correo enviado a las empresas, se incluyen 2 botones
-que permiten la aceptación/rechazo automático del registro. <strong>NOTA:</strong> Para
-poder realizarlo, su Odoo debe ser accesible al exterior y tener bien
-configurados URL, redirecciones, proxy, etc. Cuando la empresa externa pulse
-en uno de esos botones, se realizará la validación/rechazo en el registro.</li>
-<li>La empresa externa también puede responder al correo recibido, y entonces
-la respuesta se colocará en el hilo de ese registro y notificará a los
-seguidores que estén del mismo. Por defecto, el único seguidor que se
-añade es el usuario que ha realizado la declaración. <strong>NOTA:</strong> Para que
-esto funcione, debe tener bien configurado todos los parámetros relativos
-a catchall, correo entrante, etc.</li>
+<li>Cuando establezca como válido el registro, la línea aparecerá en un
+gris atenuado, y si por el contrario lo establece como no válido,
+aparecerá en un marrón claro.</li>
+<li>En la plantilla del correo enviado a las empresas, se incluyen 2
+botones que permiten la aceptación/rechazo automático del registro.
+<strong>NOTA:</strong> Para poder realizarlo, su Odoo debe ser accesible al
+exterior y tener bien configurados URL, redirecciones, proxy, etc.
+Cuando la empresa externa pulse en uno de esos botones, se realizará
+la validación/rechazo en el registro.</li>
+<li>La empresa externa también puede responder al correo recibido, y
+entonces la respuesta se colocará en el hilo de ese registro y
+notificará a los seguidores que estén del mismo. Por defecto, el
+único seguidor que se añade es el usuario que ha realizado la
+declaración. <strong>NOTA:</strong> Para que esto funcione, debe tener bien
+configurado todos los parámetros relativos a catchall, correo
+entrante, etc.</li>
 <li>También puede introducir manualmente los registros de inmuebles para
 aquellos que no estén reflejados en el modelo 115.</li>
 <li>Una vez cotejados todos los registros, se puede pulsar en el botón
-“Confirmar” para confirmar la declaración y dejar los datos ya fijos.</li>
-<li>Pulsando en el botón “Exportar a BOE”, podrá obtener un archivo para su
-subida en la web de la AEAT.</li>
+“Confirmar” para confirmar la declaración y dejar los datos ya
+fijos.</li>
+<li>Pulsando en el botón “Exportar a BOE”, podrá obtener un archivo para
+su subida en la web de la AEAT.</li>
 </ol>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
 <ul class="simple">
-<li>Permitir que un asiento (y por tanto, una factura) puede tener una fecha
-específica a efectos del modelo 347, para así cuadrar la fecha del proveedor
-con nuestro modelo aunque a efectos de IVA se declare en el siguiente
-periodo.</li>
-<li>Permitir indicar que una factura es de transmisión de inmuebles para tenerlo
-en cuenta en la suma de totales.</li>
-<li>No se incluye el cálculo automático de las claves de declaración
-C, D, E, F y G.</li>
+<li>Permitir que un asiento (y por tanto, una factura) puede tener una
+fecha específica a efectos del modelo 347, para así cuadrar la fecha
+del proveedor con nuestro modelo aunque a efectos de IVA se declare
+en el siguiente periodo.</li>
+<li>Permitir indicar que una factura es de transmisión de inmuebles para
+tenerlo en cuenta en la suma de totales.</li>
+<li>No se incluye el cálculo automático de las claves de declaración C,
+D, E, F y G.</li>
 <li>Realizar declaración solo de proveedores.</li>
 <li>No se permite marcar las operaciones como de seguro (para entidades
 aseguradoras).</li>
@@ -500,12 +509,12 @@ aseguradoras).</li>
 <li>No se incluye la gestión del criterio de caja.</li>
 <li>No se incluye la gestión de inversión de sujeto pasivo.</li>
 <li>No se incluye la gestión de depósito aduanero.</li>
-<li>No se rellena el año origen en caso de no coincidir con el actual para las
-operaciones de efectivo.</li>
+<li>No se rellena el año origen en caso de no coincidir con el actual
+para las operaciones de efectivo.</li>
 <li>Las operaciones con retención o arrendamientos aparecen en el 347 por
 defecto al tener también IVA asociado. Si no se quiere que aparezcan,
-hay que marcar la empresa o la factura con la casilla de no incluir en el
-347.</li>
+hay que marcar la empresa o la factura con la casilla de no incluir
+en el 347.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">


### PR DESCRIPTION
El asunto de la plantilla del mensaje muestra el nombre de la compañía que tiene por defecto el usuario que envía el mensaje y no la compañía del informe que se está enviando.

Viene del PR https://github.com/OCA/l10n-spain/pull/3433 en v14


[I-5612]