### PR TITLE
[16.0][IMP] l10n_es_aeat_mod347_igic: Added IGIC Exento Soportado to map

### DIFF
--- a/l10n_es_aeat_mod347_igic/data/tax_code_map_mod347_igic_data.xml
+++ b/l10n_es_aeat_mod347_igic/data/tax_code_map_mod347_igic_data.xml
@@ -39,6 +39,7 @@
                 Command.link(ref('l10n_es_igic.account_tax_template_igic_ISP95')),
                 Command.link(ref('l10n_es_igic.account_tax_template_igic_ISP15')),
                 Command.link(ref('l10n_es_igic.account_tax_template_igic_ISP20')),
+                Command.link(ref('l10n_es_igic.account_tax_template_igic_p_ex')),
                 Command.link(ref('l10n_es_igic.account_tax_template_igic_p_re0')),
                 Command.link(ref('l10n_es_igic.account_tax_template_igic_p_re03')),
                 Command.link(ref('l10n_es_igic.account_tax_template_igic_p_re07')),


### PR DESCRIPTION
Después de unas pruebas hemos detectado que faltaba un impuesto en el mapeo del 347_igic
@BinhexTeam