### PR TITLE
[14.0][IMP] l10n_es_aeat_sii_invoice_summary: Changes in the visibility and required of the fields

### DIFF
--- a/l10n_es_aeat_sii_invoice_summary/models/account_move.py
+++ b/l10n_es_aeat_sii_invoice_summary/models/account_move.py
@@ -54,3 +54,15 @@ class AccountMove(models.Model):
 
         if self.is_invoice_summary and self.is_purchase_document():
             raise exceptions.UserError(_("You can't make a supplier summary invoice."))
+
+    def write(self, vals):
+        """Cannot let change sii_invoice_summary fields
+        values in a SII registered supplier invoice"""
+        for invoice in self.filtered(
+            lambda x: x.is_invoice_summary and x.sii_state != "not_sent"
+        ):
+            if "sii_invoice_summary_start" in vals:
+                invoice._raise_exception_sii(_("SII Invoice Summary: First Invoice"))
+            if "sii_invoice_summary_end" in vals:
+                invoice._raise_exception_sii(_("SII Invoice Summary: Last Invoice"))
+        return super().write(vals)

--- a/l10n_es_aeat_sii_invoice_summary/tests/test_l10n_es_aeat_sii_invoice_summary.py
+++ b/l10n_es_aeat_sii_invoice_summary/tests/test_l10n_es_aeat_sii_invoice_summary.py
@@ -43,6 +43,11 @@ class TestL10nEsAeatSiiSummary(TestL10nEsAeatSiiBase):
             }
         )
         invoice._sii_check_exceptions()
+        invoice.sii_state = "sent"
+        with self.assertRaises(exceptions.UserError):
+            invoice.write({"sii_invoice_summary_start": 2})
+        with self.assertRaises(exceptions.UserError):
+            invoice.write({"sii_invoice_summary_end": 20})
 
     def test_get_invoice_data_summary_case_same_number(self):
         mapping = [

--- a/l10n_es_aeat_sii_invoice_summary/views/account_move_view.xml
+++ b/l10n_es_aeat_sii_invoice_summary/views/account_move_view.xml
@@ -11,17 +11,17 @@
             <field name="sii_description" position="before">
                 <field
                     name="is_invoice_summary"
-                    attrs="{'invisible': [('move_type', 'not in', ('out_invoice','out_refund'))]}"
+                    attrs="{'invisible': [('move_type', 'not in', ('out_invoice','out_refund'))], 'readonly': [('state', '!=', 'draft')]}"
                 />
                 <field
                     name="sii_invoice_summary_start"
                     string="First Invoice"
-                    attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice','out_refund')), ('is_invoice_summary', '=', False)]}"
+                    attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice','out_refund')), ('is_invoice_summary', '=', False)], 'required': [('is_invoice_summary', '=', True)], 'readonly': [('state', '!=', 'draft')]}"
                 />
                 <field
                     name="sii_invoice_summary_end"
                     string="Last Invoice"
-                    attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice','out_refund')), ('is_invoice_summary', '=', False)]}"
+                    attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice','out_refund')), ('is_invoice_summary', '=', False)], 'required': [('is_invoice_summary', '=', True)], 'readonly': [('state', '!=', 'draft')]}"
                 />
             </field>
         </field>


### PR DESCRIPTION
Cambios realizados:
- [x] Se hacen obligatorios los campos si se marca la casilla "_Resumen facturas simplificadas_".
- [x] Solo se pueden cambiar los campos de resumen si la factura está en borrador.
- [x] Controlar en el método `write()` que no se modifiquen los campos de resumen si la factura está enviada al SII

Por favor @pedrobaeza, ¿puedes revisarlo?

@Tecnativa TT49397