### PR TITLE
[16.0][FIX] l10n_es_aeat_sii_oca/l10n_es_intrastat_report: Rename test helper method

### DIFF
--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -118,7 +118,7 @@ class TestL10nEsAeatSiiBase(TestL10nEsAeatModBase, TestL10nEsAeatCertificateBase
         return invoice
 
     @classmethod
-    def _create_invoice(cls, move_type):
+    def _create_invoice_for_sii(cls, move_type):
         return cls.env["account.move"].create(
             {
                 "company_id": cls.company.id,
@@ -154,7 +154,7 @@ class TestL10nEsAeatSiiBase(TestL10nEsAeatModBase, TestL10nEsAeatCertificateBase
         cls.account_expense = cls.env.ref(
             "l10n_es.%s_account_common_600" % cls.company.id
         )
-        cls.invoice = cls._create_invoice("out_invoice")
+        cls.invoice = cls._create_invoice_for_sii("out_invoice")
         cls.company.write(
             {
                 "sii_enabled": True,
@@ -336,7 +336,7 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
             self.invoice.sii_description,
             "Test customer header | Test description",
         )
-        invoice_temp = self._create_invoice("in_invoice")
+        invoice_temp = self._create_invoice_for_sii("in_invoice")
         self.assertEqual(
             invoice_temp.sii_description,
             "Test supplier header | Test description",
@@ -388,7 +388,7 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self._activate_certificate()
         self.invoice.company_id.sii_test = True
         self._check_tax_agencies(self.invoice)
-        in_invoice = self._create_invoice("in_invoice")
+        in_invoice = self._create_invoice_for_sii("in_invoice")
         self._check_tax_agencies(in_invoice)
 
     def test_tax_agencies_production(self):
@@ -396,7 +396,7 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self._activate_certificate()
         self.invoice.company_id.sii_test = False
         self._check_tax_agencies(self.invoice)
-        in_invoice = self._create_invoice("in_invoice")
+        in_invoice = self._create_invoice_for_sii("in_invoice")
         self._check_tax_agencies(in_invoice)
 
     def test_refund_sii_refund_type(self):
@@ -486,7 +486,7 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         with self.assertRaises(exceptions.UserError):
             self.invoice.write({"thirdparty_number": "CUSTOM"})
         # in_invoice
-        in_invoice = self._create_invoice("in_invoice")
+        in_invoice = self._create_invoice_for_sii("in_invoice")
         in_invoice.ref = "REF"
         in_invoice.sii_state = "sent"
         partner = self.partner.copy()

--- a/l10n_es_aeat_sii_taxfree/tests/test_l10n_es_aeat_sii_taxfree.py
+++ b/l10n_es_aeat_sii_taxfree/tests/test_l10n_es_aeat_sii_taxfree.py
@@ -13,7 +13,7 @@ class TestL10nEsAeatSiiTaxfree(TestL10nEsAeatSii):
                 "name": "Test fiscal position",
             }
         )
-        invoice = self._create_invoice("out_invoice")
+        invoice = self._create_invoice_for_sii("out_invoice")
         invoice.fiscal_position_id = fiscal_position
         invoice.fiscal_position_id.write({"sii_refund_as_regular": False})
         self.assertFalse(invoice.fiscal_position_id.sii_refund_as_regular)
@@ -26,7 +26,7 @@ class TestL10nEsAeatSiiTaxfree(TestL10nEsAeatSii):
         inv_dict = invoice._get_sii_invoice_dict_out()
         self.assertEqual(inv_dict["FacturaExpedida"]["TipoFactura"], "F1")
 
-        invoice_1 = self._create_invoice("out_invoice")
+        invoice_1 = self._create_invoice_for_sii("out_invoice")
         invoice_1.fiscal_position_id = fiscal_position
         invoice_1.fiscal_position_id.write({"sii_refund_as_regular": True})
         self.assertTrue(invoice_1.fiscal_position_id.sii_refund_as_regular)

--- a/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
+++ b/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
@@ -16,7 +16,7 @@ from ..hooks import post_init_hook
 @tagged("post_install", "-at_install")
 class TestL10nIntraStatReport(AccountTestInvoicingCommon):
     @classmethod
-    def _create_invoice(cls, inv_type, partner, fiscal_pos, product=None):
+    def _create_invoice_for_intrastat(cls, inv_type, partner, fiscal_pos, product=None):
         product = product or cls.product
         if inv_type in ("out_invoice", "in_refund"):
             account = cls.company_data["default_account_revenue"]
@@ -137,7 +137,7 @@ class TestL10nIntraStatReport(AccountTestInvoicingCommon):
                 (cls.partner_1, cls.partner_2),
                 (cls.fiscal_position_b2b, cls.fiscal_position_b2c),
             ):
-                invoice = cls._create_invoice(inv_type, partner, fiscal)
+                invoice = cls._create_invoice_for_intrastat(inv_type, partner, fiscal)
                 cls.invoices[declaration_type]["invoices"].append(invoice)
                 cls.invoices[declaration_type][partner.country_id] += 1
 


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/07be14e3086f473ed9a8c4b12ea7c, Odoo has a helper method in AccountTestInvoicingCommon called `_create_invoice`.

There are some tests here in this repository using the same name for methods with the decorator `classmethod` and also inheriting from the previous one, so they collide.

- l10n_es_aeat_sii_oca: l10n_es_pos_sii adds the inheritance on AccountTestInvoicingCommon
- l10n_es_intrastat_report: Direct inheritance.

The solution is to rename these methods to another name.

@Tecnativa 