### PR TITLE
[16.0][FIX] l10n_es*: Post-install test + fallback to load CoA

### DIFF
--- a/l10n_es_account_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
+++ b/l10n_es_account_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
@@ -1,17 +1,27 @@
-# Copyright 2016-2018 Tecnativa - Pedro M. Baeza
+# Copyright 2016,2018,2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import base64
 
 from odoo import fields
 from odoo.modules.module import get_module_resource
-from odoo.tests import common
+from odoo.tests import common, tagged
 
 
+@tagged("post_install", "-at_install")
 class L10nEsAccountStatementImportN43(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.partner = cls.env["res.partner"].create(
             {"name": "Test partner N43", "company_id": cls.env.company.id}
         )

--- a/l10n_es_aeat_sii_force_type/tests/test_l10n_es_aeat_sii_force_type.py
+++ b/l10n_es_aeat_sii_force_type/tests/test_l10n_es_aeat_sii_force_type.py
@@ -20,6 +20,15 @@ class TestL10nEsAeatSiiForceType(common.TransactionCase):
             )
         )
         cls.company = cls.env.ref("base.main_company")
+        if not cls.company.chart_template_id:
+            # Load a CoA if there's none in the company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.company, install_demo=False)
         cls.company.sii_enabled = True
         cls.company.vat = "ES98765432M"
         cls.fiscal_position = cls.env["account.fiscal.position"].create(

--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -10,6 +10,7 @@ import xmlsig
 from lxml import etree
 
 from odoo import exceptions, fields
+from odoo.tests import tagged
 from odoo.tools.misc import mute_logger
 
 from odoo.addons.l10n_es_aeat.tests.test_l10n_es_aeat_certificate import (
@@ -17,6 +18,7 @@ from odoo.addons.l10n_es_aeat.tests.test_l10n_es_aeat_certificate import (
 )
 
 
+@tagged("post_install", "-at_install")
 class CommonTestBase(TestL10nEsAeatCertificateBase):
     @classmethod
     def setUpClass(cls):
@@ -29,6 +31,7 @@ class CommonTestBase(TestL10nEsAeatCertificateBase):
                 "amount": 21,
                 "type_tax_use": "sale",
                 "facturae_code": "01",
+                "country_id": cls.env.ref("base.es").id,
             }
         )
 
@@ -57,7 +60,16 @@ class CommonTestBase(TestL10nEsAeatCertificateBase):
         )
         main_company = self.env.ref("base.main_company")
         main_company.vat = "ESA12345674"
-        main_company.partner_id.country_id = self.env.ref("base.uk")
+        main_company.partner_id.country_id = self.env.ref("base.es")
+        if not main_company.chart_template_id:
+            # Load a CoA if there's none in the company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=main_company, install_demo=False)
         self.env["res.currency.rate"].search(
             [("currency_id", "=", main_company.currency_id.id)]
         ).write({"company_id": False})

--- a/l10n_es_payment_order_confirming_sabadell/tests/test_payment_order_confirming_sabadell.py
+++ b/l10n_es_payment_order_confirming_sabadell/tests/test_payment_order_confirming_sabadell.py
@@ -1,14 +1,24 @@
-# Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2021,2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import fields
-from odoo.tests import Form, common
+from odoo.tests import Form, common, tagged
 
 
+@tagged("post_install", "-at_install")
 class TestPaymentOrderConfirmingSabadell(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        if not cls.env.company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = cls.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = cls.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=cls.env.company, install_demo=False)
         cls.a_expense = cls.env["account.account"].create(
             {
                 "code": "TEA",

--- a/l10n_es_ticketbai_api/tests/common.py
+++ b/l10n_es_ticketbai_api/tests/common.py
@@ -692,6 +692,15 @@ class TestL10nEsTicketBAIAPI(common.TransactionCase):
         company.write(vals)
 
     def _prepare_company(self, company):
+        if not company.chart_template_id:
+            # Load a CoA if there's none in current company
+            coa = self.env.ref("l10n_generic_coa.configurable_chart_template", False)
+            if not coa:
+                # Load the first available CoA
+                coa = self.env["account.chart.template"].search(
+                    [("visible", "=", True)], limit=1
+                )
+            coa.try_loading(company=company, install_demo=False)
         test_dir_path = os.path.abspath(os.path.dirname(__file__))
         json_filepath = self.company_values_json_filepath
         with open(json_filepath) as fp:


### PR DESCRIPTION
Since odoo/odoo@d0342c8, the default existing company is not getting a CoA automatically, provoking than the current tests fail with errors like:

```
odoo.exceptions.UserError: No journal could be found in company My Company (San Francisco) for any of those types: sale
```

or

```
psycopg2.errors.CheckViolation: new row for relation "account_move_line" violates check constraint "account_move_line_check_accountable_required_fields"
```

All of them provoked by the lack of a CoA installed.

Thus, we put tests post-install for being sure localization modules are installed, the same as AccountTestInvoicingCommon does, but we don't inherit from it, as it creates an overhead creating 2 new companies and loading their CoA, and some more stuff, while we don't need all of that.

Besides, if you don't have `l10n_generic_coa` installed, you can't use another CoA (like `l10n_es`, which is here the base) easily, so we put little code to select the first available CoA.

@Tecnativa 