### PR TITLE
[17.0][FIX] l10n_es_vat_book: other_tax_ids key error in pop of create lines

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -401,7 +401,7 @@ class L10nEsVatBook(models.Model):
                     line_vals["special_tax_group"] = tax_group
                     tax_line["special_tax_group"] = tax_group
                     sp_taxes[tuple(tax_line["other_tax_ids"])] = tax_line
-                tax_line.pop("other_tax_ids")
+                tax_line.pop("other_tax_ids", None)
             # Second loop for putting the values in the other lines
             if sp_taxes:
                 for tax_line in tax_lines.values():


### PR DESCRIPTION
Fix of the issue #3786 

In some iterations the key 'other_tax_ids' is not present in the tax_line.

