### PR TITLE
[12.0][FIX] l10n_es_ticketbai: tomar impuestos exentos de mapeos, no todo el grupo de IVA 0%

### DIFF
--- a/l10n_es_ticketbai/models/account_tax.py
+++ b/l10n_es_ticketbai/models/account_tax.py
@@ -34,7 +34,11 @@ class AccountTax(models.Model):
         return self not in s_iva_ns_taxes
 
     def tbai_is_tax_exempted(self):
-        return self.tax_group_id.id == self.env.ref('l10n_es.tax_group_iva_0').id
+        map_ids = self.env["tbai.tax.map"].search([("code", "in", ["IEE", "SER"])])
+        tax_ids = self.company_id.get_taxes_from_templates(map_ids.mapped("tax_template_ids"))
+        return self in tax_ids
 
     def tbai_is_not_tax_exempted(self):
-        return self.tax_group_id.id != self.env.ref('l10n_es.tax_group_iva_0').id
+        map_ids = self.env["tbai.tax.map"].search([("code", "in", ["IEE", "SER"])])
+        tax_ids = self.company_id.get_taxes_from_templates(map_ids.mapped("tax_template_ids"))
+        return self not in tax_ids


### PR DESCRIPTION
El módulo de TicketBAI considera que todos los impuestos del grupo de impuestos de 0% son exentos, lo que es un error (p.ej. se incluye el ISP). Con el cambio se cogen los impuestos incluidos en los mapeos de exentos, que acaban siendo:
IVA 0% Exportaciones
IVA 0% Entregas Intracomunitarias exentas
IVA Exento Repercutido Sujeto

Es una estrategia distinta a #3354 , porque se da por hecho que la mayoría de los impuestos del Grupo de 0% NO son exentos.