### PR TITLE
[15.0][FIX] l10n_es_aeat_mod390: computation of fields 97 and 662

### DIFF
--- a/l10n_es_aeat_mod390/models/mod390.py
+++ b/l10n_es_aeat_mod390/models/mod390.py
@@ -849,16 +849,14 @@ class L10nEsAeatMod390Report(models.Model):
                     # Si salió a compensar, casilla 97 = casilla 71 del último periodo
                     # del año si fue a compensar
                     casilla_97 = abs(report_303_last_period.resultado_liquidacion)
-                elif report_303_last_period[0].result_type == "N":
-                    # casilla 97 = casilla 87 del último periodo del año si fue a compensar
-                    # Si salio resultado cero, pero queda pendiente a compensar
-                    casilla_97 = report_303_last_period.remaining_cuota_compensar
-                elif report_303_last_period[0].result_type in {"D", "V", "X"}:
-                    # casilla 98 = casilla 71 del último periodo del año si fue a devolver
-                    casilla_98 = abs(report_303_last_period.resultado_liquidacion)
-                    # casilla 662 = casilla 87 del último periodo del año si no se incluyo
-                    # en la casilla 97
+                else:
+                    # casilla 662 = casilla 87 del último periodo del año si no se
+                    # incluyo en la casilla 97
                     casilla_662 = report_303_last_period.remaining_cuota_compensar
+                    if report_303_last_period[0].result_type in {"D", "V", "X"}:
+                        # Si salió a devolver, casilla 98 = casilla 71 del último periodo
+                        # del año si fue a devolver
+                        casilla_98 = abs(report_303_last_period.resultado_liquidacion)
             mod390.update(
                 {
                     "casilla_85": casilla_85,

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -480,9 +480,9 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2018.casilla_85, 805.25, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 2302.12, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_97, 100.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 100.0, 2)
 
         model303_4T.return_last_period = True
         model303_4T.button_calculate()


### PR DESCRIPTION
Según la AEAT, la **casilla 97** solamente se debe rellenar en caso que el resultado de la última autoliquidación fuese a compensar. La **casilla 662**, por otro lado, tiene por objeto reflejar las cuotas a compensar generadas en el ejercicio en alguno de los períodos de liquidación distintos del último, cuando no estén incluidas en la **casilla 97** del mismo modelo 390.

Con este cambio, se calculan correctamente los importes de ambas casillas. Rellenando la **97** únicamente en caso de compensación, o aplicando el importe a la **casilla 662** en caso contrario.