### PR TITLE
[16.0][FIX] l10n_es_aeat_mod347: Handle traceback on partner selection

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -742,6 +742,10 @@ class L10nEsAeatMod347RealStateRecord(models.Model):
         """Loads some partner data when the selected partner changes."""
         if self.partner_id:
             vals = self.report_id._get_partner_347_identification(self.partner_id)
+            if not vals.get("partner_vat") or not vals.get("partner_state_code"):
+                raise exceptions.ValidationError(
+                    _("The selected partner doesn't have a VAT or a state code")
+                )
             self.update(
                 {
                     "partner_vat": vals.pop("partner_vat"),


### PR DESCRIPTION
Cuando se selecciona un contacto sin VAT genera un traceback en la sección de Real Estate records:
Traceback (most recent call last):
  File "/opt/odoo/odoo/http.py", line 1638, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/opt/odoo/odoo/http.py", line 1665, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/odoo/http.py", line 1869, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/addons/website/models/ir_http.py", line 237, in _dispatch
    response = super()._dispatch(endpoint)
  File "/opt/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/odoo/http.py", line 700, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 42, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/odoo/models.py", line 6606, in onchange
    record._onchange_eval(name, field_onchange[name], result)
  File "/opt/odoo/odoo/models.py", line 6317, in _onchange_eval
    method_res = method(self)
  File "/mnt/data/odoo-addons-dir/l10n_es_aeat_mod347/models/mod347.py", line 747, in _onchange_partner_id
    "partner_vat": vals.pop("partner_vat"),
KeyError: 'partner_vat'

The above server error caused the following client error:
null