### PR TITLE
[16.0] delivery_gls_asm: Update maintainers

### DIFF
--- a/delivery_gls_asm/__manifest__.py
+++ b/delivery_gls_asm/__manifest__.py
@@ -20,5 +20,5 @@
         "views/stock_picking_views.xml",
         "wizard/gls_asm_manifest_wizard_views.xml",
     ],
-    "maintainers": ["chienandalu", "hildickethan-S73"],
+    "maintainers": ["hildickethan"],
 }


### PR DESCRIPTION
Actualizo el usuario de maintainers ya que desde entonces se ha renombrado y no me llegan las notificaciones a este correo

Cherry-pick de https://github.com/OCA/l10n-spain/pull/4313 (dhl no está en esta versión)