### PR TITLE
[17.0] [IMP] l10n_es_vat_prorate: move prorate type to prorate level and add… … constraint

### DIFF
--- a/l10n_es_aeat_mod303_vat_prorate/models/mod303.py
+++ b/l10n_es_aeat_mod303_vat_prorate/models/mod303.py
@@ -45,7 +45,7 @@ class L10nEsAeatMod303Report(models.Model):
 
     def _calculate_casilla_44_mod303_vat_prorate(self):
         self.ensure_one()
-        theoretical_prorate = self.company_id.get_prorate(self.date_start)
+        theoretical_prorate = self.company_id.get_prorate(self.date_start).vat_prorate
         diff_perc = self.vat_prorate_percent - theoretical_prorate
         if not diff_perc:
             return

--- a/l10n_es_vat_prorate/__init__.py
+++ b/l10n_es_vat_prorate/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import pre_init_hook

--- a/l10n_es_vat_prorate/__manifest__.py
+++ b/l10n_es_vat_prorate/__manifest__.py
@@ -9,6 +9,7 @@
     "license": "AGPL-3",
     "author": "Creu Blanca, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
+    "pre_init_hook": "pre_init_hook",
     "depends": ["l10n_es_aeat"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_es_vat_prorate/hooks.py
+++ b/l10n_es_vat_prorate/hooks.py
@@ -1,0 +1,27 @@
+# Copyright 2024 Alberto Martínez <alberto.martinez@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import logging
+
+
+def pre_init_hook(env):
+    """Create computed columns if not exists when the module is installed"""
+    logger = logging.getLogger(__name__)
+    logger.info("Prepopulating stored related fields")
+    env.cr.execute(
+        """
+        ALTER TABLE account_move
+        ADD COLUMN IF NOT EXISTS prorate_id integer;
+        """
+    )
+    env.cr.execute(
+        """
+        ALTER TABLE account_move
+        ADD COLUMN IF NOT EXISTS with_special_vat_prorate BOOLEAN;
+        """
+    )
+    env.cr.execute(
+        """
+        ALTER TABLE account_move_line
+        ADD COLUMN IF NOT EXISTS with_vat_prorate BOOLEAN;
+        """
+    )

--- a/l10n_es_vat_prorate/models/account_move.py
+++ b/l10n_es_vat_prorate/models/account_move.py
@@ -9,9 +9,29 @@ from odoo.tools import float_round, frozendict
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    with_special_vat_prorate = fields.Boolean(
-        related="company_id.with_special_vat_prorate"
+    prorate_id = fields.Many2one(
+        string="Prorate",
+        comodel_name="res.company.vat.prorate",
+        compute="_compute_prorate_id",
+        ondelete="restrict",
+        store=True,
     )
+    with_special_vat_prorate = fields.Boolean(compute="_compute_prorate_id", store=True)
+
+    @api.depends(
+        "company_id.vat_prorate_ids",
+        "company_id.with_vat_prorate",
+        "date",
+        "invoice_date",
+    )
+    def _compute_prorate_id(self):
+        for rec in self:
+            if rec.company_id.with_vat_prorate:
+                prorate_date = rec.date or rec.invoice_date or fields.Date.today()
+                rec.prorate_id = rec.company_id.get_prorate(prorate_date)
+                rec.with_special_vat_prorate = rec.prorate_id.type == "special"
+            else:
+                rec.prorate_id = rec.with_special_vat_prorate = False
 
 
 class AccountMoveLine(models.Model):
@@ -24,14 +44,18 @@ class AccountMoveLine(models.Model):
     with_vat_prorate = fields.Boolean(
         string="With Vat prorate",
         help="The line will create a vat prorate",
-        default=lambda self: (
-            self.env.company.with_vat_prorate
-            and (
-                not self.env.company.with_special_vat_prorate
-                or self.env.company.with_special_vat_prorate_default
-            )
-        ),
+        compute="_compute_with_vat_prorate",
+        store=True,
+        readonly=False,
     )
+
+    @api.depends("move_id.prorate_id", "company_id")
+    def _compute_with_vat_prorate(self):
+        for rec in self:
+            rec.with_vat_prorate = rec.move_id.company_id.with_vat_prorate and (
+                rec.move_id.prorate_id.type == "general"
+                or rec.move_id.prorate_id.special_vat_prorate_default
+            )
 
     def _process_aeat_tax_fee_info(self, res, tax, sign):
         result = super()._process_aeat_tax_fee_info(res, tax, sign)
@@ -49,7 +73,6 @@ class AccountMoveLine(models.Model):
         for line in self:
             res = super(AccountMoveLine, line)._compute_all_tax()
             prorate_tax_list = {}
-            vat_prorate_date = line.date or line.invoice_date or fields.Date.today()
             for tax_key, tax_vals in line.compute_all_tax.items():
                 tax_vals["vat_prorate"] = False
                 tax = (
@@ -67,7 +90,7 @@ class AccountMoveLine(models.Model):
                     )
                 ):
                     prec = line.move_id.currency_id.rounding
-                    prorate = line.company_id.get_prorate(vat_prorate_date)
+                    prorate = line.move_id.prorate_id.vat_prorate
                     new_vals = tax_vals.copy()
                     for field in {"amount_currency", "balance"}:
                         tax_vals[field] = float_round(

--- a/l10n_es_vat_prorate/static/description/index.html
+++ b/l10n_es_vat_prorate/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -445,7 +446,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/l10n_es_vat_prorate/tests/test_vat_prorate.py
+++ b/l10n_es_vat_prorate/tests/test_vat_prorate.py
@@ -60,6 +60,12 @@ class TestVatProrate(AccountTestInvoicingCommon):
         with self.assertRaises(IntegrityError):
             vat_prorate_line.vat_prorate = 200
 
+    def test_company_special_vat_prorate_out_of_range(self):
+        # A error should be displayed if special prorates are 100%
+        prorate_id = self.env.company.vat_prorate_ids[0]
+        with self.assertRaises(exceptions.ValidationError):
+            prorate_id.write({"type": "special", "vat_prorate": 100})
+
     def test_no_company_vat_prorate_information(self):
         self.assertTrue(self.env.company.vat_prorate_ids)
         with self.assertRaises(exceptions.ValidationError):
@@ -196,10 +202,10 @@ class TestVatProrate(AccountTestInvoicingCommon):
         self.assertNotEqual(tax_lines[0].account_id, tax_lines[1].account_id)
 
     def test_special_prorate_default_true(self):
-        self.env.company.write(
+        self.env.company.vat_prorate_ids[0].write(
             {
-                "with_special_vat_prorate": True,
-                "with_special_vat_prorate_default": True,
+                "type": "special",
+                "special_vat_prorate_default": True,
             }
         )
         invoice = self.init_invoice(
@@ -209,10 +215,10 @@ class TestVatProrate(AccountTestInvoicingCommon):
         self.assertEqual(2, len(invoice.line_ids.filtered("vat_prorate")))
 
     def test_special_prorate_default_false(self):
-        self.env.company.write(
+        self.env.company.vat_prorate_ids[0].write(
             {
-                "with_special_vat_prorate": True,
-                "with_special_vat_prorate_default": False,
+                "type": "special",
+                "special_vat_prorate_default": False,
             }
         )
         invoice = self.init_invoice(
@@ -222,10 +228,10 @@ class TestVatProrate(AccountTestInvoicingCommon):
         self.assertEqual(0, len(invoice.line_ids.filtered("vat_prorate")))
 
     def test_special_prorate_mixed(self):
-        self.env.company.write(
+        self.env.company.vat_prorate_ids[0].write(
             {
-                "with_special_vat_prorate": True,
-                "with_special_vat_prorate_default": True,
+                "type": "special",
+                "special_vat_prorate_default": True,
             }
         )
         invoice = self.init_invoice(

--- a/l10n_es_vat_prorate/views/account_move_views.xml
+++ b/l10n_es_vat_prorate/views/account_move_views.xml
@@ -22,6 +22,7 @@
             >
                 <field
                     name="with_vat_prorate"
+                    string="Vat Prorate"
                     column_invisible="not parent.with_special_vat_prorate or parent.move_type not in ['in_invoice', 'in_refund']"
                 />
             </xpath>

--- a/l10n_es_vat_prorate/views/res_company_prorate_views.xml
+++ b/l10n_es_vat_prorate/views/res_company_prorate_views.xml
@@ -10,9 +10,13 @@
                 <header />
                 <sheet>
                     <group>
-                        <field name="company_id" />
                         <field name="date" />
                         <field name="vat_prorate" />
+                        <field name="type" />
+                        <field
+                            name="special_vat_prorate_default"
+                            invisible="type == 'general'"
+                        />
                     </group>
                 </sheet>
             </form>
@@ -22,8 +26,9 @@
         <field name="name">res.company.vat.prorate.tree (in l10n_es_vat_prorate)</field>
         <field name="model">res.company.vat.prorate</field>
         <field name="arch" type="xml">
-            <tree editable="bottom">
+            <tree>
                 <field name="date" />
+                <field name="type" />
                 <field name="vat_prorate" />
             </tree>
         </field>

--- a/l10n_es_vat_prorate/views/res_company_views.xml
+++ b/l10n_es_vat_prorate/views/res_company_views.xml
@@ -18,14 +18,6 @@
             </notebook>
             <field name="company_registry" position="after">
                 <field name="with_vat_prorate" />
-                <field
-                    name="with_special_vat_prorate"
-                    invisible="not with_vat_prorate"
-                />
-                <field
-                    name="with_special_vat_prorate_default"
-                    invisible="not with_special_vat_prorate"
-                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
El PR #3626 añadió la posibilidad de la prorrata especial. Sin embargo, no soporta correctamente prorratas especiales del 100%, ya que estas no se pueden utilizar en el cálculo de la casilla 44 del modelo 303 #3656