### PR TITLE
[17.0] [FIX] l10n_es_aeat_sii_oca: make some fields copy=False

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -96,8 +96,8 @@ class SiiMixin(models.AbstractModel):
         "greater o equal to 100 000 000,00 euros.",
         compute="_compute_macrodata",
     )
-    sii_send_date = fields.Datetime(string="SII Send Date", index=True)
-    sii_needs_cancel = fields.Boolean(readonly=True)
+    sii_send_date = fields.Datetime(string="SII Send Date", index=True, copy=False)
+    sii_needs_cancel = fields.Boolean(readonly=True, copy=False)
 
     def _compute_sii_refund_type(self):
         self.sii_refund_type = False


### PR DESCRIPTION
The sii_send_date and sii_needs_cancel contains delicated configuration of the sii on the invoices, and should not be copied to new ones by the users accidentally

@manuelregidor 