### PR TITLE
[16.0][FIX] l10n_es_aeat + l10n_es_facturae + l10n_es_facturae_face:

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -23,7 +23,7 @@
     "development_status": "Mature",
     "depends": ["l10n_es", "account_tax_balance"],
     # odoo_test_helper is needed for the tests
-    "external_dependencies": {"python": ["unidecode", "cryptography==3.4.8"]},
+    "external_dependencies": {"python": ["unidecode"]},
     "data": [
         "security/aeat_security.xml",
         "security/ir.model.access.csv",

--- a/l10n_es_aeat_sii_match/__manifest__.py
+++ b/l10n_es_aeat_sii_match/__manifest__.py
@@ -9,7 +9,7 @@
     "website": "https://github.com/OCA/l10n-spain",
     "author": "Studio73, Odoo Community Association (OCA)",
     "license": "AGPL-3",
-    "external_dependencies": {"python": ["deepdiff<8", "zeep"]},
+    "external_dependencies": {"python": ["deepdiff<8"]},
     "depends": ["l10n_es_aeat_sii_oca"],
     "data": [
         "security/ir.model.access.csv",

--- a/l10n_es_aeat_sii_oca/__manifest__.py
+++ b/l10n_es_aeat_sii_oca/__manifest__.py
@@ -36,7 +36,6 @@
     "installable": True,
     "development_status": "Mature",
     "maintainers": ["pedrobaeza"],
-    "external_dependencies": {"python": ["zeep", "requests"]},
     "depends": [
         "account_invoice_refund_link",
         "l10n_es",

--- a/l10n_es_facturae/__manifest__.py
+++ b/l10n_es_facturae/__manifest__.py
@@ -44,7 +44,7 @@
         "views/account_move_view.xml",
         "views/account_journal_view.xml",
     ],
-    "external_dependencies": {"python": ["pycountry", "xmlsig", "cryptography==3.4.8"]},
+    "external_dependencies": {"python": ["pycountry", "xmlsig"]},
     "installable": True,
     "maintainers": ["etobella"],
 }

--- a/l10n_es_facturae_face/__manifest__.py
+++ b/l10n_es_facturae_face/__manifest__.py
@@ -24,7 +24,6 @@
         "views/res_partner.xml",
         "views/edi_exchange_record.xml",
     ],
-    "external_dependencies": {"python": ["zeep", "cryptography==3.4.8"]},
     "installable": True,
     "maintainers": ["etobella"],
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,11 @@
 # generated from manifests external_dependencies
 chardet
-cryptography==3.4.8
 deepdiff<8
 pycountry
 pycryptodome
 qrcode
-requests
 requests_pkcs12
 suds-py3
 unidecode
 xmlsig
 xmltodict
-zeep

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
 odoo_test_helper
+cryptography==3.4.8; python_version < '3.12'  # incompatibility between pyopenssl 19.0.0 and cryptography>=37.0.0
+cryptography==42.0.8 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 42.0.8 for security fixes


### PR DESCRIPTION
remove pinned cryptograph dependency

backport de #3936

Resuelve diferentes issues con problemas de versiones en la librería cryptography https://github.com/OCA/l10n-spain/issues/3876 https://github.com/OCA/l10n-spain/issues/3551 https://github.com/OCA/l10n-spain/pull/3563 ... https://github.com/OCA/l10n-spain/issues/3507
@etobella fijó la verisón por ser consistentes con Odoo en aquel momento https://github.com/OCA/l10n-spain/commit/ea23d963670c1aab7c2d7cd07725f68dc3235b0a

Con la introducción de versiones de Python superiores a 3.10, que son las predeterminadas en sistemas como Debian 12 (Python 3.11) y Ubuntu 24.04 (Python 3.12), es probable que aumenten los problemas al instalar la localización.

Ahora, Odoo define dos versiones concretas aquí: https://github.com/odoo/odoo/blob/16.0/requirements.txt#L5
Además no veo incompatibilidad con versiones más modernas de cryptography y he testeado `l10n_es_aeat` y  `l10n_es_facturae` con cryptography==42.0.8 sin problemas.
Por lo tanto, considero necesario ajustar la dependencia fijada en los módulos `l10n_es_aeat`,  `l10n_es_facturae` y `l10n_es_facturae_face` para asegurar su compatibilidad con versiones más modernas de la librería.

