### PR TITLE
[16.0][FIX] l10n_es_facturae: traceback error when partner_id has not zip field

### DIFF
--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -145,7 +145,10 @@
                 t-length="80"
                 t-out="administrative_partner.street + (administrative_partner.street2 or '')"
             />
-            <PostCode t-length="5" t-out="administrative_partner.zip.zfill(5)" />
+            <PostCode
+                t-length="5"
+                t-out="(administrative_partner.zip or '').zfill(5)"
+            />
             <Town t-length="50" t-out="administrative_partner.city" />
             <Province t-length="20" t-out="administrative_partner.state_id.name" />
             <CountryCode t-out="administrative_partner.country_id.code_alpha3" />


### PR DESCRIPTION
When generating a Facturae file for an invoice where the partner_id does not have the `zip` field, a traceback is triggered with the following error:

```
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
AttributeError: 'bool' object has no attribute 'zfill'
Template: l10n_es_facturae.address_contact
Path: /t/AddressInSpain/PostCode
Node: <PostCode t-length="5" t-out="administrative_partner.zip.zfill(5)"/>
```

This PR fixes this issue.


![image](https://github.com/user-attachments/assets/250611d3-9c11-4f36-be3a-c9393615bdf3)
