### PR TITLE
[17.0][IMP] l10n_es_aeat_mod303_vat_prorate: add special vat prorate

### DIFF
--- a/l10n_es_aeat_mod303_vat_prorate/README.rst
+++ b/l10n_es_aeat_mod303_vat_prorate/README.rst
@@ -60,7 +60,6 @@ Usage
 Known issues / Roadmap
 ======================
 
--  La prorrata especial de IVA no está contemplada.
 -  No se incluye la posibilidad de las facturas de actividad
    diferenciada, de las que te puedes deducir el 100% del IVA de la
    factura.
@@ -94,8 +93,10 @@ Contributors
 
 -  `Sygel <https://www.sygel.es>`__
 
+   -  Harald Panten
    -  Manuel Regidor
    -  Valentín Vinagre
+   -  Alberto Martínez
 
 Maintainers
 -----------

--- a/l10n_es_aeat_mod303_vat_prorate/readme/CONTRIBUTORS.md
+++ b/l10n_es_aeat_mod303_vat_prorate/readme/CONTRIBUTORS.md
@@ -3,5 +3,7 @@
   - Víctor Martínez
   - Carolina Fernandez
 - [Sygel](https://www.sygel.es)
+  - Harald Panten
   - Manuel Regidor
   - Valentín Vinagre
+  - Alberto Martínez

--- a/l10n_es_aeat_mod303_vat_prorate/readme/ROADMAP.md
+++ b/l10n_es_aeat_mod303_vat_prorate/readme/ROADMAP.md
@@ -1,4 +1,3 @@
-- La prorrata especial de IVA no está contemplada.
 - No se incluye la posibilidad de las facturas de actividad
   diferenciada, de las que te puedes deducir el 100% del IVA de la
   factura.

--- a/l10n_es_aeat_mod303_vat_prorate/static/description/index.html
+++ b/l10n_es_aeat_mod303_vat_prorate/static/description/index.html
@@ -410,7 +410,6 @@ minoró.</li>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
 <ul class="simple">
-<li>La prorrata especial de IVA no está contemplada.</li>
 <li>No se incluye la posibilidad de las facturas de actividad
 diferenciada, de las que te puedes deducir el 100% del IVA de la
 factura.</li>
@@ -442,8 +441,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li><a class="reference external" href="https://www.sygel.es">Sygel</a><ul>
+<li>Harald Panten</li>
 <li>Manuel Regidor</li>
 <li>Valentín Vinagre</li>
+<li>Alberto Martínez</li>
 </ul>
 </li>
 </ul>

--- a/l10n_es_aeat_mod303_vat_prorate/views/mod303_views.xml
+++ b/l10n_es_aeat_mod303_vat_prorate/views/mod303_views.xml
@@ -10,6 +10,7 @@
         <field name="arch" type="xml">
             <field name="total_deducir" position="before">
                 <field name="with_vat_prorate" invisible="1" />
+                <field name="with_special_vat_prorate" invisible="1" />
                 <field
                     name="casilla_44"
                     widget="monetary"


### PR DESCRIPTION
Adaptación de l10n_es_aeat_mod303_vat_prorate para trabajar con la opción especial de prorrateo de iva agregada en el siguiente PR: #3626, a razón la la siguiente issue: [#3605](https://github.com/OCA/l10n-spain/issues/3605)

- Agregado un nuevo método para calcular el monto prorrateado basado en la suma de los movimientos prorrateados en lugar de una regla de proporción. Este nuevo método sólo se utiliza en el prorrateo especial. El antiguo método se ha mantenido en el prorrateo general debido a su estado de desarrollo más maduro. Una mejora futura podría ser la sustitución del método antiguo por el nuevo; sin embargo, la posibilidad de editar el porcentaje prorrateado del IVA directamente en el formulario 303 no está disponible en el nuevo método, y se necesita el consenso de la comunidad.

- Añadidos tests unitarios.

T-6134