### PR TITLE
[17.0][FIX] l10n_es_aeat_mod303: Remove field 96

### DIFF
--- a/l10n_es_aeat_mod303/data/2024-10/l10n.es.aeat.map.tax.line.csv
+++ b/l10n_es_aeat_mod303/data/2024-10/l10n.es.aeat.map.tax.line.csv
@@ -49,7 +49,6 @@ aeat_mod303_2024_10_map_line_83,aeat_mod303_2024_10_map,83,Operaciones exentas s
 aeat_mod303_2024_10_map_line_84,aeat_mod303_2024_10_map,84,Operaciones no sujetas por reglas de localización o con inversión del sujeto pasivo,0,all,base,both,0,,"s_iva_e,s_iva_ns,s_iva_ns_b"
 aeat_mod303_2024_10_map_line_93,aeat_mod303_2024_10_map,93,Entregas intracomunitarias exentas,0,all,base,both,0,,"s_iva0_ic,s_iva0_sp_i"
 aeat_mod303_2024_10_map_line_94,aeat_mod303_2024_10_map,94,Exportaciones y otras operaciones exentas con derecho a deducción,0,all,base,both,0,,s_iva0_e
-aeat_mod303_2024_10_map_line_96,aeat_mod303_2024_10_map,96,Operaciones realizadas por sujetos pasivos acogidos al régimen especial del recargo de equivalencia,0,all,base,both,0,,"s_req0,s_req05,s_req062,s_req014,s_req52"
 aeat_mod303_2024_10_map_line_120,aeat_mod303_2024_10_map,120,Operaciones no sujetas por reglas de localización (excepto las incluidas en la casilla 123),0,all,base,both,0,,"s_iva_e,s_iva_ns,s_iva_ns_b"
 aeat_mod303_2024_10_map_line_122,aeat_mod303_2024_10_map,122,Operaciones sujetas con inversión del sujeto pasivo,0,all,base,both,0,,s_iva0_isp
 aeat_mod303_2024_10_map_line_125,aeat_mod303_2024_10_map,125,Operaciones sujetas con inversión del sujeto pasivo,0,all,base,both,0,,s_iva0_isp

--- a/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
+++ b/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
@@ -564,7 +564,7 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
             ).amount,
             14280.0,
         )
-        self.assertAlmostEqual(self.model303_4t.casilla_88, 57280.0)
+        self.assertAlmostEqual(self.model303_4t.casilla_88, 46480.0)
         # Check change of period type
         self.model303_4t.period_type = "1T"
         self.assertEqual(self.model303_4t.exonerated_390, "2")


### PR DESCRIPTION
Forward-port + adaptation of #3924 and #3927

It was incorrectly mapped to "recargo de equivalencia" base amounts, which is not correct, as that base amounts are already included in regular operations, so it appears duplicated.

This field is for being filled in specific cases where the subject is on the special fiscal regime "Recargo de equivalencia".

The tests have been changed, as now field 88 doesn't contain this field.

@Tecnativa TT52996