### PR TITLE
[FIX] l10n_es_ticketbai: only take as exempted taxes those in the cor…

### DIFF
--- a/l10n_es_ticketbai/models/account_tax.py
+++ b/l10n_es_ticketbai/models/account_tax.py
@@ -24,7 +24,9 @@ class AccountTax(models.Model):
         return self not in s_iva_ns_taxes
 
     def tbai_is_tax_exempted(self):
-        return self.tax_group_id.id == self.env.ref("l10n_es.tax_group_iva_0").id
+        map_ids = self.env["tbai.tax.map"].search([("code", "in", ["IEE", "SER"])])
+        tax_ids = self.company_id.get_taxes_from_templates(map_ids.mapped("tax_template_ids"))
+        return self in tax_ids
 
     def tbai_get_exemption_cause(self, invoice_id):
         return (


### PR DESCRIPTION
…responding maps, not all the taxes from the 0% groups (e.g. ISP)