### PR TITLE
[16.0][FIX] l10n_es_aeat_mod130: Exported file doesn't manage bank account debit type of declaration

### DIFF
--- a/l10n_es_aeat_mod130/models/mod130.py
+++ b/l10n_es_aeat_mod130/models/mod130.py
@@ -129,12 +129,47 @@ class L10nEsAeatMod130Report(models.Model):
         compute="_compute_result",
         store=True,
     )
+    use_aeat_account = fields.Boolean(
+        "Usar cuenta corriente tributaria",
+        help=(
+            "Si está suscrito a la cuenta corriente en materia tributaria, "
+            "active esta opción para usarla en el ingreso o devolución."
+        ),
+    )
     tipo_declaracion = fields.Selection(
-        selection=[("I", "A ingresar"), ("N", "Negativa"), ("B", "A deducir")],
+        selection=[
+            ("I", "A ingresar"),
+            ("U", "Domiciliación"),
+            ("G", "A ingresar en CCT"),
+            ("N", "Negativa"),
+            ("B", "A deducir"),
+        ],
         string="Tipo declaración",
         compute="_compute_tipo_declaracion",
         store=True,
     )
+    marca_sepa = fields.Selection(
+        selection=[
+            ("0", "0 No válida para domiciliación"),
+            ("1", "1 Cuenta España SEPA"),
+            ("2", "2 Unión Europea SEPA"),
+        ],
+        compute="_compute_marca_sepa",
+    )
+
+    @api.depends("partner_bank_id", "use_aeat_account")
+    def _compute_marca_sepa(self):
+        for record in self:
+            record.marca_sepa = "0"
+            if not record.use_aeat_account:
+                partner_bank = record.partner_bank_id
+                bank = partner_bank.bank_id if partner_bank else None
+                country = bank.country if bank else None
+                if country:
+                    if country == self.env.ref("base.es"):
+                        record.marca_sepa = "1"
+                    elif country in self.env.ref("base.europe").country_ids:
+                        record.marca_sepa = "2"
 
     @api.depends("real_expenses", "non_justified_expenses")
     def _compute_casilla_02(self):
@@ -207,7 +242,11 @@ class L10nEsAeatMod130Report(models.Model):
         for report in self:
             report.result = report.casilla_17 - report.casilla_18
 
-    @api.depends("result")
+    @api.depends(
+        "result",
+        "marca_sepa",
+        "use_aeat_account",
+    )
     def _compute_tipo_declaracion(self):
         for report in self:
             result = float_compare(report.result, 0, precision_digits=2)
@@ -216,7 +255,13 @@ class L10nEsAeatMod130Report(models.Model):
             elif result < 0:
                 report.tipo_declaracion = "B" if report.period_type != "4T" else "N"
             else:
-                report.tipo_declaracion = "I"
+                if report.use_aeat_account:
+                    report.tipo_declaracion = "G"
+                elif report.marca_sepa in {"1", "2"}:
+                    # Domiciliar ingreso porque se indicó un banco SEPA
+                    report.tipo_declaracion = "U"
+                else:
+                    report.tipo_declaracion = "I"
 
     def _calc_ingresos_gastos_retenciones(self):
         self.ensure_one()

--- a/l10n_es_aeat_mod130/tests/test_l10n_es_aeat_mod130.py
+++ b/l10n_es_aeat_mod130/tests/test_l10n_es_aeat_mod130.py
@@ -129,3 +129,139 @@ class TestL10nEsAeatMod130Base(TestL10nEsAeatModBase):
         for xml_id in export_config_xml_ids:
             export_config = self.env.ref(xml_id)
             self.assertTrue(export_to_boe._export_config(model130, export_config))
