### PR TITLE
[16.0][FIX] l10n_es_vat_prorate: Fix modulo después de la actualización de la prorrata especial

### DIFF
--- a/l10n_es_vat_prorate/__manifest__.py
+++ b/l10n_es_vat_prorate/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Prorrata de IVA",
     "summary": "Prorrata de IVA para la localización española",
-    "version": "16.0.2.0.0",
+    "version": "16.0.2.0.1",
     "license": "AGPL-3",
     "author": "Creu Blanca, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",

--- a/l10n_es_vat_prorate/migrations/16.0.2.0.1/post-migrate.py
+++ b/l10n_es_vat_prorate/migrations/16.0.2.0.1/post-migrate.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Moduon - Emilio Pascual
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    """Fix account_move without `prorate_id` and account_move_line without computed
+    `with_vat_prorate` after the special prorate update."""
+    # Update prorate_id in account_move
+    cr.execute(
+        """
+        UPDATE account_move am
+        SET prorate_id = (
+            SELECT rcvp.id
+            FROM res_company_vat_prorate rcvp
+            WHERE rcvp.company_id = am.company_id
+            AND rcvp.date <= COALESCE(
+                am.date,
+                am.invoice_date,
+                CURRENT_DATE
+            )
+            ORDER BY rcvp.date DESC
+            LIMIT 1
+        )
+        FROM res_company rc
+        WHERE am.company_id = rc.id
+        AND rc.with_vat_prorate = true
+        AND am.prorate_id IS NULL
+        """
+    )
+    # Update with_vat_prorate in account_move_line
+    cr.execute(
+        """
+        UPDATE account_move_line aml
+        SET with_vat_prorate = rc.with_vat_prorate = true
+                AND (rcvp.type = 'general' OR rcvp.special_vat_prorate_default = true)
+        FROM account_move am
+        INNER JOIN res_company rc ON am.company_id = rc.id
+        LEFT JOIN res_company_vat_prorate rcvp ON am.prorate_id = rcvp.id
+        WHERE aml.move_id = am.id
+        AND aml.with_vat_prorate IS NOT TRUE
+        """
+    )


### PR DESCRIPTION
Después de actualizar el módulo con el prorrateo especial (https://github.com/OCA/l10n-spain/pull/4287), el campo `prorrate_id` no se establece en ninguna de las facturas, ni tampoco se establece el campo `with_vat_prorate` en las líneas de facturas.

Este comportamiento provoca algunos errores, por ejemplo, si se hace una rectificativa de una factura anterior a la actualización, la línea de factura tendrá el campo `with_vat_prorate`  como `false` porque Odoo copia los valores y el campo no se computa.

Con este script de migración, se establecen `prorate_id` y `with_vat_prorate`.

@yajo @pedrobaeza @etobella por favor revisar.

MT-11679 @moduon