### PR TITLE
[16.0][FIX] l10n_es_facturae: Align facturae_code field position with v17

### DIFF
--- a/l10n_es_facturae/views/account_tax_view.xml
+++ b/l10n_es_facturae/views/account_tax_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_tax_form" />
         <field name="type">form</field>
         <field name="arch" type="xml">
-            <field name="company_id" position="after">
+            <field name="country_id" position="after">
                 <field name="facturae_code" />
             </field>
         </field>


### PR DESCRIPTION
### What is this PR doing?

This PR addresses the misplacement of the `facturae_code` field in the Odoo 16 `l10n_es_facturae` module. In Odoo 16, the `facturae_code` field was placed after the `company_id` field, which was missing in the inherited view, causing it to be positioned incorrectly outside the form. This fix realigns the `facturae_code` field in the correct position to match the layout of Odoo 17.

### Why is this needed?

In Odoo 16, the `facturae_code` field is not positioned correctly within the form due to an issue with the placement of the `company_id` field. This misalignment causes the field to appear outside the expected layout. By aligning the field positioning with Odoo 17, we ensure consistency and proper layout structure.

### Solution

- Reposition the `facturae_code` field after the correct `company_id` field inside the **"Advanced Options"** tab.
- This solution mirrors the positioning seen in Odoo 17 to maintain consistency between versions.

![Captura de pantalla_20250325_163935](https://github.com/user-attachments/assets/8aebf194-d543-4ea0-b453-f9e7447d231a)


### Related Issues

- This Closes #4094 

### How to test it?

1. Install or upgrade the `l10n_es_facturae` module in an Odoo 16 instance.
2. Open the **Taxes** form view (`account.tax`).
3. Confirm that the `facturae_code` field is positioned correctly after the `company_id` field in the **"Advanced Options"** tab.

### Additional Notes

This PR ensures the `facturae_code` field follows the same layout as in Odoo 17, improving consistency across versions.