### PR TITLE
[16.0][FIX] l10n_es_irnr: Assign core tax_groups to taxes that had template…

### DIFF
--- a/l10n_es_irnr/__manifest__.py
+++ b/l10n_es_irnr/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Retenciones IRNR (No residentes)",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.2.1",
     "category": "Localization",
     "depends": ["l10n_es"],
     "development_status": "Mature",

--- a/l10n_es_irnr/migrations/16.0.1.2.1/pre-migration.py
+++ b/l10n_es_irnr/migrations/16.0.1.2.1/pre-migration.py
@@ -1,0 +1,32 @@
+# Copyright 2024 Aritz Olea <aritz.olea@factorlibre.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    retenciones_24 = env.ref("l10n_es.tax_group_retenciones_24")
+    retenciones_19 = env.ref("l10n_es.tax_group_retenciones_19")
+    retenciones_0 = env.ref("l10n_es.tax_group_retenciones_0")
+    tax_write_list = [
+        ("account_tax_template_s_irpfnrnue24", retenciones_24),
+        ("account_tax_template_p_irpfnrnue24p", retenciones_24),
+        ("account_tax_template_s_irpfnrue19", retenciones_19),
+        ("account_tax_template_p_irpfnrue19p", retenciones_19),
+        ("account_tax_template_s_irpfnrnue0", retenciones_0),
+        ("account_tax_template_p_irpfnrnue0p", retenciones_0),
+        ("account_tax_template_s_irpfnrue0", retenciones_0),
+        ("account_tax_template_p_irpfnrue0p", retenciones_0),
+    ]
+    for tax_write in tax_write_list:
+        record_ids = (
+            env["ir.model.data"]
+            .search(
+                [
+                    ("model", "=", "account.tax"),
+                    ("name", "like", tax_write[0]),
+                ]
+            )
+            .mapped("res_id")
+        )
+        env["account.tax"].browse(record_ids).tax_group_id = tax_write[1]

--- a/l10n_es_irnr/static/description/index.html
+++ b/l10n_es_irnr/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -481,9 +480,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h3><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
… removed from module

Nos ha salido el siguiente error:

```
2024-10-22 11:43:12,226 275344 INFO <dbname> odoo.addons.base.models.ir_model: Deleting 28@account.tax.group (l10n_es_irnr.tax_group_irnr_ue) 
2024-10-22 11:43:12,230 275344 ERROR <dbname> odoo.sql_db: bad query: DELETE FROM "account_tax_group" WHERE id IN (28)
ERROR: update or delete on table "account_tax_group" violates foreign key constraint "account_tax_tax_group_id_fkey" on table "account_tax"
DETAIL:  Key (id)=(28) is still referenced from table "account_tax".
```

cc. @ljsalvatierra-factorlibre @edlopen @pedrobaeza 