### PR TITLE
[16.0][FIX] l10n_es_aeat_mod123: Casilla 14 en vista lista

### DIFF
--- a/l10n_es_aeat_mod123/models/mod123.py
+++ b/l10n_es_aeat_mod123/models/mod123.py
@@ -171,6 +171,9 @@ class L10nEsAeatMod123Report(models.Model):
         states={"draft": [("readonly", False)]},
         required=True,
     )
+    amount_result = fields.Float(
+        compute="_compute_amount_result", string="Resultado a ingresar"
+    )
 
     @api.depends("casilla_03", "casilla_05")
     def _compute_casilla06(self):
@@ -206,6 +209,14 @@ class L10nEsAeatMod123Report(models.Model):
     def _compute_casilla14_2024(self):
         for report in self:
             report.casilla_14_2024 = report.casilla_12_2024 - report.casilla_13_2024
+
+    @api.depends("casilla_08", "casilla_14_2024", "year")
+    def _compute_amount_result(self):
+        for report in self:
+            if report.year < 2024:
+                report.amount_result = report.casilla_08
+            else:
+                report.amount_result = report.casilla_14_2024
 
     def calculate(self):
         pred = super().calculate()

--- a/l10n_es_aeat_mod123/tests/test_l10n_es_aeat_mod123.py
+++ b/l10n_es_aeat_mod123/tests/test_l10n_es_aeat_mod123.py
@@ -65,6 +65,8 @@ class TestL10nEsAeatMod123(TestL10nEsAeatModBase):
             _logger.debug("Checking tax line: %s" % box)
             lines = model123.tax_line_ids.filtered(lambda x: x.field_number == int(box))
             self.assertAlmostEqual(sum(lines.mapped("amount")), result, 2)
+        self.assertEqual(model123.casilla_08, 627.0)
+        self.assertEqual(model123.amount_result, 627.0)
         export_to_boe = self.env["l10n.es.aeat.report.export_to_boe"].create(
             {"name": "test_export_to_boe.txt"}
         )
@@ -129,10 +131,13 @@ class TestL10nEsAeatMod123(TestL10nEsAeatModBase):
         self.assertEqual(model123.casilla_10_2024, 0)
         self.assertEqual(model123.casilla_12_2024, 627.0)
         self.assertEqual(model123.casilla_14_2024, 627.0)
+        self.assertEqual(model123.amount_result, 627.0)
         model123.casilla_11_2024 = 180
         self.assertEqual(model123.casilla_12_2024, 807.0)
+        self.assertEqual(model123.amount_result, 807.0)
         model123.casilla_13_2024 = 240
         self.assertEqual(model123.casilla_14_2024, 567.0)
+        self.assertEqual(model123.amount_result, 567.0)
         # Export to BOE
         export_to_boe = self.env["l10n.es.aeat.report.export_to_boe"].create(
             {"name": "test_export_to_boe.txt"}

--- a/l10n_es_aeat_mod123/views/mod123_view.xml
+++ b/l10n_es_aeat_mod123/views/mod123_view.xml
@@ -251,7 +251,7 @@
                 <attribute name="string">Declaraciones AEAT 123</attribute>
             </tree>
             <field name="period_type" position="after">
-                <field name="casilla_08" string="Resultado" />
+                <field name="amount_result" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
A partir de 2024 la casilla que se debería mostrar en la vista lista del informe del 123 debería ser la nueva casilla 14.

![image](https://github.com/OCA/l10n-spain/assets/53056345/0bb76294-b05c-43b2-a8f3-ed2cb188d79c)


@rafaelbn @ArantxaSudon @HaraldPanten @pedrobaeza por favor revisar.

@moduon MT-6114