### PR TITLE
[18.0][IMP] l10n_es_vat_book: Test inactive taxes

### DIFF
--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -32,6 +32,9 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatModBase):
         # Sale invoices
         sale = self._invoice_sale_create("2017-01-13")
         self._invoice_refund(sale, "2017-01-14")
+        # Deactivate a tax for checking that everything continues working
+        tax_id = self.company._get_tax_id_from_xmlid("account_tax_template_p_iva21_sc")
+        self.env["account.tax"].browse(tax_id).active = False
         # Create model
         self.company.vat = "ES12345678Z"
         vat_book = self.env["l10n.es.vat.book"].create(


### PR DESCRIPTION
Forward-port of #4331 

Followup of #4328, for assuring in newer versions that there's no problem with inactive taxes.

@Tecnativa