### PR TITLE
[IMP] l10n_es_aeat_sii_oca: Impuesto ganadería y pesca (10,5%)

### DIFF
--- a/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
@@ -168,6 +168,7 @@
             name="taxes"
             eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_p_iva12_agr'),
+                ref('l10n_es.account_tax_template_p_iva105_gan'),
             ])]"
         />
         <field name="sii_map_id" ref="aeat_sii_map" />


### PR DESCRIPTION
Referente a la issue https://github.com/OCA/l10n-spain/issues/3881

@fcvalgar @rafaelbn @pedrobaeza revisad por favor, gracias.

@moduon MT-8089