### PR TITLE
[17.0][FIX] l10n_es_partner: Show comercial

### DIFF
--- a/l10n_es_partner/__manifest__.py
+++ b/l10n_es_partner/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Adaptación de los clientes, proveedores y bancos para España",
-    "version": "17.0.1.0.1",
+    "version": "17.0.2.0.0",
     "author": "ZikZak," "Acysos," "Tecnativa," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "category": "Localisation/Europe",

--- a/l10n_es_partner/migrations/17.0.2.0.0/post-migration.py
+++ b/l10n_es_partner/migrations/17.0.2.0.0/post-migration.py
@@ -1,0 +1,8 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    partners = env["res.partner"].search([("comercial", "!=", False)])
+    for partner in partners:
+        partner._compute_complete_name()

--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -13,6 +13,10 @@ class ResPartner(models.Model):
     display_name = fields.Char(compute="_compute_display_name")
 
     @api.depends("comercial")
+    def _compute_complete_name(self):
+        return super()._compute_complete_name()
+
+    @api.depends("comercial")
     @api.depends_context("no_display_commercial")
     def _compute_display_name(self):
         """
@@ -30,7 +34,12 @@ class ResPartner(models.Model):
 
     def _get_complete_name(self):
         name = super()._get_complete_name()
-        if self.env.context.get("display_commercial") and self.comercial:
+        display_commercial = self.env.context.get("display_commercial")
+        if not display_commercial:
+            display_commercial = not self.env.context.get(
+                "no_display_commercial", False
+            )
+        if display_commercial and self.comercial:
             name_pattern = (
                 self.env["ir.config_parameter"]
                 .sudo()

--- a/l10n_es_partner/tests/test_l10n_es_partner.py
+++ b/l10n_es_partner/tests/test_l10n_es_partner.py
@@ -72,7 +72,7 @@ class TestL10nEsPartner(common.TransactionCase):
             }
         )
         self.assertEqual(partner2.display_name, "Nombre comercial (Empresa de prueba)")
-        self.assertEqual(partner2.complete_name, "Empresa de prueba")
+        self.assertEqual(partner2.complete_name, "Nombre comercial (Empresa de prueba)")
         self.assertEqual(
             partner2.with_context(show_address=True).display_name,
             "Nombre comercial (Empresa de prueba)\nMy street",
@@ -81,7 +81,7 @@ class TestL10nEsPartner(common.TransactionCase):
         partner2.with_context(
             show_address=True, display_commercial=True
         )._compute_complete_name()
-        self.assertEqual(partner2.complete_name, "Empresa de prueba")
+        self.assertEqual(partner2.complete_name, "Nombre comercial (Empresa de prueba)")
         partner2.write({"comercial": "Nuevo nombre"})
         self.assertEqual(partner2.display_name, "Nuevo nombre (Empresa de prueba)")
         names = dict(


### PR DESCRIPTION
Se ha tenido que quitar el context en el if ya que al contener el context no añadia el nombre comercial en el nombre completo, entonces al hacer la busqueda de contactos no se podia buscar por el comercial ya que no lo contenia en nombre comercial.