### PR TITLE
[17.0][FIX] l10n_es_igic_reav: xmlid rename

### DIFF
--- a/l10n_es_igic_reav/data/template/account.fiscal.position-es_full_canary.csv
+++ b/l10n_es_igic_reav/data/template/account.fiscal.position-es_full_canary.csv
@@ -1,5 +1,5 @@
 "id","name","name@es","name@ca","country_id","tax_ids/tax_src_id","tax_ids/tax_dest_id","account_ids/account_src_id","account_ids/account_dest_id"
-"fp_igic_reav","IGIC REAV - Travel agencies","IGIC REAV - Agencias de viajes","IGIC REAV - Agències de viatges","","account_tax_template_p_igic0_bc","account_tax_template_p_igic_reav0","",""
+"fp_igic_reav","IGIC REAV - Travel agencies","IGIC REAV - Agencias de viajes","IGIC REAV - Agències de viatges","","account_tax_template_igic_sop_0","account_tax_template_p_igic_reav0","",""
 "","","","","","account_tax_template_p_igic0_sc","account_tax_template_p_igic_reav0","",""
 "","","","","","account_tax_template_p_igic3_bc","account_tax_template_p_igic_reav0","",""
 "","","","","","account_tax_template_p_igic3_sc","account_tax_template_p_igic_reav0","",""

--- a/l10n_es_igic_reav/data/template/account.fiscal.position-es_pymes_canary.csv
+++ b/l10n_es_igic_reav/data/template/account.fiscal.position-es_pymes_canary.csv
@@ -1,5 +1,5 @@
 "id","name","name@es","name@ca","country_id","tax_ids/tax_src_id","tax_ids/tax_dest_id","account_ids/account_src_id","account_ids/account_dest_id"
-"fp_igic_reav","IGIC REAV - Travel agencies","IGIC REAV - Agencias de viajes","IGIC REAV - Agències de viatges","","account_tax_template_p_igic0_bc","account_tax_template_p_igic_reav0","",""
+"fp_igic_reav","IGIC REAV - Travel agencies","IGIC REAV - Agencias de viajes","IGIC REAV - Agències de viatges","","account_tax_template_igic_sop_0","account_tax_template_p_igic_reav0","",""
 "","","","","","account_tax_template_p_igic0_sc","account_tax_template_p_igic_reav0","",""
 "","","","","","account_tax_template_p_igic3_bc","account_tax_template_p_igic_reav0","",""
 "","","","","","account_tax_template_p_igic3_sc","account_tax_template_p_igic_reav0","",""


### PR DESCRIPTION
Desde el cambio en https://github.com/OCA/l10n-spain/pull/3866 los xml_ids fueron modificados y este módulo dejó de funcionar. Esto resuelve la incidencia.
@BinhexTeam