### PR TITLE
[16.0][IMP] (l10n_es_aeat_mod303, l10n_es_aeat_mod390): Valores por defecto en compañias

### DIFF
--- a/l10n_es_aeat_mod303/__manifest__.py
+++ b/l10n_es_aeat_mod303/__manifest__.py
@@ -39,6 +39,7 @@
         "data/l10n.es.aeat.mod303.report.activity.code.csv",
         "views/mod303_view.xml",
         "views/l10n_es_aeat_mod303_report_activity_code_data_views.xml",
+        "views/res_company.xml",
         "security/l10n_es_aeat_mod303_security.xml",
         "security/ir.model.access.csv",
     ],

--- a/l10n_es_aeat_mod303/models/__init__.py
+++ b/l10n_es_aeat_mod303/models/__init__.py
@@ -1,1 +1,2 @@
 from . import mod303
+from . import res_company

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -217,68 +217,92 @@ class L10nEsAeatMod303Report(models.Model):
     main_activity_code = fields.Many2one(
         comodel_name="l10n.es.aeat.mod303.report.activity.code",
         domain=ACTIVITY_CODE_DOMAIN,
-        states=NON_EDITABLE_ON_DONE,
         string="Código actividad principal",
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     main_activity_iae = fields.Char(
-        states=NON_EDITABLE_ON_DONE,
         string="Epígrafe I.A.E. actividad principal",
         size=4,
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     other_first_activity_code = fields.Many2one(
         comodel_name="l10n.es.aeat.mod303.report.activity.code",
         domain=ACTIVITY_CODE_DOMAIN,
-        states=NON_EDITABLE_ON_DONE,
         string="Código 1ª actividad",
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     other_first_activity_iae = fields.Char(
         string="Epígrafe I.A.E. 1ª actividad",
-        states=NON_EDITABLE_ON_DONE,
         size=4,
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     other_second_activity_code = fields.Many2one(
         comodel_name="l10n.es.aeat.mod303.report.activity.code",
         domain=ACTIVITY_CODE_DOMAIN,
-        states=NON_EDITABLE_ON_DONE,
         string="Código 2ª actividad",
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     other_second_activity_iae = fields.Char(
         string="Epígrafe I.A.E. 2ª actividad",
-        states=NON_EDITABLE_ON_DONE,
         size=4,
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     other_third_activity_code = fields.Many2one(
         comodel_name="l10n.es.aeat.mod303.report.activity.code",
         domain=ACTIVITY_CODE_DOMAIN,
-        states=NON_EDITABLE_ON_DONE,
         string="Código 3ª actividad",
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     other_third_activity_iae = fields.Char(
         string="Epígrafe I.A.E. 3ª actividad",
-        states=NON_EDITABLE_ON_DONE,
         size=4,
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     other_fourth_activity_code = fields.Many2one(
         comodel_name="l10n.es.aeat.mod303.report.activity.code",
         domain=ACTIVITY_CODE_DOMAIN,
-        states=NON_EDITABLE_ON_DONE,
         string="Código 4ª actividad",
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     other_fourth_activity_iae = fields.Char(
         string="Epígrafe I.A.E. 4ª actividad",
-        states=NON_EDITABLE_ON_DONE,
         size=4,
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     other_fifth_activity_code = fields.Many2one(
         comodel_name="l10n.es.aeat.mod303.report.activity.code",
         domain=ACTIVITY_CODE_DOMAIN,
-        states=NON_EDITABLE_ON_DONE,
         string="Código 5ª actividad",
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     other_fifth_activity_iae = fields.Char(
         string="Epígrafe I.A.E. 5ª actividad",
-        states=NON_EDITABLE_ON_DONE,
         size=4,
+        readonly=False,
+        compute="_compute_activities_and_iae",
+        store=True,
     )
     casilla_88 = fields.Float(
         string="[88] Total volumen operaciones",
@@ -498,6 +522,56 @@ class L10nEsAeatMod303Report(models.Model):
                         report.result_type = "C"
                 else:
                     report.result_type = "C"
+
+    @api.depends("exonerated_390", "company_id")
+    def _compute_activities_and_iae(self):
+        for record in self:
+            if record.exonerated_390 != "2":
+                record.main_activity_code = record.company_id.main_activity_code_id
+                record.main_activity_iae = record.company_id.main_activity_iae
+                record.other_first_activity_code = (
+                    record.company_id.other_first_activity_code_id
+                )
+                record.other_first_activity_iae = (
+                    record.company_id.other_first_activity_iae
+                )
+                record.other_second_activity_code = (
+                    record.company_id.other_second_activity_code_id
+                )
+                record.other_second_activity_iae = (
+                    record.company_id.other_second_activity_iae
+                )
+                record.other_third_activity_code = (
+                    record.company_id.other_third_activity_code_id
+                )
+                record.other_third_activity_iae = (
+                    record.company_id.other_third_activity_iae
+                )
+                record.other_fourth_activity_code = (
+                    record.company_id.other_fourth_activity_code_id
+                )
+                record.other_fourth_activity_iae = (
+                    record.company_id.other_fourth_activity_iae
+                )
+                record.other_fifth_activity_code = (
+                    record.company_id.other_fifth_activity_code_id
+                )
+                record.other_fifth_activity_iae = (
+                    record.company_id.other_fifth_activity_iae
+                )
+            else:
+                record.main_activity_code = False
+                record.main_activity_iae = False
+                record.other_first_activity_code = False
+                record.other_first_activity_iae = False
+                record.other_second_activity_code = False
+                record.other_second_activity_iae = False
+                record.other_third_activity_code = False
+                record.other_third_activity_iae = False
+                record.other_fourth_activity_code = False
+                record.other_fourth_activity_iae = False
+                record.other_fifth_activity_code = False
+                record.other_fifth_activity_iae = False
 
     @api.onchange("statement_type")
     def onchange_type(self):

--- a/l10n_es_aeat_mod303/models/res_company.py
+++ b/l10n_es_aeat_mod303/models/res_company.py
@@ -1,0 +1,56 @@
+# Copyright 2024 Moduon Team - Emilio Pascual
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    main_activity_code_id = fields.Many2one(
+        comodel_name="l10n.es.aeat.mod303.report.activity.code",
+        string="Código actividad principal",
+    )
+    main_activity_iae = fields.Char(
+        string="Epígrafe I.A.E. actividad principal",
+        size=4,
+    )
+    other_first_activity_code_id = fields.Many2one(
+        comodel_name="l10n.es.aeat.mod303.report.activity.code",
+        string="Código 1ª actividad",
+    )
+    other_first_activity_iae = fields.Char(
+        string="Epígrafe I.A.E. 1ª actividad",
+        size=4,
+    )
+    other_second_activity_code_id = fields.Many2one(
+        comodel_name="l10n.es.aeat.mod303.report.activity.code",
+        string="Código 2ª actividad",
+    )
+    other_second_activity_iae = fields.Char(
+        string="Epígrafe I.A.E. 2ª actividad",
+        size=4,
+    )
+    other_third_activity_code_id = fields.Many2one(
+        comodel_name="l10n.es.aeat.mod303.report.activity.code",
+        string="Código 3ª actividad",
+    )
+    other_third_activity_iae = fields.Char(
+        string="Epígrafe I.A.E. 3ª actividad",
+        size=4,
+    )
+    other_fourth_activity_code_id = fields.Many2one(
+        comodel_name="l10n.es.aeat.mod303.report.activity.code",
+        string="Código 4ª actividad",
+    )
+    other_fourth_activity_iae = fields.Char(
+        string="Epígrafe I.A.E. 4ª actividad",
+        size=4,
+    )
+    other_fifth_activity_code_id = fields.Many2one(
+        comodel_name="l10n.es.aeat.mod303.report.activity.code",
+        string="Código 5ª actividad",
+    )
+    other_fifth_activity_iae = fields.Char(
+        string="Epígrafe I.A.E. 5ª actividad",
+        size=4,
+    )

--- a/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
+++ b/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
@@ -617,3 +617,93 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
         self.model303.date_end = "2020-03-31"
         self.model303.button_calculate()
         self._check_tax_lines()
+
+    def test_default_values_in_company(self):
+        self.company.update(
+            {
+                "main_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_A01"
+                ),
+                "main_activity_iae": "A01",
+                "other_first_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_A02"
+                ),
+                "other_first_activity_iae": "A02",
+                "other_second_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_A03"
+                ),
+                "other_second_activity_iae": "A03",
+                "other_third_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_A04"
+                ),
+                "other_third_activity_iae": "A04",
+                "other_fourth_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_A05"
+                ),
+                "other_fourth_activity_iae": "A05",
+                "other_fifth_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_B01"
+                ),
+                "other_fifth_activity_iae": "B01",
+            }
+        )
+        model303_2024_4T = self.model303.copy(
+            {
+                "name": "9994002024303",
+                "period_type": "4T",
+                "date_start": "2024-09-01",
+                "date_end": "2024-12-31",
+            }
+        )
+        model303_2024_4T.exonerated_390 = "1"
+        self.assertRecordValues(
+            model303_2024_4T,
+            [
+                {
+                    "main_activity_code": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_A01"
+                    ).id,
+                    "main_activity_iae": "A01",
+                    "other_first_activity_code": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_A02"
+                    ).id,
+                    "other_first_activity_iae": "A02",
+                    "other_second_activity_code": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_A03"
+                    ).id,
+                    "other_second_activity_iae": "A03",
+                    "other_third_activity_code": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_A04"
+                    ).id,
+                    "other_third_activity_iae": "A04",
+                    "other_fourth_activity_code": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_A05"
+                    ).id,
+                    "other_fourth_activity_iae": "A05",
+                    "other_fifth_activity_code": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_B01"
+                    ).id,
+                    "other_fifth_activity_iae": "B01",
+                }
+            ],
+        )
+        model303_2024_4T.exonerated_390 = "2"
+        self.assertRecordValues(
+            model303_2024_4T,
+            [
+                {
+                    "main_activity_code": False,
+                    "main_activity_iae": False,
+                    "other_first_activity_code": False,
+                    "other_first_activity_iae": False,
+                    "other_second_activity_code": False,
+                    "other_second_activity_iae": False,
+                    "other_third_activity_code": False,
+                    "other_third_activity_iae": False,
+                    "other_fourth_activity_code": False,
+                    "other_fourth_activity_iae": False,
+                    "other_fifth_activity_code": False,
+                    "other_fifth_activity_iae": False,
+                }
+            ],
+        )

