### PR TITLE
[16.0][FIX] l10n_es_aeat_partner_check: View is not correct

### DIFF
--- a/l10n_es_aeat_partner_check/views/res_partner_view.xml
+++ b/l10n_es_aeat_partner_check/views/res_partner_view.xml
@@ -10,6 +10,7 @@
             <page id="aeat" position="inside">
                 <group string="Partner Data Quality">
                     <button
+                        colspan="2"
                         type="object"
                         string="Check Partner Data"
                         name="aeat_check_partner"


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/458e73d7-5b37-4627-8ce4-864cad4e55b2)

Now:
![image](https://github.com/user-attachments/assets/a60590a9-633e-4b5c-87b2-1a0d4e5388bf)

