### PR TITLE
[17.0][IMP+FIX+I18N] l10n_es_vat_prorate: Feedback from v16 backport

### DIFF
--- a/l10n_es_vat_prorate/i18n/ca.po
+++ b/l10n_es_vat_prorate/i18n/ca.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-09-02 11:06+0000\n"
-"Last-Translator: Alberto Martínez <alberto.martinez@sygel.es>\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2025-07-16 18:23+0200\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@tecnativa.com>\n"
 "Language-Team: none\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.6.2\n"
+"X-Generator: Poedit 3.6\n"
 
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_account_tax__prorate_account_ids
@@ -87,10 +88,10 @@ msgstr ""
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_account_tax__company_with_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_res_company__with_vat_prorate
-msgid "If this option is enabled, all invoice lineswith VAT will be prorated"
+msgid "If this option is enabled, all invoice lines with VAT will be prorated"
 msgstr ""
-"Si aquesta opció està activada, es prorratejaran totes les línies de factura "
-"amb IVA"
+"Si aquesta opció està activada, es prorratejaran les línies de factura amb "
+"IVA"
 
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_move_line__vat_prorate
@@ -175,9 +176,13 @@ msgid "VAT prorate must be between 0.01 and 100!"
 msgstr "El prorrateig de l'IVA ha d'estar entre 0,01 i 100!"
 
 #. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.account_move_form_view
+msgid "VAT prorate?"
+msgstr "¿Prorrateig IVA?"
+
+#. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company__vat_prorate_ids
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__vat_prorate
-#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.account_move_form_view
 msgid "Vat Prorate"
 msgstr "Prorrateig de l'IVA"
 
@@ -189,18 +194,10 @@ msgid "With Special Vat Prorate"
 msgstr "Amb prorrateig d'IVA especial"
 
 #. module: l10n_es_vat_prorate
+#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_move_line__with_vat_prorate
+#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_tax__with_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company__with_vat_prorate
 msgid "With VAT Prorate"
-msgstr "Amb prorrateig d'IVA"
-
-#. module: l10n_es_vat_prorate
-#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_tax__with_vat_prorate
-msgid "With Vat Prorate"
-msgstr "Amb prorrateig d'IVA"
-
-#. module: l10n_es_vat_prorate
-#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_move_line__with_vat_prorate
-msgid "With Vat prorate"
 msgstr "Amb prorrateig d'IVA"
 
 #. module: l10n_es_vat_prorate
@@ -216,15 +213,3 @@ msgstr "No podeu tenir un prorrateig especial d'IVA del 100%"
 #, python-format
 msgid "You must complete VAT prorate information"
 msgstr "Heu d'omplir la informació del prorrateig de l'IVA"
-
-#~ msgid "Last Modified on"
-#~ msgstr "Última modificació el"
-
-#~ msgid "Prorate Account Template"
-#~ msgstr "Plantilla del compte prorratejat"
-
-#~ msgid "Template With Vat Prorate"
-#~ msgstr "Plantilla amb prorrateig d'IVA"
-
-#~ msgid "Templates for Taxes"
-#~ msgstr "Plantilles per a impostos"

--- a/l10n_es_vat_prorate/i18n/es.po
+++ b/l10n_es_vat_prorate/i18n/es.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-09-02 11:06+0000\n"
-"Last-Translator: Alberto Martínez <alberto.martinez@sygel.es>\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2025-07-16 18:22+0200\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@tecnativa.com>\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.6.2\n"
+"X-Generator: Poedit 3.6\n"
 
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_account_tax__prorate_account_ids
@@ -87,10 +88,10 @@ msgstr ""
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_account_tax__company_with_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_res_company__with_vat_prorate
-msgid "If this option is enabled, all invoice lineswith VAT will be prorated"
+msgid "If this option is enabled, all invoice lines with VAT will be prorated"
 msgstr ""
-"Si esta opción está establecida, todas las líneas de factura con IVA serán "
-"prorrateadas"
+"Si esta opción está habilitada, las líneas de facturas con IVA se "
+"prorratearán"
 
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_move_line__vat_prorate
@@ -175,9 +176,13 @@ msgid "VAT prorate must be between 0.01 and 100!"
 msgstr "¡La prorrata del IVA debe estar comprendida entre 0,01 y 100!"
 
 #. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.account_move_form_view
+msgid "VAT prorate?"
+msgstr "¿Prorrata IVA?"
+
+#. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company__vat_prorate_ids
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__vat_prorate
-#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.account_move_form_view
 msgid "Vat Prorate"
 msgstr "Prorrata del IVA"
 
@@ -189,18 +194,10 @@ msgid "With Special Vat Prorate"
 msgstr "Con prorrata especial de IVA"
 
 #. module: l10n_es_vat_prorate
+#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_move_line__with_vat_prorate
+#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_tax__with_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company__with_vat_prorate
 msgid "With VAT Prorate"
-msgstr "Con prorrata de IVA"
-
-#. module: l10n_es_vat_prorate
-#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_tax__with_vat_prorate
-msgid "With Vat Prorate"
-msgstr "Con prorrata de IVA"
-
-#. module: l10n_es_vat_prorate
-#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_move_line__with_vat_prorate
-msgid "With Vat prorate"
 msgstr "Con prorrata de IVA"
 
 #. module: l10n_es_vat_prorate
@@ -216,15 +213,3 @@ msgstr "No puede tener una prorrata especial de IVA del 100%"
 #, python-format
 msgid "You must complete VAT prorate information"
 msgstr "Debe cumplimentar la información sobre el prorrateo del IVA"
