### PR TITLE
[17.0] [FIX] l10n_es_aeat_mod_130: Error in referenced field of the result of declaration

### DIFF
--- a/l10n_es_aeat_mod130/data/aeat_export_mod130_data.xml
+++ b/l10n_es_aeat_mod130/data/aeat_export_mod130_data.xml
@@ -365,7 +365,7 @@
         <field
             name="name"
         >Liquidación (3). III. Total Liquidación - [19] Resultado de la autoliquidación ([17]-[18])</field>
-        <field name="expression">${object.casilla_13}</field>
+        <field name="expression">${object.result}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
         <field name="size">17</field>


### PR DESCRIPTION
The file refers to an incorrect field. When importing the file into the AEAT, it warns that the result field had to be recalculated, showing an error.