### PR TITLE
[15.0][FIX] delivery_dhl_parcel: show full name

### DIFF
--- a/delivery_dhl_parcel/models/delivery_carrier.py
+++ b/delivery_dhl_parcel/models/delivery_carrier.py
@@ -73,8 +73,20 @@ class DeliveryCarrier(models.Model):
         address = partner.street or ""
         if partner.street2:
             address += " " + partner.street2
+        partner_name = partner.name
+        # We have a limit of 40 chars, so we'll try to allocate as much space possible
+        # for both parent an contact name, trying to use all the available space if
+        # possible and otherwise, cutting it to 19 chars max (letting 2 chars for
+        # the separation of both names)
+        if partner.parent_id:
+            max_parent_length = min(
+                len(partner.parent_id.name), 19 + max(19 - len(partner_name), 0)
+            )
+            partner_name = (
+                f"{partner.parent_id.name[:max_parent_length]}, {partner_name}"
+            )
         return {
-            "Name": partner.name or partner.parent_id.name or "",
+            "Name": partner_name[:40],
             "Address": address[:40],
             "City": partner.city or "",
             "PostalCode": partner.zip or "",


### PR DESCRIPTION
Si solo mostramos el nombre del contacto habrá casos en los que estaremos perdiendo la información más relevante del destinario, que es la organización a la que estamos haciendo el envío.

cc @Tecnativa TT49966

revisa, por favor @victoralmau 

¿Te parece correcto? @hildickethan-S73 

