### PR TITLE
[16.0][FIX] l10n_es_payment_order_confirming_aef: Fix search domain for AEF confirming payment method in bank journal

### DIFF
--- a/l10n_es_payment_order_confirming_aef/models/__init__.py
+++ b/l10n_es_payment_order_confirming_aef/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from . import account_payment_mode
 from . import account_payment_order
+from . import account_payment_method

--- a/l10n_es_payment_order_confirming_aef/models/account_payment_method.py
+++ b/l10n_es_payment_order_confirming_aef/models/account_payment_method.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Worldwide Vision Business Solutions SL - Gil Arasa Verge
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class AccountPaymentMethod(models.Model):
+    _inherit = "account.payment.method"
+
+    @api.model
+    def _get_payment_method_information(self):
+        res = super()._get_payment_method_information()
+        res["confirming_aef"] = {"mode": "multi", "domain": [("type", "=", "bank")]}
+        return res


### PR DESCRIPTION
The same needs to be done for sabadell confirming module.

Fixes confirming not showing up in field search:
![image](https://github.com/OCA/l10n-spain/assets/45542433/b31e93aa-1656-42b0-aa63-257eedb3cec2)
