### PR TITLE
[16.0][FIX] l10n_es_pos: compatibility with kitchen order printers

### DIFF
--- a/l10n_es_pos/static/src/xml/pos.xml
+++ b/l10n_es_pos/static/src/xml/pos.xml
@@ -58,7 +58,7 @@
         >
             <attribute
                 name="t-if"
-            >!env.pos.config.is_simplified_config or receipt.is_to_invoice</attribute>
+            >!env.pos.config.is_simplified_config or receipt.is_to_invoice or env.pos.config.iface_printers</attribute>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
As we use the simplified invoice ref, the internal reference is usually useless. But when a kitchen order is printed that's the only reference we've got. This way we can show that reference in the ticket only when kitchen printers are configured in the point of sale.

cc @Tecnativa TT52521

please review @pedrobaeza @carlos-lopez-tecnativa 