### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_match: Match result view

### DIFF
--- a/l10n_es_aeat_sii_match/views/aeat_sii_match_report.xml
+++ b/l10n_es_aeat_sii_match/views/aeat_sii_match_report.xml
@@ -241,12 +241,8 @@
                         <field name="sii_match_state" />
                         <field name="sii_contrast_state" />
                     </group>
-                    <group
-                        col="1"
-                        colspan="2"
-                        invisible="sii_match_difference_ids == []"
-                    >
-                        <label for="sii_match_difference_ids" colspan="2" />
+                    <group colspan="4" invisible="sii_match_difference_ids == []">
+                        <label for="sii_match_difference_ids" />
                         <field name="sii_match_difference_ids" nolabel="1">
                             <tree>
                                 <field name="sii_field" />
@@ -254,13 +250,10 @@
                                 <field name="sii_sent_field_value" />
                             </tree>
                             <form>
-                                <group col="3">
-                                    <label for="sii_field" />
-                                    <label for="sii_return_field_value" />
-                                    <label for="sii_sent_field_value" />
-                                    <field name="sii_field" nolabel="1" />
-                                    <field name="sii_return_field_value" nolabel="1" />
-                                    <field name="sii_sent_field_value" nolabel="1" />
+                                <group>
+                                    <field name="sii_field" />
+                                    <field name="sii_return_field_value" />
+                                    <field name="sii_sent_field_value" />
                                 </group>
                             </form>
                         </field>


### PR DESCRIPTION
Was not properly formatted, and it can be simplied the col distribution.

Before:

<img width="967" height="504" alt="image" src="https://github.com/user-attachments/assets/e1114fbc-18b6-4ffa-a0a1-0b5e2e3a8c3f" />

After:

<img width="967" height="504" alt="image" src="https://github.com/user-attachments/assets/ccc64862-1e94-479f-941d-d227608df18d" />

@Tecnativa