### PR TITLE
[14.0][FIX] l10n_es_vat_book: Take into account inactive taxes

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -437,8 +437,10 @@ class L10nEsVatBook(models.Model):
             # Searches for all possible usable lines to report
             moves = rec._get_account_move_lines()
             for book_type in ["issued", "received"]:
-                map_lines = self.env["aeat.vat.book.map.line"].search(
-                    [("book_type", "=", book_type)]
+                map_lines = (
+                    self.env["aeat.vat.book.map.line"]
+                    .with_context(active_test=False)
+                    .search([("book_type", "=", book_type)])
                 )
                 taxes = self.env["account.tax"]
                 accounts = {}

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -32,6 +32,8 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatModBase):
         # Sale invoices
         sale = self._invoice_sale_create("2017-01-13")
         self._invoice_refund(sale, "2017-01-14")
+        # Deactivate a tax template for checking that everything continues working
+        self.env.ref("l10n_es.account_tax_template_p_iva21_sc").active = False
         # Create model
         self.company.vat = "ES12345678Z"
         vat_book = self.env["l10n.es.vat.book"].create(


### PR DESCRIPTION
Backport of #4328 and #4329

If calculating VAT books from 2024 with 5% taxes right now, they are not shown, as Odoo deactivated these tax templates after they were obsolete, and the computation doesn't take into account archived records.

The context variable makes that the map lines return all the mapped templates, no matter if they are archived or not.

@Tecnativa TT57462