### PR TITLE
[18.0][IMP] l10n_es_aeat: vat_representative by default

### DIFF
--- a/l10n_es_aeat/i18n/es.po
+++ b/l10n_es_aeat/i18n/es.po
@@ -1066,6 +1066,7 @@ msgstr "Apuntes contables"
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report__representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping__representative_vat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_res_company__representative_vat
 msgid "L.R. VAT number"
 msgstr "NIF del representante legal"
 
@@ -1109,6 +1110,14 @@ msgstr "Última actualización el"
 #: model:ir.model.fields.selection,name:l10n_es_aeat.selection__aeat_model_export_config_line__alignment__left
 msgid "Left"
 msgstr "Izquierda"
+
+#. module: l10n_es_aeat
+#: model:ir.model.fields,help:l10n_es_aeat.field_res_company__representative_vat
+msgid ""
+"Legal Representative VAT number for all the AEAT reports of this company."
+msgstr ""
+"NIF del representante legal para todos los informes de la AEAT de esta "
+"compañía."
 
 #. module: l10n_es_aeat
 #: model:ir.model.fields,help:l10n_es_aeat.field_l10n_es_aeat_report__representative_vat

--- a/l10n_es_aeat/i18n/l10n_es_aeat.pot
+++ b/l10n_es_aeat/i18n/l10n_es_aeat.pot
@@ -980,6 +980,7 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report__representative_vat
 #: model:ir.model.fields,field_description:l10n_es_aeat.field_l10n_es_aeat_report_tax_mapping__representative_vat
+#: model:ir.model.fields,field_description:l10n_es_aeat.field_res_company__representative_vat
 msgid "L.R. VAT number"
 msgstr ""
 
@@ -1022,6 +1023,12 @@ msgstr ""
 #. module: l10n_es_aeat
 #: model:ir.model.fields.selection,name:l10n_es_aeat.selection__aeat_model_export_config_line__alignment__left
 msgid "Left"
+msgstr ""
+
+#. module: l10n_es_aeat
+#: model:ir.model.fields,help:l10n_es_aeat.field_res_company__representative_vat
+msgid ""
+"Legal Representative VAT number for all the AEAT reports of this company."
 msgstr ""
 
 #. module: l10n_es_aeat

--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -123,6 +123,9 @@ class L10nEsAeatReport(models.AbstractModel):
         string="L.R. VAT number",
         size=9,
         help="Legal Representative VAT number.",
+        compute="_compute_representative_vat",
+        store=True,
+        readonly=False,
     )
     year = fields.Integer(
         default=_default_year,
@@ -312,6 +315,11 @@ class L10nEsAeatReport(models.AbstractModel):
                     report.date_end = fields.Date.to_date(
                         f"{report.year}-{month}-{monthrange(report.year, month)[1]}"
                     )
+
+    @api.depends("company_id")
+    def _compute_representative_vat(self):
+        for report in self:
+            report.representative_vat = report.company_id.representative_vat
 
     @api.depends("date_start")
     def _compute_export_config_id(self):

--- a/l10n_es_aeat/models/res_company.py
+++ b/l10n_es_aeat/models/res_company.py
@@ -13,6 +13,12 @@ class ResCompany(models.Model):
     _inherit = "res.company"
 
     tax_agency_id = fields.Many2one("aeat.tax.agency", string="Tax Agency")
+    representative_vat = fields.Char(
+        string="L.R. VAT number",
+        size=9,
+        help="Legal Representative VAT number for all the AEAT reports of this "
+        "company.",
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/l10n_es_aeat/tests/test_l10n_es_aeat_report.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_report.py
@@ -5,6 +5,7 @@
 from odoo_test_helper import FakeModelLoader
 
 from odoo import exceptions, fields
+from odoo.tests import Form
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -82,3 +83,8 @@ class TestL10nEsAeatReport(BaseCommon):
                 [("name", "=", "aeat999-sequence"), ("company_id", "=", company.id)]
             )
         )
+
+    def test_default_representative_vat(self):
+        self.env.company.representative_vat = "36477262K"
+        report_form = Form(self.AeatReport)
+        self.assertEqual(report_form.representative_vat, "36477262K")

--- a/l10n_es_aeat/views/res_company_view.xml
+++ b/l10n_es_aeat/views/res_company_view.xml
@@ -12,6 +12,7 @@
                     <group>
                         <group name="aeat_config">
                             <field name="tax_agency_id" />
+                            <field name="representative_vat" />
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
Forward-port adaptado de #3389 / #3994

@Tecnativa 