### PR TITLE
[15.0][FIX] l10n_es_aeat_mod347: Take into account inactive taxes

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -207,7 +207,7 @@ class L10nEsAeatMod347Report(models.Model):
     def _get_taxes(self, map_rec):
         """Obtain all the taxes to be considered for 347."""
         self.ensure_one()
-        tax_templates = map_rec.mapped("tax_ids")
+        tax_templates = map_rec.with_context(active_test=False).tax_ids
         if not tax_templates:
             raise exceptions.UserError(_("No Tax Mapping was found"))
         return self.get_taxes_from_templates(tax_templates)


### PR DESCRIPTION
Backport of #3943 

Since odoo/odoo#179797, IVA 5% taxes templates are deactivated, and if you calculate a 347 report containing them, they are not included.

This commit takes this situation into account.

This is similar to what has been done in #3744 and #3758

@Tecnativa TT54641