### PR TITLE
[16.0][IMP] l10n_es_aeat_mod347:  Field Not in mod347 in partner converted to company dependent

### DIFF
--- a/l10n_es_aeat_mod347/__manifest__.py
+++ b/l10n_es_aeat_mod347/__manifest__.py
@@ -10,7 +10,7 @@
 
 {
     "name": "AEAT modelo 347",
-    "version": "16.0.1.10.5",
+    "version": "16.0.1.11.5",
     "author": "Tecnativa,PESOL,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "category": "Accounting",

--- a/l10n_es_aeat_mod347/migrations/16.0.1.11.5/post-migration.py
+++ b/l10n_es_aeat_mod347/migrations/16.0.1.11.5/post-migration.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Moduon Team S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+
+from openupgradelib import openupgrade
+
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    openupgrade.convert_to_company_dependent(
+        env, "res.partner", "old_not_in_mod347", "not_in_mod347"
+    )

--- a/l10n_es_aeat_mod347/migrations/16.0.1.11.5/pre-migration.py
+++ b/l10n_es_aeat_mod347/migrations/16.0.1.11.5/pre-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2025 Moduon Team S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+
+from openupgradelib import openupgrade
+
+
+def migrate(cr, version):
+    openupgrade.rename_columns(
+        cr, {"res_partner": [("not_in_mod347", "old_not_in_mod347")]}
+    )

--- a/l10n_es_aeat_mod347/models/res_partner.py
+++ b/l10n_es_aeat_mod347/models/res_partner.py
@@ -14,6 +14,7 @@ class ResPartner(models.Model):
         "any AEAT 347 model report, independently from the total "
         "amount of its operations.",
         default=False,
+        company_dependent=True,
     )
 
     @api.model


### PR DESCRIPTION
Se convierte el campo `not_in_347mod` en el contacto como depenciente de la compañía (Issue: https://github.com/OCA/l10n-spain/issues/4173).

Se cambia el nombre porque en el script de migración se utiliza el método [`convert_to_company_dependent`](https://github.com/OCA/openupgradelib/blob/master/openupgradelib/openupgrade.py#L3533) y es obligatorio cambiar el nombre del campo.

https://www.loom.com/share/62d99bc8002e48d08f37d951e863644d?sid=5bcfab4b-aaae-4d28-81ba-e4348267d92a

¿@rafaelbn @pedrobaeza @chienandalu @ArantxaSudon podéis revisarlo? Gracias.

MT-10026 @moduon