### PR TITLE
[16.0][FIX] l10n_es_atc: No auto-install

### DIFF
--- a/l10n_es_atc/__manifest__.py
+++ b/l10n_es_atc/__manifest__.py
@@ -15,5 +15,5 @@
         "data/atc_partner.xml",
     ],
     "installable": True,
-    "auto_install": True,
+    "auto_install": False,
 }


### PR DESCRIPTION
It should be installed on demand, as having AEAT doesn't mean we should install ATC.

@Tecnativa 