### PR TITLE
[16.0][FIX] Vista form en 123: Atributos states y attrs no funcionan bien juntos

### DIFF
--- a/l10n_es_aeat_mod123/views/mod123_view.xml
+++ b/l10n_es_aeat_mod123/views/mod123_view.xml
@@ -13,8 +13,7 @@
                 <group
                     string="Resultado"
                     colspan="4"
-                    states="calculated,done,cancelled"
-                    attrs="{'invisible': [('year', '&gt;=', 2024)]}"
+                    attrs="{'invisible': ['|', ('state', '=', 'draft'), ('year', '&gt;=', 2024)]}"
                 >
                     <group string="Retenciones e ingresos a cuenta">
                         <field name="casilla_01" />
@@ -64,8 +63,7 @@
                 <group
                     string="Número de rentas"
                     col="3"
-                    states="calculated,done,cancelled"
-                    attrs="{'invisible': [('year', '&lt;', 2024)]}"
+                    attrs="{'invisible': ['|', ('state', '=', 'draft'), ('year', '&lt;', 2024)]}"
                 >
                     <group>
                         <label
@@ -87,8 +85,7 @@
                 <group
                     string="Base de retenciones e ingresos a cuenta"
                     col="3"
-                    states="calculated,done,cancelled"
-                    attrs="{'invisible': [('year', '&lt;', 2024)]}"
+                    attrs="{'invisible': ['|', ('state', '=', 'draft'), ('year', '&lt;', 2024)]}"
                 >
                     <group>
                         <label
@@ -125,8 +122,7 @@
                 <group
                     string="Retenciones e ingresos a cuenta"
                     col="3"
-                    states="calculated,done,cancelled"
-                    attrs="{'invisible': [('year', '&lt;', 2024)]}"
+                    attrs="{'invisible': ['|', ('state', '=', 'draft'), ('year', '&lt;', 2024)]}"
                 >
                     <group>
                         <label
@@ -163,8 +159,7 @@
                 <group
                     string="Periodificación"
                     col="3"
-                    states="calculated,done,cancelled"
-                    attrs="{'invisible': [('year', '&lt;', 2024)]}"
+                    attrs="{'invisible': ['|', ('state', '=', 'draft'), ('year', '&lt;', 2024)]}"
                 >
                     <group />
                     <group>
@@ -185,8 +180,7 @@
                 <group
                     string="Total Liquidación"
                     col="3"
-                    states="calculated,done,cancelled"
-                    attrs="{'invisible': [('year', '&lt;', 2024)]}"
+                    attrs="{'invisible': ['|', ('state', '=', 'draft'), ('year', '&lt;', 2024)]}"
                 >
                     <group />
                     <group />

--- a/l10n_es_aeat_mod390/static/description/index.html
+++ b/l10n_es_aeat_mod390/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -473,7 +474,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Cuando el informe del 123 está en estado procesado, hecho o cancelado se ven los campos previos a la versión 2024 y los del 2024.
Este error es debido a que el attributo states a veces no funciona bien con el atributo attrs.
https://www.odoo.com/documentation/16.0/developer/reference/backend/views.html
![image](https://github.com/OCA/l10n-spain/assets/53056345/d0935886-e6bc-46b9-a33e-d6e93e2158a0)

@rafaelbn @pedrobaeza @HaraldPanten revisad por favor.

@moduon MT-6114