### PR TITLE
[16.0][IMP] l10n_es_vat_prorate: Constrain para prevenir errores manuales

### DIFF
--- a/l10n_es_vat_prorate/i18n/es.po
+++ b/l10n_es_vat_prorate/i18n/es.po
@@ -231,6 +231,13 @@ msgstr "Con prorrata de IVA"
 
 #. module: l10n_es_vat_prorate
 #. odoo-python
+#: code:addons/l10n_es_vat_prorate/models/account_move.py:0
+#, python-format
+msgid "You cannot use this account (%s) to the VAT prorate."
+msgstr "No puede usar esta cuenta (%s) para la prorrata del IVA."
+
+#. module: l10n_es_vat_prorate
+#. odoo-python
 #: code:addons/l10n_es_vat_prorate/models/res_company.py:0
 #, python-format
 msgid "You can't have a special VAT prorrate of 100%"

--- a/l10n_es_vat_prorate/i18n/l10n_es_vat_prorate.pot
+++ b/l10n_es_vat_prorate/i18n/l10n_es_vat_prorate.pot
@@ -229,6 +229,13 @@ msgstr ""
 
 #. module: l10n_es_vat_prorate
 #. odoo-python
+#: code:addons/l10n_es_vat_prorate/models/account_move.py:0
+#, python-format
+msgid "You cannot use this account (%s) to the VAT prorate."
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#. odoo-python
 #: code:addons/l10n_es_vat_prorate/models/res_company.py:0
 #, python-format
 msgid "You must complete VAT prorate information"

--- a/l10n_es_vat_prorate/models/account_move.py
+++ b/l10n_es_vat_prorate/models/account_move.py
@@ -2,7 +2,8 @@
 # Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 from odoo.tools import float_round, frozendict
 
 
@@ -115,3 +116,28 @@ class AccountMoveLine(models.Model):
             if prorate_tax_list:
                 line.compute_all_tax.update(prorate_tax_list)
         return res
+
+    @api.constrains("account_id", "vat_prorate")
+    def _check_vat_prorate_account(self):
+        """Prevent set tax accounts in a line with vat prorate"""
+        if not self.filtered("vat_prorate"):
+            return
+        map_tax_accounts = {
+            tax.id: (tax.invoice_repartition_line_ids | tax.refund_repartition_line_ids)
+            .filtered(lambda r: r.repartition_type == "tax")
+            .mapped("account_id")
+            for tax in self.filtered("vat_prorate").mapped(
+                "tax_repartition_line_id.tax_id"
+            )
+        }
+        for line in self.filtered("vat_prorate"):
+            if (
+                line.account_id
+                in map_tax_accounts[line.tax_repartition_line_id.tax_id.id]
+            ):
+                raise UserError(
+                    _(
+                        "You cannot use this account (%s) to the VAT prorate.",
+                        line.account_id.display_name,
+                    )
+                )

--- a/l10n_es_vat_prorate/tests/test_vat_prorate.py
+++ b/l10n_es_vat_prorate/tests/test_vat_prorate.py
@@ -59,6 +59,16 @@ class TestVatProrate(AccountTestInvoicingCommon):
         with self.assertRaises(IntegrityError):
             self.env.company.vat_prorate_ids[0].vat_prorate = 200
 
+    def test_restriction_vat_prorate_in_accounts(self):
+        """Test that the restriction of the VAT prorate in the accounts works"""
+        invoice = self.init_invoice("in_invoice", products=[self.product_a])
+        line = invoice.line_ids.filtered("vat_prorate")
+        account = line.tax_line_id.invoice_repartition_line_ids.filtered(
+            lambda x: x.account_id
+        ).account_id
+        with self.assertRaises(exceptions.UserError):
+            line.account_id = account
+
     def test_company_special_vat_prorate_out_of_range(self):
         # A error should be displayed if special prorates are 100%
         prorate_id = self.env.company.vat_prorate_ids[0]


### PR DESCRIPTION
La cuenta en una apunte marcado con la prorrata del IVA puede ser cambiado manualmente. Con esta restricción se evita que se puedan asingar cuentas no deseadas, como llevarlo al alguna cuenta que esté configurada en la distribución del impuesto.

MT-9939 @moduon