### PR TITLE
[16.0][IMP] l10n_es_location_nuts: Remove warning

### DIFF
--- a/l10n_es_location_nuts/hooks.py
+++ b/l10n_es_location_nuts/hooks.py
@@ -11,12 +11,7 @@ _logger = logging.getLogger(__name__)
 
 def post_init_hook(cr, registry):
     """Define Spanish specific configuration in res.country."""
-    with api.Environment.manage():
-        env = api.Environment(cr, SUPERUSER_ID, {})
-        spain = env.ref("base.es")
-        _logger.info("Setting Spain NUTS configuration")
-        spain.write(
-            {
-                "state_level": 4,
-            }
-        )
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    spain = env.ref("base.es")
+    _logger.info("Setting Spain NUTS configuration")
+    spain.write({"state_level": 4})


### PR DESCRIPTION
WARNING odoo py.warnings: /usr/lib/python3.10/contextlib.py:135: DeprecationWarning: Since Odoo 15.0, Environment.manage() is useless.

@Tecnativa