### PR TITLE
[16.0][FIX] l10n_es_aeat_sii_oca: cancel one invoice

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -699,7 +699,7 @@ class AccountMove(models.Model):
             else:
                 eta = company._get_sii_eta()
                 new_delay = (
-                    self.sudo()
+                    invoice.sudo()
                     .with_context(company_id=company.id)
                     .with_delay(eta=eta)
                     .cancel_one_invoice()


### PR DESCRIPTION
Forward of

- https://github.com/OCA/l10n-spain/pull/3878

If we really want to cancel just one invoice we should send the whole recordset, as the effect will be looping over the same tasks over and over again.

cc @Tecnativa TT52550

please check @pedrobaeza @carlosdauden 