### PR TITLE
[18.0][FIX] l10n_es_partner: Reduce logger level using local data

### DIFF
--- a/l10n_es_partner/wizard/l10n_es_partner_wizard.py
+++ b/l10n_es_partner/wizard/l10n_es_partner_wizard.py
@@ -47,7 +47,8 @@ class L10nEsPartnerImportWizard(models.TransientModel):
         ):
             # BDE is forbidding on certain conditions to get the file, so we use a
             # local file. Latest update: 2023-10-07
-            _logger.warning("Error while downloading data. Using local file.")
+            log = _logger.warning if tools.config["test_enable"] else _logger.info
+            log("Error while downloading data. Using local file.")
             src_file_name = tools.file_path(
                 "l10n_es_partner/gen_src/REGBANESP_CONESTAB_A.xls",
             )


### PR DESCRIPTION
As the CI fails with warnings, let's put info level if performing tests.

Example: https://github.com/OCA/l10n-spain/actions/runs/16503580398/job/46668363562#step:8:504

@Tecnativa