### PR TITLE
[16.0][FIX] l10n_es_partner: Contact name may be empty

### DIFF
--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -31,8 +31,9 @@ class ResPartner(models.Model):
             return origin
         if self.env.context.get("show_address"):
             return origin.replace(
-                self.name,
-                name_pattern % {"name": self.name, "comercial_name": self.comercial},
+                self.name or "",
+                name_pattern
+                % {"name": self.name or "", "comercial_name": self.comercial},
                 1,  # Just replace the first occurrence
             )
         return name_pattern % {"name": origin, "comercial_name": self.comercial}


### PR DESCRIPTION
Odoo allows to have empty name on children contacts, provoking an error when displaying the address with name_get:

  File "/opt/odoo/auto/addons/l10n_es_partner/models/res_partner.py", line 33, in _get_name
    return origin.replace(
TypeError: replace() argument 1 must be str, not bool

![imagen](https://github.com/user-attachments/assets/7d3bcd0e-b98b-4396-9588-1df6a7ba5feb)

Let's cover that situation for avoiding the crash.

@Tecnativa TT55861