### PR TITLE
[18.0][FIX] l10n_es_aeat_mod303: Caso de uso cuando la casilla 87 es igual a 0 en el informe anterior

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -495,7 +495,7 @@ class L10nEsAeatMod303Report(models.Model):
                         - fields.Date.to_date(mod303.date_start)
                     ),
                 )
-                if prev_report.remaining_cuota_compensar > 0:
+                if prev_report.remaining_cuota_compensar >= 0:
                     amount = prev_report.remaining_cuota_compensar
                     if prev_report.result_type == "C":
                         amount -= prev_report.resultado_liquidacion

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -401,15 +401,14 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
 
         model303_4T.return_last_period = True
         model303_4T.button_calculate()
-        model303_4T.potential_cuota_compensar = 560.85
-        model303_4T.cuota_compensar = 560.85
+        model303_4T.potential_cuota_compensar = 760.85
         self.model390_2023.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2023.casilla_85, 0.0, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_98, 1121.7, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_662, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_662, 200.0, 2)
 
         model303_1T.potential_cuota_compensar = 500.0
         model303_1T.button_calculate()
@@ -419,7 +418,7 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2023.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_98, 1121.7, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_662, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_662, 200.0, 2)
 
         model303_1T.potential_cuota_compensar = 1000.0
         model303_1T.button_calculate()
@@ -429,7 +428,7 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2023.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_98, 1121.7, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_662, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_662, 200.0, 2)
 
     def test_model_390_using_303_03(self):
         # Check use 303 activated, 303 reports exist and last period is to compensate
@@ -442,7 +441,6 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self._invoice_sale_create("2023-01-01")
         self._invoice_sale_create("2023-04-01")
         self._invoice_sale_create("2023-07-01")
-        self._invoice_sale_create("2023-10-01")
         # Reports 303
         model303_1T = self.env["l10n.es.aeat.mod303.report"].create(
             {
@@ -489,33 +487,31 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         model303_1T.button_calculate()
         model303_2T.button_calculate()
         model303_3T.button_calculate()
-        model303_4T.potential_cuota_compensar = 905.25
-        model303_4T.cuota_compensar = 805.25
         model303_4T.button_calculate()
         self.model390_2023.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2023.casilla_85, 0.0, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_95, 1407.75, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_97, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_97, 560.85, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_98, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_662, 436.0, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_662, 0.0, 2)
 
         model303_1T.potential_cuota_compensar = 2000.0
         model303_1T.button_calculate()
         self.model390_2023.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
-        self.assertAlmostEqual(self.model390_2023.casilla_85, 938.5, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_85, 469.25, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_95, 938.5, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_97, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_97, 560.85, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_98, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_662, 436.0, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_662, 0.0, 2)
 
         model303_4T.return_last_period = True
         model303_4T.button_calculate()
         self.model390_2023.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
-        self.assertAlmostEqual(self.model390_2023.casilla_85, 1374.5, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_85, 469.25, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_95, 938.5, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_97, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2023.casilla_98, 436.00, 2)
+        self.assertAlmostEqual(self.model390_2023.casilla_98, 560.85, 2)
         self.assertAlmostEqual(self.model390_2023.casilla_662, 0.0, 2)


### PR DESCRIPTION
Fw-port de https://github.com/OCA/l10n-spain/pull/4337

Si en el informe anterior la casilla 87 es igual a 0, el resultado es para compensar y la 71 es negativa, entonces también se
debe traer a la 110 del informe actual la cantidad pendiente de compensar.

@moduon MT-10979