### PR TITLE
[15.0][FIX] l10n_es_aeat_mod349: Don't look for cancelled reports

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -212,6 +212,7 @@ class Mod349(models.Model):
             # Fetch the latest presentation made for this move
             original_details = detail_obj.search(
                 [
+                    ("report_id.state", "!=", "cancelled"),
                     ("move_line_id.move_id", "=", origin_invoice.id),
                     ("partner_record_id.operation_key", "=", op_key),
                     ("id", "not in", visited_details.ids),


### PR DESCRIPTION
Forward-port of #4320 

There can be multiple cancelled reports that shouldn't be taken into account when looking for previous 349 reports.

@Tecnativa 