### PR TITLE
[16.0][FIX] l10n_es_vat_prorate: Avoid false prorate lines

### DIFF
--- a/l10n_es_vat_prorate/models/account_move.py
+++ b/l10n_es_vat_prorate/models/account_move.py
@@ -52,6 +52,7 @@ class AccountMoveLine(models.Model):
                         or tax_key.get("account_id") in tax.prorate_account_ids.ids
                     )
                 ):
+                    tax_vals["vat_prorate"] = False  # assure value for regular tax line
                     prec = line.move_id.currency_id.rounding
                     prorate = line.company_id.get_prorate(vat_prorate_date)
                     new_vals = tax_vals.copy()


### PR DESCRIPTION
When you publish a vendor bill with prorate taxes, and then reset it to draft and change amounts, there's a chance that Odoo rewrites the move lines switching the prorated expense and the tax, causing that the new tax line, being the old expense one, have the flag `vat_prorate` set, and thus not being included in AEAT reports.

<img width="629" height="196" alt="image" src="https://github.com/user-attachments/assets/a604a761-f3d9-422f-b9fe-0c7fca08c169" />

As it seems we can't do anything for assuring the same move lines processing order upstream, what we do is to force in all the entries the False value, and then only putting to True when building the VAT prorate expense line.

@Tecnativa TT57089