### PR TITLE
[16.0][IMP] l10n_es_aeat_mod349: search methods for l10n_es_aeat_349_operation_key in account.move.line and account.tax

### DIFF
--- a/l10n_es_aeat_mod349/models/account_move.py
+++ b/l10n_es_aeat_mod349/models/account_move.py
@@ -35,6 +35,7 @@ class AccountMoveLine(models.Model):
         ],
         string="AEAT 349 Operation key",
         compute="_compute_l10n_es_aeat_349_operation_key",
+        search="_search_l10n_es_aeat_349_operation_key",
     )
 
     @api.depends("tax_ids", "move_id.eu_triangular_deal")
@@ -50,3 +51,19 @@ class AccountMoveLine(models.Model):
                             tax.l10n_es_aeat_349_operation_key
                         )
                         break
+
+    def _search_l10n_es_aeat_349_operation_key(self, operator, value):
+        if operator not in ["=", "!="]:
+            raise ValueError(
+                f"Operator {operator} is not supported for selection fields"
+            )
+        if value == "T":
+            amls = self.env["account.move.line"].search(
+                [("move_id.eu_triangular_deal", "=", True)]
+            )
+        else:
+            taxes = self.env["account.tax"].search(
+                [("l10n_es_aeat_349_operation_key", "=", value)]
+            )
+            amls = self.env["account.move.line"].search([("tax_ids", "in", taxes.ids)])
+        return [("id", "in", amls.ids)]

--- a/l10n_es_aeat_mod349/models/account_tax.py
+++ b/l10n_es_aeat_mod349/models/account_tax.py
@@ -17,6 +17,7 @@ class AccountTax(models.Model):
         selection=_selection_operation_key,
         string="AEAT 349 Operation key",
         compute="_compute_l10n_es_aeat_349_operation_key",
+        search="_search_l10n_es_aeat_349_operation_key",
     )
 
     def _compute_l10n_es_aeat_349_operation_key(self):
@@ -28,3 +29,26 @@ class AccountTax(models.Model):
                 if tax in tax.company_id.get_taxes_from_templates(line.tax_tmpl_ids):
                     tax.l10n_es_aeat_349_operation_key = line.operation_key
                     break
+
+    def _search_l10n_es_aeat_349_operation_key(self, operator, value):
+        if operator not in ["=", "!="]:
+            raise ValueError(
+                f"Operator {operator} is not supported for selection fields"
+            )
+        company_id = self.env.company
+        map_349 = self.env["aeat.349.map.line"].search(
+            [("operation_key", operator, value)]
+        )
+        tax_ids = []
+        for line in map_349:
+            taxes = company_id.get_taxes_from_templates(line.tax_tmpl_ids).ids
+            tax_ids = (
+                self.browse(taxes)
+                .filtered(lambda tax: tax.id in taxes)
+                .filtered(lambda tax: tax.l10n_es_aeat_349_operation_key == value)
+                .ids
+            )
+        if operator == "=":
+            return [("id", "in", tax_ids)]
+        else:
+            return [("id", "not in", tax_ids)]

--- a/l10n_es_aeat_mod349/tests/test_l10n_es_aeat_mod349.py
+++ b/l10n_es_aeat_mod349/tests/test_l10n_es_aeat_mod349.py
@@ -470,3 +470,45 @@ class TestL10nEsAeatMod349Base(TestL10nEsAeatModBase):
             lambda x: x.partner_vat == self.customer.vat
         )
         self.assertTrue(partner_record.partner_record_ok)
+
+    def test_mod349_no_previous_349_declaration(self):
+        # Add some test data
+        self.supplier.write(
+            {"vat": "BG0000100159", "country_id": self.env.ref("base.bg").id}
+        )
+        # # Purchase invoices
+        p1 = self._invoice_purchase_create("2017-01-01")
+        self._invoice_refund(p1, "2017-04-01")
+        # Create model
+        model349_model = self.env["l10n.es.aeat.mod349.report"].with_user(
+            self.account_manager
+        )
+        model349_2t = model349_model.create(
+            {
+                "name": "3490000000001",
+                "company_id": self.company.id,
+                "company_vat": "1234567890",
+                "contact_name": "Test owner",
+                "statement_type": "N",
+                "support_type": "T",
+                "contact_phone": "911234455",
+                "year": 2017,
+                "period_type": "2T",
+                "date_start": "2017-04-01",
+                "date_end": "2017-06-30",
+            }
+        )
+        # Calculate
+        _logger.debug("Calculate AEAT 349 2T 2017")
+        model349_2t.button_calculate()
+        # Direct search on account.move.line for l10n_es_aeat_349_operation_key
+        l10n_es_aeat_349_operation_key = p1.invoice_line_ids[
+            0
+        ].l10n_es_aeat_349_operation_key
+        amls = self.env["account.move.line"].search(
+            [
+                ("l10n_es_aeat_349_operation_key", "=", l10n_es_aeat_349_operation_key),
+                ("move_id", "=", p1.id),
+            ]
+        )
+        self.assertEqual(len(amls), 2)


### PR DESCRIPTION
Corrige:

`Non-stored field 'account.move.line.l10n_es_aeat_349_operation_key' cannot be searched.`

Para el bloque ([/models/mod349.py](https://github.com/OCA/l10n-spain/blob/c5a84391e3e2ff87cbbc99f606f386798ea4cfad/l10n_es_aeat_mod349/models/mod349.py#L258)):

```python
                # There's no previous 349 declaration report in Odoo
                original_amls = move_line_obj.search(
                    [
                        ("tax_ids", "in", taxes.ids),
                        ("l10n_es_aeat_349_operation_key", "=", op_key), # <--------------
                        ("move_id", "=", origin_invoice.id),
                    ]
```
