### PR TITLE
[15.0][FIX] l10n_es_aeat_mod303: Avoid negatives in fee to compensate

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -519,18 +519,11 @@ class L10nEsAeatMod303Report(models.Model):
                         - fields.Date.to_date(mod303.date_start)
                     ),
                 )
-                if prev_report and (
-                    prev_report.remaining_cuota_compensar > 0
-                    or prev_report.result_type == "C"
-                ):
-                    mod303.write(
-                        {
-                            "potential_cuota_compensar": (
-                                prev_report.remaining_cuota_compensar
-                                - prev_report.resultado_liquidacion
-                            ),
-                        }
-                    )
+                if prev_report.remaining_cuota_compensar > 0:
+                    amount = prev_report.remaining_cuota_compensar
+                    if prev_report.result_type == "C":
+                        amount -= prev_report.resultado_liquidacion
+                    mod303.potential_cuota_compensar = amount if amount > 0 else 0
             if mod303.return_last_period:
                 cuota_compensar = mod303.potential_cuota_compensar
             elif (
@@ -547,7 +540,6 @@ class L10nEsAeatMod303Report(models.Model):
             else:
                 cuota_compensar = 0
             mod303.cuota_compensar = cuota_compensar
-
         return res
 
     def button_confirm(self):

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -407,6 +407,8 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
 
         model303_4T.return_last_period = True
         model303_4T.button_calculate()
+        model303_4T.potential_cuota_compensar = 674.48
+        model303_4T.cuota_compensar = 674.48
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2018.casilla_85, 0.0, 2)


### PR DESCRIPTION
Backport of #4048 to 15.0