### PR TITLE
[16.0][REM] test_requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,0 @@
-odoo_test_helper


### PR DESCRIPTION
The test_requirements seems to be wrong and failing in the tests. [Source](https://github.com/OCA/l10n-spain/actions/runs/14303596017/job/40082439280)

This is a test to see if removing it fixes it