### PR TITLE
[16.0][IMP] l10n_es_sigaus_sale: call sigaus from sale line creation

### DIFF
--- a/l10n_es_sigaus_account/models/account_move.py
+++ b/l10n_es_sigaus_account/models/account_move.py
@@ -63,45 +63,47 @@ class AccountMove(models.Model):
         return []
 
     def manage_sigaus_invoice_lines(self):
-        self.ensure_one()
-        independent_lines_domain = self.get_independent_invoice_lines_domain()
-        independent_sigaus_lines_domain = expression.AND(
-            [
+        for rec in self:
+            independent_lines_domain = rec.get_independent_invoice_lines_domain()
+            independent_sigaus_lines_domain = expression.AND(
                 [
-                    ("move_id", "=", self.id),
-                    ("is_sigaus", "=", True),
-                ],
-                independent_lines_domain,
-            ]
-        )
-        self.env["account.move.line"].search(independent_sigaus_lines_domain).unlink()
-        # Invoice lines not related to other documents (i.e. sales)
-        independent_lines_domain = expression.AND(
-            [
+                    [
+                        ("move_id", "=", rec.id),
+                        ("is_sigaus", "=", True),
+                    ],
+                    independent_lines_domain,
+                ]
+            )
+            rec.env["account.move.line"].search(
+                independent_sigaus_lines_domain
+            ).unlink()
+            # Invoice lines not related to other documents (i.e. sales)
+            independent_lines_domain = expression.AND(
                 [
-                    ("move_id", "=", self.id),
-                    ("product_id", "!=", False),
-                    ("product_id.sigaus_has_amount", "=", True),
-                ],
-                independent_lines_domain,
-            ]
-        )
-        independent_lines = self.env["account.move.line"].search(
-            independent_lines_domain
-        )
-        if independent_lines:
-            self.create_sigaus_line(independent_lines)
+                    [
+                        ("move_id", "=", rec.id),
+                        ("product_id", "!=", False),
+                        ("product_id.sigaus_has_amount", "=", True),
+                    ],
+                    independent_lines_domain,
+                ]
+            )
+            independent_lines = rec.env["account.move.line"].search(
+                independent_lines_domain
+            )
+            if independent_lines:
+                rec.create_sigaus_line(independent_lines)
 
     def create_sigaus_line(self, lines, **kwargs):
         values = self._get_sigaus_line_vals(lines, **kwargs)
         self.env["account.move.line"].create(values)
 
     def apply_sigaus(self):
-        for invoice in self.filtered(
+        f_invoices = self.filtered(
             lambda a: a.state == "draft" and a.is_sigaus and a.sigaus_is_date and a.id
-        ):
-            invoice.automatic_sigaus_exception()
-            invoice.with_context(avoid_recursion=True).manage_sigaus_invoice_lines()
+        )
+        f_invoices.automatic_sigaus_exception()
+        f_invoices.with_context(avoid_recursion=True).manage_sigaus_invoice_lines()
 
     def write(self, vals):
         res = super().write(vals)
