### PR TITLE
[16.0][IMP] l10n_es_atc: Modificar pestaña AEAT en contacto

### DIFF
--- a/l10n_es_atc/__init__.py
+++ b/l10n_es_atc/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_es_atc/models/__init__.py
+++ b/l10n_es_atc/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/l10n_es_atc/models/res_partner.py
+++ b/l10n_es_atc/models/res_partner.py
@@ -1,0 +1,25 @@
+# Copyright 2018 PESOL - Angel Moya <info@pesol.es>
+# Copyright 2019 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from lxml import etree
+
+from odoo import api, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.model
+    def get_view(self, view_id=None, view_type="form", **options):
+        res = super().get_view(view_id=view_id, view_type=view_type, **options)
+        if view_type == "form":
+            doc = etree.XML(res["arch"])
+            aeat_page = doc.xpath("//page[@id='aeat']")
+            if aeat_page:
+                aeat_page = aeat_page[0]
+                aeat_page.attrib["string"] = "%s / ATC" % aeat_page.attrib.get(
+                    "string", ""
+                )
+                res["arch"] = etree.tostring(doc)
+        return res

--- a/l10n_es_atc/static/description/index.html
+++ b/l10n_es_atc/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -408,7 +408,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Se planteó también crear una pestaña nueva, pero teniendo en cuenta que la identificación ya existe en la pestaña de AEAT y es utilizada por la ATC, creo que es mejor renombrar la pestaña a "AEAT / ATC".