### PR TITLE
[IMP] l10n_es_mis_report: Include 4757

### DIFF
--- a/l10n_es_mis_report/data/mis_report_balance_normal.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_normal.xml
@@ -786,7 +786,7 @@
         <field
             name="description"
         >6. Otros créditos con las Administraciones Públicas</field>
-        <field name="expression">+bale[4700%,4708%,471%,472%,473%]</field>
+        <field name="expression">+bale[4700%,4707%,4708%,471%,472%,473%]</field>
         <field name="auto_expand_accounts">True</field>
         <field
             name="auto_expand_accounts_style_id"
@@ -1972,7 +1972,7 @@
         <field
             name="description"
         >6. Otras deudas con las Administraciones Públicas</field>
-        <field name="expression">-bale[4750%,4751%,4758%,4759%,476%,477%]</field>
+        <field name="expression">-bale[4750%,4751%,4757%,4758%,4759%,476%,477%]</field>
         <field name="auto_expand_accounts">True</field>
         <field
             name="auto_expand_accounts_style_id"


### PR DESCRIPTION
Según lo expuesto en la resolución publicada en el BOE ([Resolución de 16 de diciembre de 1992, del Instituto de Contabilidad y Auditoría de Cuentas, por la que se desarrollan algunos criterios a aplicar para la valoración y el registro contable del Impuesto General Indirecto Canario (IGIC)](https://www.boe.es/buscar/doc.php?id=BOE-A-1992-28829)), la cuenta desarrollada para este fin es la 4757. Hacienda Pública, acreedor por IGIC. 

De todas formas, esta resolución es anterior al actual plan contable y el PGC no incluye dentro de su estructura mención alguna del 4757 como subgrupo propio, pero tal vez se pudiera dar su inclusión teniendo como base esta disposición. Así se hace, por ejemplo, en el caso del Plan General de Contabilidad Pública utilizado por las Administraciones Públicas, que sí incluye como subgrupo la 4757.

[Orden EHA/1037/2010, de 13 de abril, por la que se aprueba el Plan General de Contabilidad Pública.](https://www.boe.es/eli/es/o/2010/04/13/eha1037/con)

En cualquier caso, parece un agujero en el PGC actual y teniendo en cuenta que no es necesario definir el la cuenta, no me parece mal añadirlo directamente en el Balance. ¿como lo veis?

@binhexsystems 