### PR TITLE
[15.0][FIX] l10n_es_payment_order_confirming*: Use appropriate field (communication) first

### DIFF
--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -240,7 +240,7 @@ class ConfirmingAEF(object):
         # 1 Valor fijo
         text = "6"
         # 2 - 21 Num factura
-        referencia_factura = line.move_line_id.move_id.ref or line.communication
+        referencia_factura = line.communication or line.move_line_id.move_id.ref
         text += self._aef_convert_text(referencia_factura.replace("-", ""), 20, "left")
         # 22 - 22 signo
         signo_factura = "+" if line.amount_currency >= 0 else "-"

--- a/l10n_es_payment_order_confirming_sabadell/models/confirming_sabadell.py
+++ b/l10n_es_payment_order_confirming_sabadell/models/confirming_sabadell.py
@@ -198,7 +198,7 @@ class ConfirmingSabadell(object):
         )
         text += self._sab_convert_text(cuenta, 20, "left")
         # 52 - 66 Num Factura
-        num_factura = line.move_line_id.move_id.ref or line.communication
+        num_factura = line.communication or line.move_line_id.move_id.ref
         text += self._sab_convert_text(num_factura, 15, "left")
         # 67 - 81 Importe de la factura
         text += self._sab_convert_text(line.amount_currency, 14)


### PR DESCRIPTION
Utilizar los campos de comunicación en el orden adecuado.

Por favor @pedrobaeza ¿puedes revisarlo?

@Tecnativa TT50128