### PR TITLE
[17.0][IMP]l10n_es_facturae: cambio restricciones Unidad Tramitadora y Oficina Contable

### DIFF
--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -157,10 +157,6 @@ class AccountMove(models.Model):
             raise ValidationError(_("Partner vat is too small"))
         if not self.partner_id.state_id:
             raise ValidationError(_("Partner state not provided"))
-        if not self.partner_id.unidad_tramitadora:
-            raise ValidationError(_("Unidad Tramitadora not provided"))
-        if not self.partner_id.oficina_contable:
-            raise ValidationError(_("Oficina Contable not provided"))
         if not self.payment_mode_id:
             raise ValidationError(_("Payment mode is required"))
         if self.payment_mode_id.facturae_code:

--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -751,15 +751,3 @@ class CommonTest(CommonTestBase):
             .create({})
         )
         return wizard
-
-    def test_create_facturae_file_without_unidad_tramitadora(self):
-        wizard = self._create_wizard_facturae_file()
-        self.partner.unidad_tramitadora = False
-        with self.assertRaises(exceptions.ValidationError):
-            wizard.create_facturae_file()
-
-    def test_create_facturae_file_without_oficina_contable(self):
-        wizard = self._create_wizard_facturae_file()
-        self.partner.oficina_contable = False
-        with self.assertRaises(exceptions.ValidationError):
-            wizard.create_facturae_file()

--- a/l10n_es_facturae_face/models/account_move.py
+++ b/l10n_es_facturae_face/models/account_move.py
@@ -87,6 +87,19 @@ class AccountMove(models.Model):
 
     def validate_facturae_fields(self):
         super().validate_facturae_fields()
-        if not self.partner_id.organo_gestor:
+        if (
+            self.partner_id.l10n_es_facturae_sending_code == "face"
+            and not self.partner_id.organo_gestor
+        ):
             raise ValidationError(_("Organo Gestor not provided"))
+        if (
+            self.partner_id.l10n_es_facturae_sending_code == "face"
+            and not self.partner_id.unidad_tramitadora
+        ):
+            raise ValidationError(_("Unidad Tramitadora not provided"))
+        if (
+            self.partner_id.l10n_es_facturae_sending_code == "face"
+            and not self.partner_id.oficina_contable
+        ):
+            raise ValidationError(_("Oficina Contable not provided"))
         return

--- a/l10n_es_facturae_face/tests/test_facturae_face.py
+++ b/l10n_es_facturae_face/tests/test_facturae_face.py
@@ -227,6 +227,32 @@ class EDIBackendTestCase(
         with self.assertRaises(exceptions.ValidationError):
             wizard.create_facturae_file()
 
+    def test_create_facturae_file_without_unidad_tramitadora(self):
+        self._activate_certificate(self.certificate_password)
+        self.move.action_post()
+        self.move.name = "2999/99999"
+        wizard = (
+            self.env["create.facturae"]
+            .with_context(active_ids=self.move.ids, active_model="account.move")
+            .create({})
+        )
+        self.partner.unidad_tramitadora = False
+        with self.assertRaises(exceptions.ValidationError):
+            wizard.create_facturae_file()
+
+    def test_create_facturae_file_without_oficina_contable(self):
+        self._activate_certificate(self.certificate_password)
+        self.move.action_post()
+        self.move.name = "2999/99999"
+        wizard = (
+            self.env["create.facturae"]
+            .with_context(active_ids=self.move.ids, active_model="account.move")
+            .create({})
+        )
+        self.partner.oficina_contable = False
+        with self.assertRaises(exceptions.ValidationError):
+            wizard.create_facturae_file()
+
     def test_facturae_face_0(self):
         class DemoService:
             def __init__(self, value):


### PR DESCRIPTION
Este commit realiza dos cambios:
- Suprime las comprobaciones de Unidad Tramitadora y Oficina Contable establecidas en el cliente del módulo l10n_es_facturae.
- Añade las comprobaciones de Unidad Tramitadora y Oficina Contable establecidas en el cliente del módulo l10n_es_facturae_face, que se comprobarán si el cliente utiliza FACE.

@HaraldPanten @ValentinVinagre @luis-ron @Jesarregui 

T-7742