### PR TITLE
[17.0][FIX] l10n_es_account_statement_import_n43: use file_path instead of get_module_resource in tests

### DIFF
--- a/l10n_es_account_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
+++ b/l10n_es_account_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
@@ -4,8 +4,8 @@
 import base64
 
 from odoo import fields
-from odoo.modules.module import get_module_resource
 from odoo.tests import common
+from odoo.tools.misc import file_path
 
 
 class L10nEsAccountStatementImportN43(common.TransactionCase):
@@ -51,9 +51,7 @@ class L10nEsAccountStatementImportN43(common.TransactionCase):
                 "currency_id": eur_currency.id,
             }
         )
-        n43_file_path = get_module_resource(
-            "l10n_es_account_statement_import_n43", "tests", "test.n43"
-        )
+        n43_file_path = file_path("l10n_es_account_statement_import_n43/tests/test.n43")
         n43_file = base64.b64encode(open(n43_file_path, "rb").read())
         cls.import_wizard = (
             cls.env["account.statement.import"]
@@ -62,8 +60,8 @@ class L10nEsAccountStatementImportN43(common.TransactionCase):
         )
 
     def test_import_n43_multi(self):
-        n43_file_path = get_module_resource(
-            "l10n_es_account_statement_import_n43", "tests", "testmulti.n43"
+        n43_file_path = file_path(
+            "l10n_es_account_statement_import_n43/tests/testmulti.n43"
         )
         n43_file = base64.b64encode(open(n43_file_path, "rb").read())
         self.import_wizard.statement_file = n43_file


### PR DESCRIPTION
Before this fix, obselete method get_module_resource was used in tests.

This fix replaces get_module_resource with file_path, which is currently the right method.