### PR TITLE
[15.0][FIX] l10n_es_aeat_mod390: Calculation of field 85

### DIFF
--- a/l10n_es_aeat_mod390/models/mod390.py
+++ b/l10n_es_aeat_mod390/models/mod390.py
@@ -408,11 +408,10 @@ class L10nEsAeatMod390Report(models.Model):
         string="[85] Compens. ejercicio anterior",
         readonly=True,
         states=EDITABLE_ON_CALCULATED,
-        help="Si en la autoliquidación del último período del ejercicio "
-        "anterior resultó un saldo a su favor y usted optó por la "
-        "compensación, consigne en esta casilla la cantidad a "
-        "compensar, salvo que la misma haya sido modificada por la "
-        "Administración, en cuyo caso se consignará esta última.",
+        help="Se consignará el importe de las cuotas pendientes de compensación "
+        "generadas en ejercicios anteriores y aplicadas en el ejercicio (es "
+        "decir, que se hubiesen consignado en la casilla 78 de alguna de las "
+        "autoliquidaciones del periodo).",
     )
     casilla_86 = fields.Float(
         compute="_compute_casilla_86",
@@ -817,6 +816,27 @@ class L10nEsAeatMod390Report(models.Model):
                 _("You cannot make complementary reports for this model.")
             )
 
+    def _calculate_casilla_85(self, reports_303_this_year):
+        self.ensure_one()
+        report_303_first_period = reports_303_this_year.filtered(
+            lambda r: r.period_type in {"1T", "1"}
+        )
+        # Si no hay autoliquidaciones del primer periodo del ejercicio, asumimos
+        # que el total viene de ejercicios anteriores
+        if not report_303_first_period:
+            return sum(reports_303_this_year.mapped("cuota_compensar"))
+        # Obtenemos cuotas pendientes de compensación generadas en ejercicios anteriores
+        # Casilla [110] de la primera autoliquidación del ejercicio
+        remaining_cuota_compensar = report_303_first_period.potential_cuota_compensar
+        # Obtenemos total a compensar aplicado en el ejercicio
+        # Casilla [78] de todas las autoliquidaciones del ejercicio (suma)
+        total_cuota_compensar = sum(reports_303_this_year.mapped("cuota_compensar"))
+        # Si durante el ejercicio se ha aplicado más de remaining_cuota_compensar,
+        # entonces hemos aplicado el total durante el ejercicio.
+        # En caso contrario, solo hemos aplicado una parte de
+        # remaining_cuota_compensar, usamos la suma de las casillas [78]
+        return min(total_cuota_compensar, remaining_cuota_compensar)
+
     def calculate(self):
         res = super().calculate()
         for mod390 in self:
@@ -832,8 +852,9 @@ class L10nEsAeatMod390Report(models.Model):
             )
             if not reports_303_this_year:
                 continue
-            # casilla 85 = sumatorio de las casilla 78 de los periodos del año
-            casilla_85 = sum(reports_303_this_year.mapped("cuota_compensar"))
+            # casilla 85 = cuotas pendientes de compensación generadas en ejercicios
+            # anteriores y aplicadas en el ejercicio
+            casilla_85 = self._calculate_casilla_85(reports_303_this_year)
             # casilla 95 = sumatorio de las casilla 71 de los periodos del año que
             # sean a ingresar
             casilla_95 = sum(

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -409,6 +409,26 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         model303_4T.button_calculate()
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
+        self.assertAlmostEqual(self.model390_2018.casilla_85, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+
+        model303_1T.potential_cuota_compensar = 500.0
+        model303_1T.button_calculate()
+        self.model390_2018.button_calculate()
+        # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
+        self.assertAlmostEqual(self.model390_2018.casilla_85, 500.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+
+        model303_1T.potential_cuota_compensar = 1000.0
+        model303_1T.button_calculate()
+        self.model390_2018.button_calculate()
+        # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2018.casilla_85, 674.48, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
@@ -478,8 +498,18 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         model303_4T.button_calculate()
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
-        self.assertAlmostEqual(self.model390_2018.casilla_85, 805.25, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_85, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 2302.12, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_98, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 100.0, 2)
+
+        model303_1T.potential_cuota_compensar = 2000.0
+        model303_1T.button_calculate()
+        self.model390_2018.button_calculate()
+        # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
+        self.assertAlmostEqual(self.model390_2018.casilla_85, 1610.50, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_95, 1496.87, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_662, 100.0, 2)
@@ -488,8 +518,8 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         model303_4T.button_calculate()
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
-        self.assertAlmostEqual(self.model390_2018.casilla_85, 905.25, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_95, 2302.12, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_85, 1710.5, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_95, 1496.87, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 100.00, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)


### PR DESCRIPTION
Según la AEAT:

- **Casilla 85:** Se consignará el importe de las cuotas pendientes de compensación generadas en ejercicios anteriores y aplicadas en el ejercicio (es decir, que se hubiesen consignado en la casilla 78 de alguna de las autoliquidaciones del período).

Antes de este commit, la casilla [85] se calculaba como la suma de las casillas [78] de los modelos 303 del ejercicio actual. Este cálculo es incorrecto, ya que la cifra puede incluir cuotas pendientes de compensación generadas en el ejercicio actual.

Este commit asegura que únicamente se consideren las cuotas pendientes de compensación generadas en **ejercicios anteriores** aplicadas en el ejercicio actual. El código incluye numerosos comentarios que detallan y explican los cálculos y cambios hechos.