### PR TITLE
[17.0][IMP] l10n_es_payment_order_confirming_sabadell + l10n_es_payment_order_confirming_aef: Remove WARNING Two fields have the same label

### DIFF
--- a/l10n_es_payment_order_confirming_aef/models/account_payment_mode.py
+++ b/l10n_es_payment_order_confirming_aef/models/account_payment_mode.py
@@ -9,7 +9,7 @@ class AccountPaymentMode(models.Model):
     _inherit = "account.payment.mode"
 
     aef_confirming_type = fields.Selection(
-        string="Tipo de pago",
+        string="Tipo de pago (AEF)",
         default="T",
         selection=[
             ("T", "Transferencia"),

--- a/l10n_es_payment_order_confirming_aef/views/account_payment_mode_view.xml
+++ b/l10n_es_payment_order_confirming_aef/views/account_payment_mode_view.xml
@@ -14,7 +14,7 @@
                     name="config_confirming_aef"
                     invisible="payment_method_code != 'confirming_aef'"
                 >
-                    <field name="aef_confirming_type" />
+                    <field name="aef_confirming_type" string="Tipo de pago" />
                     <field name="aef_confirming_modality" />
                     <field
                         name="aef_confirming_contract"

--- a/l10n_es_payment_order_confirming_sabadell/models/account_payment_mode.py
+++ b/l10n_es_payment_order_confirming_sabadell/models/account_payment_mode.py
@@ -10,7 +10,7 @@ class AccountPaymentMode(models.Model):
     _inherit = "account.payment.mode"
 
     conf_sabadell_type = fields.Selection(
-        string="Tipo de pago",
+        string="Tipo de pago (Sabadell)",
         default="56",
         selection=[
             ("56", "Tranferencia"),

--- a/l10n_es_payment_order_confirming_sabadell/views/account_payment_mode_view.xml
+++ b/l10n_es_payment_order_confirming_sabadell/views/account_payment_mode_view.xml
@@ -14,7 +14,7 @@
                     name="config_confirming_sabadell"
                     invisible="payment_method_code != 'conf_sabadell'"
                 >
-                    <field name="conf_sabadell_type" />
+                    <field name="conf_sabadell_type" string="Tipo de pago" />
                     <field
                         name="contrato_bsconfirming"
                         required="payment_method_code == 'conf_sabadell'"


### PR DESCRIPTION
Remove WARNING Two fields have the same label

```
WARNING devel odoo.addons.base.models.ir_model: Two fields (conf_sabadell_type, aef_confirming_type)
of account.payment.mode() have the same label: Tipo de pago. [Modules: l10n_es_payment_order_confirming_sabadell and l10n_es_payment_order_confirming_aef]
```

@Tecnativa