### PR TITLE
[16.0][FIX] l10n_es_aeat_mod190: Cálculo retenciones y percepciones incapacidad

### DIFF
--- a/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
+++ b/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
@@ -613,7 +613,7 @@ class L10nEsAeatMod190ReportLine(models.Model):
     @api.depends("report_id", "report_id.tax_line_ids", "discapacidad")
     def _compute_percepciones_dinerarias_incap(self):
         """La misma lógica que para percepciones_dinerarias."""
-        for item in self.filtered(lambda x: x.discapacidad or x.discapacidad != "0"):
+        for item in self.filtered(lambda x: x.discapacidad and x.discapacidad != "0"):
             tax_lines = item.report_id.tax_line_ids.filtered(
                 lambda x: x.field_number in (11, 15) and x.res_id == item.report_id.id
             )
@@ -625,7 +625,7 @@ class L10nEsAeatMod190ReportLine(models.Model):
     @api.depends("report_id", "report_id.tax_line_ids", "discapacidad")
     def _compute_retenciones_dinerarias_incap(self):
         """La misma lógica que para retenciones_dinerarias."""
-        for item in self.filtered(lambda x: x.discapacidad or x.discapacidad != "0"):
+        for item in self.filtered(lambda x: x.discapacidad and x.discapacidad != "0"):
             tax_lines = item.report_id.tax_line_ids.filtered(
                 lambda x: x.field_number in (12, 16) and x.res_id == item.report_id.id
             )
@@ -637,7 +637,7 @@ class L10nEsAeatMod190ReportLine(models.Model):
     @api.depends("report_id", "report_id.tax_line_ids", "discapacidad")
     def _compute_percepciones_en_especie_incap(self):
         """La misma lógica que para percepciones_en_especie."""
-        for item in self.filtered(lambda x: x.discapacidad or x.discapacidad != "0"):
+        for item in self.filtered(lambda x: x.discapacidad and x.discapacidad != "0"):
             tax_lines = item.report_id.tax_line_ids.filtered(
                 lambda x: x.field_number == 13 and x.res_id == item.report_id.id
             )
@@ -650,7 +650,7 @@ class L10nEsAeatMod190ReportLine(models.Model):
     @api.depends("report_id", "report_id.tax_line_ids", "discapacidad")
     def _compute_ingresos_a_cuenta_efectuados_incap(self):
         """La misma lógica que para ingresos_a_cuenta_efectuados."""
-        for item in self.filtered(lambda x: x.discapacidad or x.discapacidad != "0"):
+        for item in self.filtered(lambda x: x.discapacidad and x.discapacidad != "0"):
             tax_lines = item.report_id.tax_line_ids.filtered(
                 lambda x: x.field_number == 13 and x.res_id == item.report_id.id
             )
@@ -662,7 +662,7 @@ class L10nEsAeatMod190ReportLine(models.Model):
     @api.depends("report_id", "report_id.tax_line_ids", "discapacidad")
     def _compute_ingresos_a_cuenta_repercutidos_incap(self):
         """La misma lógica que para ingresos_a_cuenta_repercutidos."""
-        for item in self.filtered(lambda x: x.discapacidad or x.discapacidad != "0"):
+        for item in self.filtered(lambda x: x.discapacidad and x.discapacidad != "0"):
             tax_lines = item.report_id.tax_line_ids.filtered(
                 lambda x: x.field_number == 13 and x.res_id == item.report_id.id
             )


### PR DESCRIPTION
Con la condición actual `x.discapacidad or x.discapacidad != "0` si el contacto no tiene marcada ninguna discapacidad o la opción 0, se calcula también como discapacidad.

Antes:
![image](https://github.com/user-attachments/assets/fbe86fb8-3c13-477e-b9a1-05384ce27db1)
Se calculaba las retenciones y percepciones ya fuesen dinerarias o en pespecie por incapacidad aunque la razón social no estuviera rellena la discapacidad o seleccionada la opción 0.
![image](https://github.com/user-attachments/assets/fdd4da31-235a-4b2d-bd1c-a6a2ab5fccbb)

Ahora:
![image](https://github.com/user-attachments/assets/9542471a-cb3c-41c9-8452-b78278955d62)
No se calculan las las retenciones y percepciones ya fuesen dinerarias o en pespecie por incapacidad si la razón social no está marcado con incapacidad.

@ArantxaSudon @loida-vm @jvpascual @pedrobaeza por favor revisad, gracias.

@moduon MT-8454