### PR TITLE
[18.0][FIX] l10n_es_aeat: Restore file name in AEAT export

### DIFF
--- a/l10n_es_aeat/wizard/export_to_boe_wizard.xml
+++ b/l10n_es_aeat/wizard/export_to_boe_wizard.xml
@@ -6,6 +6,7 @@
         <field name="model">l10n.es.aeat.report.export_to_boe</field>
         <field name="arch" type="xml">
             <form string="Export AEAT BOE file">
+                <field name="name" invisible="1" />
                 <div invisible="state != 'open'">
                     <p>Pulse el botón <strong
                     >Exportar</strong> para iniciar el proceso de exportación del archivo BOE de la AEAT.</p>


### PR DESCRIPTION
The invisible field "name" was incorrectly removed from the wizard in the belief that is auto-populated, as it happens with the fields in the visibility condition.

Fixes #4302

@Tecnativa 