### PR TITLE
16.0 fix l10n es aeat remove cryptograph dependency

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -23,7 +23,7 @@
     "development_status": "Mature",
     "depends": ["l10n_es", "account_tax_balance"],
     # odoo_test_helper is needed for the tests
-    "external_dependencies": {"python": ["unidecode", "cryptography==3.4.8"]},
+    "external_dependencies": {"python": ["unidecode"]},
     "data": [
         "security/aeat_security.xml",
         "security/ir.model.access.csv",

--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -23,7 +23,7 @@
     "development_status": "Mature",
     "depends": ["l10n_es", "account_tax_balance"],
     # odoo_test_helper is needed for the tests
-    "external_dependencies": {"python": ["unidecode"]},
+    "external_dependencies": {"python": ["unidecode", "cryptography==3.4.8"]},
     "data": [
         "security/aeat_security.xml",
         "security/ir.model.access.csv",


### PR DESCRIPTION
Paso el PR para quitar la dependencia python si no hay ningún inconveniente. 

Estoy de acuerdo con etobella en el issues https://github.com/OCA/l10n-spain/issues/3551, hemos tenido el mismo problema. En cambio, agregando la librería en una versión más reciente funciona correctamente. Viendo las explicaciones, no encuentro razones suficientes para mantener la librería en el __manifest __de un módulo tan importante como es el l10n_es_aeat. 