### PR TITLE
[17.0][FIX] l10n_es_facturae: Fallo al instalar el modulo

### DIFF
--- a/l10n_es_facturae/data/template/account.tax-es_common.csv
+++ b/l10n_es_facturae/data/template/account.tax-es_common.csv
@@ -25,7 +25,6 @@
 "account_tax_template_s_iva10b","01"
 "account_tax_template_s_iva10s","01"
 "account_tax_template_s_iva21s","01"
-"account_tax_template_s_iva21isp","01"
 "account_tax_template_p_iva4_ic_bc","01"
 "account_tax_template_p_iva4_sp_in","01"
 "account_tax_template_p_iva4_ic_bi","01"
@@ -87,3 +86,4 @@
 "account_tax_template_p_iva21_isp_bi","01"
 "account_tax_template_p_iva12_agr","01"
 "account_tax_template_p_iva105_gan","01"
+"account_tax_template_s_iva0_g_i","01"


### PR DESCRIPTION
Al instalar el modulo en las ultimas versiones de odoo me da el siguiente error:
```
psycopg2.errors.NotNullViolation: el valor nulo en la columna «name» de la relación «account_tax» viola la restricción de no nulo
DETAIL:  La fila que falla contiene (168, 1, 1, 1, null, 68, 1, 1, sale, null, percent, on_invoice, null, null, null, 0.0000, t, f, f, t, null, 2025-02-03 13:42:10.542659, 2025-02-03 13:42:10.542659, null, sujeto, f, 01, 01).
```
Lo soluciono actualizando el  archivo `account.tax-es_common.csv`