### PR TITLE
[16.0][FIX] l10n_es_aeat_mod_369: No recalcular line_number debido a incons…

### DIFF
--- a/l10n_es_aeat_mod369/models/mod369.py
+++ b/l10n_es_aeat_mod369/models/mod369.py
@@ -167,7 +167,6 @@ class L10nEsAeatMod369Report(models.Model):
         previous_tax_count = 0
         for country, taxes in oss_countries.items():
             if previous_country and country != previous_country:
-                line_number += 8 - (previous_tax_count * 2)
                 previous_tax_count = 0
             for tax in taxes:
                 previous_tax_count += 1


### PR DESCRIPTION
…istencias en ciertos casos donde genera que se repita el mismo número y reemplaza registros del dict oss_taxes_map

Existe un caso muy específico en el método `_get_oss_taxes_map`. Al iterar en `for country, taxes in oss_countries.items()` y tenemos que `previous_tax_count == 5` la fórmula indicada `line_number += 8 - (previous_tax_count * 2)` siempre se traducirá a `line_number += -2`. Por ende, en este caso `line_number` siempre será equivalente al `line_number` del último impuesto añadido a `oss_taxes_map` y debido a esto, ese último impuesto será reemplazado por el actual y provoca que no se vea reflejado en el reporte 369.

###### Para replicar en runbot:
- Compañía: ES Company.
- Desde Ajustes -> Contabilidad -> Impuestos -> OSS de la UE OCA -> Añadir nuevos impuestos.
- Seleccionar por ejemplo, 3 países (Alemania, Austria y Bélgica).
- Impuestos generales -> Por ejemplo IVA 21% (Bienes)

Se entiende que al realizar esta búsqueda al comienzo del método:
`oss_taxes = self.env["account.tax"].search([("oss_country_id", "!=", False), ("company_id", "=", self.company_id.id)])`
El primer registro siempre será el último creado, entonces:
- Para, por ejemplo, Austria, crear 2 nuevos impuestos (se puede duplicar y cambiar nombre e importe)
- Y para, por ejemplo, Alemania, crear 4 nuevos impuestos (así este queda con 5 para replicar el caso en cuestión)

Crear clientes:
- Crear cliente b2c para Austria
- Crear cliente b2c para Alemania

Crear facturas:
- Crear factura para Cliente Austria con cualquiera de sus impuestos OSS.
- Crear factura para Cliente Alemania con al menos que una línea tenga el último impuesto OSS que se vea disponible en el selector.

Generar 369:
- NO se refleja el impuesto de Alemania.


https://github.com/user-attachments/assets/704ff687-425c-4aca-a706-24841ee306bc


- Con el PR, si se refleja.


https://github.com/user-attachments/assets/e9a8dd4c-9f52-47e3-af0f-3407a3308888



No termino de darle el sentido a la fórmula `line_number += 8 - (previous_tax_count * 2)`. Al dejar que siga con su secuencia de +2 en cada iteración, el reporte se genera igual de correcto.
