### PR TITLE
[16.0][FIX] l10n_es_aeat_mod130: Set correctly firstname and lastname in the exported file.

### DIFF
--- a/l10n_es_aeat_mod130/data/aeat_export_mod130_data.xml
+++ b/l10n_es_aeat_mod130/data/aeat_export_mod130_data.xml
@@ -82,7 +82,7 @@
         <field name="sequence">8</field>
         <field name="export_config_id" ref="aeat_mod130_sub_export_config" />
         <field name="name">Declarante (1). Sujeto pasivo. Apellidos</field>
-        <field name="expression">${object.company_id.name}</field>
+        <field name="expression">${object.lastname}</field>
         <field name="export_type">string</field>
         <field name="size">60</field>
         <field name="alignment">left</field>
@@ -92,9 +92,7 @@
         <field name="sequence">9</field>
         <field name="export_config_id" ref="aeat_mod130_sub_export_config" />
         <field name="name">Declarante (1). Sujeto pasivo. Nombre</field>
-        <field
-            name="expression"
-        >${object.company_id.name if object.company_vat[0].isdigit() else ''}</field>
+        <field name="expression">${object.firstname}</field>
         <field name="export_type">string</field>
         <field name="size">20</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod130/models/mod130.py
+++ b/l10n_es_aeat_mod130/models/mod130.py
@@ -157,6 +157,28 @@ class L10nEsAeatMod130Report(models.Model):
         ],
         compute="_compute_marca_sepa",
     )
+    firstname = fields.Char(string="Nombre", compute="_compute_firstname", store=False)
+    lastname = fields.Char(string="Apellidos", compute="_compute_lastname", store=False)
+
+    def _compute_firstname(self):
+        for record in self:
+            if record.partner_id.is_company:
+                record.firstname = ""
+            else:
+                record.firstname = (
+                    record.partner_id.firstname if hasattr(record.partner_id, 'firstname') 
+                    else record.company_id.name
+                )
+
+    def _compute_lastname(self):
+        for record in self:
+            if record.partner_id.is_company:
+                record.lastname = ""
+            else:
+                record.lastname = (
+                    record.partner_id.lastname if hasattr(record.partner_id, 'lastname') 
+                    else record.company_id.name
+                )
 
     @api.depends("partner_bank_id", "use_aeat_account")
     def _compute_marca_sepa(self):

--- a/l10n_es_aeat_mod130/models/mod130.py
+++ b/l10n_es_aeat_mod130/models/mod130.py
@@ -129,12 +129,51 @@ class L10nEsAeatMod130Report(models.Model):
         compute="_compute_result",
         store=True,
     )
+    use_aeat_account = fields.Boolean(
+        "Usar cuenta corriente tributaria",
+        help=(
+            "Si está suscrito a la cuenta corriente en materia tributaria, "
+            "active esta opción para usarla en el ingreso o devolución."
+        ),
+    )
     tipo_declaracion = fields.Selection(
-        selection=[("I", "A ingresar"), ("N", "Negativa"), ("B", "A deducir")],
+        selection=[
+            ("I", "A ingresar"),
+            ("U", "Domiciliación"),
+            ("G", "A ingresar en CCT"),
+            ("N", "Negativa"),
+            ("B", "A deducir"),
+        ],
         string="Tipo declaración",
         compute="_compute_tipo_declaracion",
         store=True,
     )
+    marca_sepa = fields.Selection(
+        selection=[
+            ("0", "0 Vacía"),
+            ("1", "1 Cuenta España"),
+            ("2", "2 Unión Europea SEPA"),
+            ("3", "3 Resto Países"),
+        ],
+        compute="_compute_marca_sepa",
+    )
+
+    @api.depends("partner_bank_id", "use_aeat_account")
+    def _compute_marca_sepa(self):
+        for record in self:
+            if record.use_aeat_account:
+                record.marca_sepa = "0"
+            elif record.partner_bank_id.bank_id.country == self.env.ref("base.es"):
+                record.marca_sepa = "1"
+            elif (
+                record.partner_bank_id.bank_id.country
+                in self.env.ref("base.europe").country_ids
+            ):
+                record.marca_sepa = "2"
+            elif record.partner_bank_id.bank_id.country:
+                record.marca_sepa = "3"
+            else:
+                record.marca_sepa = "0"
 
     @api.depends("real_expenses", "non_justified_expenses")
     def _compute_casilla_02(self):
@@ -207,16 +246,26 @@ class L10nEsAeatMod130Report(models.Model):
         for report in self:
             report.result = report.casilla_17 - report.casilla_18
 
-    @api.depends("result")
+    @api.depends(
+        "result",
+        "marca_sepa",
+        "use_aeat_account",
+    )
     def _compute_tipo_declaracion(self):
         for report in self:
             result = float_compare(report.result, 0, precision_digits=2)
             if result == 0:
                 report.tipo_declaracion = "N"
-            elif result < 0:
-                report.tipo_declaracion = "B" if report.period_type != "4T" else "N"
+            elif result == 1:
+                if report.use_aeat_account:
+                    report.tipo_declaracion = "G"
+                elif report.marca_sepa in {"1", "2"}:
+                    # Domiciliar ingreso porque se indicó un banco SEPA
+                    report.tipo_declaracion = "U"
+                else:
+                    report.tipo_declaracion = "I"
             else:
-                report.tipo_declaracion = "I"
+                report.tipo_declaracion = "B" if report.period_type != "4T" else "N"
 
     def _calc_ingresos_gastos_retenciones(self):
         self.ensure_one()

--- a/l10n_es_aeat_mod130/views/mod130_view.xml
+++ b/l10n_es_aeat_mod130/views/mod130_view.xml
@@ -21,6 +21,14 @@
         <field name="model">l10n.es.aeat.mod130.report</field>
         <field name="inherit_id" ref="l10n_es_aeat.view_l10n_es_aeat_report_form" />
         <field name="arch" type="xml">
+            <field name="partner_bank_id" position="before">
+                <field name="use_aeat_account" />
+            </field>
+            <field name="partner_bank_id" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('use_aeat_account', '=', True), ('tipo_declaracion', 'not in', ('I', 'U', 'N'))], 'required': [('use_aeat_account', '=', False), ('tipo_declaracion', 'in', ('N'))]}</attribute>
+            </field>
             <xpath expr="//group[@name='group_declaration']" position="after">
                 <group string="Datos a completar" colspan="4" col="6">
                     <group colspan="2">
@@ -109,13 +117,8 @@
                     </group>
                 </group>
                 <group string="Observaciones" colspan="4">
-                    <field name="comments" nolabel="1" />
+                    <field name="comments" nolabel="1" colspan="2" />
                 </group>
-                <field name="partner_bank_id" position="attributes">
-                    <attribute
-                        name="attrs"
-                    >{'invisible': [('tipo_declaracion', 'not in', ('I'))]}</attribute>
-                </field>
             </xpath>
             <xpath expr="//sheet" position="after">
                 <div class="oe_chatter">


### PR DESCRIPTION
El modelo 130 requiere y diferencia entre el apellido y el nombre del declarante.
En el código que propongo, aplico esa diferenciación.

Para que funcione como se espera, es apropiado tener activado el módulo 'partner_firstname', aunque no he querido poner este módulo como una dependencia, es necesario un módulo que gestione esta separación y ese módulo OCA lo hace.