### PR TITLE
[16.0][IMP] l10n_es_aeat_sii_oca: Add Enable SII to journals to enable compatibilities (hr_expense for example)

### DIFF
--- a/l10n_es_aeat_sii_oca/models/__init__.py
+++ b/l10n_es_aeat_sii_oca/models/__init__.py
@@ -6,5 +6,6 @@ from . import product_product
 from . import queue_job
 from . import account_fiscal_position
 from . import sii_mixin
+from . import account_journal
 from . import account_move
 from . import res_partner

--- a/l10n_es_aeat_sii_oca/models/account_journal.py
+++ b/l10n_es_aeat_sii_oca/models/account_journal.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    company_sii_enabled = fields.Boolean(
+        related="company_id.sii_enabled", string="Company enable SII"
+    )
+    sii_enabled = fields.Boolean(string="Enable SII", default=True)

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -789,6 +789,8 @@ class AccountMove(models.Model):
     @api.depends(
         "company_id",
         "company_id.sii_enabled",
+        "journal_id",
+        "journal_id.sii_enabled",
         "move_type",
         "fiscal_position_id",
         "fiscal_position_id.aeat_active",
@@ -796,7 +798,11 @@ class AccountMove(models.Model):
     def _compute_sii_enabled(self):
         """Compute if the invoice is enabled for the SII"""
         for invoice in self:
-            if invoice.company_id.sii_enabled and invoice.is_invoice():
+            if (
+                invoice.company_id.sii_enabled
+                and invoice.journal_id.sii_enabled
+                and invoice.is_invoice()
+            ):
                 invoice.sii_enabled = (
                     invoice.fiscal_position_id
                     and invoice.fiscal_position_id.aeat_active

--- a/l10n_es_aeat_sii_oca/views/account_journal_view.xml
+++ b/l10n_es_aeat_sii_oca/views/account_journal_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- Copyright 2022 Moduon - Eduardo de Miguel
+     Copyright 2024 Tecnativa - Víctor Martínez
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="view_account_journal_thirdparty_form" model="ir.ui.view">
@@ -10,6 +11,13 @@
                 <attribute
                     name="attrs"
                 >{'invisible': [('type', 'not in', ('sale', 'purchase'))]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='thirdparty_invoice']" position="after">
+                <field name="company_sii_enabled" invisible="1" />
+                <field
+                    name="sii_enabled"
+                    attrs="{'invisible': ['|', ('company_sii_enabled', '=', False), ('type', 'not in', ('sale', 'purchase'))]}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Add Enable SII to journals to enable compatibilities (hr_expense for example)

Steps to reproduce:
- Install hr_expense
- Create a purchase type journal named Expenses and uncheck the Enable SII field.
- Go to Expense > Configuration > Settings and define in Employee Expense Journal the Expenses journal previously created
- Create an expense and an expense sheet
- Click on the Submit to manager button
- Click on the Approve button
- Click on the Post journal entries button
- The journal entry will be created correctly without any error

Please @pedrobaeza can you review it?

@Tecnativa TT51825