--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -52,11 +52,11 @@
                         <field
                             name="main_activity_code"
                             widget="selection"
-                            attrs="{'required': [('exonerated_390', '!=', '2')]}"
+                            attrs="{'required': [('exonerated_390', '!=', '2')], 'readonly': [('state', '!=', 'draft')]}"
                         />
                         <field
                             name="main_activity_iae"
-                            attrs="{'required': [('exonerated_390', '!=', '2')]}"
+                            attrs="{'required': [('exonerated_390', '!=', '2')], 'readonly': [('state', '!=', 'draft')]}"
                         />
                     </group>
                     <group name="group_others_390" string="Otros">
@@ -68,36 +68,71 @@
                         string="Otras - 1ª actividad"
                         name="group_other_first_activity"
                     >
-                        <field name="other_first_activity_code" widget="selection" />
-                        <field name="other_first_activity_iae" />
+                        <field
+                            name="other_first_activity_code"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                            widget="selection"
+                        />
+                        <field
+                            name="other_first_activity_iae"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                        />
                     </group>
                     <group
                         string="Otras - 2ª actividad"
                         name="group_other_second_activity"
                     >
-                        <field name="other_second_activity_code" widget="selection" />
-                        <field name="other_second_activity_iae" />
+                        <field
+                            name="other_second_activity_code"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                            widget="selection"
+                        />
+                        <field
+                            name="other_second_activity_iae"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                        />
                     </group>
                     <group
                         string="Otras - 3ª actividad"
                         name="group_other_third_activity"
                     >
