### PR TITLE
[17.0][FIX] l10n_es_intrastat_report: Define the appropriate fiscal positions with Intrastat

### DIFF
--- a/l10n_es_intrastat_report/hooks.py
+++ b/l10n_es_intrastat_report/hooks.py
@@ -1,4 +1,5 @@
 # Copyright 2020 ACSONE SA/NV
+# Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
@@ -10,9 +11,13 @@ def post_init_hook(env):
         [
             ("model", "=", "account.fiscal.position"),
             ("name", "like", "%_fp_intra%"),
-            ("module", "=", "l10n_es"),
+            ("module", "=", "account"),
         ]
     )
-    env["account.fiscal.position"].browse(items.mapped("res_id")).write(
-        {"intrastat": "b2b", "vat_required": True}
-    )
+    # Avoid modifying fiscal positions created with accounting plans other than l10n_es
+    env["account.fiscal.position"].search(
+        [
+            ("id", "in", items.mapped("res_id")),
+            ("company_id.chart_template", "like", "es_%"),
+        ]
+    ).write({"intrastat": "b2b", "vat_required": True})

--- a/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
+++ b/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
@@ -140,23 +140,51 @@ class TestL10nIntraStatReport(AccountTestInvoicingCommon):
                 cls.invoices[declaration_type][partner.country_id] += 1
 
     def test_post_init_hook(self):
-        fp = self.env["account.fiscal.position"].create(
+        """Simulate intra community fiscal positions and other positions from l10n_es
+        and other fiscal positions created with other chart templates."""
+        fp_es_ok = self.fiscal_position_b2b
+        fp_es_ok.intrastat = False
+        fp_es_ko = self.fiscal_position_b2c
+        fp_es_ko.intrastat = False
+        fp_not_es_ok = (
+            self.env["account.fiscal.position"]
+            .sudo()
+            .create(
+                {
+                    "name": "Test FP",
+                    "company_id": self.env.ref("base.main_company").id,
+                }
+            )
+        )
+        self.env["ir.model.data"].create(
             {
-                "name": "Test FP",
-                "intrastat": False,
+                "name": "es_fp_intra_private",
+                "model": fp_es_ok._name,
+                "module": "account",
+                "res_id": fp_es_ok.id,
             }
         )
-        item = self.env["ir.model.data"].create(
+        self.env["ir.model.data"].create(
             {
-                "name": "l10n_es_intrastat_report_fp_intra_private",
-                "model": "account.fiscal.position",
-                "module": "l10n_es",
-                "res_id": fp.id,
+                "name": "es_fp_custom_private",
+                "model": fp_es_ko._name,
+                "module": "account",
+                "res_id": fp_es_ko.id,
+            }
+        )
+        self.env["ir.model.data"].create(
+            {
+                "name": "not_eses_fp_custom_private",
+                "model": fp_not_es_ok._name,
+                "module": "account",
+                "res_id": fp_not_es_ok.id,
             }
         )
         post_init_hook(self.env)
-        fp = self.env["account.fiscal.position"].browse(item.res_id)
-        self.assertTrue(fp.intrastat)
+        self.assertTrue(fp_es_ok.intrastat)
+        self.assertFalse(fp_es_ko.intrastat)
+        self.assertFalse(fp_not_es_ok.intrastat)
+        self.assertTrue(fp_es_ok.vat_required)
 
     def _check_move_lines_present(self, original, target):
         for move in original:


### PR DESCRIPTION
Define the appropriate fiscal positions with Intrastat

Since v17, `ir.model.data` records (external identifiers) are no longer created with the localization module (`l10n_es`). Account is defined in all of them, so the `post_init_hook()` method must be adjusted so that the appropriate fiscal positions have the appropriate Intrastat data.

Please @pedrobaeza can you review it?

@Tecnativa