### PR TITLE
[15.0][FIX] l10n_es_intrastat_report: wrong country code for csv export

### DIFF
--- a/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
+++ b/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
@@ -174,7 +174,7 @@ class L10nEsIntrastatProductDeclaration(models.Model):
             # Código mercancías CN8
             line.hs_code_id.local_code,
             # País origen
-            line.product_origin_country_id.code,
+            line.product_origin_country_code,
             # Régimen estadístico
             False,
             # Masa neta


### PR DESCRIPTION
When export csv file is generated, calculated origin country code for declaration lines is ignored, using default country code instead. This error arises e.g. when a UK product is selected, saving at csv file GB instead of XU. This fixes it.

For later versions of this addon, this is already fixed (during 16.0 migration).

@victoralmau @RabbitJon-S73 podríais revisar? Gracias!