### PR TITLE
[16.0][IMP] Agencia tributaria en los cálculos del modelo 111 y 190

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
@@ -121,6 +121,7 @@ class L10nEsAeatReportTaxMapping(models.AbstractModel):
             move_line_domain.append(("debit", ">", 0))
         elif map_line.sum_type == "credit":
             move_line_domain.append(("credit", ">", 0))
+        move_line_domain += self._get_partner_domain()
         if map_line.exigible_type == "yes":
             move_line_domain.extend(
                 (
@@ -139,7 +140,6 @@ class L10nEsAeatReportTaxMapping(models.AbstractModel):
                     ("tax_ids.tax_exigibility", "=", "on_payment"),
                 )
             )
-        move_line_domain += self._get_partner_domain()
         return move_line_domain
 
     def _get_tax_lines(self, date_start, date_end, map_line):

--- a/l10n_es_aeat/models/res_company.py
+++ b/l10n_es_aeat/models/res_company.py
@@ -12,7 +12,12 @@ _logger = logging.getLogger(__name__)
 class ResCompany(models.Model):
     _inherit = "res.company"
 
-    tax_agency_id = fields.Many2one("aeat.tax.agency", string="Tax Agency")
+    tax_agency_id = fields.Many2one(
+        "aeat.tax.agency",
+        string="Tax Agency",
+        related="partner_id.tax_agency_id",
+        readonly=False,
+    )
     representative_vat = fields.Char(
         string="L.R. VAT number",
         size=9,

--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -29,6 +29,7 @@ class ResPartner(models.Model):
             ("06", "Another document"),
         ],
     )
+    tax_agency_id = fields.Many2one("aeat.tax.agency", string="Tax Agency")
     aeat_identification = fields.Char(help="Identification for AEAT purposes")
     # There are other options (but these options are managed automatically
     #   on _parse_aeat_vat_info):

--- a/l10n_es_aeat/views/res_partner_view.xml
+++ b/l10n_es_aeat/views/res_partner_view.xml
@@ -13,6 +13,7 @@
                             name="aeat_identification"
                             attrs="{'required': [('aeat_identification_type', '!=', False)], 'invisible': [('aeat_identification_type', '=', False)]}"
                         />
+                        <field name="tax_agency_id" />
                     </group>
                 </page>
             </notebook>

--- a/l10n_es_aeat_mod111/models/mod111.py
+++ b/l10n_es_aeat_mod111/models/mod111.py
@@ -378,3 +378,12 @@ class L10nEsAeatMod111Report(models.Model):
     def _compute_casilla_30(self):
         for report in self:
             report.casilla_30 = report.casilla_28 - report.casilla_29
+
+    def _get_partner_domain(self):
+        domain = super()._get_partner_domain()
+        for report in self:
+            if report.tax_agency_ids:
+                domain.extend(
+                    [("partner_id.tax_agency_id", "in", report.tax_agency_ids.ids)]
+                )
+        return domain

--- a/l10n_es_aeat_mod111/views/mod111_view.xml
+++ b/l10n_es_aeat_mod111/views/mod111_view.xml
@@ -25,6 +25,7 @@
         <field name="arch" type="xml">
             <field name="previous_number" position="after">
                 <field name="tipo_declaracion" />
+                <field name="tax_agency_ids" widget="many2many_tags" />
                 <field name="colegio_concertado" />
             </field>
             <group name="group_declaration" position="after">

--- a/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
+++ b/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
@@ -71,6 +71,15 @@ class L10nEsAeatMod190Report(models.Model):
         self._check_report_lines()
         return super().button_confirm()
 
+    def _get_partner_domain(self):
+        domain = super()._get_partner_domain()
+        for report in self:
+            if report.tax_agency_ids:
+                domain.extend(
+                    [("partner_id.tax_agency_id", "in", report.tax_agency_ids.ids)]
+                )
+        return domain
+
     # flake8: noqa: C901
     def calculate(self):
         res = super().calculate()

--- a/l10n_es_aeat_mod190/views/mod190_view.xml
+++ b/l10n_es_aeat_mod190/views/mod190_view.xml
@@ -20,6 +20,9 @@
         <field name="model">l10n.es.aeat.mod190.report</field>
         <field name="inherit_id" ref="l10n_es_aeat.view_l10n_es_aeat_report_form" />
         <field name="arch" type="xml">
+            <field name="previous_number" position="after">
+                <field name="tax_agency_ids" widget="many2many_tags" />
+            </field>
             <field name="statement_type" position="after">
                 <field name="calculado" invisible="1" />
                 <field


### PR DESCRIPTION
Hola,

En una empresa que por ejemplo tenga un centro de trabajo en Álava y otro en Madrid, debe presentar dos modelos 111 o dos modelos 190 al estar cada centro de trabajo en una agencia tributaria distinta.