### PR TITLE
[15.0][IMP] l10n_es_aeat_sii_oca: send with quarters only for voluntary

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -508,7 +508,7 @@ class AccountMove(models.Model):
         invoice_date = self._change_date_format(self.invoice_date)
         reg_date = self._change_date_format(self._get_account_registration_date())
         ejercicio = fields.Date.to_date(self.date).year
-        periodo = "%02d" % fields.Date.to_date(self.date).month
+        periodo = self._get_document_period()
         partner = self._sii_get_partner()
         desglose_factura, tax_amount, not_in_amount_total = self._get_sii_in_taxes()
         inv_dict = {

--- a/l10n_es_aeat_sii_oca/models/res_company.py
+++ b/l10n_es_aeat_sii_oca/models/res_company.py
@@ -69,6 +69,13 @@ class ResCompany(models.Model):
     )
     sent_time = fields.Float()
     delay_time = fields.Float()
+    sii_period = fields.Selection(
+        selection=[
+            ("monthly", "Monthly"),
+            ("quarterly", "Quarterly"),
+        ],
+        default="monthly",
+    )
 
     def _get_sii_eta(self):
         if self.send_mode == "fixed":

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -426,7 +426,12 @@ class SiiMixin(models.AbstractModel):
         return fields.Date.to_date(self._get_document_fiscal_date()).year
 
     def _get_document_period(self):
-        return "%02d" % fields.Date.to_date(self._get_document_fiscal_date()).month
+        month = fields.Date.to_date(self._get_document_fiscal_date()).month
+        if self.company_id.sii_period == "monthly":
+            period = "%02d" % month
+        else:
+            period = str(int(((month - 1) / 3) + 1)) + "T"
+        return period
 
     def _get_document_serial_number(self):
         raise NotImplementedError()

--- a/l10n_es_aeat_sii_oca/views/res_company_view.xml
+++ b/l10n_es_aeat_sii_oca/views/res_company_view.xml
@@ -17,6 +17,7 @@
                         <group name="sii_config">
                             <field name="sii_test" />
                             <field name="sii_method" />
+                            <field name="sii_period" />
                         </group>
                         <group name="sii_description" string="Description config">
                             <field name="sii_description_method" />


### PR DESCRIPTION
Hola,

Este es un caso atípico del SII, pero se da cuando una empresa presenta voluntariamente el SII. En vez de presentar mensualmente, puede presentar trimestralmente. El formato es el mismo pero cambia el "periodo".

Consulta 1.6 de preguntas frecuentes:
https://sede.agenciatributaria.gob.es/Sede/impuestos-tasas/iva/iva-libros-registro-iva-traves-aeat/preguntas-frecuentes.html?faqId=5dbd795accac9510VgnVCM100000dc381e0aRCRD

Un saludo