### PR TITLE
[16.0][FIX] l10n_es_partner: prevent replacing multiple times

### DIFF
--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -33,6 +33,7 @@ class ResPartner(models.Model):
             return origin.replace(
                 self.name,
                 name_pattern % {"name": self.name, "comercial_name": self.comercial},
+                1,  # Just replace the first occurrence
             )
         return name_pattern % {"name": origin, "comercial_name": self.comercial}
 

--- a/l10n_es_partner/tests/test_l10n_es_partner.py
+++ b/l10n_es_partner/tests/test_l10n_es_partner.py
@@ -108,3 +108,14 @@ class TestL10nEsPartner(common.TransactionCase):
             "50001 Zaragoza (Zaragoza)<br/>"
             "Spain",
         )
+        # Make the partner match part of the address. It should be replaced with the pattern
+        # just once
+        partner2.name = "Zaragoza"
+        names = dict(partner2.with_context(show_address=True).name_get())
+        self.assertEqual(
+            names.get(partner2.id),
+            "Nuevo nombre (Zaragoza)\n"
+            "Calle Mayor, 1\n"
+            "50001 Zaragoza (Zaragoza)\n"
+            "Spain",
+        )


### PR DESCRIPTION
Relacionado con #4116 para prevenir una potencial coincidencia del nombre de contacto con alguna cadena de la dirección. No muy probable, pero tampoco imposible. 

@moduon @Shide @EmilioPascual MT-8475