### PR TITLE
[17.0][FIX] l10n_es_facturae: Fix base64 decoding for attachments

### DIFF
--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -223,7 +223,7 @@ class AccountMove(models.Model):
             description, content_type = attachment.filename.rsplit(".", 1)
             result.append(
                 {
-                    "data": attachment.file,
+                    "data": base64.b64encode(attachment.file).decode("utf-8"),
                     "content_type": content_type,
                     "encoding": "BASE64",
                     "description": description,


### PR DESCRIPTION
Fixes an issue where attachments were not decoded to UTF-8, making them unreadable.

cc https://github.com/APSL 4011

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review