### PR TITLE
[17.0][FIX] l10n_es_aeat: fix name external id, deleted 'account' in final name

### DIFF
--- a/l10n_es_aeat/migrations/17.0.2.3.1/pre-migration.py
+++ b/l10n_es_aeat/migrations/17.0.2.3.1/pre-migration.py
@@ -17,4 +17,4 @@ def migrate(env, version):
                         ("module", "=", "account"),
                         ("name", "=", f"{comp.id}_account_tax_template_{src}"),
                     ]
-                ).name = f"account.{comp.id}_account_tax_template_{dest}"
+                ).name = f"{comp.id}_account_tax_template_{dest}"


### PR DESCRIPTION
before:

> account.account_1_account_tax_template_s_iva0_g_i

after:

> account.1_account_tax_template_s_iva0_g_i