### PR TITLE
[16.0][FIX] l10n_es_aeat_mod347: fix on partner_records' states

### DIFF
--- a/l10n_es_aeat_mod347/__init__.py
+++ b/l10n_es_aeat_mod347/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import controllers
+from . import wizard
 from . import models

--- a/l10n_es_aeat_mod347/__manifest__.py
+++ b/l10n_es_aeat_mod347/__manifest__.py
@@ -6,6 +6,7 @@
 # Copyright 2016 Tecnativa - Angel Moya <odoo@tecnativa.com>
 # Copyright 2018 PESOL - Angel Moya <info@pesol.es>
 # Copyright 2014-2022 Tecnativa - Pedro M. Baeza
+# Copyright 2023 FactorLibre - Alejandro Ji Cheung
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/l10n_es_aeat_mod347/__manifest__.py
+++ b/l10n_es_aeat_mod347/__manifest__.py
@@ -6,7 +6,6 @@
 # Copyright 2016 Tecnativa - Angel Moya <odoo@tecnativa.com>
 # Copyright 2018 PESOL - Angel Moya <info@pesol.es>
 # Copyright 2014-2022 Tecnativa - Pedro M. Baeza
-# Copyright 2023 FactorLibre - Alejandro Ji Cheung
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -176,7 +176,7 @@ class L10nEsAeatMod347Report(models.Model):
 
     def button_send_mails(self):
         self.partner_record_ids.filtered(
-            lambda x: x.state == "pending" and x.partner_id.email
+            lambda x: x.state == "pending"
         ).send_email_direct()
 
     def btn_list_records(self):
@@ -629,13 +629,12 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
 
     def send_email_direct(self):
         template = self._get_partner_report_email_template()
-        sent_records = self.env["l10n.es.aeat.mod347.partner_record"]
-        for record in self:
-            mail_id = template.send_mail(record.id)
-            if mail_id:
-                sent_records |= record
-        if sent_records:
-            sent_records.write({"state": "sent"})
+        for rec in self:
+            address_id = rec.partner_id.address_get(["invoice"])["invoice"]
+            address = self.env["res.partner"].browse(address_id)
+            if address.email:
+                template.send_mail(rec.id)
+                rec.state = "sent"
 
     def action_pending(self):
         self.write({"state": "pending"})

--- a/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
+++ b/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
@@ -185,3 +185,24 @@ class TestL10nEsAeatMod347(TestL10nEsAeatModBase):
         for xml_id in export_config_xml_ids:
             export_config = self.env.ref(xml_id)
             self.assertTrue(export_to_boe._export_config(self.model347, export_config))
+
+    def test_partner_record_ids_states(self):
+        self.model347.button_calculate()
+        first_partner_mod347_record = self.model347.partner_record_ids[0]
+        first_partner = first_partner_mod347_record.partner_id
+        self.assertFalse(first_partner.email)
+
+        second_partner_mod347_record = self.model347.partner_record_ids[1]
+        second_partner = second_partner_mod347_record.partner_id
+        second_partner.email = "test@email.com"
+
+        self.model347.button_send_mails()
+        self.assertTrue(first_partner_mod347_record.state, "pending")
+        self.assertTrue(second_partner_mod347_record.state, "sent")
+
+        first_partner_mod347_record.action_send()
+        self.assertTrue(first_partner_mod347_record.state, "pending")
+
+        first_partner.email = "test1@email.com"
+        first_partner_mod347_record.action_send()
+        self.assertTrue(first_partner_mod347_record.state, "sent")

--- a/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
+++ b/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
@@ -200,9 +200,9 @@ class TestL10nEsAeatMod347(TestL10nEsAeatModBase):
         self.assertTrue(first_partner_mod347_record.state, "pending")
         self.assertTrue(second_partner_mod347_record.state, "sent")
 
-        first_partner_mod347_record.action_send()
+        self.model347.button_send_mails()
         self.assertTrue(first_partner_mod347_record.state, "pending")
 
         first_partner.email = "test1@email.com"
-        first_partner_mod347_record.action_send()
+        self.model347.button_send_mails()
         self.assertTrue(first_partner_mod347_record.state, "sent")

--- a/l10n_es_aeat_mod347/wizard/__init__.py
+++ b/l10n_es_aeat_mod347/wizard/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2023 FactorLibre - Alejandro Ji Cheung
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import mail_compose_message

--- a/l10n_es_aeat_mod347/wizard/mail_compose_message.py
+++ b/l10n_es_aeat_mod347/wizard/mail_compose_message.py
@@ -1,0 +1,18 @@
+# Copyright 2023 FactorLibre - Alejandro Ji Cheung
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class MailComposer(models.TransientModel):
+    _inherit = "mail.compose.message"
+
+    def _action_send_mail(self, auto_commit=False):
+        res = super()._action_send_mail(auto_commit=auto_commit)
+        default_model = self._context.get("default_model", False)
+        if default_model == "l10n.es.aeat.mod347.partner_record":
+            result_message = res[1]
+            active_id = self._context.get("active_id")
+            record = self.env["l10n.es.aeat.mod347.partner_record"].browse(active_id)
+            if result_message.mail_ids:
+                record.write({"state": "sent"})
+        return res

--- a/l10n_es_aeat_mod347/wizard/mail_compose_message.py
+++ b/l10n_es_aeat_mod347/wizard/mail_compose_message.py
@@ -9,10 +9,9 @@ class MailComposer(models.TransientModel):
     def _action_send_mail(self, auto_commit=False):
         res = super()._action_send_mail(auto_commit=auto_commit)
         default_model = self._context.get("default_model", False)
-        if default_model == "l10n.es.aeat.mod347.partner_record":
-            result_message = res[1]
+        partner_record_model = "l10n.es.aeat.mod347.partner_record"
+        if default_model == partner_record_model:
             active_id = self._context.get("active_id")
-            record = self.env["l10n.es.aeat.mod347.partner_record"].browse(active_id)
-            if result_message.mail_ids:
-                record.write({"state": "sent"})
+            record = self.env[partner_record_model].browse(active_id)
+            record.write({"state": "sent"})
         return res


### PR DESCRIPTION
Continúa el PR https://github.com/OCA/l10n-spain/pull/3310, que fue cerrado por inactividad.

@pedrobaeza siguiendo lo que comentabas en[ el hilo](https://github.com/OCA/l10n-spain/pull/3310#discussion_r1530843005) he tratado de hacer lo que comentabas, pero he visto que cuando se envía por el composer nunca llega a pasar por `def message_post(self, **kwargs)`.

He optado por hacer que el mecanismo de envío siempre sea el mismo, envíes de forma masiva o individual se envía ahora directamente sin utilizar el composer.

Un commit adicional da prioridad a la dirección de facturación en el filtrado de registros.

Comentabas también 

> sería conveniente que el mensaje no se auto-elimine para dejar el rastro

La plantilla tiene `auto_delete` a falso, no se deberían eliminar los registros `mail.mail`.