### PR TITLE
[FIX] [16.0] l10n_es_facturae_face: Display the FACE sending method in children when is opened directly

### DIFF
--- a/l10n_es_facturae_face/readme/CONTRIBUTORS.rst
+++ b/l10n_es_facturae_face/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Enric Tobella <etobella@creublanca.es>
 * Eric Antones <eantones@nuobit.com>
+* Quim Rebull <quim.rebull@coopdevs.org>

--- a/l10n_es_facturae_face/views/res_partner.xml
+++ b/l10n_es_facturae_face/views/res_partner.xml
@@ -22,6 +22,16 @@
                     attrs="{'invisible': [('facturae', '=', False)]}"
                 />
             </xpath>
+            <xpath
+                expr="//group[@name='group_facturae_wo_accounting']/field[@name='facturae_version']"
+                position="before"
+            >
+                <field
+                    name="l10n_es_facturae_sending_code"
+                    attrs="{'invisible': [('facturae', '=', False)]}"
+                />
+            </xpath>
+
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Partners childs facturae_sending_code is visible if we open the view from the parent partner (via child_ids) but not when we open the child partner directly. This PR correct this.

Since https://github.com/OCA/l10n-spain/pull/3372, in views without accounting information, there is a new view group with invoice information.

As far this module depends on l10n_es_facturae, it should inherit this behavior. The only change is to add facturae_sending_code to the same view group "group_facturae_wo_accounting" as the rest of the facturae information.