### PR TITLE
[16.0][FIX] l10n_es_partner: Inject _rec_names_search properly

### DIFF
--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -37,6 +37,9 @@ class ResPartner(models.Model):
         res += ["comercial"]
         return res
 
-    def _auto_init(self):
-        self.env["res.partner"]._rec_names_search.append("comercial")
-        return super()._auto_init()
+    @api.model
+    def name_search(self, name="", args=None, operator="ilike", limit=100):
+        # Inject the field comercial in _rec_names_search if not exists
+        if "comercial" not in self._rec_names_search:
+            self._rec_names_search.append("comercial")
+        return super().name_search(name=name, args=args, operator=operator, limit=limit)


### PR DESCRIPTION
Previous patch was overriding `_auto_init` method for injecting the `comercial` field in the list of fields to search for (`_rec_names_search`), but this method is only called on module installation/update, so if you restart the Odoo server after that, you lose the injection.

Thus, let's inject it if not present when calling name_search, and this way we always have it available.

@Tecnativa TT55241