### PR TITLE
[17.0][FIX] l10n_es_aeat_mod216: evitar doble migración

### DIFF
--- a/l10n_es_aeat_mod216/migrations/17.0.1.1.0/pre-migrate.py
+++ b/l10n_es_aeat_mod216/migrations/17.0.1.1.0/pre-migrate.py
@@ -46,6 +46,8 @@ _rename_fields = [
 @openupgrade.migrate()
 def migrate(env, version):
     for model, table, oldfield, newfield in _rename_fields:
-        if not openupgrade.column_exists(env.cr, table, oldfield):
+        if not openupgrade.column_exists(
+            env.cr, table, oldfield
+        ) or openupgrade.column_exists(env.cr, table, newfield):
             continue
         openupgrade.rename_fields(env, [(model, table, oldfield, newfield)])


### PR DESCRIPTION
Cuando se viene de una v16 ya migrada, este script falla porque intenta crear
una columna que ya existe.

@moduon MT-10479
