### PR TITLE
[FIX] l10n_es_partner: Corregido mostrar dirección completa tras rellenar nombre comercial

### DIFF
--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -22,12 +22,11 @@ class ResPartner(models.Model):
         )
         no_display_commercial = self.env.context.get("no_display_commercial")
         for partner in self:
-            if no_display_commercial or not name_pattern or not partner.comercial:
-                super(ResPartner, partner)._compute_display_name()
-            else:
+            super(ResPartner, partner)._compute_display_name()
+            if partner.comercial and not no_display_commercial and name_pattern:
                 partner.display_name = name_pattern % {
-                    "name": partner.complete_name,
-                    "comercial_name": partner.comercial,
+                    "name": partner.display_name,
+                    "comercial_name": partner.comercial or "",
                 }
         return True
 


### PR DESCRIPTION
En los formularios de pedidos y facturas, cuando el campo "nombre comercial" (comercial) está rellenado, los campos de dirección del cliente (calle, ciudad, código postal, etc.) desaparecen del formulario y también de las impresiones PDF. 

Se ha corregido la función para que esto no suceda