-                        <field name="other_third_activity_code" widget="selection" />
-                        <field name="other_third_activity_iae" />
+                        <field
+                            name="other_third_activity_code"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                            widget="selection"
+                        />
+                        <field
+                            name="other_third_activity_iae"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                        />
                     </group>
                     <group
                         string="Otras - 4ª actividad"
                         name="group_other_fourth_activity"
                     >
-                        <field name="other_fourth_activity_code" widget="selection" />
-                        <field name="other_fourth_activity_iae" />
+                        <field
+                            name="other_fourth_activity_code"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                            widget="selection"
+                        />
+                        <field
+                            name="other_fourth_activity_iae"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                        />
                     </group>
                     <group
                         string="Otras - 5ª actividad"
                         name="group_other_fifth_activity"
                     >
-                        <field name="other_fifth_activity_code" widget="selection" />
-                        <field name="other_fifth_activity_iae" />
+                        <field
+                            name="other_fifth_activity_code"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                            widget="selection"
+                        />
+                        <field
+                            name="other_fifth_activity_iae"
+                            attrs="{'readonly': [('state', '!=', 'draft')]}"
+                        />
                     </group>
                 </group>
                 <group

--- a/l10n_es_aeat_mod303/views/res_company.xml
+++ b/l10n_es_aeat_mod303/views/res_company.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Emilio Pascual
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_company_aeat_mod303_form" model="ir.ui.view">
+        <field name="name">res.company.aeat.mod303.form</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="l10n_es_aeat.view_company_aeat_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='aeat_config']/parent::group" position="after">
+                <group name="default_values_aeat_303">
+                    <group string="Actividad principal" name="group_main_activity">
+                        <field name="main_activity_code_id" />
+                        <field name="main_activity_iae" />
+                    </group>
+                    <group
+                        string="Otras - 1ª actividad"
+                        name="group_other_first_activity"
+                    >
+                        <field name="other_first_activity_code_id" />
+                        <field name="other_first_activity_iae" />
+                    </group>
+                    <group
+                        string="Otras - 2ª actividad"
+                        name="group_other_second_activity"
+                    >
+                        <field name="other_second_activity_code_id" />
+                        <field name="other_second_activity_iae" />
+                    </group>
+                    <group
+                        string="Otras - 3ª actividad"
+                        name="group_other_third_activity"
+                    >
+                        <field name="other_third_activity_code_id" />
+                        <field name="other_third_activity_iae" />
+                    </group>
+                    <group
+                        string="Otras - 4ª actividad"
+                        name="group_other_fourth_activity"
+                    >
+                        <field name="other_fourth_activity_code_id" />
+                        <field name="other_fourth_activity_iae" />
+                    </group>
+                    <group
+                        string="Otras - 5ª actividad"
+                        name="group_other_fifth_activity"
+                    >
+                        <field name="other_fifth_activity_code_id" />
+                        <field name="other_fifth_activity_iae" />
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/l10n_es_aeat_mod390/__manifest__.py
+++ b/l10n_es_aeat_mod390/__manifest__.py
@@ -37,6 +37,7 @@
         # rest of stuff
         "views/mod390_view.xml",
         "views/account_move_view.xml",
+        "views/res_company.xml",
         "security/ir.model.access.csv",
         "security/l10n_es_aeat_mod390_security.xml",
     ],

--- a/l10n_es_aeat_mod390/models/__init__.py
+++ b/l10n_es_aeat_mod390/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import mod390
 from . import account_move
+from . import res_company

