### PR TITLE
[16.0][FIX] l10n_es_aeat_mod190: computo primeros hijos

### DIFF
--- a/l10n_es_aeat_mod190/i18n/es.po
+++ b/l10n_es_aeat_mod190/i18n/es.po
@@ -6,8 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-01-22 13:36+0000\n"
-"Last-Translator: loida-vm <loida@moduon.team>\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2025-02-28 09:45+0100\n"
+"Last-Translator: Emilio Pascual <emilio@moduon.team>\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -872,6 +873,12 @@ msgid "Is Aeat Perception Subkey Visible"
 msgstr "Es visible la subclave Aeat de Percepción"
 
 #. module: l10n_es_aeat_mod190
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_res_partner__is_first_child_computation_visible
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_res_users__is_first_child_computation_visible
+msgid "Is First Child Computation Visible"
+msgstr "Cómputo de los primeros hijos visible"
+
+#. module: l10n_es_aeat_mod190
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_l10n_es_aeat_mod190_report__message_is_follower
 msgid "Is Follower"
 msgstr "Es Seguidor/a"
@@ -1719,25 +1726,3 @@ msgstr "[03] Importe de las retenciones"
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_l10n_es_aeat_mod190_report_line__ejercicio_devengo
 msgid "year"
 msgstr "año"
-
-#~ msgid "Calculated"
-#~ msgstr "Calculado"
-
-#, python-format
-#~ msgid "You have to recalculate the report before confirm it."
-#~ msgstr "Debe volver a calcular el informe antes de confirmarlo."
-
-#~ msgid "Number of messages which requires an action"
-#~ msgstr "Número de mensajes que requieren una acción"
-
-#~ msgid "Number of unread messages"
-#~ msgstr "Número de mensajes no leídos"
-
-#~ msgid "SMS Delivery error"
-#~ msgstr "Error en la entrega de sms"
-
-#~ msgid "Unread Messages"
-#~ msgstr "Mensajes No Leídos"
-
-#~ msgid "Unread Messages Counter"
-#~ msgstr "Contador de Mensajes no leídos"

--- a/l10n_es_aeat_mod190/i18n/l10n_es_aeat_mod190.pot
+++ b/l10n_es_aeat_mod190/i18n/l10n_es_aeat_mod190.pot
@@ -819,6 +819,12 @@ msgid "Is Aeat Perception Subkey Visible"
 msgstr ""
 
 #. module: l10n_es_aeat_mod190
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_res_partner__is_first_child_computation_visible
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_res_users__is_first_child_computation_visible
+msgid "Is First Child Computation Visible"
+msgstr ""
+
+#. module: l10n_es_aeat_mod190
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_l10n_es_aeat_mod190_report__message_is_follower
 msgid "Is Follower"
 msgstr ""

--- a/l10n_es_aeat_mod190/models/res_partner.py
+++ b/l10n_es_aeat_mod190/models/res_partner.py
@@ -240,6 +240,9 @@ class ResPartner(models.Model):
     is_aeat_perception_subkey_visible = fields.Boolean(
         compute="_compute_is_aeat_perception_subkey_visible"
     )
+    is_first_child_computation_visible = fields.Boolean(
+        compute="_compute_is_first_child_computation_visible"
+    )
 
     @api.depends("aeat_perception_key_id", "aeat_perception_subkey_id")
     def _compute_ad_required(self):
@@ -262,6 +265,24 @@ class ResPartner(models.Model):
                         ),
                     ]
                 )
+            )
+
+    @api.depends("aeat_perception_key_id", "aeat_perception_subkey_id")
+    def _compute_is_first_child_computation_visible(self):
+        aeat_perception_key_id = [  # A, C
+            "l10n_es_aeat_mod190.aeat_m190_perception_key_01",
+            "l10n_es_aeat_mod190.aeat_m190_perception_key_03",
+        ]
+        aeat_perception_subkey_id = [  # B01, B03
+            "l10n_es_aeat_mod190.aeat_m190_perception_subkey_02_01",
+            "l10n_es_aeat_mod190.aeat_m190_perception_subkey_02_03",
+        ]
+        for record in self:
+            record.is_first_child_computation_visible = (
+                record.aeat_perception_key_id
+                in {self.env.ref(item) for item in aeat_perception_key_id}
+                or record.aeat_perception_subkey_id
+                in {self.env.ref(item) for item in aeat_perception_subkey_id}
             )
 
     @api.onchange("aeat_perception_key_id")

--- a/l10n_es_aeat_mod190/views/partner_view.xml
+++ b/l10n_es_aeat_mod190/views/partner_view.xml
@@ -27,6 +27,10 @@
                         />
                         <field name="ad_required" invisible="1" />
                         <field name="is_aeat_perception_subkey_visible" invisible="1" />
+                        <field
+                            name="is_first_child_computation_visible"
+                            invisible="1"
+                        />
                     </group>
                     <group
                         string="Perception data"
@@ -62,7 +66,7 @@
                     <group
                         groups="account.group_account_invoice,l10n_es_aeat.group_account_aeat"
                         string="First 3 compute"
-                        attrs="{'invisible': [('is_aeat_perception_subkey_visible', '=', False)]}"
+                        attrs="{'invisible': [('is_first_child_computation_visible', '=', False)]}"
                     >
                         <field name="computo_primeros_hijos_1" string="1" />
                         <field name="computo_primeros_hijos_2" string="2" />


### PR DESCRIPTION
El computo de los 3 primeros hijos sólo debe ser visible para percepciones correspondientes a las claves A, B01, B03 y C siguiendo el [último diseño de registro del modelo 190](https://sede.agenciatributaria.gob.es/static_files/Sede/Disenyo_registro/DR_100_199/archivos_24/DISENOS_LOGICOS_190-2024.pdf)

![image](https://github.com/user-attachments/assets/03710207-2cc7-4912-8ed2-423b42bdf0dd)

Tal y como está ahora no se puede rellenar cuando se selecciona la clave A

![image](https://github.com/user-attachments/assets/5708bae8-fd04-4d87-b5b5-d786267fa224)

Pero si aparece para otras claves que no debería.

![image](https://github.com/user-attachments/assets/9fb9f0a4-df3a-468f-9ddf-193b258d7d82)


@moduon MT-8874

@loida-vm @Shide @pedrobaeza @etobella @victoralmau podéis revisarlo, por favor. Gracias