### PR TITLE
[16.0][IMP] l10n_es_aeat_mod347: Reubicate not_in_mod347

### DIFF
--- a/l10n_es_aeat_mod347/views/account_move_view.xml
+++ b/l10n_es_aeat_mod347/views/account_move_view.xml
@@ -5,7 +5,7 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='journal_div']" position="after">
+            <xpath expr="//field[@name='fiscal_position_id']" position="after">
                 <field name="not_in_mod347" />
             </xpath>
         </field>


### PR DESCRIPTION
The place where it's located is too prominent for something that is barely used, and it's stealing vertical space for displaying invoice lines.

Thus, let's move the field to the page "Other information", after the fiscal position, which is related as fiscal information.

![imagen](https://github.com/user-attachments/assets/ff0e2ab8-8f51-443d-8cdc-918e87279fda)

@Tecnativa TT51848