### PR TITLE
[16.0][IMP] l10n_es_pos_by_device: Secuenciación de dispositivos configurable por punto de venta

### DIFF
--- a/l10n_es_pos_by_device/README.rst
+++ b/l10n_es_pos_by_device/README.rst
@@ -41,7 +41,8 @@ Configuration
 
 **Activación de secuencia por dispositivo**
 
-* Esta configuración se activa en *Punto de venta > Configuración > Ajustes > Secuenciación > Secuencia TPV por dispositivo*.
+* Esta configuración se activa en *Punto de venta > Configuración > Ajustes > Secuenciación > Secuencia TPV por dispositivo*
+   y aplica unicamente al TPV en el que se esté configurando.
 
 **Configuración de dispositivos físicos por TPV**
 
@@ -51,7 +52,9 @@ Configuration
 
 * En *Punto de venta > Configuración > Ajustes > Secuenciación > Dispositivos físicos TPV*.
    - Establecer los dispositivos físicos disponibles en ese punto de venta.
-     Si se deja en blanco, se podrán seleccionar todos los dispositivos creados.
+
+* En *Punto de venta > Configuración > Dispositivos Físicos TPV*.
+   - Establecer los TPVs a los que pertenece cada dispositivo.
 
 Usage
 =====
@@ -113,6 +116,7 @@ Contributors
 * `Factor Libre <https://www.factorlibre.com>`_:
 
   * Juan Carlos Bonilla <juancarlos.bonilla@factorlibre.com>
+  * Pablo Calvo <pablo.calvo@factorlibre.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_pos_by_device/i18n/es.po
+++ b/l10n_es_pos_by_device/i18n/es.po
@@ -4,29 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0+e\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-24 11:31+0000\n"
-"PO-Revision-Date: 2024-03-25 20:38+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
+"POT-Creation-Date: 2024-07-19 11:22+0000\n"
+"PO-Revision-Date: 2024-07-19 11:22+0000\n"
+"Last-Translator: \n"
 "Language-Team: \n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
-
-#. module: l10n_es_pos_by_device
-#: model_terms:ir.ui.view,arch_db:l10n_es_pos_by_device.view_res_config_settings_pos_seq_device
-msgid ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" groups="
-"\"base.group_multi_company\" role=\"img\"/>"
-msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
-"specific.\" aria-label=\"Values set here are company-specific.\" groups="
-"\"base.group_multi_company\" role=\"img\"/>"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_pos_by_device
 #: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_pos_config__pos_device_ids
@@ -41,11 +28,6 @@ msgstr "Dispositivos TPV disponibles"
 #, python-format
 msgid "Cannot establish device. Clossing POS."
 msgstr "No es posible establecer dispositivo. Cerrando TPV."
-
-#. module: l10n_es_pos_by_device
-#: model:ir.model,name:l10n_es_pos_by_device.model_res_company
-msgid "Companies"
-msgstr "Compañías"
 
 #. module: l10n_es_pos_by_device
 #: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_pos_device__company_id
@@ -136,7 +118,7 @@ msgstr "Dispositivos físicos TPV"
 #. module: l10n_es_pos_by_device
 #: model:ir.model,name:l10n_es_pos_by_device.model_pos_device
 msgid "PoS Device"
-msgstr ""
+msgstr "Dispositivo TPV"
 
 #. module: l10n_es_pos_by_device
 #: model:ir.model,name:l10n_es_pos_by_device.model_pos_config
@@ -154,9 +136,13 @@ msgid "Point of Sale Session"
 msgstr "Sesión TPV"
 
 #. module: l10n_es_pos_by_device
+#: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_pos_device__pos_config_ids
+msgid "Points of Sale"
+msgstr "Puntos de venta"
+
+#. module: l10n_es_pos_by_device
 #: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_pos_config__pos_sequence_by_device
 #: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_pos_order__pos_sequence_by_device
-#: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_res_company__pos_sequence_by_device
 #: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_res_config_settings__pos_sequence_by_device
 msgid "Pos Sequence By Device"
 msgstr "Secuencia TPV por dispositivo"
@@ -205,11 +191,21 @@ msgid "Simplified Invoice prefix"
 msgstr "Prefijo de Factura Simplificada"
 
 #. module: l10n_es_pos_by_device
+#: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_pos_config__smart_search
+#: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_pos_device__smart_search
+#: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_pos_order__smart_search
+#: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_pos_session__smart_search
+#: model:ir.model.fields,field_description:l10n_es_pos_by_device.field_res_config_settings__smart_search
+msgid "Smart Search"
+msgstr "Búsqueda Inteligente"
+
+#. module: l10n_es_pos_by_device
 #. odoo-python
 #: code:addons/l10n_es_pos_by_device/models/pos_config.py:0
 #, python-format
 msgid "There are no physical devices available. Cannot start session."
