### PR TITLE
[17.0][FIX]l10n_es_facturae: solucion error facturae sin campos DIR3

### DIFF
--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -85,7 +85,9 @@
             />
         </TaxIdentification>
         <PartyIdentification t-if="False" />
-        <AdministrativeCentres t-if="partner.facturae">
+        <AdministrativeCentres
+            t-if="partner.facturae and (partner.oficina_contable or partner.organo_gestor or partner.unidad_tramitadora or partner.organo_proponente)"
+        >
             <t t-call="l10n_es_facturae.administrative_center">
                 <t
                     t-set="centre_code"


### PR DESCRIPTION
@etobella Para que no haya problemas con la generación de la factura elecrtónica tras los cambios de ayer, he tenido en cuenta en este fix los cambios en el fichero report_facturae.xml del módulo l10n_es_facturae que incluyes en este PR: https://github.com/OCA/l10n-spain/pull/3213

¿Si echas algo más en falta no los puedes comentar y lo añadimos? Muchas gracias!

@HaraldPanten  @luis-ron @Jesarregui @ValentinVinagre 

T-7742