### PR TITLE
[16.0][IMP] l10n_es_aeat_mod190: Cálculo gastos deducibles

### DIFF
--- a/l10n_es_aeat_mod190/data/tax_code_map_mod190_data.xml
+++ b/l10n_es_aeat_mod190/data/tax_code_map_mod190_data.xml
@@ -111,4 +111,18 @@
             eval="[(6, False, [ref('l10n_es.account_tax_template_p_irpf1'), ref('l10n_es.account_tax_template_p_irpf2'), ref('l10n_es.account_tax_template_p_irpf7'), ref('l10n_es.account_tax_template_p_irpf9'), ref('l10n_es.account_tax_template_p_irpf15'), ref('l10n_es.account_tax_template_p_irpf18'), ref('l10n_es.account_tax_template_p_irpf19'), ref('l10n_es.account_tax_template_p_irpf20'), ref('l10n_es.account_tax_template_p_irpf21p')])]"
         />
     </record>
+    <record id="aeat_mod190_map_line_17" model="l10n.es.aeat.map.tax.line">
+        <field name="map_parent_id" ref="aeat_mod190_map" />
+        <field name="field_number">17</field>
+        <field name="name">Gastos deducibles</field>
+        <field name="field_type">base</field>
+        <field name="sum_type">both</field>
+        <field name="inverse" eval="False" />
+        <!-- Couta facturas de compra (haber) - Couta facturas rectificativas de compra (debe):
+             S_GD0 -->
+        <field
+            name="tax_ids"
+            eval="[(6, False, [ref('l10n_es.account_tax_template_s_gd0')])]"
+        />
+    </record>
 </odoo>

--- a/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
+++ b/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
@@ -119,7 +119,7 @@ class L10nEsAeatMod190Report(models.Model):
         manual_records.partner_record_ids.unlink()
         for report in self - manual_records:
             tax_lines = report.tax_line_ids.filtered(
-                lambda x: x.field_number in (11, 12, 13, 14, 15, 16)
+                lambda x: x.field_number in (11, 12, 13, 14, 15, 16, 17)
                 and x.res_id == report.id
             )
             tax_line_vals = {}
@@ -347,7 +347,12 @@ class L10nEsAeatMod190ReportLine(models.Model):
         store=True,
     )
     reduccion_aplicable = fields.Float(string="Applicable reduction")
-    gastos_deducibles = fields.Float(string="Deductible expenses")
+    gastos_deducibles = fields.Float(
+        string="Deductible expenses",
+        compute="_compute_percepciones",
+        store=True,
+        readonly=False,
+    )
     pensiones_compensatorias = fields.Float(string="Compensatory pensions")
     anualidades_por_alimentos = fields.Float(string="Annuities for food")
     prestamos_vh = fields.Selection(
@@ -575,6 +580,7 @@ class L10nEsAeatMod190ReportLine(models.Model):
                 "14": report._get_grouped_data(14, domain),
                 "15": report._get_grouped_data(15, domain),
                 "16": report._get_grouped_data(16, domain),
+                "17": report._get_grouped_data(17, domain),
             }
         for item in self:
             keys = [
@@ -620,6 +626,9 @@ class L10nEsAeatMod190ReportLine(models.Model):
             )
             item.ingresos_a_cuenta_repercutidos_incap = (
                 incapacidad and ingresos_a_cuenta_efectuados
+            )
+            item.gastos_deducibles = sum(
+                tax_data[item.report_id.id]["17"].get(key, 0) for key in keys
             )
 
     @api.onchange("partner_id")

--- a/l10n_es_aeat_mod190/tests/test_mod190.py
+++ b/l10n_es_aeat_mod190/tests/test_mod190.py
@@ -20,6 +20,7 @@ class TestL10nEsAeatMod190Base(TestL10nEsAeatModBase):
         # tax code: (base, tax_amount)
         "P_IRPF19": (100, -19),
         "P_IRPF20": (1000, -200),
+        "S_GD0": (100, 0),
     }
 
     @classmethod
@@ -104,6 +105,7 @@ class TestL10nEsAeatMod190Base(TestL10nEsAeatModBase):
         )
         self.assertEqual(supplier_record.percepciones_dinerarias, 2200)
         self.assertEqual(supplier_record.retenciones_dinerarias, 438)
+        self.assertEqual(supplier_record.gastos_deducibles, -200)
         self.assertEqual(2, supplier_record.ad_required)
         self.assertEqual(2, self.supplier.ad_required)
         self.customer.write(

--- a/l10n_es_aeat_mod190/views/mod190_line_view.xml
+++ b/l10n_es_aeat_mod190/views/mod190_line_view.xml
@@ -156,6 +156,7 @@
                                     <field
                                         name="gastos_deducibles"
                                         string="Gastos deducibles"
+                                        attrs="{'readonly': [('state', '!=', 'calculated')]}"
                                     />
                                 </group>
                                 <group>


### PR DESCRIPTION
Después de este commit https://github.com/odoo/odoo/pull/198546/commits/9056fc6fa21d6e9dd7088dade22075795e23eeef donde odoo añadió el impuesto para gastos deducibles, es posible calcular los gastos deducbieles para cada perceptor.

@etobella @pedrobaeza @rafaelbn podéis revisarlo por favor, gracias.

@moduon MT-8853