--- a/l10n_es_aeat_mod390/models/mod390.py
+++ b/l10n_es_aeat_mod390/models/mod390.py
@@ -54,9 +54,10 @@ class L10nEsAeatMod390Report(models.Model):
     )
     main_activity = fields.Char(
         string="Actividad principal",
-        readonly=True,
+        readonly=False,
         size=40,
-        states=REQUIRED_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     main_activity_code = fields.Selection(
         selection=ACTIVITY_CODE_SELECTION,
@@ -72,23 +73,27 @@ class L10nEsAeatMod390Report(models.Model):
         "   '|', ('date_end', '=', False), ('date_end', '>=', date_end),"
         "]",
         string="Código actividad principal",
+        readonly=False,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     main_activity_iae = fields.Char(
         string="Epígrafe I.A.E. actividad principal",
-        readonly=True,
+        readonly=False,
         size=4,
-        states=REQUIRED_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_first_activity = fields.Char(
         string="1ª actividad",
-        readonly=True,
+        readonly=False,
         size=40,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_first_activity_code = fields.Selection(
         selection=ACTIVITY_CODE_SELECTION,
         string="Código 1ª actividad (antiguo)",
-        readonly=True,
     )
     other_first_activity_code_id = fields.Many2one(
         comodel_name="l10n.es.aeat.mod303.report.activity.code",
@@ -100,18 +105,23 @@ class L10nEsAeatMod390Report(models.Model):
         "   '|', ('date_end', '=', False), ('date_end', '>=', date_end),"
         "]",
         string="Código 1ª actividad",
+        readonly=False,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_first_activity_iae = fields.Char(
         string="Epígrafe I.A.E. 1ª actividad",
-        readonly=True,
+        readonly=False,
         size=4,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_second_activity = fields.Char(
         string="2ª actividad",
-        readonly=True,
+        readonly=False,
         size=40,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_second_activity_code = fields.Selection(
         selection=ACTIVITY_CODE_SELECTION,
@@ -129,18 +139,23 @@ class L10nEsAeatMod390Report(models.Model):
         "   '|', ('date_end', '=', False), ('date_end', '>=', date_end),"
         "]",
         string="Código 2ª actividad",
+        readonly=False,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_second_activity_iae = fields.Char(
         string="Epígrafe I.A.E. 2ª actividad",
-        readonly=True,
+        readonly=False,
         size=4,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_third_activity = fields.Char(
         string="3ª actividad",
-        readonly=True,
+        readonly=False,
         size=40,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_third_activity_code = fields.Selection(
         selection=ACTIVITY_CODE_SELECTION,
@@ -157,18 +172,23 @@ class L10nEsAeatMod390Report(models.Model):
         "   '|', ('date_end', '=', False), ('date_end', '>=', date_end),"
         "]",
         string="Código 3ª actividad",
+        readonly=False,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_third_activity_iae = fields.Char(
         string="Epígrafe I.A.E. 3ª actividad",
-        readonly=True,
+        readonly=False,
         size=4,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_fourth_activity = fields.Char(
         string="4ª actividad",
-        readonly=True,
+        readonly=False,
         size=40,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_fourth_activity_code = fields.Selection(
         selection=ACTIVITY_CODE_SELECTION,
@@ -185,18 +205,23 @@ class L10nEsAeatMod390Report(models.Model):
         "   '|', ('date_end', '=', False), ('date_end', '>=', date_end),"
         "]",
         string="Código 4ª actividad",
+        readonly=False,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_fourth_activity_iae = fields.Char(
         string="Epígrafe I.A.E. 4ª actividad",
-        readonly=True,
+        readonly=False,
         size=4,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_fifth_activity = fields.Char(
         string="5ª actividad",
-        readonly=True,
+        readonly=False,
         size=40,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_fifth_activity_code = fields.Selection(
         selection=ACTIVITY_CODE_SELECTION,
@@ -214,88 +239,106 @@ class L10nEsAeatMod390Report(models.Model):
         "   '|', ('date_end', '=', False), ('date_end', '>=', date_end),"
         "]",
         string="Código 5ª actividad",
+        readonly=False,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     other_fifth_activity_iae = fields.Char(
         string="Epígrafe I.A.E. 5ª actividad",
-        readonly=True,
+        readonly=False,
         size=4,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     # 4. Representantes
     first_representative_name = fields.Char(
         string="Nombre del primer representante",
-        readonly=True,
+        readonly=False,
         size=80,
         states=REQUIRED_ON_CALCULATED,
         help=REPRESENTATIVE_HELP,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     first_representative_vat = fields.Char(
         string="NIF del primer representante",
-        readonly=True,
+        readonly=False,
         size=9,
         states=REQUIRED_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     first_representative_date = fields.Date(
         string="Fecha poder del primer representante",
-        readonly=True,
-        states=EDITABLE_ON_CALCULATED,
+        readonly=False,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     first_representative_notary = fields.Char(
         string="Notaría del primer representante",
-        readonly=True,
+        readonly=False,
         size=12,
         help=NOTARY_CODE_HELP,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     second_representative_name = fields.Char(
         string="Nombre del segundo representante",
-        readonly=True,
+        readonly=False,
         size=80,
-        states=EDITABLE_ON_CALCULATED,
         help=REPRESENTATIVE_HELP,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     second_representative_vat = fields.Char(
         string="NIF del segundo representante",
-        readonly=True,
+        readonly=False,
         size=9,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     second_representative_date = fields.Date(
         string="Fecha poder del segundo representante",
-        readonly=True,
-        states=EDITABLE_ON_CALCULATED,
+        readonly=False,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     second_representative_notary = fields.Char(
         string="Notaría del segundo representante",
-        readonly=True,
+        readonly=False,
         size=12,
-        states=EDITABLE_ON_CALCULATED,
         help=NOTARY_CODE_HELP,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     third_representative_name = fields.Char(
         string="Nombre del tercer representante",
-        readonly=True,
+        readonly=False,
         size=80,
-        states=EDITABLE_ON_CALCULATED,
         help=REPRESENTATIVE_HELP,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     third_representative_vat = fields.Char(
         string="NIF del tercer representante",
-        readonly=True,
+        readonly=False,
         size=9,
-        states=EDITABLE_ON_CALCULATED,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     third_representative_date = fields.Date(
         string="Fecha poder del tercer representante",
-        readonly=True,
-        states=EDITABLE_ON_CALCULATED,
+        readonly=False,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     third_representative_notary = fields.Char(
         string="Notaría del tercer representante",
-        readonly=True,
+        readonly=False,
         size=12,
-        states=EDITABLE_ON_CALCULATED,
         help=NOTARY_CODE_HELP,
+        compute="_compute_activities_iae_representatives",
+        store=True,
     )
     # 5. Régimen general
     casilla_33 = fields.Float(
@@ -809,6 +852,116 @@ class L10nEsAeatMod390Report(models.Model):
                     lambda x: x.field_number in (106, 107)
                 ).mapped("amount")
             )
+
+    @api.depends("state", "company_id")
+    def _compute_activities_iae_representatives(self):
+        for record in self:
+            if record.state == "calculated":
+                record.main_activity = record.company_id.main_activity
+                record.main_activity_code_id = record.company_id.main_activity_code_id
+                record.main_activity_iae = record.company_id.main_activity_iae
+                record.other_first_activity = record.company_id.other_first_activity
+                record.other_first_activity_code_id = (
+                    record.company_id.other_first_activity_code_id
+                )
+                record.other_first_activity_iae = (
+                    record.company_id.other_first_activity_iae
+                )
+                record.other_second_activity = record.company_id.other_second_activity
+                record.other_second_activity_code_id = (
+                    record.company_id.other_second_activity_code_id
+                )
+                record.other_second_activity_iae = (
+                    record.company_id.other_second_activity_iae
+                )
+                record.other_third_activity = record.company_id.other_third_activity
+                record.other_third_activity_code_id = (
+                    record.company_id.other_third_activity_code_id
+                )
+                record.other_third_activity_iae = (
+                    record.company_id.other_third_activity_iae
+                )
+                record.other_fourth_activity = record.company_id.other_fourth_activity
+                record.other_fourth_activity_code_id = (
+                    record.company_id.other_fourth_activity_code_id
+                )
+                record.other_fourth_activity_iae = (
+                    record.company_id.other_fourth_activity_iae
+                )
+                record.other_fifth_activity = record.company_id.other_fifth_activity
+                record.other_fifth_activity_code_id = (
+                    record.company_id.other_fifth_activity_code_id
+                )
+                record.other_fifth_activity_iae = (
+                    record.company_id.other_fifth_activity_iae
+                )
+                record.first_representative_name = (
+                    record.company_id.first_representative_name
+                )
+                record.first_representative_vat = (
+                    record.company_id.first_representative_vat
+                )
+                record.first_representative_date = (
+                    record.company_id.first_representative_date
+                )
+                record.first_representative_notary = (
+                    record.company_id.first_representative_notary
+                )
+                record.second_representative_name = (
+                    record.company_id.second_representative_name
+                )
+                record.second_representative_vat = (
+                    record.company_id.second_representative_vat
+                )
+                record.second_representative_date = (
+                    record.company_id.second_representative_date
+                )
+                record.second_representative_notary = (
+                    record.company_id.second_representative_notary
+                )
+                record.third_representative_name = (
+                    record.company_id.third_representative_name
+                )
+                record.third_representative_vat = (
+                    record.company_id.third_representative_vat
+                )
+                record.third_representative_date = (
+                    record.company_id.third_representative_date
+                )
+                record.third_representative_notary = (
+                    record.company_id.third_representative_notary
+                )
+            elif record.state == "draft":
+                record.main_activity = False
+                record.main_activity_code_id = False
+                record.main_activity_iae = False
+                record.other_first_activity = False
+                record.other_first_activity_code_id = False
+                record.other_first_activity_iae = False
+                record.other_second_activity = False
+                record.other_second_activity_code_id = False
+                record.other_second_activity_iae = False
+                record.other_third_activity = False
+                record.other_third_activity_code_id = False
+                record.other_third_activity_iae = False
+                record.other_fourth_activity = False
+                record.other_fourth_activity_code_id = False
+                record.other_fourth_activity_iae = False
+                record.other_fifth_activity = False
+                record.other_fifth_activity_code_id = False
+                record.other_fifth_activity_iae = False
+                record.first_representative_name = False
+                record.first_representative_vat = False
+                record.first_representative_date = False
+                record.first_representative_notary = False
+                record.second_representative_name = False
+                record.second_representative_vat = False
+                record.second_representative_date = False
+                record.second_representative_notary = False
+                record.third_representative_name = False
+                record.third_representative_vat = False
+                record.third_representative_date = False
+                record.third_representative_notary = False
 
     @api.constrains("statement_type")
     def _check_type(self):

--- a/l10n_es_aeat_mod390/models/res_company.py
+++ b/l10n_es_aeat_mod390/models/res_company.py
@@ -1,0 +1,89 @@
+# Copyright 2024 Moduon Team - Emilio Pascual
+
+from odoo import _, fields, models
+
+REPRESENTATIVE_HELP = _("Nombre y apellidos del representante")
+NOTARY_CODE_HELP = _(
+    "Código de la notaría en la que se concedió el poder de representación "
+    "para esta persona."
+)
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    main_activity = fields.Char(
+        string="Actividad principal",
+        size=40,
+    )
+    other_first_activity = fields.Char(
+        string="1ª actividad",
+        size=40,
+    )
+    other_second_activity = fields.Char(
+        string="2ª actividad",
+        size=40,
+    )
+    other_third_activity = fields.Char(
+        string="3ª actividad",
+        size=40,
+    )
+    other_fourth_activity = fields.Char(
+        string="4ª actividad",
+        size=40,
+    )
+    other_fifth_activity = fields.Char(
+        string="5ª actividad",
+        size=40,
+    )
+    first_representative_name = fields.Char(
+        string="Nombre del primer representante",
+        size=80,
+        help=REPRESENTATIVE_HELP,
+    )
+    first_representative_vat = fields.Char(
+        string="NIF del primer representante",
+        size=9,
+    )
+    first_representative_date = fields.Date(
+        string="Fecha poder del primer representante",
+    )
+    first_representative_notary = fields.Char(
+        string="Notaría del primer representante",
+        size=12,
+        help=NOTARY_CODE_HELP,
+    )
+    second_representative_name = fields.Char(
+        string="Nombre del segundo representante",
+        size=80,
+        help=REPRESENTATIVE_HELP,
+    )
+    second_representative_vat = fields.Char(
+        string="NIF del segundo representante",
+        size=9,
+    )
+    second_representative_date = fields.Date(
+        string="Fecha poder del segundo representante",
+    )
+    second_representative_notary = fields.Char(
+        string="Notaría del segundo representante",
+        size=12,
+        help=NOTARY_CODE_HELP,
+    )
+    third_representative_name = fields.Char(
+        string="Nombre del tercer representante",
+        size=80,
+        help=REPRESENTATIVE_HELP,
+    )
+    third_representative_vat = fields.Char(
+        string="NIF del tercer representante",
+        size=9,
+    )
+    third_representative_date = fields.Date(
+        string="Fecha poder del tercer representante",
+    )
+    third_representative_notary = fields.Char(
+        string="Notaría del tercer representante",
+        size=12,
+        help=NOTARY_CODE_HELP,
+    )

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -3,7 +3,7 @@
 
 from collections import OrderedDict
 
-from odoo import exceptions
+from odoo import exceptions, fields
 
 from odoo.addons.l10n_es_aeat.tests.test_l10n_es_aeat_mod_base import (
     TestL10nEsAeatModBase,
@@ -492,3 +492,156 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 100.00, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+
+    def test_default_values_in_company(self):
+        self.company.update(
+            {
+                "main_activity": "A01 Test",
+                "main_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_A01"
+                ),
+                "main_activity_iae": "A01",
+                "other_first_activity": "A02 Test",
+                "other_first_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_A02"
+                ),
+                "other_first_activity_iae": "A02",
+                "other_second_activity": "A03 Test",
+                "other_second_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_A03"
+                ),
+                "other_second_activity_iae": "A03",
+                "other_third_activity": "A04 Test",
+                "other_third_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_A04"
+                ),
+                "other_third_activity_iae": "A04",
+                "other_fourth_activity": "A05 Test",
+                "other_fourth_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_A05"
+                ),
+                "other_fourth_activity_iae": "A05",
+                "other_fifth_activity": "B01 Test",
+                "other_fifth_activity_code_id": self.env.ref(
+                    "l10n_es_aeat_mod303.aeat_mod303_activity_code_B01"
+                ),
+                "other_fifth_activity_iae": "B01",
+                "first_representative_name": "Test Name 1",
+                "first_representative_vat": "123456789",
+                "first_representative_date": "2018-01-01",
+                "first_representative_notary": "Test Notary1",
+                "second_representative_name": "Test Name 2",
+                "second_representative_vat": "987654321",
+                "second_representative_date": "2018-01-02",
+                "second_representative_notary": "Test Notary2",
+                "third_representative_name": "Test Name 3",
+                "third_representative_vat": "123456780",
+                "third_representative_date": "2018-01-03",
+                "third_representative_notary": "Test Notary3",
+            }
+        )
+        model390 = self.env["l10n.es.aeat.mod390.report"].create(
+            {
+                "name": "9990002024390",
+                "company_id": self.company.id,
+                "company_vat": "1234567890",
+                "contact_name": "Test owner",
+                "statement_type": "N",
+                "support_type": "T",
+                "contact_phone": "911234455",
+                "year": 2024,
+                "period_type": "0A",
+                "date_start": "2024-01-01",
+                "date_end": "2024-12-31",
+                "journal_id": self.journal_misc.id,
+            }
+        )
+        model390.button_calculate()
+        self.assertRecordValues(
+            model390,
+            [
+                {
+                    "main_activity": "A01 Test",
+                    "main_activity_code_id": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_A01"
+                    ).id,
+                    "main_activity_iae": "A01",
+                    "other_first_activity": "A02 Test",
+                    "other_first_activity_code_id": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_A02"
+                    ).id,
+                    "other_first_activity_iae": "A02",
+                    "other_second_activity": "A03 Test",
+                    "other_second_activity_code_id": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_A03"
+                    ).id,
+                    "other_second_activity_iae": "A03",
+                    "other_third_activity": "A04 Test",
+                    "other_third_activity_code_id": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_A04"
+                    ).id,
+                    "other_third_activity_iae": "A04",
+                    "other_fourth_activity": "A05 Test",
+                    "other_fourth_activity_code_id": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_A05"
+                    ).id,
+                    "other_fourth_activity_iae": "A05",
+                    "other_fifth_activity": "B01 Test",
+                    "other_fifth_activity_code_id": self.env.ref(
+                        "l10n_es_aeat_mod303.aeat_mod303_activity_code_B01"
+                    ).id,
+                    "other_fifth_activity_iae": "B01",
+                    "first_representative_name": "Test Name 1",
+                    "first_representative_vat": "123456789",
+                    "first_representative_date": fields.date(2018, 1, 1),
+                    "first_representative_notary": "Test Notary1",
+                    "second_representative_name": "Test Name 2",
+                    "second_representative_vat": "987654321",
+                    "second_representative_date": fields.date(2018, 1, 2),
+                    "second_representative_notary": "Test Notary2",
+                    "third_representative_name": "Test Name 3",
+                    "third_representative_vat": "123456780",
+                    "third_representative_date": fields.date(2018, 1, 3),
+                    "third_representative_notary": "Test Notary3",
+                }
+            ],
+        )
+        model390.button_cancel()
+        model390.button_recover()
+        self.assertRecordValues(
+            model390,
+            [
+                {
+                    "main_activity": False,
+                    "main_activity_code": False,
+                    "main_activity_iae": False,
+                    "other_first_activity": False,
+                    "other_first_activity_code": False,
+                    "other_first_activity_iae": False,
+                    "other_second_activity": False,
+                    "other_second_activity_code": False,
+                    "other_second_activity_iae": False,
+                    "other_third_activity": False,
+                    "other_third_activity_code": False,
+                    "other_third_activity_iae": False,
+                    "other_fourth_activity": False,
+                    "other_fourth_activity_code": False,
+                    "other_fourth_activity_iae": False,
+                    "other_fifth_activity": False,
+                    "other_fifth_activity_code": False,
+                    "other_fifth_activity_iae": False,
+                    "first_representative_name": False,
+                    "first_representative_vat": False,
+                    "first_representative_date": False,
+                    "first_representative_notary": False,
+                    "second_representative_name": False,
+                    "second_representative_vat": False,
+                    "second_representative_date": False,
+                    "second_representative_notary": False,
+                    "third_representative_name": False,
+                    "third_representative_vat": False,
+                    "third_representative_date": False,
+                    "third_representative_notary": False,
+                }
+            ],
+        )

--- a/l10n_es_aeat_mod390/views/mod390_view.xml
+++ b/l10n_es_aeat_mod390/views/mod390_view.xml
@@ -42,7 +42,10 @@
                             <field name="has_347" />
                         </group>
                         <group string="Actividad principal" name="group_main_activity">
-                            <field name="main_activity" />
+                            <field
+                                name="main_activity"
+                                attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                            />
                             <field
                                 name="main_activity_code"
                                 attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&gt;', 2021)], 'required': [('state', '=', 'calculated'), ('year', '&lt;', 2022)]}"
@@ -51,14 +54,20 @@
                                 name="main_activity_code_id"
                                 attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&lt;', 2022)], 'required': [('state', '=', 'calculated'), ('year', '&gt;', 2021)]}"
                             />
-                            <field name="main_activity_iae" />
+                            <field
+                                name="main_activity_iae"
+                                attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                            />
                         </group>
                         <group>
                             <group
                                 string="Otras - 1ª actividad"
                                 name="group_other_first_activity"
                             >
-                                <field name="other_first_activity" />
+                                <field
+                                    name="other_first_activity"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                                 <field
                                     name="other_first_activity_code"
                                     attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&gt;', 2021)]}"
@@ -67,13 +76,19 @@
                                     name="other_first_activity_code_id"
                                     attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&lt;', 2022)]}"
                                 />
-                                <field name="other_first_activity_iae" />
+                                <field
+                                    name="other_first_activity_iae"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                             </group>
                             <group
                                 string="Otras - 2ª actividad"
                                 name="group_other_second_activity"
                             >
-                                <field name="other_second_activity" />
+                                <field
+                                    name="other_second_activity"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                                 <field
                                     name="other_second_activity_code"
                                     attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&gt;', 2021)]}"
@@ -82,13 +97,19 @@
                                     name="other_second_activity_code_id"
                                     attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&lt;', 2022)]}"
                                 />
-                                <field name="other_second_activity_iae" />
+                                <field
+                                    name="other_second_activity_iae"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                             </group>
                             <group
                                 string="Otras - 3ª actividad"
                                 name="group_other_third_activity"
                             >
-                                <field name="other_third_activity" />
+                                <field
+                                    name="other_third_activity"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                                 <field
                                     name="other_third_activity_code"
                                     attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&gt;', 2021)]}"
@@ -97,13 +118,19 @@
                                     name="other_third_activity_code_id"
                                     attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&lt;', 2022)]}"
                                 />
-                                <field name="other_third_activity_iae" />
+                                <field
+                                    name="other_third_activity_iae"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                             </group>
                             <group
                                 string="Otras - 4ª actividad"
                                 name="group_other_fourth_activity"
                             >
-                                <field name="other_fourth_activity" />
+                                <field
+                                    name="other_fourth_activity"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                                 <field
                                     name="other_fourth_activity_code"
                                     attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&gt;', 2021)]}"
@@ -112,13 +139,19 @@
                                     name="other_fourth_activity_code_id"
                                     attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&lt;', 2022)]}"
                                 />
-                                <field name="other_fourth_activity_iae" />
+                                <field
+                                    name="other_fourth_activity_iae"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                             </group>
                             <group
                                 string="Otras - 5ª actividad"
                                 name="group_other_fifth_activity"
                             >
-                                <field name="other_fifth_activity" />
+                                <field
+                                    name="other_fifth_activity"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                                 <field
                                     name="other_fifth_activity_code"
                                     attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&gt;', 2021)]}"
@@ -127,7 +160,10 @@
                                     name="other_fifth_activity_code_id"
                                     attrs="{'readonly': [('state', '!=', 'calculated')], 'invisible': [('year', '&lt;', 2022)]}"
                                 />
-                                <field name="other_fifth_activity_iae" />
+                                <field
+                                    name="other_fifth_activity_iae"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                             </group>
                         </group>
                     </page>
@@ -137,28 +173,64 @@
                                 name="group_first_representative"
                                 string="Primer representante"
                             >
-                                <field name="first_representative_name" />
-                                <field name="first_representative_vat" />
-                                <field name="first_representative_date" />
-                                <field name="first_representative_notary" />
+                                <field
+                                    name="first_representative_name"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
+                                <field
+                                    name="first_representative_vat"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
+                                <field
+                                    name="first_representative_date"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
+                                <field
+                                    name="first_representative_notary"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                             </group>
                             <group
                                 name="group_second_representative"
                                 string="Segundo representante"
                             >
-                                <field name="second_representative_name" />
-                                <field name="second_representative_vat" />
-                                <field name="second_representative_date" />
-                                <field name="second_representative_notary" />
+                                <field
+                                    name="second_representative_name"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
+                                <field
+                                    name="second_representative_vat"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
+                                <field
+                                    name="second_representative_date"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
+                                <field
+                                    name="second_representative_notary"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                             </group>
                             <group
                                 name="group_third_representative"
                                 string="Tercer representante"
                             >
-                                <field name="third_representative_name" />
-                                <field name="third_representative_vat" />
-                                <field name="third_representative_date" />
-                                <field name="third_representative_notary" />
+                                <field
+                                    name="third_representative_name"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
+                                <field
+                                    name="third_representative_vat"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
+                                <field
+                                    name="third_representative_date"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
+                                <field
+                                    name="third_representative_notary"
+                                    attrs="{'readonly': [('state', '!=', 'calculated')]}"
+                                />
                             </group>
                         </group>
                     </page>

--- a/l10n_es_aeat_mod390/views/res_company.xml
+++ b/l10n_es_aeat_mod390/views/res_company.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Emilio Pascual
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_company_aeat_mod390_form" model="ir.ui.view">
+        <field name="name">res.company.aeat.mod390.form</field>
+        <field name="model">res.company</field>
+        <field
+            name="inherit_id"
+            ref="l10n_es_aeat_mod303.view_company_aeat_mod303_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='main_activity_code_id']" position="before">
+                <field name="main_activity" />
+            </xpath>
+            <xpath
+                expr="//field[@name='other_first_activity_code_id']"
+                position="before"
+            >
+                <field name="other_first_activity" />
+            </xpath>
+            <xpath
+                expr="//field[@name='other_second_activity_code_id']"
+                position="before"
+            >
+                <field name="other_second_activity" />
+            </xpath>
+            <xpath
+                expr="//field[@name='other_third_activity_code_id']"
+                position="before"
+            >
+                <field name="other_third_activity" />
+            </xpath>
+            <xpath
+                expr="//field[@name='other_fourth_activity_code_id']"
+                position="before"
+            >
+                <field name="other_fourth_activity" />
+            </xpath>
+            <xpath
+                expr="//field[@name='other_fifth_activity_code_id']"
+                position="before"
+            >
+                <field name="other_fifth_activity" />
+            </xpath>
+            <xpath expr="//group[@name='default_values_aeat_303']" position="after">
+                <group name="representantes">
+                    <group
+                        name="group_first_representative"
+                        string="Primer representante"
+                    >
+                        <field name="first_representative_name" />
+                        <field name="first_representative_vat" />
+                        <field name="first_representative_date" />
+                        <field name="first_representative_notary" />
+                    </group>
+                    <group
+                        name="group_second_representative"
+                        string="Segundo representante"
+                    >
+                        <field name="second_representative_name" />
+                        <field name="second_representative_vat" />
+                        <field name="second_representative_date" />
+                        <field name="second_representative_notary" />
+                    </group>
+                    <group
+                        name="group_third_representative"
+                        string="Tercer representante"
+                    >
+                        <field name="third_representative_name" />
+                        <field name="third_representative_vat" />
+                        <field name="third_representative_date" />
+                        <field name="third_representative_notary" />
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Al cumplimentar un informe del modelo 303 del cuarto trimestre si está exonerado del 390 o cuando tienes que hacer un informe del 390 hay campos relativos a la compañía como actividades, epígrafes o representantes que suelen ser los mismos todos los años y todos los años hay que rellenarlos.

Propongo este PR para dejar configurada esa información en la compañia y que automáticamente se asignen.

¿@loida-vm @ArantxaSudon @pedrobaeza podéis revisar por favor? Gracias

@moduon MT-8488 MT-8682