### PR TITLE
[17.0][FIX] l10n_es_facturae: The city field in the partner is required for the FacturaE process. If the user does not provide it, document generation fails and module crashes.

### DIFF
--- a/l10n_es_facturae/models/res_partner.py
+++ b/l10n_es_facturae/models/res_partner.py
@@ -34,7 +34,7 @@ class ResPartner(models.Model):
                 return "U"
         return "E"
 
-    @api.constrains("facturae", "vat", "state_id", "country_id", "street")
+    @api.constrains("facturae", "vat", "city", "state_id", "country_id", "street")
     def check_facturae(self):
         for record in self:
             if record.facturae:
@@ -52,6 +52,13 @@ class ResPartner(models.Model):
                 if not record.street:
                     raise ValidationError(
                         _("Street must be defined for factura-e enabled partners.")
+                    )
+                if not record.city and record.country_id == self.env.ref("base.es"):
+                    raise ValidationError(
+                        _(
+                            "City must be defined for Spanish "
+                            "factura-e enabled partners."
+                        )
                     )
                 if not record.country_id:
                     raise ValidationError(


### PR DESCRIPTION
The change involves modifying the validation process, just to check the existence of some value in the city field for Spanish partners.

Part of the error message in Odoo:

  File "/opt/addons/reporting-engine/report_xml/reports/report_report_xml_abstract.py", line 53, in generate_report
    result_bin = ir_report._render_template(ir_report.report_name, data)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/odoo/addons/base/models/ir_actions_report.py", line 686, in _render_template
    return view_obj._render_template(template, values).encode()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/odoo/addons/base/models/ir_ui_view.py", line 2061, in _render_template
    return self.env['ir.qweb']._render(template, values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/odoo/tools/profiler.py", line 294, in _tracked_method_render
    return method_render(self, template, values, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo17/odoo/addons/base/models/ir_qweb.py", line 605, in _render
    result = ''.join(rendering)
             ^^^^^^^^^^^^^^^^^^
  File "<1394>", line 34, in template_1394
  File "<1394>", line 23, in template_1394_content
  File "<1393>", line 3040, in template_1393
  File "<1393>", line 3022, in template_1393_content
  File "<1393>", line 319, in template_1393_t_call_0
  File "<1391>", line 341, in template_1391
  File "<1391>", line 142, in template_1391_content
  File "<1390>", line 170, in template_1390
  File "<1390>", line 116, in template_1390_content
  File "<1392>", line 327, in template_1392
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
TypeError: 'bool' object is not subscriptable
Template: l10n_es_facturae.address_contact
Path: /t/AddressInSpain/Town
Node: <Town t-length="50" t-out="administrative_partner.city"/>