### PR TITLE
[16.0] [FIX] l10n_es_pos_by_device: remove dead code overwrite in pos.config

### DIFF
--- a/l10n_es_pos_by_device/models/pos_config.py
+++ b/l10n_es_pos_by_device/models/pos_config.py
@@ -35,12 +35,6 @@ class PosConfig(models.Model):
                 config._check_available_devices()
         return super(PosConfig, self).open_ui()
 
-    def open_session_cb(self, check_coa=True):
-        for config in self:
-            if config.pos_sequence_by_device:
-                config._check_available_devices()
-        return super(PosConfig, self).open_session_cb(check_coa)
-
     def _open_session(self, session_id):
         for config in self:
             if config.pos_sequence_by_device:


### PR DESCRIPTION
In Odoo v16, the `open_session_cb` method has been removed from the `pos.config` model. If you were relying on this method in previous versions, you may need to refactor your code.
