### PR TITLE
[16.0][FIX] l10n_es_vat_book: avoid KeyError if other_tax_ids not present

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -416,8 +416,9 @@ class L10nEsVatBook(models.Model):
                     tax_group = sp_taxes_dic[tax_line["tax_id"]]["special_tax_group"]
                     line_vals["special_tax_group"] = tax_group
                     tax_line["special_tax_group"] = tax_group
-                    sp_taxes[tuple(tax_line["other_tax_ids"])] = tax_line
-                tax_line.pop("other_tax_ids")
+                    if "other_tax_ids" in tax_line:
+                        sp_taxes[tuple(tax_line["other_tax_ids"])] = tax_line
+                tax_line.pop("other_tax_ids", None)
             # Second loop for putting the values in the other lines
             if sp_taxes:
                 for tax_line in tax_lines.values():


### PR DESCRIPTION
Backport of cb072e3a5d4cb897556eaf3f978566f148893a31