### PR TITLE
[17.0][FIX] l10n_es_aeat_mod303: Avoid negatives in fee to compensate

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -487,18 +487,11 @@ class L10nEsAeatMod303Report(models.Model):
                         - fields.Date.to_date(mod303.date_start)
                     ),
                 )
-                if prev_report and (
-                    prev_report.remaining_cuota_compensar > 0
-                    or prev_report.result_type == "C"
-                ):
-                    mod303.write(
-                        {
-                            "potential_cuota_compensar": (
-                                prev_report.remaining_cuota_compensar
-                                - prev_report.resultado_liquidacion
-                            ),
-                        }
-                    )
+                if prev_report.remaining_cuota_compensar > 0:
+                    amount = prev_report.remaining_cuota_compensar
+                    if prev_report.result_type == "C":
+                        amount -= prev_report.resultado_liquidacion
+                    mod303.potential_cuota_compensar = amount if amount > 0 else 0
             if mod303.return_last_period:
                 cuota_compensar = mod303.potential_cuota_compensar
             elif (
@@ -515,7 +508,6 @@ class L10nEsAeatMod303Report(models.Model):
             else:
                 cuota_compensar = 0
             mod303.cuota_compensar = cuota_compensar
-
         return res
 
     def button_confirm(self):

--- a/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
+++ b/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
@@ -698,6 +698,8 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
             }
         )
         model303_3T.button_calculate()
+        model303_3T.potential_cuota_compensar = 819
+        model303_3T.cuota_compensar = 609
         model303_3T.button_confirm()
         model303_3T.button_post()
         # Check move lines from 303 3T 2025

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -401,6 +401,8 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
 
         model303_4T.return_last_period = True
         model303_4T.button_calculate()
+        model303_4T.potential_cuota_compensar = 560.85
+        model303_4T.cuota_compensar = 560.85
         self.model390_2023.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2023.casilla_85, 0.0, 2)


### PR DESCRIPTION
Forward-port of #4048 

If the previous 303 report has remaining fee to compensate, and the result of the report is positive and bigger than the fee to compensate, when computing the current one, the constraint

  "The fee to compensate must be indicated as a positive number."

will raise always.

To avoid it, two changes have been done:

1. Only substract report result if it's of type C.
2. Nullify any possible result when it's less than 0.

Amendment of 4bd1c0280cbdaf7f452435d398fe5000ec344a6f

@Tecnativa TT55245