### PR TITLE
[17.0][FIX] l10n_es_facturae: Fixed issue with double Base64 encoding on facturae attachments

### DIFF
--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -223,7 +223,7 @@ class AccountMove(models.Model):
             description, content_type = attachment.filename.rsplit(".", 1)
             result.append(
                 {
-                    "data": base64.b64encode(attachment.file).decode("utf-8"),
+                    "data": attachment.file.decode("utf-8"),
                     "content_type": content_type,
                     "encoding": "BASE64",
                     "description": description,


### PR DESCRIPTION
Facturae attachments were double Base64 encoded, requiring two decodings to be accessible.