### PR TITLE
[18.0][FIX] l10n_es_aeat: Consider Northern Ireland as European

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -87,7 +87,7 @@ class ResPartner(models.Model):
             europe = self.env["res.country.group"].search(
                 [("name", "=", "Europe")], limit=1
             )
-        return europe.country_ids.mapped("code")
+        return europe.country_ids.mapped("code") + ["XI"]
 
     @ormcache("self.vat, self.country_id")
     def _parse_aeat_vat_info(self):


### PR DESCRIPTION
Forward-port de #4129

VAT numbers starting with XI, which comes from the EORI number (https://www.gov.uk/eori/eori-northern-ireland), even being from United Kingdom, are still under European intra-community operations, so we have to include this prefix for issuing IDType=2 identifier and accept intra-community VAT.

@Tecnativa TT55678