### PR TITLE
[FIX] [16.0] l10n_es_vat_prorate: Recompute VAT prorate bills and refunds in a period

### DIFF
--- a/l10n_es_vat_prorate/README.rst
+++ b/l10n_es_vat_prorate/README.rst
@@ -34,6 +34,8 @@ Prorrata de IVA
 
 El módulo nos divide los IVA según la prorrata de la compañía.
 
+Permite recalcular la prórrata del IVA de todas las facturas y reembolsos de proveedores para un periodo determinado.
+
 **Table of contents**
 
 .. contents::
@@ -92,6 +94,8 @@ Contributors
 * `Sygel <https://www.sygel.es/>`_:
   * Harald Panten
   * Alberto Martínez
+
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_vat_prorate/i18n/es.po
+++ b/l10n_es_vat_prorate/i18n/es.po
@@ -6,20 +6,41 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2025-07-16 16:12+0000\n"
-"Last-Translator: \"Pedro M. Baeza\" <pedro.baeza@tecnativa.com>\n"
+"POT-Creation-Date: 2025-07-29 11:20+0000\n"
+"PO-Revision-Date: 2025-07-29 12:21+0100\n"
+"Last-Translator: Jairo Llopis <jairo@moduon.team>\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.10.4\n"
+"X-Generator: Poedit 3.5\n"
 
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_account_tax__prorate_account_ids
 msgid "Accounts to apply the recompute"
 msgstr "Cuentas para aplicar el recálculo"
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid ""
+"Are you sure you want to recompute prorata in all Bills and Refunds of this "
+"period? This action cannot be undone."
+msgstr ""
+"¿Estás seguro que quieres recomputar la prórrata del IVA en todas las "
+"Facturas y Reembolsos de Proveedores para este periodo? Esta acción no se "
+"puede deshacer."
+
+#. module: l10n_es_vat_prorate
+#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__can_reprorate
+msgid "Can re-prorate"
+msgstr "Puede re-prorratearse"
+
+#. module: l10n_es_vat_prorate
+#: model:ir.model.fields,help:l10n_es_vat_prorate.field_res_company_vat_prorate__can_reprorate
+msgid "Check if the period can be re-prorated"
+msgstr "Comprueba si el periodo puede re-prorratearse"
 
 #. module: l10n_es_vat_prorate
 #: model:ir.model,name:l10n_es_vat_prorate.model_res_company
@@ -55,6 +76,11 @@ msgstr "Fecha"
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__display_name
 msgid "Display Name"
 msgstr "Mostrar Nombre"
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Full reprorate"
+msgstr "Reprorrateado completo"
 
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields.selection,name:l10n_es_vat_prorate.selection__res_company_vat_prorate__type__general
@@ -105,7 +131,7 @@ msgstr "Asiento contable"
 #. module: l10n_es_vat_prorate
 #: model:ir.model,name:l10n_es_vat_prorate.model_account_move_line
 msgid "Journal Item"
-msgstr "Artículo Diario"
+msgstr "Apunte contable"
 
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate____last_update
@@ -121,6 +147,21 @@ msgstr "Actualizado por Última vez por"
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__write_date
 msgid "Last Updated on"
 msgstr "Última Actualización el"
+
+#. module: l10n_es_vat_prorate
+#: model:ir.model.fields.selection,name:l10n_es_vat_prorate.selection__res_company_vat_prorate__can_reprorate__no
+msgid "No"
+msgstr "No"
+
+#. module: l10n_es_vat_prorate
+#: model:ir.model.fields.selection,name:l10n_es_vat_prorate.selection__res_company_vat_prorate__can_reprorate__partial
+msgid "Partial"
+msgstr "Parcial"
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Partial reprorate"
+msgstr "Reprorrateado parcial"
 
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_bank_statement_line__prorate_id
@@ -150,6 +191,30 @@ msgid "Prorrate Investment Account"
 msgstr "Cuenta de inversión de prorrata"
 
 #. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_form_view
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Recompute period"
+msgstr "Recomputar periodo"
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Recompute period partially"
+msgstr "Recomputar periodo parcialmente"
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Recompute prorata in all Bills and Refunds of this period"
+msgstr ""
+"Recomputar la prórrata del IVA en estas Facturas y Reembolsos de este periodo"
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Recompute prorata in all Bills and Refunds of this period partially"
+msgstr ""
+"Recomputar la prórrata del IVA en estas Facturas y Reembolsos de este "
+"periodo parcialmente"
+
+#. module: l10n_es_vat_prorate
 #: model:ir.model.fields.selection,name:l10n_es_vat_prorate.selection__res_company_vat_prorate__type__special
 msgid "Special"
 msgstr "Especial"
