### PR TITLE
Revert "[16.0][FIX] pinned requests_pkcs12 version due cryptography dependency"

### DIFF
--- a/l10n_es_ticketbai_api_batuz/__manifest__.py
+++ b/l10n_es_ticketbai_api_batuz/__manifest__.py
@@ -17,12 +17,7 @@
     "development_status": "Beta",
     "maintainers": ["ao-landoo"],
     "depends": ["l10n_es_ticketbai_api"],
-    "external_dependencies": {
-        "python": [
-            "xmltodict",
-            "requests_pkcs12==1.22",  # compatible with python_version < '3.12' >= '3.12'
-        ]
-    },
+    "external_dependencies": {"python": ["xmltodict", "requests_pkcs12"]},
     "data": [
         "security/ir.model.access.csv",
         "data/tax_agency_data.xml",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ deepdiff<8
 pycountry
 pycryptodome
 qrcode
-requests_pkcs12==1.22
+requests_pkcs12
 suds-py3
 unidecode
 xmlsig

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
 odoo_test_helper
+cryptography==3.4.8; python_version < '3.12'  # incompatibility between pyopenssl 19.0.0 and cryptography>=37.0.0
+cryptography==42.0.8 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 42.0.8 for security fixes


### PR DESCRIPTION
Aquí revierto https://github.com/OCA/l10n-spain/pull/3954 pues el fix empezó a romper nuestro CI:

```
ERROR: Cannot install requests_pkcs12 because these package versions have conflicting dependencies. The conflict is caused by:
    requests-pkcs12 1.22 depends on requests>=2.26.0
    The user requested (constraint) requests==2.25.1
To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

En resumidas cuentas, lo que viene diciendo es que al exigir `requests-pkcs12==1.22`, estamos rompiendo [este constraint de Odoo](https://github.com/odoo/odoo/blob/c52aae67247f27e23629310c766cba407e6ee5c7/requirements.txt#L69).

Esto me ha empezado a suceder porque usamos el archivo `requirements.txt` de Odoo como un [pip contraint](https://pip.pypa.io/en/stable/user_guide/#constraints-files) y no como un [pip requirements](https://pip.pypa.io/en/stable/user_guide/#requirements-files). Algo así:

    pip install \
        -r https://github.com/OCA/l10n-spain/raw/refs/heads/16.0/requirements.txt \
        -c https://github.com/odoo/odoo/raw/refs/heads/16.0/requirements.txt


Lo hacemos así para siempre coger las dependencias más modernas que necesitan los módulos de OCA, pero respetando las restricciones últimas que establece Odoo. Para que esto funcione, es mejor que los repos de OCA no definan restricciones de versiones<sup>1</sup>, y dejar que sea Odoo quien las restrinja.

Dicho de otra forma, si usas el `requirements.txt` de OCA, es mejor que dicho archivo no congele versiones para que sea Odoo quien lo haga.

~~Dejo el PR en borrador hasta que compruebe si esto realmente resuelve el problema.~~

---

<sup>1</sup> Las restricciones de versiones que tengan sentido se deben poner, por supuesto (si el módulo es incompatible con cierta versión de cierta dependencia). Pero si se ponen solo para evitar conflictos o reinstalaciones, es contraproducente, y es preferible hacerlo con constraints como se explica arriba.

@moduon MT-8983