### PR TITLE
[15.0][IMP] l10n_es_aeat*: Show only fields with values by default

### DIFF
--- a/l10n_es_aeat/i18n/es.po
+++ b/l10n_es_aeat/i18n/es.po
@@ -1763,6 +1763,11 @@ msgid "Value for no"
 msgstr "Valor para el no"
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping__valued_tax_line_ids
+msgid "Valued tax lines"
+msgstr "Líneas de impuestos con valores"
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_aeat_model_export_config_line__bool_yes
 msgid "Value for yes"
 msgstr "Valor para el sí"

--- a/l10n_es_aeat/i18n/l10n_es_aeat.pot
+++ b/l10n_es_aeat/i18n/l10n_es_aeat.pot
@@ -1726,6 +1726,11 @@ msgid "Value for yes"
 msgstr ""
 
 #. module: l10n_es_aeat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping__valued_tax_line_ids
+msgid "Valued tax lines"
+msgstr ""
+
+#. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report__website_message_ids
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping__website_message_ids
 msgid "Website Messages"

--- a/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
@@ -20,6 +20,14 @@ class L10nEsAeatReportTaxMapping(models.AbstractModel):
         readonly=True,
         string="Tax lines",
     )
+    valued_tax_line_ids = fields.One2many(
+        comodel_name="l10n.es.aeat.tax.line",
+        inverse_name="res_id",
+        domain=lambda self: [("model", "=", self._name), ("amount", "!=", 0)],
+        auto_join=True,
+        readonly=True,
+        string="Valued tax lines",
+    )
 
     def calculate(self):
         res = super().calculate()

--- a/l10n_es_aeat_mod303/i18n/es.po
+++ b/l10n_es_aeat_mod303/i18n/es.po
@@ -944,6 +944,11 @@ msgid "VAT number"
 msgstr "NIF"
 
 #. module: l10n_es_aeat_mod303
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_mod303.view_l10n_es_aeat_mod303_report_form
+msgid "Valued tax lines"
+msgstr "Líneas de impuestos con valores"
+
+#. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report__website_message_ids
 msgid "Website Messages"
 msgstr "Mensajes del sitio web"

--- a/l10n_es_aeat_mod303/i18n/l10n_es_aeat_mod303.pot
+++ b/l10n_es_aeat_mod303/i18n/l10n_es_aeat_mod303.pot
@@ -891,6 +891,11 @@ msgid "VAT number"
 msgstr ""
 
 #. module: l10n_es_aeat_mod303
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_mod303.view_l10n_es_aeat_mod303_report_form
+msgid "Valued tax lines"
+msgstr ""
+
+#. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report__website_message_ids
 msgid "Website Messages"
 msgstr ""

--- a/l10n_es_aeat_mod303/views/mod303_view.xml
+++ b/l10n_es_aeat_mod303/views/mod303_view.xml
@@ -191,14 +191,14 @@
                     />
                     <field name="result_type" />
                 </group>
-                <group
-                    string="Tax lines"
-                    name="group_tax_lines"
-                    colspan="4"
-                    attrs="{'invisible': [('state', '=', 'draft')]}"
-                >
-                    <field name="tax_line_ids" nolabel="1" readonly="1" />
-                </group>
+                <notebook attrs="{'invisible': [('state', '=', 'draft')]}">
+                    <page string="Valued tax lines">
+                        <field name="valued_tax_line_ids" nolabel="1" readonly="1" />
+                    </page>
+                    <page string="Tax lines">
+                        <field name="tax_line_ids" nolabel="1" readonly="1" />
+                    </page>
+                </notebook>
             </group>
             <form position="inside">
                 <div class="oe_chatter">

--- a/l10n_es_aeat_mod390/i18n/es.po
+++ b/l10n_es_aeat_mod390/i18n/es.po
@@ -869,6 +869,11 @@ msgid "VAT number"
 msgstr "NIF"
 
 #. module: l10n_es_aeat_mod390
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_mod390.view_l10n_es_aeat_mod390_report_form
+msgid "Valued tax lines"
+msgstr "Líneas de impuestos con valores"
+
+#. module: l10n_es_aeat_mod390
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod390.field_l10n_es_aeat_mod390_report__website_message_ids
 msgid "Website Messages"
 msgstr "Mensajes del sitio web"

--- a/l10n_es_aeat_mod390/i18n/l10n_es_aeat_mod390.pot
+++ b/l10n_es_aeat_mod390/i18n/l10n_es_aeat_mod390.pot
@@ -819,6 +819,11 @@ msgid "VAT number"
 msgstr ""
 
 #. module: l10n_es_aeat_mod390
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_mod390.view_l10n_es_aeat_mod390_report_form
+msgid "Valued tax lines"
+msgstr ""
+
+#. module: l10n_es_aeat_mod390
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod390.field_l10n_es_aeat_mod390_report__website_message_ids
 msgid "Website Messages"
 msgstr ""

--- a/l10n_es_aeat_mod390/views/mod390_view.xml
+++ b/l10n_es_aeat_mod390/views/mod390_view.xml
@@ -219,14 +219,14 @@
                         </group>
                     </page>
                 </notebook>
-                <group
-                    string="Tax lines"
-                    name="group_tax_lines"
-                    colspan="4"
-                    attrs="{'invisible': [('state', '=', 'draft')]}"
-                >
-                    <field name="tax_line_ids" nolabel="1" readonly="1" />
-                </group>
+                <notebook attrs="{'invisible': [('state', '=', 'draft')]}">
+                    <page string="Valued tax lines">
+                        <field name="valued_tax_line_ids" nolabel="1" readonly="1" />
+                    </page>
+                    <page string="Tax lines">
+                        <field name="tax_line_ids" nolabel="1" readonly="1" />
+                    </page>
+                </notebook>
             </group>
             <form position="inside">
                 <div class="oe_chatter">


### PR DESCRIPTION
Backport of #3974

Models like 303 and 390 have a lot of fields, so showing them all even if the amount is 0 can be counterproductive. Thanks to the magic of one2many fields, we can continue calculating all the fields and showing them for traceability purposes, but filter out in another o2m field those with amount with hardly no cost, and now 2 tabs are shown for these lines, having precedence the filtered one.

@Tecnativa 