### PR TITLE
[15.0][FIX] l10n_es_payment_order_confirming_aef: Cuenta bancaria en posición correcta

### DIFF
--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -131,7 +131,7 @@ class ConfirmingAEF(object):
         cuenta = self.record.company_partner_bank_id.acc_number.replace(" ", "")
         if self.record.company_partner_bank_id.acc_type != "bank":
             cuenta = cuenta[4:]
-        text += self._aef_convert_text(cuenta, 34)
+        text += self._aef_convert_text(cuenta, 34, "left")
         # 137 - 139 Código divisa
         text += self._aef_convert_text(self.record.company_currency_id.name, 3)
         # 140 - 140 Estandar / Pronto Pago/ Otros


### PR DESCRIPTION
Cuenta bancaria en posición correcta

Se debe especificar la cuenta bancaria en la posición correcta (103) por lo que se debe utilizar `ljust()` para rellenar espacios al final de la cuenta bancaria.

En la documentación se identifica: "_Los campos alfanuméricos se alinearán a la izquierda (“Nombre “) completándose con espacios por la derecha_".

@Tecnativa TT49550