### PR TITLE
[15.0] Revert "[FIX] l10n_es_aeat_mod349: origin amount incorrect"

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -223,53 +223,12 @@ class Mod349(models.Model):
             if original_details:
                 # There's at least one previous 349 declaration report
                 report = original_details.mapped("report_id")[:1]
-                partner_id = original_details.mapped("partner_id")[:1]
                 original_details = original_details.filtered(
                     lambda d: d.report_id == report
                 )
                 origin_amount = sum(original_details.mapped("amount_untaxed"))
                 period_type = report.period_type
                 year = str(report.year)
-
-                # Sum all details period origin
-                all_details_period = detail_obj.search(
-                    [
-                        ("partner_id", "=", partner_id.id),
-                        ("partner_record_id.operation_key", "=", op_key),
-                        ("report_id", "=", report.id),
-                    ],
-                    order="report_id desc",
-                )
-                origin_amount = sum(all_details_period.mapped("amount_untaxed"))
-
-                # If there are intermediate periods between the original
-                # period and the period where the rectification is taking
-                # place, it's necessary to check if there is any rectification
-                # of the original period in between these periods. This
-                # happens in this way because the right original_amount
-                # will be the value of the total_operation_amount
-                # corresponding to the last period found in between the periods
-                other_invoice_period = (
-                    all_details_period.mapped("move_id") - origin_invoice
-                )
-                refund_invoice_ids = self.env["account.move"].search(
-                    [("reversed_entry_id", "in", other_invoice_period.ids)]
-                )
-                if refund_invoice_ids:
-                    last_refund_detail = refund_detail_obj.search(
-                        [
-                            ("report_id.date_start", ">", report.date_end),
-                            ("report_id.date_end", "<", self.date_start),
-                            ("move_id", "in", refund_invoice_ids.ids),
-                        ],
-                        order="date desc",
-                        limit=1,
-                    )
-                    if last_refund_detail:
-                        origin_amount = (
-                            last_refund_detail.refund_id.total_operation_amount
-                        )
-
             else:
                 # There's no previous 349 declaration report in Odoo
                 original_amls = move_line_obj.search(


### PR DESCRIPTION
This reverts commit 0e7847eb70314e42f89e098a306a03417e5f5950.

Este parche fue metido sin advertirse en la migración a 14.0, cuando el PR original de 11.0 no estaba aprobado ni la solución estaba clara que fuera la adecuada:

![imagen](https://github.com/user-attachments/assets/ee3744ba-58f1-4026-bc06-08532b55da9f)

y aparte de drenar rendimiento por asignar dos veces la variable `origin_amount` con mapeos que requieren obtener los datos, está provocando problemas de importes negativos.

Voy a comprobar en el caso real reportado por el cliente si sale correcto sin el parche. Si es así, fusionaré y cualesquiera que fueran los problemas existentes con el anterior código, deben expresarse y parchearse por el procedimiento regular.

@Tecnativa TT50922