### PR TITLE
[17.0][FIX] l10n_es_facturae + l10n_es_facturae_face: remove pinned cryptograph dependency

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -24,7 +24,7 @@
     "development_status": "Mature",
     "depends": ["l10n_es", "account_tax_balance"],
     # odoo_test_helper is needed for the tests
-    "external_dependencies": {"python": ["unidecode", "cryptography"]},
+    "external_dependencies": {"python": ["unidecode"]},
     "data": [
         "security/aeat_security.xml",
         "security/ir.model.access.csv",

--- a/l10n_es_facturae/__manifest__.py
+++ b/l10n_es_facturae/__manifest__.py
@@ -45,7 +45,7 @@
         "views/account_move_view.xml",
         "views/account_journal_view.xml",
     ],
-    "external_dependencies": {"python": ["pycountry", "xmlsig", "cryptography==3.4.8"]},
+    "external_dependencies": {"python": ["pycountry", "xmlsig"]},
     "post_init_hook": "post_init_hook",
     "installable": True,
     "maintainers": ["etobella"],

--- a/l10n_es_facturae_face/__manifest__.py
+++ b/l10n_es_facturae_face/__manifest__.py
@@ -24,7 +24,6 @@
         "views/res_partner.xml",
         "views/edi_exchange_record.xml",
     ],
-    "external_dependencies": {"python": ["zeep", "cryptography==3.4.8"]},
     "installable": True,
     "maintainers": ["etobella"],
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
 # generated from manifests external_dependencies
 chardet
-cryptography
-cryptography==3.4.8
 pycountry
 pycryptodome
 suds-py3
 unidecode
 xmlsig
-zeep


### PR DESCRIPTION
Resuelve diferentes issues con problemas de versiones en la librería cryptography #3876 #3551 #3563 ... #3507 
@etobella fijó la verisón por ser consistentes con Odoo en aquel momento https://github.com/OCA/l10n-spain/commit/ea23d963670c1aab7c2d7cd07725f68dc3235b0a

Con la introducción de versiones de Python superiores a 3.10, que son las predeterminadas en sistemas como Debian 12 (Python 3.11) y Ubuntu 24.04 (Python 3.12), es probable que aumenten los problemas al instalar la localización.

Ahora, Odoo define dos versiones concretas aquí: https://github.com/odoo/odoo/blob/17.0/requirements.txt#L5
Además no veo incompatibilidad con versiones más modernas de cryptography y he testeado `l10n_es_facturae` con cryptography==42.0.8 sin problemas.
Por lo tanto, considero necesario ajustar la dependencia fijada en los módulos `l10n_es_facturae` y `l10n_es_facturae_face` para asegurar su compatibilidad con versiones más modernas de la librería.