### PR TITLE
[17.0][IMP] l10n_es_aeat: Allow set tax agency by journal

### DIFF
--- a/l10n_es_aeat/data/aeat_tax_agency_data.xml
+++ b/l10n_es_aeat/data/aeat_tax_agency_data.xml
@@ -18,6 +18,6 @@
         <field name="name">Hacienda Foral de Navarra</field>
     </record>
     <record id="aeat_tax_agency_canarias" model="aeat.tax.agency">
-        <field name="name">Agencia Tributaria Canaria</field>
+        <field name="name">Agencia Tributaria Canaria (1.0)</field>
     </record>
 </odoo>

--- a/l10n_es_aeat/models/account_journal.py
+++ b/l10n_es_aeat/models/account_journal.py
@@ -1,4 +1,5 @@
 # Copyright 2022 Moduon - Eduardo de Miguel
+# Copyright 2025 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
@@ -10,4 +11,15 @@ class AccountJournal(models.Model):
     thirdparty_invoice = fields.Boolean(
         string="Third-party invoice",
         copy=False,
+    )
+    # You can define distinct agencies in some journals.
+    # For example, a company can send invoices to AEAT SII platform and send it to
+    # ATC SII (Canary Islands) too. So user can make the invoices in different journals
+    # to send it.
+    tax_agency_id = fields.Many2one(
+        comodel_name="aeat.tax.agency",
+        string="Tax Agency",
+        copy=False,
+        help="You can select a tax agency other than the one defined in the company,"
+        "so you can pay taxes at different agencies.",
     )

--- a/l10n_es_aeat/views/account_journal_view.xml
+++ b/l10n_es_aeat/views/account_journal_view.xml
@@ -6,8 +6,21 @@
         <field name="model">account.journal</field>
         <field name="inherit_id" ref="account.view_account_journal_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='type'][last()]" position="after">
-                <field name="thirdparty_invoice" invisible="1" />
+            <xpath expr="//page[@name='advanced_settings']" position="before">
+                <page
+                    name="page_aeat"
+                    string="Localization Settings"
+                    invisible="country_code != 'ES' or type not in ['sale', 'purchase']"
+                >
+                    <group>
+                        <group>
+                            <field name="thirdparty_invoice" invisible="1" />
+                        </group>
+                        <group>
+                            <field name="tax_agency_id" />
+                        </group>
+                    </group>
+                </page>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
cc @Tecnativa 

Hay empresas que siendo nacionales estan acogidas tanto al SII de AEAT como al SII de ATC (Gobierno de canarias)

Este PR simplemente añade el campo en el diario para ser usado en los modulos (https://github.com/OCA/l10n-spain/tree/17.0/l10n_es_aeat_sii_oca) y el de Canarias que esta en desarrollo.

ping @carlosdauden @carlos-lopez-tecnativa @omar7r  @Christian-RB 