+
+        # Test partner account at AEAT
+        model130_account_aeat = model130.copy(
+            {
+                "name": "9990000004130",
+                "activity_type": "other",
+                "date_start": "2019-01-01",
+                "date_end": "2019-03-31",
+                "use_aeat_account": True,
+            }
+        )
+        model130_account_aeat.button_calculate()
+        self.assertEqual(model130_account_aeat.tipo_declaracion, "G")
+
+        # Test Spanish bank account debit declaration
+        model130_es_bank_account = model130.copy(
+            {
+                "name": "9990000005130",
+                "activity_type": "other",
+                "date_start": "2019-01-01",
+                "date_end": "2019-03-31",
+                "use_aeat_account": False,
+            }
+        )
+        model130_es_bank_account.partner_bank_id = self.customer_bank.id
+        model130_es_bank_account.button_calculate()
+        self.assertEqual(model130_es_bank_account.tipo_declaracion, "U")
+        self.assertEqual(model130_es_bank_account.marca_sepa, "1")
+
+        # Test European, but not Spanish, bank account debit declaration
+        model130_eu_bank_account = model130.copy(
+            {
+                "name": "9990000006130",
+                "activity_type": "other",
+                "date_start": "2019-01-01",
+                "date_end": "2019-03-31",
+                "use_aeat_account": False,
+            }
+        )
+        Bank = self.env["res.bank"]
+        bic = "PSSTFRPPXXX"
+        bank = Bank.create(
+            {
+                "name": "LA BANQUE POSTALE",
+                "country": self.env.ref("base.fr").id,
+                "bic": bic,
+            }
+        )
+        bank_acc = self.env["res.partner.bank"].create(
+            {
+                "acc_number": "FR20 1242 1242 1242 1242 1242 124",
+                "partner_id": self.customer.id,
+                "bank_id": bank.id,
+            }
+        )
+        model130_eu_bank_account.partner_bank_id = bank_acc.id
+        model130_eu_bank_account._compute_marca_sepa()
+        model130_eu_bank_account.button_calculate()
+        self.assertEqual(model130_eu_bank_account.tipo_declaracion, "U")
+        self.assertEqual(model130_eu_bank_account.marca_sepa, "2")
+
+        # Test non European bank account debit declaration
+        model130_non_eu_bank_account = model130.copy(
+            {
+                "name": "9990000007130",
+                "activity_type": "other",
+                "date_start": "2019-01-01",
+                "date_end": "2019-03-31",
+                "use_aeat_account": False,
+            }
+        )
+        bic = "JPMGUS33XXX"
+        bank = Bank.create(
+            {
+                "name": "JPMorgan Chase & Co",
+                "country": self.env.ref("base.us").id,
+                "bic": bic,
+            }
+        )
+        bank_acc = self.env["res.partner.bank"].create(
+            {
+                "acc_number": "1234567890",
+                "partner_id": self.customer.id,
+                "bank_id": bank.id,
+            }
+        )
+        model130_non_eu_bank_account.partner_bank_id = bank_acc.id
+        model130_non_eu_bank_account.button_calculate()
+        self.assertEqual(model130_non_eu_bank_account.tipo_declaracion, "I")
+        self.assertEqual(model130_non_eu_bank_account.marca_sepa, "0")
+
+        # Test compensate result
+        model130_comp_result = model130.copy(
+            {
+                "name": "9990000008130",
+                "activity_type": "other",
+                "period_type": "1T",
+                "date_start": "2019-01-01",
+                "date_end": "2019-03-31",
+                "use_aeat_account": False,
+            }
+        )
+        self.taxes_purchase["P_IVA21_BC"] = (1200,)
+        self._invoice_purchase_create("2019-01-01")
+        model130_comp_result.button_calculate()
+        self.assertEqual(model130_comp_result.tipo_declaracion, "N")
+
+        # Test negative result
+        model130_neg_result = model130.copy(
+            {
+                "name": "9990000009130",
+                "activity_type": "other",
+                "period_type": "1T",
+                "date_start": "2019-01-01",
+                "date_end": "2019-03-31",
+                "use_aeat_account": False,
+                "casilla_18": 2000.0,
+            }
+        )
+        self.taxes_purchase["P_IVA21_BC"] = (1200,)
+        self._invoice_purchase_create("2019-01-01")
+        model130_neg_result.button_calculate()
+        self.assertEqual(model130_neg_result.tipo_declaracion, "B")
+
+        test_marca_sepa = model130.copy(
+            {
+                "name": "9990000010130",
+                "activity_type": "other",
+                "period_type": "1T",
+                "date_start": "2019-01-01",
+                "date_end": "2019-03-31",
+                "use_aeat_account": True,
+            }
+        )
+        test_marca_sepa._compute_marca_sepa()
+        self.assertEqual(test_marca_sepa.marca_sepa, "0")

--- a/l10n_es_aeat_mod130/views/mod130_view.xml
+++ b/l10n_es_aeat_mod130/views/mod130_view.xml
@@ -21,6 +21,14 @@
         <field name="model">l10n.es.aeat.mod130.report</field>
         <field name="inherit_id" ref="l10n_es_aeat.view_l10n_es_aeat_report_form" />
         <field name="arch" type="xml">
+            <field name="partner_bank_id" position="before">
+                <field name="use_aeat_account" />
+            </field>
+            <field name="partner_bank_id" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('use_aeat_account', '=', True), ('tipo_declaracion', 'not in', ('I', 'U', 'N'))], 'required': [('use_aeat_account', '=', False), ('tipo_declaracion', 'in', ('N'))]}</attribute>
+            </field>
             <xpath expr="//group[@name='group_declaration']" position="after">
                 <group string="Datos a completar" colspan="4" col="6">
                     <group colspan="2">
@@ -109,13 +117,8 @@
                     </group>
                 </group>
                 <group string="Observaciones" colspan="4">
-                    <field name="comments" nolabel="1" />
+                    <field name="comments" nolabel="1" colspan="2" />
                 </group>
-                <field name="partner_bank_id" position="attributes">
-                    <attribute
-                        name="attrs"
-                    >{'invisible': [('tipo_declaracion', 'not in', ('I'))]}</attribute>
-                </field>
             </xpath>
             <xpath expr="//sheet" position="after">
                 <div class="oe_chatter">


### PR DESCRIPTION
En caso de salir a pagar, siempre sale 'a ingresar', pudiendo domiciliar el pago.
He cogido parte del código de la implementación del modelo 303 en ese punto.
He aprovechado para mejorar el apartado de observaciones que aparecía al final.