### PR TITLE
[16.0][IMP] l10n_es_vat_book + l10n_es_aeat: Drill through on tax summary

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -541,3 +541,12 @@ class L10nEsAeatReport(models.AbstractModel):
                 rcontext
             )
         return result
+
+    @api.model
+    def _view_move_lines(self, amls):
+        res = self.env.ref("account.action_account_moves_all_a").sudo().read()[0]
+        view = self.env.ref("l10n_es_aeat.view_move_line_tree")
+        res["context"] = {"create": 0}
+        res["views"] = [(view.id, "tree")]
+        res["domain"] = [("id", "in", amls.ids)]
+        return res

--- a/l10n_es_aeat/models/l10n_es_aeat_tax_line.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_tax_line.py
@@ -34,8 +34,4 @@ class L10nEsAeatTaxLine(models.Model):
     model = fields.Char(index=True, readonly=True, required=True, string="Model name")
 
     def get_calculated_move_lines(self):
-        res = self.env.ref("account.action_account_moves_all_a").sudo().read()[0]
-        view = self.env.ref("l10n_es_aeat.view_move_line_tree")
-        res["views"] = [(view.id, "tree")]
-        res["domain"] = [("id", "in", self.move_line_ids.ids)]
-        return res
+        return self.env["l10n.es.aeat.report"]._view_move_lines(self.move_line_ids)

--- a/l10n_es_vat_book/models/l10n_es_vat_book_line_tax.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book_line_tax.py
@@ -30,7 +30,11 @@ class L10nEsVatBookLineTax(models.Model):
         compute="_compute_total_amount",
         store=True,
     )
-
+    base_move_line_ids = fields.Many2many(
+        comodel_name="account.move.line",
+        string="Move Lines (Base)",
+        relation="account_move_line_l10n_es_vat_book_line_tax_base_rel",
+    )
     move_line_ids = fields.Many2many(
         comodel_name="account.move.line", string="Move Lines"
     )

--- a/l10n_es_vat_book/models/l10n_es_vat_book_tax_summary.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book_tax_summary.py
@@ -20,3 +20,17 @@ class L10nEsVatBookIssuedTaxSummary(models.Model):
         required=True,
         ondelete="cascade",
     )
+    base_move_line_ids = fields.Many2many(
+        comodel_name="account.move.line",
+        string="Journal items (Base)",
+        relation="account_move_line_l10n_es_vat_book_tax_summary_base_rel",
+    )
+    move_line_ids = fields.Many2many(
+        comodel_name="account.move.line", string="Journal items"
+    )
+
+    def view_move_lines_base(self):
+        return self.env["l10n.es.aeat.report"]._view_move_lines(self.base_move_line_ids)
+
+    def view_move_lines_tax(self):
+        return self.env["l10n.es.aeat.report"]._view_move_lines(self.move_line_ids)

--- a/l10n_es_vat_book/views/l10n_es_vat_book_tax_summary.xml
+++ b/l10n_es_vat_book/views/l10n_es_vat_book_tax_summary.xml
@@ -24,8 +24,25 @@
             <tree decoration-muted="special_tax_group">
                 <field name="special_tax_group" />
                 <field name="base_amount" />
+                <!-- We don't add a visibility condition, as that would mean to have
+                a field determining if there are moves or not, which can drain the
+                performance -->
+                <button
+                    name="view_move_lines_base"
+                    type="object"
+                    aria-label="Show journal items"
+                    title="Show journal items"
+                    icon="fa-search-plus"
+                />
                 <field name="tax_id" />
                 <field name="tax_amount" />
+                <button
+                    name="view_move_lines_tax"
+                    type="object"
+                    aria-label="Show journal items"
+                    title="Show journal items"
+                    icon="fa-search-plus"
+                />
                 <field name="total_amount" />
             </tree>
         </field>


### PR DESCRIPTION
Forward-port of #3919 

Allow to drill through in the tax summary to list journal items that leads to the base and tax amounts.

As we are on this, there's a tool method now in base module `l10n_es_aeat` for opening this kind of view, and fixing that the journal items was always open with move grouping by default.

![imagen](https://github.com/user-attachments/assets/2fd244c6-48f9-40a6-9eb4-21e1b3e9abf6)

@Tecnativa TT52996