### PR TITLE
[16.0][FIX+IMP]: l10n_es_verifactu_oca: Init time + fine-tuning

### DIFF
--- a/l10n_es_verifactu_oca/__init__.py
+++ b/l10n_es_verifactu_oca/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizards
+from .hooks import pre_init_hook, post_init_hook

--- a/l10n_es_verifactu_oca/__manifest__.py
+++ b/l10n_es_verifactu_oca/__manifest__.py
@@ -40,4 +40,6 @@
         "views/report_invoice.xml",
         "views/verifactu_invoice_entry_response_view.xml",
     ],
+    "pre_init_hook": "pre_init_hook",
+    "post_init_hook": "post_init_hook",
 }

--- a/l10n_es_verifactu_oca/hooks.py
+++ b/l10n_es_verifactu_oca/hooks.py
@@ -1,0 +1,43 @@
+# Copyright 2025 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import SUPERUSER_ID, api, tools
+
+
+def pre_init_hook(cr):
+    """Avoid the heavy compute methods, specially when account.move table is very
+    populated, pre-creating the columns and filling them with sane defaultes. Some of it
+    is done on post-init hook.
+    WARNING: For special cases like IGIC or other, the default value doesn't serve.
+    """
+    column_exists = tools.sql.column_exists
+    create_column = tools.sql.create_column
+    if not column_exists(cr, "account_move", "verifactu_refund_type"):
+        create_column(cr, "account_move", "verifactu_refund_type", "varchar")
+        cr.execute(
+            "UPDATE account_move SET verifactu_refund_type = 'I' "
+            "WHERE move_type = 'out_refund'"
+        )
+    if not column_exists(cr, "account_move", "verifactu_registration_key"):
+        create_column(cr, "account_move", "verifactu_registration_key", "int4")
+        # Initialization done on post-init
+    if not column_exists(cr, "account_move", "verifactu_tax_key"):
+        create_column(cr, "account_move", "verifactu_tax_key", "varchar")
+        cr.execute(
+            "UPDATE account_move SET verifactu_tax_key = '01' "
+            "WHERE move_type IN ('out_invoice', 'out_refund')"
+        )
+
+
+def post_init_hook(cr, registry):
+    """Perform the initialization of this column once the registration keys have been
+    loaded.
+    WARNING: Only 01 case is covered here, so existing export/intra-community/other
+    invoices should be changed later.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    key = env.ref("l10n_es_verifactu_oca.verifactu_registration_keys_01")
+    cr.execute(
+        "UPDATE account_move SET verifactu_registration_key = %s "
+        "WHERE move_type = 'out_refund' AND verifactu_registration_key IS NULL",
+        (key.id,),
+    )

--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -66,8 +66,9 @@ class AccountMove(models.Model):
                 and invoice.invoice_date >= invoice.company_id.verifactu_start_date
             ):
                 invoice.verifactu_enabled = (
-                    invoice.fiscal_position_id
-                    and invoice.fiscal_position_id.aeat_active
+                    invoice.fiscal_position_id.aeat_active
+                    if invoice.fiscal_position_id
+                    else True
                 )
             else:
                 invoice.verifactu_enabled = False

--- a/l10n_es_verifactu_oca/views/account_move_view.xml
+++ b/l10n_es_verifactu_oca/views/account_move_view.xml
@@ -36,12 +36,12 @@
                             <field
                                 name="verifactu_refund_type"
                                 string="Refund type"
-                                attrs="{'required': [('verifactu_enabled', '=', True),('move_type', 'in', ('out_refund','in_refund'))], 'invisible': [('move_type', 'not in', ('out_refund','in_refund'))]}"
+                                attrs="{'required': [('verifactu_enabled', '=', True),('move_type', '=', 'out_refund')], 'invisible': ['|', ('verifactu_enabled', '=', False), ('move_type', '!=', 'out_refund')]}"
                             />
                             <field
                                 name="verifactu_refund_specific_type"
                                 string="Refund specific type"
-                                attrs="{'invisible': [('move_type', '!=', 'out_refund')]}"
+                                attrs="{'invisible': ['|', ('verifactu_enabled', '=', False), ('move_type', '!=', 'out_refund')]}"
                             />
                             <field
                                 name="verifactu_tax_key"


### PR DESCRIPTION
- Use hooks for reducing installation time, pre-creating columns with some sane defaults (but not accurate).
- Mark as enabled when no fiscal position is set, but the rest of condition are OK.
- Don't show VERI*FACTU refund types on vendor bill refunds or if no VERI*FACTU enabled.

@Tecnativa