### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_oca: No taxable reason for services

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -576,11 +576,12 @@ class SiiMixin(models.AbstractModel):
                     ]["DetalleIVA"]
                     sub.append(self._get_sii_tax_dict(tax_line, tax_lines))
                 if tax in taxes_sfesns:
+                    default_no_taxable_cause = self._get_no_taxable_cause()
                     nsub_dict = service_dict.setdefault(
                         "NoSujeta",
-                        {"ImporteTAIReglasLocalizacion": 0},
+                        {default_no_taxable_cause: 0},
                     )
-                    nsub_dict["ImporteTAIReglasLocalizacion"] += tax_line["base"]
+                    nsub_dict[default_no_taxable_cause] += tax_line["base"]
         # Ajustes finales breakdown
         # - DesgloseFactura y DesgloseTipoOperacion son excluyentes
         # - Ciertos condicionantes obligan DesgloseTipoOperacion


### PR DESCRIPTION
Forward-port of #4252 and #4253

When using the not subjected tax for services, the reason stated in the journal was ignored, always putting "ImporteTAIReglasLocalizacion", on contrary than with goods, so let's call the same method to get the reason:

https://github.com/OCA/l10n-spain/blob/667f01a9d5d045556e91ba433897685d5f9296ef/l10n_es_aeat_sii_oca/models/sii_mixin.py#L613

@Tecnativa 