### PR TITLE
[16.0][FIX] l10n_es_aeat_sii_oca: check coming from move

### DIFF
--- a/l10n_es_aeat_sii_oca/wizards/account_move_reversal.py
+++ b/l10n_es_aeat_sii_oca/wizards/account_move_reversal.py
@@ -37,7 +37,7 @@ class AccountMoveReversal(models.TransientModel):
         if (
             "sii_refund_type" in fields_list
             or "sii_refund_type_required" in fields_list
-        ):
+        ) and self.env.context.get("active_model") == "account.move":
             invoices = self.env["account.move"].browse(
                 self.env.context.get("active_ids"),
             )


### PR DESCRIPTION
Some others modules call reversal but active_ids is not an account.move: module OE helpdesk_account (from a helpdesk ticket, we can create a "Refund")