### PR TITLE
[15.0][WIP] l10n_es_aeat_mod592: Definir datos correctos en el excel que se exporta

### DIFF
--- a/l10n_es_aeat_mod592/models/mod592_acquirer.py
+++ b/l10n_es_aeat_mod592/models/mod592_acquirer.py
@@ -94,13 +94,14 @@ class L10nEsAeatmod592LineAcquirer(models.Model):
             "Fecha Hecho Contabilizado": "date_done",
             "Concepto": "concept",
             "Clave Producto": "product_key",
-            "Descripción Producto": "fiscal_acquirer",
+            "Descripción Producto": "product_description",
+            "Regimen fiscal": "fiscal_acquirer",
             "Justificante": "proof",
-            "Kilogramos": "kgs",
-            "Kilogramos No Reciclados": "no_recycling_kgs",
             "Prov./Dest.: Tipo Documento": "supplier_document_type",
             "Prov./Dest.: Nº Documento": "supplier_document_number",
             "Prov./Dest.: Razón Social": "supplier_social_reason",
+            "Kilogramos": "kgs",
+            "Kilogramos No Reciclados": "no_recycling_kgs",
             "Observaciones": "entry_note",
         }
         res = {}
@@ -114,6 +115,5 @@ class L10nEsAeatmod592LineAcquirer(models.Model):
     def _get_csv_report_info(self):
         self.ensure_one()
         data = super()._get_csv_report_info()
-        data["concept"] = self.concept
         data["fiscal_acquirer"] = self.fiscal_acquirer
         return self._get_csv_report_info_mapped(data)

--- a/l10n_es_aeat_mod592/models/mod592_line_mixin.py
+++ b/l10n_es_aeat_mod592/models/mod592_line_mixin.py
@@ -58,6 +58,9 @@ class L10nEsAeatmod592LineMixin(models.AbstractModel):
     product_id = fields.Many2one(
         comodel_name="product.product", related="stock_move_id.product_id"
     )
+    product_description = fields.Char(
+        string="Product description", compute="_compute_product_description"
+    )
     product_uom_qty = fields.Float(
         compute="_compute_product_uom_qty",
         store=True,
@@ -143,6 +146,11 @@ class L10nEsAeatmod592LineMixin(models.AbstractModel):
                 item.product_id.plastic_weight_non_recyclable * item.product_uom_qty
             )
 
+    @api.depends("product_id")
+    def _compute_product_description(self):
+        for item in self:
+            item.product_description = item.product_id.name
+
     @api.depends("error_text")
     def _compute_entries_ok(self):
         for item in self:
@@ -171,7 +179,9 @@ class L10nEsAeatmod592LineMixin(models.AbstractModel):
         return {
             "entry_number": self.entry_number,
             "date_done": self.date_done.strftime("%d/%m/%Y"),
+            "concept": self.concept,
             "product_key": self.product_key,
+            "product_description": self.product_description,
             "proof": self.proof,
             "supplier_document_type": self.supplier_document_type,
             "supplier_document_number": self.supplier_document_number,

--- a/l10n_es_aeat_mod592/models/mod592_manufacturer.py
+++ b/l10n_es_aeat_mod592/models/mod592_manufacturer.py
@@ -37,9 +37,6 @@ class L10nEsAeatmod592LineManufacturer(models.Model):
         compute="_compute_concept",
         store=True,
     )
-    product_description = fields.Char(
-        string="Product description", compute="_compute_product_description"
-    )
     fiscal_manufacturer = fields.Selection(
         selection=FISCAL_MANUFACTURERS,
         string="Fiscal regime manufacturer",
@@ -75,11 +72,6 @@ class L10nEsAeatmod592LineManufacturer(models.Model):
             elif dest_loc_scrap:
                 concept = "5"
             item.concept = concept
-
-    @api.depends("product_id")
-    def _compute_product_description(self):
-        for item in self:
-            item.product_description = item.product_id.name
 
     @api.depends("product_id")
     def _compute_fiscal_manufacturer(self):
@@ -135,7 +127,5 @@ class L10nEsAeatmod592LineManufacturer(models.Model):
     def _get_csv_report_info(self):
         self.ensure_one()
         data = super()._get_csv_report_info()
-        data["concept"] = self.concept
-        data["product_description"] = self.product_description
         data["fiscal_manufacturer"] = self.fiscal_manufacturer
         return self._get_csv_report_info_mapped(data)


### PR DESCRIPTION
Definir datos correctos en el excel que se exporta

Cambios hechos:
- Se añade el concepto y el product_description al método _get_csv_report_info() del mixin (necesario en ambos)
- Se añade el campo product_description al mixin (necesario en ambos)
- Adquiriente: Se define como Descripción Producto la descripción del producto en lugar de fiscal_acquirer
- Adquiriente: Se añade la columna Régimen fiscal (fiscal_acquirer)  después de la descripción de producto
- Adquiriente: Se mueven los campo Prov./Dest. al lugar adecuado, antes de Kilogramos

@Tecnativa TT52986