### PR TITLE
[16.0][FIX] l10n_es_vat_prorrate: Method `_compute_with_vat_prorate` is not running in some times

### DIFF
--- a/l10n_es_vat_prorate/views/account_move_views.xml
+++ b/l10n_es_vat_prorate/views/account_move_views.xml
@@ -23,7 +23,7 @@
                 <field
                     name="with_vat_prorate"
                     string="VAT prorate?"
-                    attrs="{'column_invisible': ['|', ('parent.with_special_vat_prorate','=', False), ('parent.move_type', 'not in', ['in_invoice', 'in_refund'])]}"
+                    attrs="{'column_invisible': ['|', ('parent.with_special_vat_prorate','=', False), ('parent.move_type', 'not in', ['in_invoice', 'in_refund'])], 'readonly': ['|', ('parent.with_special_vat_prorate','=', False), ('parent.move_type', 'not in', ['in_invoice', 'in_refund'])]}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
In some times the method `_compute_with_vat_prorate` is not running before the account move line is created, so the account move line is not prorated.

With this fix, the field is computed always when it is invisible because it will be readonly

MT-11182 @moduon

@yajo @pedrobaeza @etobella revisad por favor