### PR TITLE
[FIX] l10n_es_aeat_mod369: takes all periods

### DIFF
--- a/l10n_es_aeat_mod369/models/mod369_line_grouped.py
+++ b/l10n_es_aeat_mod369/models/mod369_line_grouped.py
@@ -65,10 +65,11 @@ class L10nEsAeatMod369LineGrouped(models.Model):
                         ("is_refund", "=", True),
                         ("country_code", "=", group.country_code),
                     ],
-                    limit=1,
                 )
                 if refund_line:
-                    group_keys["neg_corrections"] = refund_line.tax_correction
+                    group_keys["neg_corrections"] = sum(
+                        refund_line.mapped("tax_correction")
+                    )
                 group_keys["result_total"] = (
                     group_keys["amount"]
                     + group_keys["pos_corrections"]


### PR DESCRIPTION
Fix the calculation of section 8, when there is more than one "refund" line of a country for the different quarters, the calculation is only made with the first one and not calculating the real total.