### PR TITLE
[17.0][FIX] l10n_es_aeat: post_install report tests

### DIFF
--- a/l10n_es_aeat/tests/test_l10n_es_aeat_report.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_report.py
@@ -5,12 +5,13 @@
 from odoo_test_helper import FakeModelLoader
 
 from odoo import exceptions, fields
-from odoo.tests import common
+from odoo.tests import common, tagged
 from odoo.tests.common import Form
 
 TEST_MODEL_NAME = "l10n.es.aeat.mod999.report"
 
 
+@tagged("post_install", "-at_install")
 class TestL10nEsAeatReport(common.TransactionCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Si movemos los tests de los reportes a post_install se solucionan los errores en todos los tests referentes al IGIC:
- [ ] https://github.com/OCA/l10n-spain/pull/4097
- [ ] https://github.com/OCA/l10n-spain/pull/3870
- [ ] https://github.com/OCA/l10n-spain/pull/3871

No creo que el cambio modifique la naturaleza de lo que se pretende comprobar en los tests, déjame saber que piensas @pedrobaeza 🙏🏻 