### PR TITLE
[18.0][FIX] l10n_es_aeat_mod123: Update parent menu

### DIFF
--- a/l10n_es_aeat_mod123/views/mod123_view.xml
+++ b/l10n_es_aeat_mod123/views/mod123_view.xml
@@ -284,7 +284,7 @@
     </record>
     <menuitem
         id="menu_aeat_mod123_report"
-        parent="l10n_es_aeat.menu_root_aeat"
+        parent="l10n_es_aeat.menu_l10n_es_aeat_submenu"
         action="action_l10n_es_aeat_mod123_report"
         sequence="123"
         name="AEAT 123 Model"


### PR DESCRIPTION
Se cambio la estrucutra de menús en https://github.com/OCA/l10n-spain/pull/4225

Actualmente:
![image](https://github.com/user-attachments/assets/b48cc6fa-fb0f-447c-887d-d180fda19968)

@moduon
MT-9957
