### PR TITLE
[17.0][FIX] l10n_es_facturae: no attribute 'cr'

### DIFF
--- a/l10n_es_facturae/migrations/17.0.1.1.3/pre-migration.py
+++ b/l10n_es_facturae/migrations/17.0.1.1.3/pre-migration.py
@@ -10,7 +10,7 @@ def migrate(env, version):
     ):
         # Avoid computation of the field
         openupgrade.add_fields(
-            env.cr,
+            env,
             [
                 (
                     "facturae_withheld_amount",


### PR DESCRIPTION
Este PR corrige el error: 'psycopg2.extensions.cursor' object has no attribute 'cr'