### PR TITLE
[15.0][IMP+FIX] l10n_es_payment_order_confirming_aef: Cambios en archivo de confirming

### DIFF
--- a/l10n_es_payment_order_confirming_aef/README.rst
+++ b/l10n_es_payment_order_confirming_aef/README.rst
@@ -44,7 +44,9 @@ Configuration
 Para poder generar el archivo de exportación confirming AEF, hay que definir un modo de
 pago que use el tipo de pago "Confirming AEF". Para ello, vaya a Facturación / Contabilidad >
 Configuración > Modos de pago, y escoja el tipo de pago a realizar
-(Transferencia o cheque).
+(Transferencia o cheque). La modalidad de remesa es un campo opcional que deberá consultar
+con la entidad bancaria para definir el valor correcto (1: Estándar, 2: Pronto Pago, 3: Otros);
+en algunos casos es posible dejarlo vacío y en otros únicamente aceptan uno.
 
 El nº de contrato de Confirming será el valor asignado en el campo `Contrato AEF Confirming`
 dentro del modo de pago creado anteriormente

--- a/l10n_es_payment_order_confirming_aef/models/account_payment_mode.py
+++ b/l10n_es_payment_order_confirming_aef/models/account_payment_mode.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Tecnativa - Ernesto García Medina
+# Copyright 2024 Tecnativa - Víctor Martínez
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from odoo import fields, models
@@ -14,6 +15,16 @@ class AccountPaymentMode(models.Model):
             ("T", "Transferencia"),
             ("C", "Cheque"),
         ],
+    )
+    aef_confirming_modality = fields.Selection(
+        string="Modalidad remesa",
+        default=False,
+        selection=[
+            ("1", "Estandar"),
+            ("2", "Pronto pago"),
+            ("3", "Otros"),
+        ],
+        help="Opcional: Consultar con la entidad bancaria",
     )
     aef_confirming_contract = fields.Char(
         string="Contrato AEF Confirming \

--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -131,7 +131,7 @@ class ConfirmingAEF(object):
         cuenta = self.record.company_partner_bank_id.acc_number.replace(" ", "")
         if self.record.company_partner_bank_id.acc_type != "bank":
             cuenta = cuenta[4:]
-        text += self._aef_convert_text(cuenta, 34)
+        text += self._aef_convert_text(cuenta, 34, "left")
         # 137 - 139 Código divisa
         text += self._aef_convert_text(self.record.company_currency_id.name, 3)
         # 140 - 140 Estandar / Pronto Pago/ Otros

--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -129,8 +129,6 @@ class ConfirmingAEF(object):
         text += self._aef_convert_text(contract_cxb, 20, "left")
         # 103 - 136 Cuenta de cargo
         cuenta = self.record.company_partner_bank_id.acc_number.replace(" ", "")
-        if self.record.company_partner_bank_id.acc_type != "bank":
-            cuenta = cuenta[4:]
         text += self._aef_convert_text(cuenta, 34, "left")
         # 137 - 139 Código divisa
         text += self._aef_convert_text(self.record.company_currency_id.name, 3)

--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -135,7 +135,9 @@ class ConfirmingAEF(object):
         # 137 - 139 Código divisa
         text += self._aef_convert_text(self.record.company_currency_id.name, 3)
         # 140 - 140 Estandar / Pronto Pago/ Otros
-        text += self._aef_convert_text("", 1)
+        text += self._aef_convert_text(
+            self.record.payment_mode_id.aef_confirming_modality or "", 1
+        )
         # 141 - 170 Referencia/Nombre fichero
         text += self._aef_convert_text("", 30)
         # 171 - 172 Tipo Formato

--- a/l10n_es_payment_order_confirming_aef/readme/CONFIGURE.rst
+++ b/l10n_es_payment_order_confirming_aef/readme/CONFIGURE.rst
@@ -1,7 +1,9 @@
 Para poder generar el archivo de exportación confirming AEF, hay que definir un modo de
 pago que use el tipo de pago "Confirming AEF". Para ello, vaya a Facturación / Contabilidad >
 Configuración > Modos de pago, y escoja el tipo de pago a realizar
-(Transferencia o cheque).
+(Transferencia o cheque). La modalidad de remesa es un campo opcional que deberá consultar
+con la entidad bancaria para definir el valor correcto (1: Estándar, 2: Pronto Pago, 3: Otros);
+en algunos casos es posible dejarlo vacío y en otros únicamente aceptan uno.
 
 El nº de contrato de Confirming será el valor asignado en el campo `Contrato AEF Confirming`
 dentro del modo de pago creado anteriormente

--- a/l10n_es_payment_order_confirming_aef/static/description/index.html
+++ b/l10n_es_payment_order_confirming_aef/static/description/index.html
@@ -391,7 +391,9 @@ que es una adaptación libre del formato CSB 34.</p>
 <p>Para poder generar el archivo de exportación confirming AEF, hay que definir un modo de
 pago que use el tipo de pago “Confirming AEF”. Para ello, vaya a Facturación / Contabilidad &gt;
 Configuración &gt; Modos de pago, y escoja el tipo de pago a realizar
-(Transferencia o cheque).</p>
+(Transferencia o cheque). La modalidad de remesa es un campo opcional que deberá consultar
+con la entidad bancaria para definir el valor correcto (1: Estándar, 2: Pronto Pago, 3: Otros);
+en algunos casos es posible dejarlo vacío y en otros únicamente aceptan uno.</p>
 <p>El nº de contrato de Confirming será el valor asignado en el campo <cite>Contrato AEF Confirming</cite>
 dentro del modo de pago creado anteriormente</p>
 </div>

--- a/l10n_es_payment_order_confirming_aef/views/account_payment_mode_view.xml
+++ b/l10n_es_payment_order_confirming_aef/views/account_payment_mode_view.xml
@@ -15,6 +15,7 @@
                     attrs="{'invisible': [('payment_method_code', '!=', 'confirming_aef')]}"
                 >
                     <field name="aef_confirming_type" />
+                    <field name="aef_confirming_modality" />
                     <field
                         name="aef_confirming_contract"
                         attrs="{'required': [('payment_method_code', '=', 'confirming_aef')]}"


### PR DESCRIPTION
Cambios hechos:
- [x] [IMP] Añadir campo Modalidad remesa
- [x] [FIX]  Cuenta bancaria en posición correcta

1. Añadir campo Modalidad remesa

El dato relativo a la modalidad de la reserva se estaba definiendo vacío, es posible definirlo ahora según las diferentes opciones existentes según la documentación del archivo de confirming.

Links documentación:
- https://factoringasociacion.com/wp-content/uploads/2022/11/formato-estandar.pdf
- https://www.laboralkutxa.com/pdf/es/gestion-ficheros/confirming.pdf
- https://docs.bankinter.com/file_source/empresas/estaticos/stf/plataformas/empresas/gestion/ficheros/formatos_fichero/formato-aef-espanol.pdf
- https://criterium.es/sepa/generasepa/manual/confirming-estandar-AEF

2. Cuenta bancaria en posición correcta

Se debe especificar la cuenta bancaria en la posición correcta (103) por lo que se debe utilizar `ljust()` para rellenar espacios al final de la cuenta bancaria.

En la documentación se identifica: "_Los campos alfanuméricos se alinearán a la izquierda (“Nombre “) completándose con espacios por la derecha_".

@Tecnativa TT49479 TT49550