### PR TITLE
[16.0][IMP] l10n_es_aeat_mod347: Display move name or move ref depending on its move_type

### DIFF
--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -62,7 +62,9 @@
                             <tbody class="invoice_tbody">
                                 <tr t-foreach="o.move_record_ids" t-as="l">
                                     <td>
-                                        <span t-esc="l.move_id.ref or l.move_id.name" />
+                                        <span
+                                            t-esc="l.move_id.name if l.move_id.move_type in ['out_invoice', 'out_refund'] else (l.move_id.ref or l.move_id.name)"
+                                        />
                                     </td>
                                     <td>
                                         <span t-field="l.move_id.date" />


### PR DESCRIPTION
Se muestra `move.name` si `move.move_type` es `out_invoice` o `out_refund`
Caso contrario muestra `move.ref`.