### PR TITLE
[17.0][FIX] l10n_es_facturae: Taxes withheld need to be divided by 100, just like taxes

### DIFF
--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -618,10 +618,10 @@
                                         </TaxableBase>
                                         <TaxAmount>
                                             <TotalAmount
-                                                t-esc="('%.2f' if version == '3_2' else '%.8f') % (sign * (line.price_subtotal * (-line_tax.amount)))"
+                                                t-esc="('%.2f' if version == '3_2' else '%.8f') % (sign * (line.price_subtotal * (-line_tax.amount) / 100))"
                                             />
                                             <EquivalentInEuros
-                                                t-esc="'%.2f' % (sign * (line.price_subtotal * (-line_tax.amount) * euro_rate / currency_rate))"
+                                                t-esc="'%.2f' % (sign * (line.price_subtotal * (-line_tax.amount) / 100 * euro_rate / currency_rate))"
                                             />
                                         </TaxAmount>
                                     </Tax>


### PR DESCRIPTION
In the view document 'report_facturae.xml', you can see that the division by 100 is missing for withheld taxes in the TaxesWithheld element, while it does appear for taxes in the TaxesOutputs element.