-msgstr "No hay dispositivos físicos disponibles. No es posible iniciar sesión."
+msgstr ""
+"No hay dispositivos físicos disponibles. No es posible iniciar sesión."
 
 #. module: l10n_es_pos_by_device
 #. odoo-javascript
@@ -229,6 +225,3 @@ msgstr "Desbloquear el dispositivo"
 msgid "Use a different subsequence for each physical device on POS."
 msgstr ""
 "Utilice una subsecuencia diferente para cada dispositivo físico en el TPV."
-
-#~ msgid "pos.device"
-#~ msgstr "pos.dispositivo"

--- a/l10n_es_pos_by_device/migrations/16.0.1.1.0/post-migration.py
+++ b/l10n_es_pos_by_device/migrations/16.0.1.1.0/post-migration.py
@@ -1,0 +1,16 @@
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute(
+        """
+        UPDATE pos_config
+        SET pos_sequence_by_device = res_company.pos_sequence_by_device_legacy
+        FROM res_company
+        WHERE pos_config.company_id = res_company.id;
+    """
+    )
+    cr.execute(
+        """
+        ALTER TABLE res_company DROP COLUMN pos_sequence_by_device_legacy;
+    """
+    )

--- a/l10n_es_pos_by_device/migrations/16.0.1.1.0/pre-migration.py
+++ b/l10n_es_pos_by_device/migrations/16.0.1.1.0/pre-migration.py
@@ -1,0 +1,21 @@
+def migrate(cr, version):
+    if not version:
+        return
+
+    cr.execute(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name='res_company' AND column_name='pos_sequence_by_device'
+    """
+    )
+    column_exists = cr.fetchone()
+
+    if column_exists:
+        cr.execute(
+            """
+            ALTER TABLE res_company
+            RENAME COLUMN pos_sequence_by_device TO
+            pos_sequence_by_device_legacy
+        """
+        )

--- a/l10n_es_pos_by_device/models/__init__.py
+++ b/l10n_es_pos_by_device/models/__init__.py
@@ -1,6 +1,5 @@
 from . import pos_config
 from . import pos_device
 from . import pos_order
-from . import res_company
 from . import res_config_settings
 from . import pos_session

--- a/l10n_es_pos_by_device/models/pos_config.py
+++ b/l10n_es_pos_by_device/models/pos_config.py
@@ -7,7 +7,7 @@ from odoo.exceptions import ValidationError
 class PosConfig(models.Model):
     _inherit = "pos.config"
 
-    pos_sequence_by_device = fields.Boolean(related="company_id.pos_sequence_by_device")
+    pos_sequence_by_device = fields.Boolean()
     pos_device_ids = fields.Many2many(
         "pos.device",
         string="Available POS devices",

--- a/l10n_es_pos_by_device/models/pos_device.py
+++ b/l10n_es_pos_by_device/models/pos_device.py
@@ -17,6 +17,14 @@ class PosDevice(models.Model):
         readonly=True,
         default=lambda self: self.env.company,
     )
+    pos_config_ids = fields.Many2many(
+        "pos.config",
+        string="Points of Sale",
+        relation="pos_config_pos_device_rel",
+        column1="pos_device_id",
+        column2="pos_config_id",
+        domain=[("pos_sequence_by_device", "=", True)],
+    )
     device_simplified_invoice_prefix = fields.Char(
         "Simplified Invoice prefix",
         readonly=True,

--- a/l10n_es_pos_by_device/models/res_company.py
+++ b/l10n_es_pos_by_device/models/res_company.py
@@ -1,9 +1,0 @@
-# Copyright 2023 Landoo Sistemas de Informacion SL
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
-
-
-class ResCompany(models.Model):
-    _inherit = "res.company"
-
-    pos_sequence_by_device = fields.Boolean()

--- a/l10n_es_pos_by_device/models/res_config_settings.py
+++ b/l10n_es_pos_by_device/models/res_config_settings.py
@@ -7,7 +7,7 @@ class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     pos_sequence_by_device = fields.Boolean(
-        related="company_id.pos_sequence_by_device", readonly=False
+        related="pos_config_id.pos_sequence_by_device", readonly=False
     )
     pos_device_ids = fields.Many2many(
         related="pos_config_id.pos_device_ids", readonly=False

--- a/l10n_es_pos_by_device/readme/CONFIGURE.rst
+++ b/l10n_es_pos_by_device/readme/CONFIGURE.rst
@@ -1,6 +1,7 @@
 **Activación de secuencia por dispositivo**
 
-* Esta configuración se activa en *Punto de venta > Configuración > Ajustes > Secuenciación > Secuencia TPV por dispositivo*.
+* Esta configuración se activa en *Punto de venta > Configuración > Ajustes > Secuenciación > Secuencia TPV por dispositivo*
+   y aplica unicamente al TPV en el que se esté configurando.
 
 **Configuración de dispositivos físicos por TPV**
 
@@ -10,4 +11,6 @@
 
 * En *Punto de venta > Configuración > Ajustes > Secuenciación > Dispositivos físicos TPV*.
    - Establecer los dispositivos físicos disponibles en ese punto de venta.
-     Si se deja en blanco, se podrán seleccionar todos los dispositivos creados.
+
+* En *Punto de venta > Configuración > Dispositivos Físicos TPV*.
+   - Establecer los TPVs a los que pertenece cada dispositivo.

--- a/l10n_es_pos_by_device/readme/CONTRIBUTORS.rst
+++ b/l10n_es_pos_by_device/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
 * `Factor Libre <https://www.factorlibre.com>`_:
 
   * Juan Carlos Bonilla <juancarlos.bonilla@factorlibre.com>
+  * Pablo Calvo <pablo.calvo@factorlibre.com>

--- a/l10n_es_pos_by_device/static/description/index.html
+++ b/l10n_es_pos_by_device/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -391,7 +392,11 @@ en el caso de que los dispositivos se queden sin conexión.</li>
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
 <p><strong>Activación de secuencia por dispositivo</strong></p>
 <ul class="simple">
-<li>Esta configuración se activa en <em>Punto de venta &gt; Configuración &gt; Ajustes &gt; Secuenciación &gt; Secuencia TPV por dispositivo</em>.</li>
+<li><dl class="first docutils">
+<dt>Esta configuración se activa en <em>Punto de venta &gt; Configuración &gt; Ajustes &gt; Secuenciación &gt; Secuencia TPV por dispositivo</em></dt>
+<dd>y aplica unicamente al TPV en el que se esté configurando.</dd>
+</dl>
+</li>
 </ul>
 <p><strong>Configuración de dispositivos físicos por TPV</strong></p>
 <ul class="simple">
@@ -407,8 +412,15 @@ propia secuencia.</li>
 <li><dl class="first docutils">
 <dt>En <em>Punto de venta &gt; Configuración &gt; Ajustes &gt; Secuenciación &gt; Dispositivos físicos TPV</em>.</dt>
 <dd><ul class="first last">
-<li>Establecer los dispositivos físicos disponibles en ese punto de venta.
-Si se deja en blanco, se podrán seleccionar todos los dispositivos creados.</li>
+<li>Establecer los dispositivos físicos disponibles en ese punto de venta.</li>
+</ul>
+</dd>
+</dl>
+</li>
+<li><dl class="first docutils">
+<dt>En <em>Punto de venta &gt; Configuración &gt; Dispositivos Físicos TPV</em>.</dt>
+<dd><ul class="first last">
+<li>Establecer los TPVs a los que pertenece cada dispositivo.</li>
 </ul>
 </dd>
 </dl>
@@ -465,6 +477,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.factorlibre.com">Factor Libre</a>:<ul>
 <li>Juan Carlos Bonilla &lt;<a class="reference external" href="mailto:juancarlos.bonilla&#64;factorlibre.com">juancarlos.bonilla&#64;factorlibre.com</a>&gt;</li>
+<li>Pablo Calvo &lt;<a class="reference external" href="mailto:pablo.calvo&#64;factorlibre.com">pablo.calvo&#64;factorlibre.com</a>&gt;</li>
 </ul>
 </li>
 </ul>
@@ -472,7 +485,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/l10n_es_pos_by_device/views/pos_views.xml
+++ b/l10n_es_pos_by_device/views/pos_views.xml
@@ -56,6 +56,7 @@
                 <field name="name" />
                 <field name="sequence" />
                 <field name="company_id" />
+                <field name="pos_config_ids" widget="many2many_tags" />
                 <field name="locked" invisible="1" />
                 <button
                     name="unlock_device"

--- a/l10n_es_pos_by_device/views/res_config_views.xml
+++ b/l10n_es_pos_by_device/views/res_config_views.xml
@@ -22,13 +22,6 @@
                                 string="Secuencing by physical device"
                                 for="pos_sequence_by_device"
                             />
-                            <span
-                                class="fa fa-lg fa-building-o"
-                                title="Values set here are company-specific."
-                                aria-label="Values set here are company-specific."
-                                groups="base.group_multi_company"
-                                role="img"
-                            />
                             <div class="text-muted">
                                 Use a different subsequence for each physical device on POS.
                             </div>


### PR DESCRIPTION
Con este PR se busca modificar comportamiento actual de la secuenciación de dispositivos para que sea a nivel de punto de venta y no de compañía.

- No  todos los TPVs de una compañía tienen por qué compartir esta configuración.

-  Ademas, he creado un script de migración para evitar la perdida de información con el cambio de modelo del campo, tras estos cambios, los TPVs estarán configurados según la configuración actual de la compañía.

FL-571-3105

