### PR TITLE
[16.0][FIX] l10n_es_intrastat_report: Define the appropriate data in post_init_hook

### DIFF
--- a/l10n_es_intrastat_report/hooks.py
+++ b/l10n_es_intrastat_report/hooks.py
@@ -1,4 +1,5 @@
 # Copyright 2020 ACSONE SA/NV
+# Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import SUPERUSER_ID, api
@@ -9,13 +10,23 @@ def post_init_hook(cr, registry):
     This is necessary for the intrastat report generation
     """
     env = api.Environment(cr, SUPERUSER_ID, {})
-    items = env["ir.model.data"].search(
+    b2b_items = env["ir.model.data"].search(
         [
             ("model", "=", "account.fiscal.position"),
-            ("name", "like", "%_fp_intra%"),
+            ("name", "like", "%_fp_intra"),
             ("module", "=", "l10n_es"),
         ]
     )
-    env["account.fiscal.position"].browse(items.mapped("res_id")).write(
+    b2c_items = env["ir.model.data"].search(
+        [
+            ("model", "=", "account.fiscal.position"),
+            ("name", "like", "%_fp_intra_private"),
+            ("module", "=", "l10n_es"),
+        ]
+    )
+    env["account.fiscal.position"].browse(b2b_items.mapped("res_id")).write(
         {"intrastat": "b2b", "vat_required": True}
+    )
+    env["account.fiscal.position"].browse(b2c_items.mapped("res_id")).write(
+        {"intrastat": "b2c", "vat_required": False}
     )

--- a/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
+++ b/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
@@ -142,23 +142,50 @@ class TestL10nIntraStatReport(AccountTestInvoicingCommon):
                 cls.invoices[declaration_type][partner.country_id] += 1
 
     def test_post_init_hook(self):
-        fp = self.env["account.fiscal.position"].create(
+        """Simulate intra community fiscal positions and other positions from l10n_es
+        and other fiscal positions created with other chart templates."""
+        fp_es_b2b = self.fiscal_position_b2b
+        fp_es_b2b.intrastat = False
+        fp_es_b2c = self.fiscal_position_b2c
+        fp_es_b2c.intrastat = False
+        fp_model = self.env["account.fiscal.position"].sudo()
+        fp_es_ok = fp_model.create(
             {
-                "name": "Test FP",
-                "intrastat": False,
+                "name": "Test FP (es)",
+                "company_id": self.env.company.id,
             }
         )
-        item = self.env["ir.model.data"].create(
+        self.env["ir.model.data"].create(
             {
-                "name": "l10n_es_intrastat_report_fp_intra_private",
-                "model": "account.fiscal.position",
+                "name": f"{self.env.company}_fp_intra_private",
+                "model": fp_es_b2c._name,
                 "module": "l10n_es",
-                "res_id": fp.id,
+                "res_id": fp_es_b2c.id,
+            }
+        )
+        self.env["ir.model.data"].create(
+            {
+                "name": f"{self.env.company}_fp_intra",
+                "model": fp_es_b2b._name,
+                "module": "l10n_es",
+                "res_id": fp_es_b2b.id,
+            }
+        )
+        self.env["ir.model.data"].create(
+            {
+                "name": f"{self.env.company}_fp_custom",
+                "model": fp_es_ok._name,
+                "module": "l10n_es",
+                "res_id": fp_es_ok.id,
             }
         )
         post_init_hook(self.env.cr, None)
-        fp = self.env["account.fiscal.position"].browse(item.res_id)
-        self.assertTrue(fp.intrastat)
+        self.assertEqual(fp_es_b2b.intrastat, "b2b")
+        self.assertTrue(fp_es_b2b.vat_required)
+        self.assertEqual(fp_es_b2c.intrastat, "b2c")
+        self.assertFalse(fp_es_b2c.vat_required)
+        self.assertFalse(fp_es_ok.intrastat)
+        self.assertFalse(fp_es_ok.vat_required)
 
     def _check_move_lines_present(self, original, target):
         for move in original:


### PR DESCRIPTION
Define the appropriate data in `post_init_hook`

Define the appropriate data (`intrastat`+`vat_required`) in the fiscal positions to be consistent with what is indicated in the `_get_fiscal_position()` method of `account.chart.template` https://github.com/OCA/l10n-spain/blob/d0eaf440eabf17245a552cd21483d2d9c0302219/l10n_es_intrastat_report/data/account_fiscal_position_template.xml#L9

Please @pedrobaeza can you review it?

@Tecnativa