### PR TITLE
[16.0][IMP] l10n_es_facturae: Restar el importe de retención de garantía del total

### DIFF
--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -636,6 +636,11 @@ class CommonTest(CommonTestBase):
             )[0].text,
             ("%.2f" if version == "3_2" else "%.8f") % 5,
         )
+        sign = -1 if move.move_type == "out_refund" else 1
+        self.assertEqual(
+            generated_facturae.xpath("//InvoiceTotals//TotalExecutableAmount")[0].text,
+            ("%.2f" if version == "3_2" else "%.8f") % (float(total) - (sign * 5)),
+        )
 
     def test_move_rounding(self):
         self._activate_certificate(self.certificate_password)

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -497,7 +497,7 @@
                             />
                         </AmountsWithheld>
                         <TotalExecutableAmount
-                            t-out="('%.2f' if version == '3_2' else '%.8f') % (sign * move.amount_total)"
+                            t-out="('%.2f' if version == '3_2' else '%.8f') % (sign * move.amount_total - (sign * move.facturae_withheld_amount))"
                         />
                         <TotalReimbursableExpenses t-if="False" />
                         <t t-if="version not in ('3_2', '3_2_1')">


### PR DESCRIPTION
Restar el importe de retención de garantía del total

Relacionado con https://github.com/OCA/l10n-spain/blob/abf6a4bb0ee52305649f07036568f52c220f1c84/l10n_es_facturae/data/Facturaev3_2_2.xsd#L884

@Tecnativa TT55080