### PR TITLE
[17.0][FIX] l10n_es_aeat_mod190: Visible computo de los 3 primeros hijos

### DIFF
--- a/l10n_es_aeat_mod190/i18n/es.po
+++ b/l10n_es_aeat_mod190/i18n/es.po
@@ -6,8 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-01-22 13:36+0000\n"
-"Last-Translator: loida-vm <loida@moduon.team>\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2025-02-28 09:45+0100\n"
+"Last-Translator: Emilio Pascual <emilio@moduon.team>\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -872,6 +873,12 @@ msgid "Is Aeat Perception Subkey Visible"
 msgstr "Es visible la subclave Aeat de Percepción"
 
 #. module: l10n_es_aeat_mod190
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_res_partner__is_first_child_computation_visible
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_res_users__is_first_child_computation_visible
+msgid "Is First Child Computation Visible"
+msgstr "Cómputo de los primeros hijos visible"
+
+#. module: l10n_es_aeat_mod190
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_l10n_es_aeat_mod190_report__message_is_follower
 msgid "Is Follower"
 msgstr "Es Seguidor/a"
@@ -1706,9 +1713,3 @@ msgstr "[03] Importe de las retenciones"
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_l10n_es_aeat_mod190_report_line__ejercicio_devengo
 msgid "year"
 msgstr "año"
-
-#~ msgid "Last Modified on"
-#~ msgstr "Última Modificación el"
-
-#~ msgid "Main Attachment"
-#~ msgstr "Archivo Adjunto Principal"

--- a/l10n_es_aeat_mod190/i18n/l10n_es_aeat_mod190.pot
+++ b/l10n_es_aeat_mod190/i18n/l10n_es_aeat_mod190.pot
@@ -819,6 +819,12 @@ msgid "Is Aeat Perception Subkey Visible"
 msgstr ""
 
 #. module: l10n_es_aeat_mod190
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_res_partner__is_first_child_computation_visible
+#: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_res_users__is_first_child_computation_visible
+msgid "Is First Child Computation Visible"
+msgstr ""
+
+#. module: l10n_es_aeat_mod190
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod190.field_l10n_es_aeat_mod190_report__message_is_follower
 msgid "Is Follower"
 msgstr ""

--- a/l10n_es_aeat_mod190/models/res_partner.py
+++ b/l10n_es_aeat_mod190/models/res_partner.py
@@ -240,6 +240,9 @@ class ResPartner(models.Model):
     is_aeat_perception_subkey_visible = fields.Boolean(
         compute="_compute_is_aeat_perception_subkey_visible"
     )
+    is_first_child_computation_visible = fields.Boolean(
+        compute="_compute_is_first_child_computation_visible"
+    )
 
     @api.depends("aeat_perception_key_id", "aeat_perception_subkey_id")
     def _compute_ad_required(self):
@@ -262,6 +265,24 @@ class ResPartner(models.Model):
                         ),
                     ]
                 )
+            )
+
+    @api.depends("aeat_perception_key_id", "aeat_perception_subkey_id")
+    def _compute_is_first_child_computation_visible(self):
+        aeat_perception_key_id = [  # A, C
+            "l10n_es_aeat_mod190.aeat_m190_perception_key_01",
+            "l10n_es_aeat_mod190.aeat_m190_perception_key_03",
+        ]
+        aeat_perception_subkey_id = [  # B01, B03
+            "l10n_es_aeat_mod190.aeat_m190_perception_subkey_02_01",
+            "l10n_es_aeat_mod190.aeat_m190_perception_subkey_02_03",
+        ]
+        for record in self:
+            record.is_first_child_computation_visible = (
+                record.aeat_perception_key_id
+                in {self.env.ref(item) for item in aeat_perception_key_id}
+                or record.aeat_perception_subkey_id
+                in {self.env.ref(item) for item in aeat_perception_subkey_id}
             )
 
     @api.onchange("aeat_perception_key_id")

--- a/l10n_es_aeat_mod190/views/partner_view.xml
+++ b/l10n_es_aeat_mod190/views/partner_view.xml
@@ -27,6 +27,10 @@
                         />
                         <field name="ad_required" invisible="1" />
                         <field name="is_aeat_perception_subkey_visible" invisible="1" />
+                        <field
+                            name="is_first_child_computation_visible"
+                            invisible="1"
+                        />
                     </group>
                     <group string="Perception data" invisible="not incluir_190">
                         <group>
@@ -59,7 +63,7 @@
                     <group
                         groups="account.group_account_invoice,l10n_es_aeat.group_account_aeat"
                         string="First 3 compute"
-                        invisible="not is_aeat_perception_subkey_visible"
+                        invisible="not is_first_child_computation_visible"
                     >
                         <field name="computo_primeros_hijos_1" string="1" />
                         <field name="computo_primeros_hijos_2" string="2" />


### PR DESCRIPTION
FW-Port de https://github.com/OCA/l10n-spain/pull/4037

El computo de los 3 primeros hijos sólo debe ser visible para percepciones correspondientes a las claves A, B01, B03 y C

@moduon MT-8874