### PR TITLE
[13.0] [FIX] l10n_es_eaet y l10n_es_aeat_mod303

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_map_tax.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_map_tax.py
@@ -34,10 +34,10 @@ class L10nEsAeatMapTax(models.Model):
     @api.constrains("date_from", "date_to", "model")
     def _unique_date_range(self):
         for map_tax in self:
-            domain = ["&", ("model", "=", map_tax.model), ("id", "!=", map_tax.id)]
-            if self.date_from:
+            domain = [("model", "=", map_tax.model), ("id", "!=", map_tax.id)]
+            if map_tax.date_from:
                 domain.append(("date_to_search", ">=", map_tax.date_from))
-            if self.date_to:
+            if map_tax.date_to:
                 domain.append(("date_from_search", "<=", map_tax.date_to))
             if map_tax.search(domain):
                 raise exceptions.Warning(

--- a/l10n_es_aeat_mod303/data/2023/l10n.es.aeat.map.tax.csv
+++ b/l10n_es_aeat_mod303/data/2023/l10n.es.aeat.map.tax.csv
@@ -1,2 +1,2 @@
 id,model,date_from,date_to
-aeat_mod303_2023_map,303,2023-01-01,
+aeat_mod303_2023_map,303,2023-01-01,2024-09-30


### PR DESCRIPTION
Durante la migración de la versión 12.0 a 13.0, se produjo el siguiente error al cargar `l10n_es_aeat_mod303/data/2023/l10n.es.aeat.map.tax.csv`:

```
2025-09-16 03:36:22,644 1 INFO devel odoo.modules.loading: loading l10n_es_aeat_mod303/data/2023/l10n.es.aeat.map.tax.csv
2025-09-16 03:36:23,158 1 ERROR devel odoo.modules.registry: Failed to load registry
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 489, in load_modules
    force, status, report, loaded_modules, update_module, models_to_check, upg_registry)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 368, in load_marked_modules
    upg_registry=upg_registry,
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 248, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package, report=report)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 72, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind, report)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 737, in convert_file
    convert_csv_import(cr, module, pathname, fp.read(), idref, mode, noupdate)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 784, in convert_csv_import
    raise Exception(_('Module loading %s failed: file %s could not be processed:\n %s') % (module, fname, warning_msg))
Exception: Module loading l10n_es_aeat_mod303 failed: file l10n_es_aeat_mod303/data/2023/l10n.es.aeat.map.tax.csv could not be processed:
 Unknown error during import: <class 'odoo.exceptions.UserError'>: ("Error! The dates of the record overlap with an existing record. 14 ['&', ('model', '=', 303), ('id', '!=', 14), ('date_to_search', '>=', datetime.date(2023, 1, 1))] [15]", '')
2025-09-16 03:36:23,165 1 CRITICAL devel odoo.service.server: Failed to initialize database `devel`.
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/service/server.py", line 1194, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 489, in load_modules
    force, status, report, loaded_modules, update_module, models_to_check, upg_registry)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 368, in load_marked_modules
    upg_registry=upg_registry,
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 248, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package, report=report)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 72, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind, report)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 737, in convert_file
    convert_csv_import(cr, module, pathname, fp.read(), idref, mode, noupdate)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 784, in convert_csv_import
    raise Exception(_('Module loading %s failed: file %s could not be processed:\n %s') % (module, fname, warning_msg))
Exception: Module loading l10n_es_aeat_mod303 failed: file l10n_es_aeat_mod303/data/2023/l10n.es.aeat.map.tax.csv could not be processed:
 Unknown error during import: <class 'odoo.exceptions.UserError'>: ("Error! The dates of the record overlap with an existing record.")
```

El conjunto de datos involucrado fue:

id | model | date_from  | date_to   | date_from_search | date_to_search
---|-------|------------|-----------|------------------|----------------
13 | 303   | 2021-07-01 | 2022-12-31 | 2021-07-01       | 2022-12-31
14 | 303   | 2023-01-01 | 2024-09-30 | 2023-01-01       | 2024-09-30
15 | 303   | 2024-10-01 |            | 2024-10-01       | 2999-12-31
16 | 303   |            | 2021-06-30 | 1900-01-01       | 2021-06-30

Como se observa, no hay solapamiento real.

El problema se originó porque en el CSV, el registro `aeat_mod303_2023_map` tenía el campo `date_to` vacío:

https://github.com/OCA/l10n-spain/blob/e9ff894991686e245c7cbc1a99fbdb85284efb53/l10n_es_aeat_mod303/data/2023/l10n.es.aeat.map.tax.csv#L1-L2

Inicialmente pensé que el problema era el '&' innecesario en el domain (poco probable) y la llamada a `self` dentro de un `for` a `self`:

https://github.com/OCA/l10n-spain/blob/e9ff894991686e245c7cbc1a99fbdb85284efb53/l10n_es_aeat/models/l10n_es_aeat_map_tax.py#L34-L48

Debido a que `date_to` estaba en blanco, la segunda condición en `_unique_date_range` se omitió y el dominio solo incluía la comprobación de `date_to_search`. Esto resultó en un falso positivo de solapamiento entre los registros 14 y 15.

La solución aplicada:
- Se aseguró que `date_to` esté correctamente definido en el CSV para `aeat_mod303_2023_map` (consistente con versiones posteriores).
- Se ajustó `_unique_date_range`.

Con esto se resuelve el error de importación.
