### PR TITLE
[16.0][FIX] l10n_es_aeat_mod303_vat_prorate: Add analytic_distribution only if prorate_analytic_account_id is set

### DIFF
--- a/l10n_es_aeat_mod303_vat_prorate/models/mod303.py
+++ b/l10n_es_aeat_mod303_vat_prorate/models/mod303.py
@@ -97,13 +97,16 @@ class L10nEsAeatMod303Report(models.Model):
         """Add the amount of the regularization to the liquidation entry."""
         lines = super()._prepare_regularization_extra_move_lines()
         if self.casilla_44 and self.with_vat_prorate:
-            lines.append(
-                {
-                    "name": _("VAT prorate regularization"),
-                    "account_id": self.prorate_account_id.id,
-                    "analytic_distribution": {self.prorate_analytic_account_id.id: 100},
-                    "debit": -self.casilla_44 if self.casilla_44 < 0 else 0.0,
-                    "credit": self.casilla_44 if self.casilla_44 > 0 else 0.0,
+            line_vals = {
+                "name": _("VAT prorate regularization"),
+                "account_id": self.prorate_account_id.id,
+                "debit": -self.casilla_44 if self.casilla_44 < 0 else 0.0,
+                "credit": self.casilla_44 if self.casilla_44 > 0 else 0.0,
+            }
+            # Add analytic_distribution only if prorate_analytic_account_id is set
+            if self.prorate_analytic_account_id:
+                line_vals["analytic_distribution"] = {
+                    self.prorate_analytic_account_id.id: 100
                 }
-            )
+            lines.append(line_vals)
         return lines


### PR DESCRIPTION
Add `analytic_distribution` only if `prorate_analytic_account_id` is set

Caso de uso
- Definir distribución analítica "incorrecta" (no vinculada a ninguna cuenta analítica).

Error:
```
File "/opt/odoo/auto/addons/account_financial_report/models/account_move_line.py", line 21, in _compute_analytic_account_ids
    for account_id in map(int, record.analytic_distribution):
ValueError: invalid literal for int() with base 10: 'false'
```


@Tecnativa