### PR TITLE
[16.0][FIX] l10n_es_aeat_mod303: Caso de uso cuando la casilla 87 es igual a 0 en el informe anterior

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -519,7 +519,7 @@ class L10nEsAeatMod303Report(models.Model):
                         - fields.Date.to_date(mod303.date_start)
                     ),
                 )
-                if prev_report.remaining_cuota_compensar > 0:
+                if prev_report.remaining_cuota_compensar >= 0:
                     amount = prev_report.remaining_cuota_compensar
                     if prev_report.result_type == "C":
                         amount -= prev_report.resultado_liquidacion

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -395,7 +395,6 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         model303_2T.button_calculate()
         model303_3T.button_calculate()
         model303_4T.button_calculate()
-        # model303_4T.cuota_compensar = 0
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2018.casilla_85, 0.0, 2)
@@ -406,15 +405,14 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
 
         model303_4T.return_last_period = True
         model303_4T.button_calculate()
-        model303_4T.potential_cuota_compensar = 674.48
-        model303_4T.cuota_compensar = 674.48
+        model303_4T.potential_cuota_compensar = 874.48
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2018.casilla_85, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 200.0, 2)
 
         model303_1T.potential_cuota_compensar = 500.0
         model303_1T.button_calculate()
@@ -424,7 +422,7 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 200.0, 2)
 
         model303_1T.potential_cuota_compensar = 1000.0
         model303_1T.button_calculate()
@@ -434,7 +432,7 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 200.0, 2)
 
     def test_model_390_using_303_03(self):
         # Check use 303 activated, 303 reports exist and last period is to compensate
@@ -447,7 +445,6 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self._invoice_sale_create("2018-01-01")
         self._invoice_sale_create("2018-04-01")
         self._invoice_sale_create("2018-07-01")
-        self._invoice_sale_create("2018-10-01")
         # Reports 303
         model303_1T = self.env["l10n.es.aeat.mod303.report"].create(
             {
@@ -494,33 +491,31 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         model303_1T.button_calculate()
         model303_2T.button_calculate()
         model303_3T.button_calculate()
-        model303_4T.potential_cuota_compensar = 905.25
-        model303_4T.cuota_compensar = 805.25
         model303_4T.button_calculate()
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2018.casilla_85, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 2302.12, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_97, 560.85, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 100.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
 
         model303_1T.potential_cuota_compensar = 2000.0
         model303_1T.button_calculate()
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
-        self.assertAlmostEqual(self.model390_2018.casilla_85, 1610.50, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_85, 805.25, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 1496.87, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_97, 560.85, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 100.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
 
         model303_4T.return_last_period = True
         model303_4T.button_calculate()
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
-        self.assertAlmostEqual(self.model390_2018.casilla_85, 1710.5, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_85, 805.25, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 1496.87, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_98, 100.00, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_98, 560.85, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)


### PR DESCRIPTION
Si en el informe anterior la casilla 87 es igual a 0, el resultado es para compensar y la 71 es negativa, entonces también se debe traer a la 110 del informe actual la cantidad pendiente de compensar.

@ArantxaSudon @rafaelbn por favor revisad.

@moduon MT-10979