### PR TITLE
[18.0][FIX] l10n_es_payment_order_confirming_aef,l10n_es_payment_order_confirming_sabadell

### DIFF
--- a/l10n_es_payment_order_confirming_aef/tests/test_payment_order_confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/tests/test_payment_order_confirming_aef.py
@@ -32,7 +32,7 @@ class TestPaymentOrderOutboundBaseAEF(TestPaymentOrderOutboundBase):
             self.env["account.payment.line.create"]
             .with_context(active_model="account.payment.order", active_id=order.id)
             .create(
-                {"date_type": "move", "move_date": datetime.now() + timedelta(days=1)}
+                {"date_type": "move", "filter_date": datetime.now() + timedelta(days=1)}
             )
         )
         line_create.payment_mode = "any"

--- a/l10n_es_payment_order_confirming_sabadell/tests/test_payment_order_confirming_sabadell.py
+++ b/l10n_es_payment_order_confirming_sabadell/tests/test_payment_order_confirming_sabadell.py
@@ -98,7 +98,7 @@ class TestPaymentOrderConfirmingSabadell(common.TransactionCase):
                 active_model="account.payment.order",
                 active_id=payment_order.id,
             )
-            .create({"date_type": "move", "move_date": fields.Date.today()})
+            .create({"date_type": "move", "filter_date": fields.Date.today()})
         )
         line_create.journal_ids = self.purchase_journal.ids
         line_create.populate()


### PR DESCRIPTION
Adapt tests to changes in `account_payment_order` https://github.com/OCA/bank-payment/pull/1487/