### PR TITLE
[16.0][IMP] l10n_es_aeat_mod592: Define quoting=QUOTE_NONE to avoid quotation marks in the generated csv file

### DIFF
--- a/l10n_es_aeat_mod592/report/l10n_es_aeat_mod592_csv.py
+++ b/l10n_es_aeat_mod592/report/l10n_es_aeat_mod592_csv.py
@@ -21,7 +21,7 @@ class Mod592CsvManufacturer(models.AbstractModel):
         model = self.env["l10n.es.aeat.mod592.report.line.manufacturer"]
         res["fieldnames"] = model._get_csv_report_header()
         res["delimiter"] = ";"
-        res["quoting"] = csv.QUOTE_ALL
+        res["quoting"] = csv.QUOTE_NONE
         return res
 
 
@@ -41,5 +41,5 @@ class Mod592CsvAcquirer(models.AbstractModel):
         model = self.env["l10n.es.aeat.mod592.report.line.acquirer"]
         res["fieldnames"] = model._get_csv_report_header()
         res["delimiter"] = ";"
-        res["quoting"] = csv.QUOTE_ALL
+        res["quoting"] = csv.QUOTE_NONE
         return res


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/l10n-spain/pull/4163

Define quoting=QUOTE_NONE to avoid quotation marks in the generated csv file.

@Tecnativa TT55894