### PR TITLE
[16.0][FIX] l10n_es_aeat_mod190: Computes de casilla 02 y 03

### DIFF
--- a/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
+++ b/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
@@ -71,12 +71,8 @@ class L10nEsAeatMod190Report(models.Model):
                     item.mapped("partner_record_ids.percepciones_en_especie_incap")
                 )
             else:
-                tax_lines = item.tax_line_ids.search(
-                    [
-                        ("field_number", "in", (11, 13, 15)),
-                        ("model", "=", item._name),
-                        ("res_id", "=", item.id),
-                    ]
+                tax_lines = item.tax_line_ids.filtered(
+                    lambda x: x.field_number in {11, 13, 15}
                 )
                 for move_line in tax_lines.move_line_ids:
                     value += move_line.debit - move_line.credit
@@ -98,12 +94,8 @@ class L10nEsAeatMod190Report(models.Model):
                     item.mapped("partner_record_ids.retenciones_dinerarias_incap")
                 )
             else:
-                tax_lines = self.tax_line_ids.search(
-                    [
-                        ("field_number", "in", (12, 14, 16)),
-                        ("model", "=", item._name),
-                        ("res_id", "=", item.id),
-                    ]
+                tax_lines = item.tax_line_ids.filtered(
+                    lambda x: x.field_number in {12, 14, 16}
                 )
                 for move_line in tax_lines.move_line_ids:
                     value += move_line.credit - move_line.debit


### PR DESCRIPTION
Con `search` se estaban volviendo a buscar los `tax_line_ids` lo que daba lugar a algún bug.

@moduon MT-8802