### PR TITLE
[16.0][FIX] l10n_es_facturae_face: ensure invoice.factura.numeroRegistro exists

### DIFF
--- a/l10n_es_facturae_face/models/edi_exchange_record.py
+++ b/l10n_es_facturae_face/models/edi_exchange_record.py
@@ -87,6 +87,8 @@ class EdiExchangeRecord(models.Model):
                 _logger.info(_("Company %s cannot be processed") % company.display_name)
                 continue
             for invoice in response.facturas.consultarListadoFactura:
+                if not exchange_dict.get(invoice.factura.numeroRegistro, False):
+                    continue
                 exchange_record = exchange_dict[invoice.factura.numeroRegistro]
                 if invoice.codigo != "0":
                     # Probably processed from another system


### PR DESCRIPTION
avoids:

```bash
Traceback (most recent call last):
  File "/opt/odoo/odoo-base/odoo-server/odoo/tools/safe_eval.py", line 399, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(1074,)", line 1, in <module>
  File "/opt/odoo/odoo-base/common-16.0/l10n-spain/l10n_es_facturae_face/models/edi_exchange_record.py", line 90, in _cron_face_update_method
    exchange_record = exchange_dict[invoice.factura.numeroRegistro]
KeyError: 'False'
```