### PR TITLE
[15.0][FIX] l10n_es_aeat_mod347: Proper view inheritance

### DIFF
--- a/l10n_es_aeat_mod347/views/res_partner_view.xml
+++ b/l10n_es_aeat_mod347/views/res_partner_view.xml
@@ -4,7 +4,7 @@
     <record id="view_partner_form_mod347" model="ir.ui.view">
         <field name="name">Partners - Add 'include in 347'</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="account.view_partner_property_form" />
+        <field name="inherit_id" ref="l10n_es_aeat.view_partner_form" />
         <field name="arch" type="xml">
             <group name="fiscal_information">
                 <field name="not_in_mod347" />


### PR DESCRIPTION
Backport of #4133 

The locator is on an inherited view, so we have to put the inheritance correctly.

@Tecnativa 