@@ -172,7 +237,7 @@ msgstr "Plantilla con prorrateo del IVA"
 #. module: l10n_es_vat_prorate
 #: model:ir.model,name:l10n_es_vat_prorate.model_account_tax_template
 msgid "Templates for Taxes"
-msgstr "Plantillas para impuestos"
+msgstr "Plantilla de impuestos"
 
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_account_move_line__vat_prorate
@@ -185,9 +250,36 @@ msgid "The line will create a vat prorate"
 msgstr "La línea creará una prorrata de IVA"
 
 #. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_form_view
+msgid "This action will recompute Prorata in all Bills of this period"
+msgstr ""
+"Esta acción recomputará la prórrata del IVA en todas las Facturas y "
+"Reembolsos de este periodo"
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid ""
+"This period is partially allowed to be recomputed. Are you sure you want to "
+"recompute prorata in all Bills and Refunds of this partial period? This "
+"action cannot be undone."
+msgstr ""
+"Este periodo es parcialmente recomputable ¿Estás seguro que quieres "
+"recomputar la prórrata del IVA en todas las Facturas y Reembolsos de "
+"Proveedores para este periodo de manera parcial? Esta acción no se puede "
+"deshacer."
+
+#. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__type
 msgid "Type"
 msgstr "Tipo"
+
+#. module: l10n_es_vat_prorate
+#. odoo-python
+#: code:addons/l10n_es_vat_prorate/models/res_company.py:0
+#, python-format
+msgid "Unable to recompute VAT prorate Bills and Refunds"
+msgstr ""
+"Imposible recomputar la prórrata del IVA en estas Facturas y Reembolsos"
 
 #. module: l10n_es_vat_prorate
 #: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_form_view
@@ -230,11 +322,23 @@ msgid "With VAT Prorate"
 msgstr "Con prorrata de IVA"
 
 #. module: l10n_es_vat_prorate
+#: model:ir.model.fields.selection,name:l10n_es_vat_prorate.selection__res_company_vat_prorate__can_reprorate__yes
+msgid "Yes"
+msgstr "Sí"
+
+#. module: l10n_es_vat_prorate
 #. odoo-python
 #: code:addons/l10n_es_vat_prorate/models/res_company.py:0
 #, python-format
 msgid "You can't have a special VAT prorrate of 100%"
 msgstr "No puede tener una prorrata especial de IVA del 100%"
+
+#. module: l10n_es_vat_prorate
+#. odoo-python
+#: code:addons/l10n_es_vat_prorate/models/res_company.py:0
+#, python-format
+msgid "You cannot re-prorate this period"
+msgstr "No puedes re-prorratear este periodo"
 
 #. module: l10n_es_vat_prorate
 #. odoo-python

--- a/l10n_es_vat_prorate/i18n/l10n_es_vat_prorate.pot
+++ b/l10n_es_vat_prorate/i18n/l10n_es_vat_prorate.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-29 11:20+0000\n"
+"PO-Revision-Date: 2025-07-29 11:20+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,6 +18,23 @@ msgstr ""
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_account_tax__prorate_account_ids
 msgid "Accounts to apply the recompute"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid ""
+"Are you sure you want to recompute prorata in all Bills and Refunds of this "
+"period? This action cannot be undone."
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__can_reprorate
+msgid "Can re-prorate"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model:ir.model.fields,help:l10n_es_vat_prorate.field_res_company_vat_prorate__can_reprorate
+msgid "Check if the period can be re-prorated"
 msgstr ""
 
 #. module: l10n_es_vat_prorate
