### PR TITLE
[18.0][FIX] l10n_es_aeat_mod303 + l10n_es_facturae: Remove missing taxes

### DIFF
--- a/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
+++ b/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
@@ -30,13 +30,12 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
         "S_REQ05": (1700, 8.5),
         "S_REQ014": (1800, 25.2),
         "S_REQ52": (1900, 98.8),
-        "S_IVA0_G_E": (2000, 0),
+        "S_IVA0_G_E": (4600, 0),
         "S_IVA_E": (2100, 0),
         "S_IVA_NS": (2200, 0),
         "S_IVA0_ISP": (2300, 0),
         "S_IVA0_G_I": (2400, 0),
         "S_IVA0_SP_I": (2500, 0),
-        "S_IVA0_E": (2600, 0),
     }
     taxes_purchase = {
         # tax code: (base, tax_amount)
@@ -371,7 +370,7 @@ class TestL10nEsAeatMod303Base(TestL10nEsAeatModBase):
         # Entregas intra. de bienes y servicios - Base ventas
         "59": (2 * 2400) + (2 * 2500),  # S_IVA0_G_I, S_IVA0_SP_I
         # Exportaciones y operaciones asimiladas - Base ventas
-        "60": (2 * 2000) + (2 * 2600),  # S_IVA0_G_E + S_IVA0
+        "60": (2 * 4600),  # S_IVA0_G_E
         # Importes de las entregas de bienes y prestaciones de servicios
         # a las que habiéndoles sido aplicado el régimen especial del
         # criterio de caja hubieran resultado devengadas conforme a la regla

--- a/l10n_es_facturae/data/template/account.tax-es_common.csv
+++ b/l10n_es_facturae/data/template/account.tax-es_common.csv
@@ -52,8 +52,6 @@
 "account_tax_template_s_iva0","01"
 "account_tax_template_s_iva0_art22","01"
 "account_tax_template_s_iva0_art23","01"
-"account_tax_template_s_iva0_e","01"
-"account_tax_template_s_iva0_ic","01"
 "account_tax_template_s_iva0_nsd","01"
 "account_tax_template_p_iva0_bc","01"
 "account_tax_template_s_irpf195a","04"


### PR DESCRIPTION
Forward-port of #4349 

Odoo has removed some taxes in https://github.com/odoo/odoo/commit/d3c7e51e94d98da9086a3817b157c4e125c80790, so although we keep the XML-ID definition in map taxes (for backwards compatibility), tests should be adapted for not using that tax.

For Facturae, the extension should be removed for missing taxes.

@Tecnativa