### PR TITLE
[16.0][IMP] l10n_es_mis_report: Usar todas las reservas especiales

### DIFF
--- a/l10n_es_mis_report/data/mis_report_balance_normal.xml
+++ b/l10n_es_mis_report/data/mis_report_balance_normal.xml
@@ -1196,7 +1196,7 @@
         <field name="sequence">830</field>
         <field name="name">es21320</field>
         <field name="description">2. Otras reservas</field>
-        <field name="expression">-bale[113%,1140%,1142%,1143%,1144%,115%,119%]</field>
+        <field name="expression">-bale[113%,114%,115%,119%]</field>
         <field name="auto_expand_accounts">True</field>
         <field
             name="auto_expand_accounts_style_id"


### PR DESCRIPTION
Existen casos en los que es necesario crear cuentas de reserva que no cuadran con las reservas especiales existentes. Por ello, en general se acaban creando cuentas dentro de la 114.

Yo he visto ejemplos como RIC (En canárias), Reserva por capitalización....

@pedrobaeza @HaraldPanten