### PR TITLE
[13.0][OU-ADD] l10n_es_aeat: We have added a compute field, we should add it in the pre-migration to avoid issues and time

### DIFF
--- a/l10n_es_aeat/migrations/13.0.1.0.0/pre-migration.py
+++ b/l10n_es_aeat/migrations/13.0.1.0.0/pre-migration.py
@@ -1,0 +1,19 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(env.cr, "account_move", "thirdparty_invoice"):
+        openupgrade.add_fields(
+            env,
+            [
+                (
+                    "thirdparty_invoice",
+                    "account.move",
+                    "account_move",
+                    "boolean",
+                    False,
+                    "l10n_es_aeat",
+                ),
+            ],
+        )


### PR DESCRIPTION
Cuando account.move es grande, falla.

La solución es crear el campo en el pre-migration script.

Se añadió aquí el campo (venía de otros módulos)

https://github.com/OCA/l10n-spain/pull/2622