### PR TITLE
[16.0][FIX] pinned requests_pkcs12 version due cryptography dependency

### DIFF
--- a/l10n_es_ticketbai_api_batuz/__manifest__.py
+++ b/l10n_es_ticketbai_api_batuz/__manifest__.py
@@ -17,7 +17,12 @@
     "development_status": "Beta",
     "maintainers": ["ao-landoo"],
     "depends": ["l10n_es_ticketbai_api"],
-    "external_dependencies": {"python": ["xmltodict", "requests_pkcs12"]},
+    "external_dependencies": {
+        "python": [
+            "xmltodict",
+            "requests_pkcs12==1.22",  # compatible with python_version < '3.12' >= '3.12'
+        ]
+    },
     "data": [
         "security/ir.model.access.csv",
         "data/tax_agency_data.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ deepdiff<8
 pycountry
 pycryptodome
 qrcode
-requests_pkcs12
+requests_pkcs12==1.22
 suds-py3
 unidecode
 xmlsig

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,1 @@
 odoo_test_helper
-cryptography==3.4.8; python_version < '3.12'  # incompatibility between pyopenssl 19.0.0 and cryptography>=37.0.0
-cryptography==42.0.8 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 42.0.8 for security fixes


### PR DESCRIPTION
Tal y como se indica en #3937 

La dependencia de requests_pkcs12 en su última versión necesita cryptography>=42.0.0:
```
requests-pkcs12==1.25
├── cryptography [required: >=42.0.0, installed: 44.0.0]
│   └── cffi [required: >=1.12, installed: 1.17.1]
│       └── pycparser [required: Any, installed: 2.22]
└── requests [required: >=2.26.0, installed: 2.32.3]
    ├── certifi [required: >=2017.4.17, installed: 2024.12.14]
    ├── charset-normalizer [required: >=2,<4, installed: 3.4.1]
    ├── idna [required: >=2.5,<4, installed: 2.10]
    └── urllib3 [required: >=1.21.1,<3, installed: 1.26.5]
```

Por lo que hay que ajustar a requests_pkcs12==1.22 para versiones python_version < '3.12' si no tendremos problemas de que se instala una versión incompatible de cryptography
