### PR TITLE
[17.0][IMP] l10n_es_aeat_mod303: Follow 2 column layout in exonerated 390

### DIFF
--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -53,100 +53,96 @@
                     name="group_exonerated_390"
                     invisible="exonerated_390 == '2'"
                 >
-                    <group>
-                        <group string="Actividad principal" name="group_main_activity">
-                            <field
-                                name="main_activity_code"
-                                widget="selection"
-                                readonly="state == 'done'"
-                                required="exonerated_390 != '2'"
-                            />
-                            <field
-                                name="main_activity_iae"
-                                readonly="state == 'done'"
-                                required="exonerated_390 != '2'"
-                            />
-                        </group>
-                        <group name="group_others_390" string="Otros">
-                            <field
-                                name="has_operation_volume"
-                                readonly="state != 'draft'"
-                            />
-                            <field name="has_347" readonly="state == 'done'" />
-                            <field name="is_voluntary_sii" readonly="state == 'done'" />
-                        </group>
+                    <group string="Actividad principal" name="group_main_activity">
+                        <field
+                            name="main_activity_code"
+                            widget="selection"
+                            readonly="state == 'done'"
+                            required="exonerated_390 != '2'"
+                        />
+                        <field
+                            name="main_activity_iae"
+                            readonly="state == 'done'"
+                            required="exonerated_390 != '2'"
+                        />
                     </group>
-                    <group col="3">
-                        <group
-                            string="Otras - 1ª actividad"
-                            name="group_other_first_activity"
-                        >
-                            <field
-                                name="other_first_activity_code"
-                                readonly="state == 'done'"
-                                widget="selection"
-                            />
-                            <field
-                                name="other_first_activity_iae"
-                                readonly="state == 'done'"
-                            />
-                        </group>
-                        <group
-                            string="Otras - 2ª actividad"
-                            name="group_other_second_activity"
-                        >
-                            <field
-                                name="other_second_activity_code"
-                                readonly="state == 'done'"
-                                widget="selection"
-                            />
-                            <field
-                                name="other_second_activity_iae"
-                                readonly="state == 'done'"
-                            />
-                        </group>
-                        <group
-                            string="Otras - 3ª actividad"
-                            name="group_other_third_activity"
-                        >
-                            <field
-                                name="other_third_activity_code"
-                                readonly="state == 'done'"
-                                widget="selection"
-                            />
-                            <field
-                                name="other_third_activity_iae"
-                                readonly="state == 'done'"
-                            />
-                        </group>
-                        <group
-                            string="Otras - 4ª actividad"
-                            name="group_other_fourth_activity"
-                        >
-                            <field
-                                name="other_fourth_activity_code"
-                                readonly="state == 'done'"
-                                widget="selection"
-                            />
-                            <field
-                                name="other_fourth_activity_iae"
-                                readonly="state == 'done'"
-                            />
-                        </group>
-                        <group
-                            string="Otras - 5ª actividad"
-                            name="group_other_fifth_activity"
-                        >
-                            <field
-                                name="other_fifth_activity_code"
-                                readonly="state == 'done'"
-                                widget="selection"
-                            />
-                            <field
-                                name="other_fifth_activity_iae"
-                                readonly="state == 'done'"
-                            />
-                        </group>
+                    <group name="group_others_390" string="Otros">
+                        <field
+                            name="has_operation_volume"
+                            readonly="state != 'draft'"
+                        />
+                        <field name="has_347" readonly="state == 'done'" />
+                        <field name="is_voluntary_sii" readonly="state == 'done'" />
+                    </group>
+                    <group
+                        string="Otras - 1ª actividad"
+                        name="group_other_first_activity"
+                    >
+                        <field
+                            name="other_first_activity_code"
+                            readonly="state == 'done'"
+                            widget="selection"
+                        />
+                        <field
+                            name="other_first_activity_iae"
+                            readonly="state == 'done'"
+                        />
+                    </group>
+                    <group
+                        string="Otras - 2ª actividad"
+                        name="group_other_second_activity"
+                    >
+                        <field
+                            name="other_second_activity_code"
+                            readonly="state == 'done'"
+                            widget="selection"
+                        />
+                        <field
+                            name="other_second_activity_iae"
+                            readonly="state == 'done'"
+                        />
+                    </group>
+                    <group
+                        string="Otras - 3ª actividad"
+                        name="group_other_third_activity"
+                    >
+                        <field
+                            name="other_third_activity_code"
+                            readonly="state == 'done'"
+                            widget="selection"
+                        />
+                        <field
+                            name="other_third_activity_iae"
+                            readonly="state == 'done'"
+                        />
+                    </group>
+                    <group
+                        string="Otras - 4ª actividad"
+                        name="group_other_fourth_activity"
+                    >
+                        <field
+                            name="other_fourth_activity_code"
+                            readonly="state == 'done'"
+                            widget="selection"
+                        />
+                        <field
+                            name="other_fourth_activity_iae"
+                            readonly="state == 'done'"
+                        />
+                    </group>
+                    <group
+                        string="Otras - 5ª actividad"
+                        name="group_other_fifth_activity"
+                    >
+                        <field
+                            name="other_fifth_activity_code"
+                            readonly="state == 'done'"
+                            widget="selection"
+                        />
+                        <field
+                            name="other_fifth_activity_iae"
+                            readonly="state == 'done'"
+                        />
                     </group>
                 </group>
                 <group


### PR DESCRIPTION
Forward-port of #3889 and #3892 

If not, the fields are stretched on regular screens, and they can't be filled.

Before:

![image](https://github.com/user-attachments/assets/142197a3-9597-4a1b-9aac-d08987ee6ab6)

After:

![image](https://github.com/user-attachments/assets/29449489-c0f5-4036-a395-bf45994bd156)

@Tecnativa