### PR TITLE
[16.0][FIX] l10n_es_aeat: Take into account inactive tax templates

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
@@ -1,5 +1,5 @@
-# Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
-# Copyright 2016-2017 Tecnativa - Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2016 Tecnativa - Antonio Espinosa
+# Copyright 2016,2024 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, exceptions, fields, models
@@ -30,6 +30,7 @@ class L10nEsAeatReportTaxMapping(models.AbstractModel):
             tax_code_map = (
                 self.env["l10n.es.aeat.map.tax"]
                 .sudo()
+                .with_context(active_test=False)
                 .search(
                     [
                         ("model", "=", report.number),

--- a/l10n_es_aeat/views/aeat_tax_code_mapping_view.xml
+++ b/l10n_es_aeat/views/aeat_tax_code_mapping_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
-     Copyright 2018 Tecnativa - Pedro M. Baeza
+     Copyright 2018,2024 Tecnativa - Pedro M. Baeza
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="l10n_es_aeat_map_tax_tree" model="ir.ui.view">
@@ -28,7 +28,12 @@
                         </group>
                     </group>
                     <group string="Mapping Lines" col="4">
-                        <field name="map_line_ids" nolabel="1" colspan="4" />
+                        <field
+                            name="map_line_ids"
+                            context="{'active_test': False}"
+                            nolabel="1"
+                            colspan="4"
+                        />
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
Forward-port of #3744 

Since odoo/odoo#179797, IVA 5% taxes templates are deactivated, and if you calculate an AEAT report containing them, they are not included as not being included in the m2m field.

This commit takes this situation into account.

@Tecnativa TT51059