### PR TITLE
[15.0][FIX] l10n_es_facturae: don't copy facturae flag

### DIFF
--- a/l10n_es_facturae/models/res_partner.py
+++ b/l10n_es_facturae/models/res_partner.py
@@ -11,7 +11,7 @@ from odoo.exceptions import ValidationError
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    facturae = fields.Boolean("Factura electrónica")
+    facturae = fields.Boolean("Factura electrónica", copy=False)
     facturae_version = fields.Selection(
         [("3_2", "3.2"), ("3_2_1", "3.2.1"), ("3_2_2", "3.2.2")]
     )


### PR DESCRIPTION
The origin is an incompatibility detected with partner_vat_unique. That module sets the res.partner vat field to copy=False (so it's unique). In that case, when we try to copy a partner, if it has the facturae flag set, the it will fail as it won't have a VAT number.

cc @Tecnativa TT51626

please review @pedrobaeza @carlosdauden 