@@ -51,6 +70,11 @@ msgstr ""
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Full reprorate"
 msgstr ""
 
 #. module: l10n_es_vat_prorate
@@ -114,6 +138,21 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: l10n_es_vat_prorate
+#: model:ir.model.fields.selection,name:l10n_es_vat_prorate.selection__res_company_vat_prorate__can_reprorate__no
+msgid "No"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model:ir.model.fields.selection,name:l10n_es_vat_prorate.selection__res_company_vat_prorate__can_reprorate__partial
+msgid "Partial"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Partial reprorate"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_bank_statement_line__prorate_id
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_move__prorate_id
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_payment__prorate_id
@@ -138,6 +177,27 @@ msgstr ""
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company__prorrate_investment_account_id
 msgid "Prorrate Investment Account"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_form_view
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Recompute period"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Recompute period partially"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Recompute prorata in all Bills and Refunds of this period"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid "Recompute prorata in all Bills and Refunds of this period partially"
 msgstr ""
 
 #. module: l10n_es_vat_prorate
@@ -176,8 +236,28 @@ msgid "The line will create a vat prorate"
 msgstr ""
 
 #. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_form_view
+msgid "This action will recompute Prorata in all Bills of this period"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.res_company_vat_prorate_tree_view
+msgid ""
+"This period is partially allowed to be recomputed. Are you sure you want to "
+"recompute prorata in all Bills and Refunds of this partial period? This "
+"action cannot be undone."
+msgstr ""
+
+#. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__type
 msgid "Type"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#. odoo-python
+#: code:addons/l10n_es_vat_prorate/models/res_company.py:0
+#, python-format
+msgid "Unable to recompute VAT prorate Bills and Refunds"
 msgstr ""
 
 #. module: l10n_es_vat_prorate
@@ -221,10 +301,22 @@ msgid "With VAT Prorate"
 msgstr ""
 
 #. module: l10n_es_vat_prorate
+#: model:ir.model.fields.selection,name:l10n_es_vat_prorate.selection__res_company_vat_prorate__can_reprorate__yes
+msgid "Yes"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
 #. odoo-python
 #: code:addons/l10n_es_vat_prorate/models/res_company.py:0
 #, python-format
 msgid "You can't have a special VAT prorrate of 100%"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#. odoo-python
+#: code:addons/l10n_es_vat_prorate/models/res_company.py:0
+#, python-format
+msgid "You cannot re-prorate this period"
 msgstr ""
 
 #. module: l10n_es_vat_prorate

--- a/l10n_es_vat_prorate/models/res_company.py
+++ b/l10n_es_vat_prorate/models/res_company.py
@@ -1,9 +1,14 @@
 # Copyright 2022 Creu Blanca
 # Copyright 2023 Tecnativa Carolina Fernandez
+# Copyright 2025 Moduon Team
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
+
 from odoo import _, api, fields, models, tools
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class ResCompany(models.Model):
@@ -98,6 +103,91 @@ class ResCompanyVatProrate(models.Model):
         "whether all the invoice lines will be prorated by default",
     )
     vat_prorate = fields.Float()
