### PR TITLE
[16.0][FIX] l10n_es_aeat_sii_oca: added missing account taxes in NotIncludedInTotal

### DIFF
--- a/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
@@ -291,6 +291,8 @@
               ref('l10n_es.account_tax_template_s_irpf195a'),
               ref('l10n_es.account_tax_template_p_irpf19'),
               ref('l10n_es.account_tax_template_p_irpf19a'),
+              ref('l10n_es.account_tax_template_p_irpf19ca'),
+              ref('l10n_es.account_tax_template_p_irpf19cs'),
               ref('l10n_es.account_tax_template_p_irpf195a'),
               ref('l10n_es.account_tax_template_s_irpf20'),
               ref('l10n_es.account_tax_template_s_irpf20a'),
@@ -304,11 +306,19 @@
               ref('l10n_es.account_tax_template_p_irpf21td'),
               ref('l10n_es.account_tax_template_p_irpf21te'),
               ref('l10n_es.account_tax_template_s_irpf24'),
+              ref('l10n_es.account_tax_template_s_irpf24_rdc'),
               ref('l10n_es.account_tax_template_p_irpf24'),
+              ref('l10n_es.account_tax_template_p_irpf24_rdc'),
+              ref('l10n_es.account_tax_template_p_irpf35cya'),
+              ref('l10n_es.account_tax_template_s_irpfnrue0'),
+              ref('l10n_es.account_tax_template_s_irpfnrnue0'),
+              ref('l10n_es.account_tax_template_p_irpfnrue0p'),
               ref('l10n_es.account_tax_template_s_irpfnrnue24'),
               ref('l10n_es.account_tax_template_p_irpfnrnue24p'),
               ref('l10n_es.account_tax_template_s_irpfnrue19'),
               ref('l10n_es.account_tax_template_p_irpfnrue19p'),
+              ref('l10n_es.account_tax_template_p_rp19'),
+              ref('l10n_es.account_tax_template_p_rrD19'),
             ])]"
         />
         <field name="sii_map_id" ref="aeat_sii_map" />


### PR DESCRIPTION
Se han agregado todas las retenciones e irpf que se deban excluir del total:

- Retenciones IRPF 19% (Compra consejero de persona física)
- Retenciones IRPF 19% (Compra consejero de sociedad y Resto de rentas)
- Retención 24% (Rendimientos del capital)
- Retenciones IRPF 24% (Rendimientos del capital)
- Retenciones IRPF 35% Consejeros y administradores
- Retenciones a cuenta IRPF No residentes UE exento por convenio
- Retenciones a cuenta IRPF No residentes no-UE exento por convenio
- Retenciones IRPF No residentes UE exento por convenio
- Retenciones 19% (préstamos)
- Retenciones 19% (reparto de dividendos)

MT-11582  @moduon @EmilioPascual @ArantxaSudon @pedrobaeza 

Resuelve issue: [#4390](https://github.com/OCA/l10n-spain/issues/4390)

https://www.loom.com/share/0a535251321f4301a30e8c318704543f?sid=e8bcd055-3d73-467e-a9f0-bb9f3c771ca5