### PR TITLE
[15.0][IMP] l10n_es_aeat: Reverse order for reports

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -18,7 +18,7 @@ class L10nEsAeatReport(models.AbstractModel):
     _name = "l10n.es.aeat.report"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "AEAT report base module"
-    _order = "date_start,id"
+    _order = "date_start desc,id desc"
     _rec_name = "name"
     _aeat_number = False
     _period_quarterly = True


### PR DESCRIPTION
Backport of #3887 

It's more significant to have first the latest AEAT reports than the first ones.

@Tecnativa