### PR TITLE
[16.0][IMP] l10n_es_facturae_face: Improve cron. Allow to update a smaller set of records

### DIFF
--- a/l10n_es_facturae_face/models/edi_exchange_record.py
+++ b/l10n_es_facturae_face/models/edi_exchange_record.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+from datetime import timedelta
 
 from zeep import helpers
 
@@ -36,7 +37,7 @@ class EdiExchangeRecord(models.Model):
         readonly=True, string="Facturae Cancellation motive"
     )
 
-    def _cron_face_update_method(self, company_domain=False):
+    def _cron_face_update_method(self, company_domain=False, limit=None, days_limit=0):
         if not company_domain:
             company_domain = []
         face = self.env.ref("l10n_es_facturae_face.face_backend")
@@ -56,7 +57,10 @@ class EdiExchangeRecord(models.Model):
                     "in",
                     ["face-1200", "face-1300", "face-2400"],
                 ),
-            ]
+                ("write_date", "<", fields.Datetime.now() - timedelta(days=days_limit)),
+            ],
+            limit=limit,
+            order="write_date asc",
         )
         if not integrations:
             return
@@ -98,6 +102,9 @@ class EdiExchangeRecord(models.Model):
                     and exchange_record.l10n_es_facturae_cancellation_status
                     == revocation_code
                 ):
+                    # Already processed, but we want to update the write date
+                    # to load the proper ones on the cron
+                    exchange_record.write({})
                     continue
                 update_record = face.create_record(
                     "l10n_es_facturae_face_update",

--- a/l10n_es_facturae_face/tests/test_facturae_face.py
+++ b/l10n_es_facturae_face/tests/test_facturae_face.py
@@ -2,7 +2,10 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import logging
+from datetime import datetime, timedelta
 from unittest import mock
+
+from freezegun import freeze_time
 
 from odoo import exceptions
 from odoo.tests import tagged
@@ -17,6 +20,23 @@ try:
     from zeep import Client
 except (ImportError, IOError) as err:
     _logger.info(err)
+
+
+class DemoService(object):
+    def __init__(self, value):
+        self.value = value
+
+    def enviarFactura(self, *args):
+        return self.value
+
+    def anularFactura(self, *args):
+        return self.value
+
+    def consultarFactura(self, *args):
+        return self.value
+
+    def consultarListadoFacturas(self, *args):
+        return self.value
 
 
 @tagged("post_install", "-at_install")
@@ -312,22 +332,6 @@ class EDIBackendTestCase(
             self.move.edi_create_exchange_record(self.face_update_type.id)
 
     def test_facturae_face(self):
-        class DemoService(object):
-            def __init__(self, value):
-                self.value = value
-
-            def enviarFactura(self, *args):
-                return self.value
-
-            def anularFactura(self, *args):
-                return self.value
-
-            def consultarFactura(self, *args):
-                return self.value
-
-            def consultarListadoFacturas(self, *args):
-                return self.value
-
         self._activate_certificate(self.certificate_password)
         client = Client(
             wsdl=self.env["ir.config_parameter"].sudo().get_param("facturae.face.ws")
@@ -438,3 +442,79 @@ class EDIBackendTestCase(
             exchange_record.l10n_es_facturae_cancellation_status, "face-4200"
         )
         self.assertEqual(self.move.l10n_es_facturae_cancellation_status, "face-4200")
+
+    def test_facturae_face_cron_delayed(self):
+        now = datetime.now()
+        self._activate_certificate(self.certificate_password)
+        client = Client(
+            wsdl=self.env["ir.config_parameter"].sudo().get_param("facturae.face.ws")
+        )
+        integration_code = "1234567890"
+        response_ok = client.get_type("ns0:EnviarFacturaResponse")(
+            client.get_type("ns0:Resultado")(codigo="0", descripcion="OK"),
+            client.get_type("ns0:EnviarFactura")(numeroRegistro=integration_code),
+        )
+        self.assertFalse(self.move.exchange_record_ids)
+        with mock.patch("zeep.client.ServiceProxy") as mock_client:
+            mock_client.return_value = DemoService(response_ok)
+            self.move.with_context(
+                force_edi_send=True, test_queue_job_no_delay=True
+            ).action_post()
+            self.move.name = "2999/99998"
+            mock_client.assert_not_called()
+            exchange_record = self.move.exchange_record_ids.with_context(
+                _edi_send_break_on_error=True
+            )
+            self.assertEqual(exchange_record.edi_exchange_state, "output_pending")
+            exchange_record.backend_id.exchange_send(exchange_record)
+            self.assertEqual(
+                exchange_record.edi_exchange_state, "output_sent_and_processed"
+            )
+            mock_client.assert_called_once()
+        self.move.invalidate_recordset()
+        multi_response = client.get_type("ns0:ConsultarListadoFacturaResponse")(
+            client.get_type("ns0:Resultado")(codigo="0", descripcion="OK"),
+            client.get_type("ns0:ArrayOfConsultarListadoFactura")(
+                [
+                    client.get_type("ns0:ConsultarListadoFactura")(
+                        codigo="0",
+                        descripcion="OK",
+                        factura=client.get_type("ns0:ConsultarFactura")(
+                            "1234567890",
+                            client.get_type("ns0:EstadoFactura")(
+                                "1300", "DESC", "MOTIVO"
+                            ),
+                            client.get_type("ns0:EstadoFactura")(
+                                "4100", "DESC", "MOTIVO"
+                            ),
+                        ),
+                    )
+                ]
+            ),
+        )
+        with mock.patch("zeep.client.ServiceProxy") as mock_client:
+            mock_client.return_value = DemoService(multi_response)
+            self.env["edi.exchange.record"].with_context()._cron_face_update_method(
+                limit=1, days_limit=1
+            )
+            mock_client.assert_not_called()
+            with freeze_time(now + timedelta(days=2)):
+                self.env["edi.exchange.record"].with_context()._cron_face_update_method(
+                    limit=1, days_limit=1
+                )
+            mock_client.assert_called_once()
+        exchange_record.flush_recordset()
+        exchange_record.invalidate_recordset()
+        self.assertEqual(exchange_record.l10n_es_facturae_status, "face-1300")
+
+        self.assertEqual(len(exchange_record.related_exchange_ids), 1)
+        with mock.patch("zeep.client.ServiceProxy") as mock_client:
+            mock_client.return_value = DemoService(multi_response)
+            with freeze_time(now + timedelta(days=4)):
+                self.env["edi.exchange.record"].with_context()._cron_face_update_method(
+                    limit=1, days_limit=1
+                )
+            mock_client.assert_called_once()
+        exchange_record.flush_recordset()
+        exchange_record.invalidate_recordset()
+        self.assertEqual(len(exchange_record.related_exchange_ids), 1)


### PR DESCRIPTION
Esto tiene mucho sentido en empresas grandes que tienen gran cantidad de registros. En ese caso, el cron puede ser demasiado grande, ya que FACe tarda mucho en contestar.