### PR TITLE
[16.0][IMP] delivery_gls_asm: Check value being sent

### DIFF
--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -274,7 +274,8 @@ class DeliveryCarrier(models.Model):
         for picking in pickings:
             if picking.carrier_id.gls_is_pickup_service:
                 continue
-            if len(picking.name) > 15:
+            vals = self._prepare_gls_asm_shipping(picking)
+            if len(vals.get("referencia_c", "")) > 15:
                 raise UserError(
                     _(
                         "GLS-ASM API doesn't admit a reference number higher than "
@@ -285,7 +286,6 @@ class DeliveryCarrier(models.Model):
                         "sequence to a max of 15 characters."
                     )
                 )
-            vals = self._prepare_gls_asm_shipping(picking)
             vals.update({"tracking_number": False, "exact_price": 0})
             response = gls_request._send_shipping(vals)
             self.log_xml(


### PR DESCRIPTION
- Check the actual value that is being sent to GLS, since it doesn't make sense to error for 15 characters when the value you would send doesn't actually exceed that limit

My use case is that we have some clients that deliver a whole `stock.picking.batch` instead of `stock.picking` individually, therefore the reference we use is the batch's name (overwritten through `_prepare_gls_asm_shipping`). This started erroring when the picking reference reached 16 characters while the batch reference is still only 10