### PR TITLE
[16.0][FIX] l10n_es_aeat_mod303: Missing "to regularize" flags

### DIFF
--- a/l10n_es_aeat_mod303/data/2024-10/l10n.es.aeat.map.tax.line.csv
+++ b/l10n_es_aeat_mod303/data/2024-10/l10n.es.aeat.map.tax.line.csv
@@ -58,6 +58,6 @@ aeat_mod303_2024_10_map_line_152,aeat_mod303_2024_10_map,152,Régimen General - 
 aeat_mod303_2024_10_map_line_153,aeat_mod303_2024_10_map,153,Régimen General - Base imponible 5%/7.5%,0,regular,base,both,0,,"l10n_es.account_tax_template_s_iva5b,l10n_es.account_tax_template_s_iva5s,l10n_es.account_tax_template_s_iva7-5b,l10n_es.account_tax_template_s_iva7-5s"
 aeat_mod303_2024_10_map_line_155,aeat_mod303_2024_10_map,155,Régimen General - Cuota 5%/7.5%,1,regular,amount,both,0,,"l10n_es.account_tax_template_s_iva5b,l10n_es.account_tax_template_s_iva5s,l10n_es.account_tax_template_s_iva7-5b,l10n_es.account_tax_template_s_iva7-5s"
 aeat_mod303_2024_10_map_line_165,aeat_mod303_2024_10_map,165,Régimen General - Base imponible 2%,0,regular,base,both,0,,"l10n_es.account_tax_template_s_iva2b,l10n_es.account_tax_template_s_iva2s"
-aeat_mod303_2024_10_map_line_167,aeat_mod303_2024_10_map,167,Régimen General - Cuota 2%,0,regular,amount,both,0,,"l10n_es.account_tax_template_s_iva2b,l10n_es.account_tax_template_s_iva2s"
+aeat_mod303_2024_10_map_line_167,aeat_mod303_2024_10_map,167,Régimen General - Cuota 2%,1,regular,amount,both,0,,"l10n_es.account_tax_template_s_iva2b,l10n_es.account_tax_template_s_iva2s"
 aeat_mod303_2024_10_map_line_168,aeat_mod303_2024_10_map,168,Recargo equivalencia - Base imponible 0.26%,0,regular,base,both,0,,"l10n_es.account_tax_template_s_req026"
-aeat_mod303_2024_10_map_line_170,aeat_mod303_2024_10_map,170,Recargo equivalencia - Cuota 0.26%,0,regular,amount,both,0,,"l10n_es.account_tax_template_s_req026"
+aeat_mod303_2024_10_map_line_170,aeat_mod303_2024_10_map,170,Recargo equivalencia - Cuota 0.26%,1,regular,amount,both,0,,"l10n_es.account_tax_template_s_req026"


### PR DESCRIPTION
Forward-port of #3840 

IVA 2% + Recargo equivalencia 0.26% should be included in VAT regularization entry.

@Tecnativa