### PR TITLE
[17.0] [IMP] l10n_es_aeat_sii_oca: add sii_start_date config option to company

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -800,11 +800,13 @@ class AccountMove(models.Model):
     @api.depends(
         "company_id",
         "company_id.sii_enabled",
+        "company_id.sii_start_date",
         "journal_id",
         "journal_id.sii_enabled",
         "move_type",
         "fiscal_position_id",
         "fiscal_position_id.aeat_active",
+        "invoice_date",
         "invoice_line_ids",
     )
     def _compute_sii_enabled(self):
@@ -818,16 +820,24 @@ class AccountMove(models.Model):
             ):
                 invoice.sii_enabled = (
                     (
-                        invoice.fiscal_position_id
-                        and invoice.fiscal_position_id.aeat_active
-                    )
-                    or not invoice.fiscal_position_id
-                ) and (
-                    not dua_sii_exempt_taxes
-                    or not invoice.invoice_line_ids.filtered(
-                        lambda x, dua_taxes=dua_sii_exempt_taxes: any(
-                            [tax.id in dua_taxes for tax in x.tax_ids]
+                        (
+                            invoice.fiscal_position_id
+                            and invoice.fiscal_position_id.aeat_active
                         )
+                        or not invoice.fiscal_position_id
+                    )
+                    and (
+                        not dua_sii_exempt_taxes
+                        or not invoice.invoice_line_ids.filtered(
+                            lambda x, dua_taxes=dua_sii_exempt_taxes: any(
+                                [tax.id in dua_taxes for tax in x.tax_ids]
+                            )
+                        )
+                    )
+                    and (
+                        not invoice.company_id.sii_start_date
+                        or not invoice.invoice_date
+                        or invoice.invoice_date >= invoice.company_id.sii_start_date
                     )
                 )
             else:

--- a/l10n_es_aeat_sii_oca/models/res_company.py
+++ b/l10n_es_aeat_sii_oca/models/res_company.py
@@ -55,6 +55,11 @@ class ResCompany(models.Model):
         help="By default, the invoice is sent/queued in validation process. "
         "With manual method, there's a button to send the invoice.",
     )
+    sii_start_date = fields.Date(
+        help="If this field is set, the sii won't be enabled on invoices with lower "
+        "invoice date. If not set, the sii can be enabled on all invoice dates"
+    )
+
     send_mode = fields.Selection(
         selection=[
             ("auto", "On validate"),

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -581,3 +581,14 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.assertTrue(invoice.sii_send_date)
         self.assertTrue(invoice_sii_failed.sii_send_date)
         self.assertTrue(invoice_sii_modified.sii_send_date)
+
+    def test_start_date(self):
+        self.company.sii_start_date = "2018-01-01"
+        invoice1 = self._create_invoice("out_invoice")
+        invoice1.invoice_date = "2019-01-01"
+        self.assertTrue(invoice1.sii_enabled)
+        invoice2 = self._create_invoice("out_invoice")
+        invoice2.invoice_date = "2017-01-01"
+        self.assertFalse(invoice2.sii_enabled)
+        self.company.sii_start_date = False
+        self.assertTrue(invoice2.sii_enabled)

--- a/l10n_es_aeat_sii_oca/views/res_company_view.xml
+++ b/l10n_es_aeat_sii_oca/views/res_company_view.xml
@@ -15,6 +15,7 @@
                     </group>
                     <group invisible="not sii_enabled">
                         <group name="sii_config">
+                            <field name="sii_start_date" />
                             <field name="sii_test" />
                             <field name="sii_method" />
                             <field name="sii_period" />


### PR DESCRIPTION
This PR adds a new config option co res_company called sii_start_date that allows you to disable the sii in the account moves that has a previous invoice_date