### PR TITLE
[16.0][FIX] l10n_es_facturae: The city field in the partner is required for the FacturaE process. If the user does not provide it, document generation fails and module crashes.

### DIFF
--- a/l10n_es_facturae/models/res_partner.py
+++ b/l10n_es_facturae/models/res_partner.py
@@ -34,7 +34,7 @@ class ResPartner(models.Model):
                 return "U"
         return "E"
 
-    @api.constrains("facturae", "vat", "state_id", "country_id", "street")
+    @api.constrains("facturae", "vat", "city", "state_id", "country_id", "street")
     def check_facturae(self):
         for record in self:
             if record.facturae:
@@ -52,6 +52,12 @@ class ResPartner(models.Model):
                 if not record.street:
                     raise ValidationError(
                         _("Street must be defined for factura-e enabled partners.")
+                    )
+                if not record.city and record.country_id == self.env.ref("base.es"):
+                    raise ValidationError(
+                        _(
+                            "City must be defined for Spanish factura-e enabled partners."
+                        )
                     )
                 if not record.country_id:
                     raise ValidationError(


### PR DESCRIPTION
Sorry, my previous pull request had a confusing number of commits.

The change involves modifying the validation process, just to check the existence of some value in the city field for Spanish partners.

Part of the error message in Odoo:

File "/opt/addons/l10n-spain/l10n_es_facturae/reports/report_facturae.py", line 39, in generate_report
xml_facturae, content_type = super().generate_report(
^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/addons/reporting-engine/report_xml/reports/report_report_xml_abstract.py", line 53, in generate_report
result_bin = ir_report._render_template(ir_report.report_name, data)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/odoo/odoo/addons/base/models/ir_actions_report.py", line 661, in _render_template
return view_obj._render_template(template, values).encode()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/odoo/odoo/addons/base/models/ir_ui_view.py", line 2135, in _render_template
return self.env['ir.qweb']._render(template, values)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/odoo/odoo/tools/profiler.py", line 294, in _tracked_method_render
return method_render(self, template, values, **options)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/odoo/odoo/addons/base/models/ir_qweb.py", line 593, in _render
result = ''.join(rendering)
^^^^^^^^^^^^^^^^^^
File "<1758>", line 34, in template_1758
File "<1758>", line 23, in template_1758_content
File "<1757>", line 3040, in template_1757
File "<1757>", line 3022, in template_1757_content
File "<1757>", line 319, in template_1757_t_call_0
File "<1755>", line 341, in template_1755
File "<1755>", line 142, in template_1755_content
File "<1754>", line 170, in template_1754
File "<1754>", line 116, in template_1754_content
File "<1756>", line 327, in template_1756
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
TypeError: 'bool' object is not subscriptable
Template: l10n_es_facturae.address_contact
Path: /t/AddressInSpain/Town
Node: