### PR TITLE
[16.0][IMP]l10n_es_pos_sii: Added group to sii_registration_key and sii_registration_key_code to allow the pos users to interact whit the pos orders.

### DIFF
--- a/l10n_es_pos_sii/views/pos_order.xml
+++ b/l10n_es_pos_sii/views/pos_order.xml
@@ -36,11 +36,16 @@
                         <field name="sii_registration_key_domain" invisible="1" />
                         <field
                             name="sii_registration_key"
+                            groups="l10n_es_aeat.group_account_aeat, account.group_account_invoice"
                             domain="[('type', '=', sii_registration_key_domain)]"
                             attrs="{'required': [('sii_enabled', '=', True)]}"
                             widget="selection"
                         />
-                        <field name="sii_registration_key_code" invisible="1" />
+                        <field
+                            name="sii_registration_key_code"
+                            groups="l10n_es_aeat.group_account_aeat,account.group_account_invoice"
+                            invisible="1"
+                        />
                         <field name="sii_enabled" invisible="1" />
                     </group>
                     <group


### PR DESCRIPTION
Solucionado un problema cuando los usuarios con permisos básicos de TPV inetntaban acceder a ver los pos.order, ahora pueden acceder a ver los pedidos.