+    can_reprorate = fields.Selection(
+        string="Can re-prorate",
+        selection=[("yes", "Yes"), ("partial", "Partial"), ("no", "No")],
+        compute="_compute_can_reprorate",
+        help="Check if the period can be re-prorated",
+        store=False,
+    )
+
+    def _compute_can_reprorate(self):
+        self.can_reprorate = "no"
+        for record in self:
+            company = record.company_id
+            if company.tax_lock_date and company.tax_lock_date >= record.date:
+                continue
+            user_fiscal_lock_date = company._get_user_fiscal_lock_date()
+            if user_fiscal_lock_date < record.date:
+                record.can_reprorate = "yes"
+                continue
+
+            next_period = self.search(
+                [
+                    ("company_id", "=", company.id),
+                    ("date", ">", record.date),
+                ],
+                limit=1,
+            )
+            if not next_period and record.date < user_fiscal_lock_date:
+                record.can_reprorate = "partial"
+
+    def action_recompute_period(self):
+        self.ensure_one()
+        if self.can_reprorate == "no":
+            raise UserError(_("You cannot re-prorate this period"))
+        next_vat_prorate_period = self.search(
+            [
+                ("company_id", "=", self.company_id.id),
+                ("date", ">", self.date),
+            ],
+            limit=1,
+            order="date ASC",
+        )
+        move_domain = [
+            ("move_type", "in", ["in_invoice", "in_refund"]),
+            ("state", "=", "posted"),
+        ]
+        if self.can_reprorate == "yes":
+            move_domain.append(("date", ">=", self.date))
+        else:
+            move_domain.append(
+                ("date", ">", self.company_id._get_user_fiscal_lock_date())
+            )
+
+        if next_vat_prorate_period:
+            move_domain.append(("date", "<", next_vat_prorate_period.date))
+
+        unable_to_recompute_moves = self.env["account.move"].browse()
+        for move in self.env["account.move"].search(move_domain):
+            all_reconciled_lines = move.line_ids._all_reconciled_lines().filtered(
+                lambda l: l.matched_debit_ids or l.matched_credit_ids
+            )
+            # Reset to draft
+            try:
+                move.button_draft()
+            except Exception as ex:
+                _logger.warning("Unable to re-prorate %s", move, exc_info=ex)
+                unable_to_recompute_moves |= move
+                continue
+            # Clear and Set taxes
+            inv_line_map = {
+                inv_line: inv_line.tax_ids.ids for inv_line in move.invoice_line_ids
+            }
+            move.invoice_line_ids.write({"tax_ids": [(6, 0, [])]})
+            for inv_line, tax_ids in inv_line_map.items():
+                inv_line.write({"tax_ids": [(6, 0, tax_ids)]})
+            move.action_post()
+            all_reconciled_lines.filtered(lambda line: not line.reconciled).reconcile()
+
+        if not unable_to_recompute_moves:
+            # Everything went fine
+            return True
+
+        action = self.env.ref("account.action_move_in_invoice_type").read()[0]
+        action["display_name"] = _("Unable to recompute VAT prorate Bills and Refunds")
+        action["domain"] = [("id", "in", unable_to_recompute_moves.ids)]
+        return action
 
     _sql_constraints = [
         (

--- a/l10n_es_vat_prorate/readme/CONTRIBUTORS.rst
+++ b/l10n_es_vat_prorate/readme/CONTRIBUTORS.rst
@@ -6,3 +6,5 @@
 * `Sygel <https://www.sygel.es/>`_:
   * Harald Panten
   * Alberto Martínez
+
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)

--- a/l10n_es_vat_prorate/readme/DESCRIPTION.rst
+++ b/l10n_es_vat_prorate/readme/DESCRIPTION.rst
@@ -1,1 +1,3 @@
 El módulo nos divide los IVA según la prorrata de la compañía.
+
+Permite recalcular la prórrata del IVA de todas las facturas y reembolsos de proveedores para un periodo determinado.

--- a/l10n_es_vat_prorate/static/description/index.html
+++ b/l10n_es_vat_prorate/static/description/index.html
@@ -376,6 +376,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/license-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/l10n-spain/tree/16.0/l10n_es_vat_prorate"><img alt="OCA/l10n-spain" src="https://img.shields.io/badge/github-OCA%2Fl10n--spain-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/l10n-spain-16-0/l10n-spain-16-0-l10n_es_vat_prorate"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/l10n-spain&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>El módulo nos divide los IVA según la prorrata de la compañía.</p>
+<p>Permite recalcular la prórrata del IVA de todas las facturas y reembolsos de proveedores para un periodo determinado.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -441,6 +442,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.sygel.es/">Sygel</a>:
 * Harald Panten
 * Alberto Martínez</li>
+<li>Eduardo de Miguel (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_es_vat_prorate/tests/test_prorate_sii.py
+++ b/l10n_es_vat_prorate/tests/test_prorate_sii.py
@@ -1,18 +1,24 @@
 from datetime import date
+from unittest import skipIf
 
-from odoo.tests.common import tagged
+from odoo.tests.common import TransactionCase, tagged
 
-from odoo.addons.l10n_es_aeat_sii_oca.tests import test_l10n_es_aeat_sii
+try:
+    from odoo.addons.l10n_es_aeat_sii_oca.tests.test_l10n_es_aeat_sii import (
+        TestL10nEsAeatSiiBase,
+    )
+except ModuleNotFoundError:
+    TestL10nEsAeatSiiBase = TransactionCase
 
 
 @tagged("-at_install", "post_install")
-class TestSIIVatProrate(test_l10n_es_aeat_sii.TestL10nEsAeatSiiBase):
+@skipIf(
+    TestL10nEsAeatSiiBase is TransactionCase, "l10n_es_aeat_sii_oca seems not installed"
+)
+class TestSIIVatProrate(TestL10nEsAeatSiiBase):
     @classmethod
     def setUpClass(cls):
-        try:
-            super().setUpClass()
-        except Exception:
-            cls.skipTest(cls, "l10n_es_aeat_sii_oca seems not installed")
+        super().setUpClass()
         cls.company.write(
             {
                 "with_vat_prorate": True,

--- a/l10n_es_vat_prorate/tests/test_vat_prorate.py
+++ b/l10n_es_vat_prorate/tests/test_vat_prorate.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Creu Blanca
 # Copyright 2023 Tecnativa - Pedro M. Baeza
 # Copyright 2023 Tecnativa - Carolina Fernandez
+# Copyright 2025 Moduon Team
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import date
@@ -8,7 +9,7 @@ from datetime import date
 from psycopg2 import IntegrityError
 
 from odoo import exceptions
-from odoo.tests.common import tagged
+from odoo.tests.common import Form, tagged
 from odoo.tools import mute_logger
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -272,3 +273,81 @@ class TestVatProrate(AccountTestInvoicingCommon):
             * (100 - prorate_id.vat_prorate)
             / 10000,
         )
+
+    def test_prorate_can_reprorate(self):
+        self.assertEqual(self.env.company.vat_prorate_ids[1].date, date(2000, 1, 1))
+        self.assertEqual(self.env.company.vat_prorate_ids[0].date, date(2001, 1, 1))
+        # period_lock_date, able to reprorate with permissions
+        self.env.company.write(
+            {
+                "period_lock_date": "2000-12-31",
+                "tax_lock_date": False,
+                "fiscalyear_lock_date": False,
+            }
+        )
+        self.env.company.vat_prorate_ids.invalidate_recordset()
+        self.assertEqual(self.env.company.vat_prorate_ids[1].can_reprorate, "yes")
+        self.assertEqual(self.env.company.vat_prorate_ids[0].can_reprorate, "yes")
+        # tax_lock_date, unable to reprorate even with permissions
+        self.env.company.write(
+            {
+                "period_lock_date": False,
+                "tax_lock_date": "2000-12-31",
+                "fiscalyear_lock_date": False,
+            }
+        )
+        self.env.company.vat_prorate_ids.invalidate_recordset()
+        self.assertEqual(self.env.company.vat_prorate_ids[1].can_reprorate, "no")
+        self.assertEqual(self.env.company.vat_prorate_ids[0].can_reprorate, "yes")
+        # fiscalyear_lock_date, unable to reprorate even with permissions
+        self.env.company.write(
+            {
+                "period_lock_date": False,
+                "tax_lock_date": False,
+                "fiscalyear_lock_date": "2000-12-31",
+            }
+        )
+        self.env.company.vat_prorate_ids.invalidate_recordset()
+        self.assertEqual(self.env.company.vat_prorate_ids[1].can_reprorate, "no")
+        self.assertEqual(self.env.company.vat_prorate_ids[0].can_reprorate, "yes")
+        # fiscalyear_lock_date (middle of year), partial reprorate with permissions
+        self.env.company.write(
+            {
+                "period_lock_date": False,
+                "tax_lock_date": False,
+                "fiscalyear_lock_date": "2001-06-30",
+            }
+        )
+        self.env.company.vat_prorate_ids.invalidate_recordset()
+        self.assertEqual(self.env.company.vat_prorate_ids[1].can_reprorate, "no")
+        self.assertEqual(self.env.company.vat_prorate_ids[0].can_reprorate, "partial")
+
+    def test_prorate_recompute_period(self):
+        self.env.company.vat_prorate_ids.invalidate_recordset()
+        self.product_b.property_account_expense_id = self.company_data[
+            "default_account_assets"
+        ]
+        invoice = self.init_invoice("in_invoice", products=[self.product_b], post=True)
+        initial_prorate_amount = sum(
+            invoice.line_ids.filtered_domain([("vat_prorate", "=", True)]).mapped(
+                "balance"
+            )
+        )
+        action_data = invoice.action_register_payment()
+        wizard = Form(
+            self.env["account.payment.register"].with_context(**action_data["context"])
+        ).save()
+        wizard.action_create_payments()
+        self.assertIn(invoice.payment_state, ["in_payment", "paid"])
+        company_prorate = self.env.company.vat_prorate_ids[0]
+        company_prorate.vat_prorate += 10
+        company_prorate.action_recompute_period()
+        invoice.invalidate_recordset()
+        final_prorate_amount = sum(
+            invoice.line_ids.filtered_domain([("vat_prorate", "=", True)]).mapped(
+                "balance"
+            )
+        )
+        self.assertNotEqual(initial_prorate_amount, final_prorate_amount)
+        self.assertEqual(invoice.state, "posted")
+        self.assertIn(invoice.payment_state, ["in_payment", "paid"])

--- a/l10n_es_vat_prorate/views/res_company_prorate_views.xml
+++ b/l10n_es_vat_prorate/views/res_company_prorate_views.xml
@@ -7,7 +7,15 @@
         <field name="model">res.company.vat.prorate</field>
         <field name="arch" type="xml">
             <form>
-                <header />
+                <header>
+                    <button
+                        name="action_recompute_period"
+                        string="Recompute period"
+                        type="object"
+                        class="oe_highlight"
+                        confirm="This action will recompute Prorata in all Bills of this period"
+                    />
+                </header>
                 <sheet>
                     <group>
                         <field name="company_id" />
@@ -34,6 +42,29 @@
                 <field
                     name="special_vat_prorate_default"
                     attrs="{'invisible': [('type', '=', 'general')]}"
+                />
+                <field name="can_reprorate" invisible="1" />
+                <button
+                    name="action_recompute_period"
+                    string="Full reprorate"
+                    title="Recompute period"
+                    help="Recompute prorata in all Bills and Refunds of this period"
+                    icon="fa-history"
+                    type="object"
+                    class="btn-outline-primary text-uppercase"
+                    attrs="{'invisible': [('can_reprorate', 'in', ['no', 'partial'])]}"
+                    confirm="Are you sure you want to recompute prorata in all Bills and Refunds of this period? This action cannot be undone."
+                />
+                <button
+                    name="action_recompute_period"
+                    string="Partial reprorate"
+                    title="Recompute period partially"
+                    help="Recompute prorata in all Bills and Refunds of this period partially"
+                    icon="fa-history"
+                    type="object"
+                    class="btn-outline-warning text-uppercase"
+                    attrs="{'invisible': [('can_reprorate', 'in', ['no', 'yes'])]}"
+                    confirm="This period is partially allowed to be recomputed. Are you sure you want to recompute prorata in all Bills and Refunds of this partial period? This action cannot be undone."
                 />
             </tree>
         </field>


### PR DESCRIPTION
Permite recomputar la prórrata del IVA en las Facturas y Reembolsos de proveedores dentro de un periodo de prórrata.
Las facturas o reembolsos que no se hayan podido pasar a borrador (para hacer el recómputo), las mostrará en una lista tras finalizar el proceso.

https://www.loom.com/share/ae5f6ae531ee4fbd9182a342a9bd67d6?sid=9e8143ca-d468-49a2-9812-72d05dae0393

MT-8885 @moduon @rafaelbn @fcvalgar @yajo @EmilioPascual @ArantxaSudon @pedrobaeza  revisad si queréis por favor 😄 