-
-#~ msgid "Last Modified on"
-#~ msgstr "Última Modificación el"
-
-#~ msgid "Prorate Account Template"
-#~ msgstr "Plantilla de cuenta prorrateada"
-
-#~ msgid "Template With Vat Prorate"
-#~ msgstr "Plantilla con prorrateo del IVA"
-
-#~ msgid "Templates for Taxes"
-#~ msgstr "Plantillas para impuestos"

--- a/l10n_es_vat_prorate/i18n/l10n_es_vat_prorate.pot
+++ b/l10n_es_vat_prorate/i18n/l10n_es_vat_prorate.pot
@@ -80,7 +80,7 @@ msgstr ""
 #. module: l10n_es_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_account_tax__company_with_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_res_company__with_vat_prorate
-msgid "If this option is enabled, all invoice lineswith VAT will be prorated"
+msgid "If this option is enabled, all invoice lines with VAT will be prorated"
 msgstr ""
 
 #. module: l10n_es_vat_prorate
@@ -166,9 +166,13 @@ msgid "VAT prorate must be between 0.01 and 100!"
 msgstr ""
 
 #. module: l10n_es_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.account_move_form_view
+msgid "VAT prorate?"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company__vat_prorate_ids
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company_vat_prorate__vat_prorate
-#: model_terms:ir.ui.view,arch_db:l10n_es_vat_prorate.account_move_form_view
 msgid "Vat Prorate"
 msgstr ""
 
@@ -180,18 +184,10 @@ msgid "With Special Vat Prorate"
 msgstr ""
 
 #. module: l10n_es_vat_prorate
+#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_move_line__with_vat_prorate
+#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_tax__with_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_res_company__with_vat_prorate
 msgid "With VAT Prorate"
-msgstr ""
-
-#. module: l10n_es_vat_prorate
-#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_tax__with_vat_prorate
-msgid "With Vat Prorate"
-msgstr ""
-
-#. module: l10n_es_vat_prorate
-#: model:ir.model.fields,field_description:l10n_es_vat_prorate.field_account_move_line__with_vat_prorate
-msgid "With Vat prorate"
 msgstr ""
 
 #. module: l10n_es_vat_prorate

--- a/l10n_es_vat_prorate/models/account_move.py
+++ b/l10n_es_vat_prorate/models/account_move.py
@@ -18,12 +18,7 @@ class AccountMove(models.Model):
     )
     with_special_vat_prorate = fields.Boolean(compute="_compute_prorate_id", store=True)
 
-    @api.depends(
-        "company_id.vat_prorate_ids",
-        "company_id.with_vat_prorate",
-        "date",
-        "invoice_date",
-    )
+    @api.depends("company_id", "date", "invoice_date")
     def _compute_prorate_id(self):
         for rec in self:
             if rec.company_id.with_vat_prorate:
@@ -42,7 +37,7 @@ class AccountMoveLine(models.Model):
     )
 
     with_vat_prorate = fields.Boolean(
-        string="With Vat prorate",
+        string="With VAT Prorate",
         help="The line will create a vat prorate",
         compute="_compute_with_vat_prorate",
         store=True,
@@ -89,7 +84,6 @@ class AccountMoveLine(models.Model):
                         or tax_key.get("account_id") in tax.prorate_account_ids.ids
                     )
                 ):
-                    tax_vals["vat_prorate"] = False  # assure value for regular tax line
                     prec = line.move_id.currency_id.rounding
                     prorate = line.move_id.prorate_id.vat_prorate
                     new_vals = tax_vals.copy()

--- a/l10n_es_vat_prorate/models/account_tax.py
+++ b/l10n_es_vat_prorate/models/account_tax.py
@@ -13,7 +13,10 @@ class AccountTax(models.Model):
     _inherit = "account.tax"
 
     with_vat_prorate = fields.Boolean(
-        compute="_compute_with_vat_prorate", store=True, readonly=False
+        compute="_compute_with_vat_prorate",
+        store=True,
+        readonly=False,
+        string="With VAT Prorate",
     )
     prorate_account_ids = fields.Many2many(
         "account.account",

--- a/l10n_es_vat_prorate/models/res_company.py
+++ b/l10n_es_vat_prorate/models/res_company.py
@@ -14,7 +14,7 @@ class ResCompany(models.Model):
 
     with_vat_prorate = fields.Boolean(
         string="With VAT Prorate",
-        help="If this option is enabled, all invoice lines" "with VAT will be prorated",
+        help="If this option is enabled, all invoice lines with VAT will be prorated",
     )
     vat_prorate_ids = fields.One2many(
         "res.company.vat.prorate", inverse_name="company_id"

--- a/l10n_es_vat_prorate/views/account_move_views.xml
+++ b/l10n_es_vat_prorate/views/account_move_views.xml
@@ -22,7 +22,7 @@
             >
                 <field
                     name="with_vat_prorate"
-                    string="Vat Prorate"
+                    string="VAT prorate?"
                     column_invisible="not parent.with_special_vat_prorate or parent.move_type not in ['in_invoice', 'in_refund']"
                 />
             </xpath>

--- a/l10n_es_vat_prorate/views/res_company_prorate_views.xml
+++ b/l10n_es_vat_prorate/views/res_company_prorate_views.xml
@@ -26,10 +26,14 @@
         <field name="name">res.company.vat.prorate.tree (in l10n_es_vat_prorate)</field>
         <field name="model">res.company.vat.prorate</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree editable="bottom">
                 <field name="date" />
                 <field name="type" />
                 <field name="vat_prorate" />
+                <field
+                    name="special_vat_prorate_default"
+                    invisible="type == 'general'"
+                />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
- account.move~with_special_vat_prorate can't depend on company prorate modifications, or this will trigger the line check computation, marking/unmarking all the existing invoices.
- Remove double assignation vat_prorate = False.
- Terms homogenized.
- Make prorate tree editable again.
- Better text for invoice line column.
- Translations.

@Tecnativa 