### PR TITLE
[17.0] Revert "[FIX] l10n_es_aeat_mod349: origin amount incorrect"

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -229,25 +229,12 @@ class Mod349(models.Model):
                 )
                 # There's at least one previous 349 declaration report
                 report = original_details.mapped("report_id")[:1]
-                partner_id = original_details.mapped("partner_id")[:1]
                 original_details = original_details.filtered(
                     lambda d, report=report: d.report_id == report
                 )
                 origin_amount = sum(original_details.mapped("amount_untaxed"))
                 period_type = report.period_type
                 year = str(report.year)
-
-                # Sum all details period origin
-                all_details_period = detail_obj.search(
-                    [
-                        ("partner_id", "=", partner_id.id),
-                        ("partner_record_id.operation_key", "=", op_key),
-                        ("report_id", "=", report.id),
-                    ],
-                    order="report_id desc",
-                )
-                origin_amount = sum(all_details_period.mapped("amount_untaxed"))
-
                 # If there are intermediate periods between the original
                 # period and the period where the rectification is taking
                 # place, it's necessary to check if there is any rectification
@@ -266,7 +253,6 @@ class Mod349(models.Model):
                 )
                 if last_refund_detail:
                     origin_amount = last_refund_detail.refund_id.total_operation_amount
-
             else:
                 # There's no previous 349 declaration report in Odoo
                 original_amls = move_line_obj.search(


### PR DESCRIPTION
Forward-port de #3727 y #3729 

This partially reverts commit 0e7847eb70314e42f89e098a306a03417e5f5950, amended later by 0e93183c9313675a1e37e0e1c3a3faf941abe5fb.

Este parche fue metido sin advertirse en la migración a 14.0, cuando el PR original de 11.0 no estaba aprobado ni la solución estaba clara que fuera la adecuada:

![imagen](https://github.com/user-attachments/assets/ee3744ba-58f1-4026-bc06-08532b55da9f)

y aparte de drenar rendimiento por asignar dos veces la variable `origin_amount` con mapeos que requieren obtener los datos, está provocando problemas de importes negativos. Luego más tarde en esta versión hubo una correción realizada en 0e93183c9313675a1e37e0e1c3a3faf941abe5fb, con su caso de uso, para la que se ha comprobado que una parte del código funciona, respetando esa parte.

@Tecnativa TT50922