### PR TITLE
[FIX] [16.0] l10n_es_vat_book: Añadir IVA Exento Repercutido No Sujeto al mapeo de IVA repercutido 

### DIFF
--- a/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
+++ b/l10n_es_vat_book/data/aeat_vat_book_map_data.xml
@@ -27,6 +27,7 @@
             (4, ref('l10n_es.account_tax_template_s_iva0_sp_i')),
             (4, ref('l10n_es.account_tax_template_s_iva0_ic')),
             (4, ref('l10n_es.account_tax_template_s_iva0_e')),
+            (4, ref('l10n_es.account_tax_template_s_iva0_ns')),
             (4, ref('l10n_es.account_tax_template_s_iva0')),
             (4, ref('l10n_es.account_tax_template_s_iva_ns')),
             (4, ref('l10n_es.account_tax_template_s_iva_ns_b')),


### PR DESCRIPTION
Se añade el impuesto **IVA Exento Repercutido No Sujeto** a las líneas al Mapeo AEAT libro de IVA en **IVA repercutido** de **Emitidas**.

MT-8835 @moduon @rafaelbn @ArantxaSudon @EmilioPascual @pedrobaeza revisad si queréis por favor 😄 