### PR TITLE
[16.0][IMP] l10n_es_aeat_sii_oca: Improve SII not sent filter to use sii_enabled field

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -88,6 +88,7 @@ class SiiMixin(models.AbstractModel):
     sii_enabled = fields.Boolean(
         string="Enable SII",
         compute="_compute_sii_enabled",
+        search="_search_sii_enabled",
     )
     sii_macrodata = fields.Boolean(
         string="MacroData",
@@ -150,6 +151,16 @@ class SiiMixin(models.AbstractModel):
 
     def _compute_sii_enabled(self):
         raise NotImplementedError
+
+    @api.model
+    def _is_unsupported_search_operator(self, operator):
+        return operator not in ("=", "!=")
+
+    @api.model
+    def _search_sii_enabled(self, operator, value):
+        if self._is_unsupported_search_operator(operator):
+            raise ValueError(_("Unsupported search operator"))
+        return [("company_id.sii_enabled", operator, value)]
 
     def _compute_macrodata(self):
         for document in self:

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -186,6 +186,25 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
             [("sii_wsdl_out", "!=", False)]
         )
 
+    def test_invoice_search_sii_enabled(self):
+        domain_base = [("id", "=", self.invoice.id)]
+        domain_ok = domain_base + [("sii_enabled", "=", True)]
+        items = self.env["account.move"].search(domain_ok)
+        self.assertIn(self.invoice, items)
+        domain_ko_1 = domain_base + [("sii_enabled", "=", False)]
+        items = self.env["account.move"].search(domain_ko_1)
+        self.assertNotIn(self.invoice, items)
+        domain_ko_2 = domain_base + [("sii_enabled", "!=", True)]
+        items = self.env["account.move"].search(domain_ko_2)
+        self.assertNotIn(self.invoice, items)
+        self.invoice.journal_id.sii_enabled = False
+        items = self.env["account.move"].search(domain_ok)
+        self.assertNotIn(self.invoice, items)
+        items = self.env["account.move"].search(domain_ko_1)
+        self.assertIn(self.invoice, items)
+        items = self.env["account.move"].search(domain_ko_2)
+        self.assertIn(self.invoice, items)
+
     def test_intracomunitary_customer_extracomunitary_delivery(self):
         """Comprobar venta a un cliente intracomunitario enviada al extranjero.
 

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -202,7 +202,7 @@
                     <filter
                         name="sii_not_sent"
                         string="SII not sent"
-                        domain="[('aeat_state', '=', 'not_sent'), ('date', '>=', '2017-01-01')]"
+                        domain="[('aeat_state', '=', 'not_sent'), ('sii_enabled', '=', True), ('date', '>=', '2017-01-01')]"
                         help="Never sent to SII"
                     />
                     <filter


### PR DESCRIPTION
Mejorar el filtro SII not sent para utilizar el campo `sii_enabled` (relacionado con https://github.com/OCA/l10n-spain/commit/c5343acf8e3d7a0dfbc14150269365dff3d7057a).

Por favor @pedrobaeza puedes revisarlo?

@Tecnativa TT52143