### PR TITLE
[FIX][17.0] l10n_es_aeat: Wrong field for res.company

### DIFF
--- a/l10n_es_aeat/models/aeat_mixin.py
+++ b/l10n_es_aeat/models/aeat_mixin.py
@@ -157,7 +157,7 @@ class AeatMixin(models.AbstractModel):
         is_simplified_invoice = self._is_aeat_simplified_invoice()
         if country_code == "ES" and not partner.vat and not is_simplified_invoice:
             raise UserError(_("The partner has not a VAT configured."))
-        if not self.company_id.chart_template_id:
+        if not self.company_id.chart_template:
             raise UserError(
                 _("You have to select what account chart template use this" " company.")
             )


### PR DESCRIPTION
Antes de este fix, se hace referencia al campo chart_template_id de res.company. Este campo ha desaparecido en v17 y su función ha sido reemplazada por el campo de tipo Selection chart_template.

@HaraldPanten @ValentinVinagre 

@Tisho99 Te lo revisas, por favor?

T-5833