### PR TITLE
[17.0][FIX] l10n_es_aeat: Execute tests in post-install

### DIFF
--- a/l10n_es_aeat/tests/test_l10n_es_aeat_mod_base.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_mod_base.py
@@ -5,11 +5,12 @@
 
 import logging
 
-from odoo.tests import common
+from odoo.tests import common, tagged
 
 _logger = logging.getLogger("aeat")
 
 
+@tagged("post_install", "-at_install")
 class TestL10nEsAeatModBase(common.TransactionCase):
     accounts = {}
     # Set 'debug' attribute to True to easy debug this test


### PR DESCRIPTION
To avoid this warning:

odoo.addons.account.models.chart_template: Incorrect usage of try_loading without a fully loaded registry. This could lead to issues.

and intermittent errors in integration tests with some missing taxes.

@Tecnativa