### PR TITLE
[15.0][FIX] l10n_es_vat_book: Take into account inactive taxes

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -459,7 +459,11 @@ class L10nEsVatBook(models.Model):
                     domain += [
                         ("tax_agency_ids", "in", [False] + rec.tax_agency_ids.ids),
                     ]
-                map_lines = self.env["aeat.vat.book.map.line"].search(domain)
+                map_lines = (
+                    self.env["aeat.vat.book.map.line"]
+                    .with_context(active_test=False)
+                    .search(domain)
+                )
                 taxes = self.env["account.tax"]
                 accounts = {}
                 for map_line in map_lines:

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -32,6 +32,8 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatModBase):
         # Sale invoices
         sale = self._invoice_sale_create("2017-01-13")
         self._invoice_refund(sale, "2017-01-14")
+        # Deactivate a tax template for checking that everything continues working
+        self.env.ref("l10n_es.account_tax_template_p_iva21_sc").active = False
         # Create model
         self.company.vat = "ES12345678Z"
         vat_book = self.env["l10n.es.vat.book"].create(


### PR DESCRIPTION
Backport of #4328 

If calculating VAT books from 2024 with 5% taxes right now, they are not shown, as Odoo deactivated these tax templates after they were obsolete, and the computation doesn't take into account archived records.

The context variable makes that the map lines return all the mapped templates, no matter if they are archived or not.

@Tecnativa TT57462