@@ -123,7 +125,7 @@ class AccountMove(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         moves = super().create(vals_list)
-        for move in moves.filtered(lambda a: a.is_sigaus and a.sigaus_is_date):
-            move.automatic_sigaus_exception()
-            move.apply_sigaus()
+        f_moves = moves.filtered(lambda a: a.is_sigaus and a.sigaus_is_date)
+        f_moves.automatic_sigaus_exception()
+        f_moves.apply_sigaus()
         return moves

--- a/l10n_es_sigaus_account/models/sigaus_mixin.py
+++ b/l10n_es_sigaus_account/models/sigaus_mixin.py
@@ -150,38 +150,38 @@ class SigausMixin(models.AbstractModel):
         return sigaus_vals
 
     def automatic_sigaus_exception(self):
-        self.ensure_one()
-        products_without_weight = (
-            self[self._sigaus_secondary_unit_fields["line_ids"]]
-            .mapped("product_id")
-            .filtered(lambda a: a.sigaus_has_amount and a.weight <= 0.0)
-        )
-        if products_without_weight:
-            values = {
-                "model": self._name,
-                "origin": self.id,
-                "products": products_without_weight,
-            }
-            note = self.env["ir.qweb"]._render(
-                "l10n_es_sigaus_account.exception_sigaus", values
+        for rec in self:
+            products_without_weight = (
+                rec[rec._sigaus_secondary_unit_fields["line_ids"]]
+                .mapped("product_id")
+                .filtered(lambda a: a.sigaus_has_amount and a.weight <= 0.0)
             )
-            if not self.sigaus_automated_exception_id:
-                odoobot_id = self.env.ref("base.partner_root").id
-                activity = self.activity_schedule(
-                    "mail.mail_activity_data_warning",
-                    date.today(),
-                    note=note,
-                    user_id=self.user_id.id or SUPERUSER_ID,
+            if products_without_weight:
+                values = {
+                    "model": rec._name,
+                    "origin": rec.id,
+                    "products": products_without_weight,
+                }
+                note = rec.env["ir.qweb"]._render(
+                    "l10n_es_sigaus_account.exception_sigaus", values
                 )
-                activity.write(
-                    {
-                        "create_uid": odoobot_id,
-                    }
-                )
-                self.write(
-                    {
-                        "sigaus_automated_exception_id": activity.id,
-                    }
-                )
-            else:
-                self.sigaus_automated_exception_id.write({"note": note})
+                if not rec.sigaus_automated_exception_id:
+                    odoobot_id = rec.env.ref("base.partner_root").id
+                    activity = rec.activity_schedule(
+                        "mail.mail_activity_data_warning",
+                        date.today(),
+                        note=note,
+                        user_id=rec.user_id.id or SUPERUSER_ID,
+                    )
+                    activity.write(
+                        {
+                            "create_uid": odoobot_id,
+                        }
+                    )
+                    rec.write(
+                        {
+                            "sigaus_automated_exception_id": activity.id,
+                        }
+                    )
+                else:
+                    rec.sigaus_automated_exception_id.write({"note": note})

--- a/l10n_es_sigaus_purchase/models/purchase_order.py
+++ b/l10n_es_sigaus_purchase/models/purchase_order.py
@@ -65,11 +65,10 @@ class PurchaseOrder(models.Model):
                 for line in a.order_line.filtered("product_id")
             )
         )
-        for purchase in sigaus_purchases.filtered("id"):
-            if self.env.context.get("avoid_recursion"):
-                continue
-            purchase.automatic_sigaus_exception()
-            purchase.apply_sigaus()
+        if not self.env.context.get("avoid_recursion"):
+            f_purchases = sigaus_purchases.filtered("id")
+            f_purchases.automatic_sigaus_exception()
+            f_purchases.apply_sigaus()
         (self - sigaus_purchases).filtered(
             lambda a: (
                 not a.is_sigaus
@@ -85,16 +84,16 @@ class PurchaseOrder(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         purchases = super().create(vals_list)
-        for purchase in purchases.filtered(
+        f_purchases = purchases.filtered(
             lambda a: a.is_sigaus
             and a.sigaus_is_date
             and any(
                 line.product_id.sigaus_has_amount
                 for line in a.order_line.filtered("product_id")
             )
-        ):
-            purchase.automatic_sigaus_exception()
-            purchase.apply_sigaus()
+        )
+        f_purchases.automatic_sigaus_exception()
+        f_purchases.apply_sigaus()
         return purchases
 
     def copy(self, default=None):

--- a/l10n_es_sigaus_sale/models/sale_order.py
+++ b/l10n_es_sigaus_sale/models/sale_order.py
@@ -77,7 +77,9 @@ class SaleOrder(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        sales = super().create(vals_list)
+        sales = super(SaleOrder, self.with_context(avoid_line_recursion=True)).create(
+            vals_list
+        )
         for sale in sales.filtered(
             lambda a: a.is_sigaus
             and a.sigaus_is_date

--- a/l10n_es_sigaus_sale/models/sale_order_line.py
+++ b/l10n_es_sigaus_sale/models/sale_order_line.py
@@ -40,3 +40,12 @@ class SaleOrderLine(models.Model):
             else:
                 line.invoice_status = "no"
         return super(SaleOrderLine, self - sigaus_lines)._compute_invoice_status()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        lines = super().create(vals_list)
+        if not self.env.context.get("avoid_line_recursion"):
+            sales = lines.filtered(lambda li: li.product_id.sigaus_has_amount).mapped('order_id')
+            sales.automatic_sigaus_exception()
+            sales.apply_sigaus()
+        return lines

--- a/l10n_es_sigaus_sale/models/sale_order_line.py
+++ b/l10n_es_sigaus_sale/models/sale_order_line.py
@@ -45,7 +45,9 @@ class SaleOrderLine(models.Model):
     def create(self, vals_list):
         lines = super().create(vals_list)
         if not self.env.context.get("avoid_line_recursion"):
-            sales = lines.filtered(lambda li: li.product_id.sigaus_has_amount).mapped('order_id')
+            sales = lines.filtered(lambda li: li.product_id.sigaus_has_amount).mapped(
+                "order_id"
+            )
             sales.automatic_sigaus_exception()
             sales.apply_sigaus()
         return lines

--- a/l10n_es_sigaus_sale/tests/test_l10n_es_sigaus_sale.py
+++ b/l10n_es_sigaus_sale/tests/test_l10n_es_sigaus_sale.py
@@ -47,6 +47,34 @@ class TestL10nEsSigausSales(TestL10nEsSigausCommon):
         self.assertTrue(sale.is_sigaus)
         self.assertTrue(sale.sigaus_automated_exception_id)
 
+    def test_sale_line_with_sigaus(self):
+        sale = self.create_sale_order("2023-01-01", self.fiscal_position_sigaus, [])
+        self.env["sale.order.line"].create(
+            [
+                {
+                    "order_id": sale.id,
+                    "product_id": self.product_sigaus_in_product.id,
+                    "product_uom_qty": 1.0,
+                    "price_unit": 2,
+                },
+                {
+                    "order_id": sale.id,
+                    "product_id": self.product_sigaus_in_category.id,
+                    "product_uom_qty": 2.0,
+                    "price_unit": 3,
+                },
+                {
+                    "order_id": sale.id,
+                    "product_id": self.product_sigaus_in_category_excluded.id,
+                    "product_uom_qty": 3.0,
+                    "price_unit": 4,
+                },
+            ]
+        )
+        self.assertTrue(sale.is_sigaus)
+        self.assertTrue(sale.sigaus_has_line)
+        self.assertEqual(sale.amount_untaxed, 20.3)
+
     def test_sale_with_sigaus(self):
         lines = [
             {


### PR DESCRIPTION
There are situations when lines are created directly from the sale order line create method, and the sigaux is not updated because the create or write methods of the sale order are not called.

This PR covers those cases

Related with https://github.com/OCA/sale-workflow/pull/3658

I-7204