### PR TITLE
[IMP] l10n_es_aeat_mod347: Calculations wo partner records in state exception

### DIFF
--- a/l10n_es_aeat_mod347/data/aeat_export_mod347_data.xml
+++ b/l10n_es_aeat_mod347/data/aeat_export_mod347_data.xml
@@ -222,7 +222,9 @@
         <field name="name">Tipo de Registro 2 – Registro de declarado</field>
         <field name="subconfig_id" ref="aeat_mod347_partner_export_config" />
         <field name="export_type">subconfig</field>
-        <field name="repeat_expression">object.partner_record_ids</field>
+        <field
+            name="repeat_expression"
+        >object.partner_record_ids.filtered(lambda x: x.state != "exception")</field>
     </record>
     <!-- Tipo registro 2 – Registro de inmueble: -->
     <record id="aeat_mod347_main_export_line_21" model="aeat.model.export.config.line">

--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -36,17 +36,28 @@ class L10nEsAeatMod347Report(models.Model):
         "partner_record_ids.amount",
         "partner_record_ids.cash_amount",
         "partner_record_ids.real_estate_transmissions_amount",
+        "partner_record_ids.state",
     )
     def _compute_totals(self):
         """Calculates the total_* fields from the line values."""
         for record in self:
-            record.total_partner_records = len(record.partner_record_ids)
-            record.total_amount = sum(record.mapped("partner_record_ids.amount"))
+            record.total_partner_records = len(
+                record.partner_record_ids.filtered(lambda x: x.state != "exception")
+            )
+            record.total_amount = sum(
+                record.partner_record_ids.filtered(
+                    lambda x: x.state != "exception"
+                ).mapped("amount")
+            )
             record.total_cash_amount = sum(
-                record.mapped("partner_record_ids.cash_amount")
+                record.partner_record_ids.filtered(
+                    lambda x: x.state != "exception"
+                ).mapped("cash_amount")
             )
             record.total_real_estate_transmissions_amount = sum(
-                record.mapped("partner_record_ids.real_estate_transmissions_amount")
+                record.partner_record_ids.filtered(
+                    lambda x: x.state != "exception"
+                ).mapped("real_estate_transmissions_amount")
             )
 
     @api.depends("real_estate_record_ids", "real_estate_record_ids.amount")

--- a/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
+++ b/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
@@ -206,3 +206,23 @@ class TestL10nEsAeatMod347(TestL10nEsAeatModBase):
         first_partner.email = "test1@email.com"
         self.model347.button_send_mails()
         self.assertTrue(first_partner_mod347_record.state, "sent")
+
+    def test_aeat_mod347_partner_records_ids_with_exception(self):
+        """Test computes with partner records with state exception"""
+        self.model347.button_calculate()
+        self.model347.partner_record_ids[0].action_exception()
+        self.model347.partner_record_ids[-1].action_exception()
+        partner_record_vals = [
+            # amount, cash_amount
+            (-4400, 0),
+            (4400, 0),
+            (6600, 6600),
+            (-5500, 0),
+        ]
+        self.assertEqual(self.model347.total_partner_records, len(partner_record_vals))
+        self.assertAlmostEqual(
+            self.model347.total_amount, sum(x[0] for x in partner_record_vals)
+        )
+        self.assertAlmostEqual(
+            self.model347.total_cash_amount, sum(x[1] for x in partner_record_vals)
+        )


### PR DESCRIPTION
Los registros marcados con excepción no deberían tenerse en cuenta para los cálculos del 347, ni deberían ser informados a la AEAT.
Issue: https://github.com/OCA/l10n-spain/issues/4173

@rafaelbn @chienandalu @pedrobaeza @ArantxaSudon revisadlo si podéis 😊. Gracias

MT-10026 @moduon