### PR TITLE
[16.0][IMP] l10n_es_aeat_sii_oca: add sii_start_date config option to company

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -796,7 +796,7 @@ class AccountMove(models.Model):
         "move_type",
         "fiscal_position_id",
         "fiscal_position_id.aeat_active",
-        "invoice_date",
+        "date",
     )
     def _compute_sii_enabled(self):
         """Compute if the invoice is enabled for the SII"""
@@ -807,8 +807,8 @@ class AccountMove(models.Model):
                 and invoice.is_invoice()
                 and (
                     not invoice.company_id.sii_start_date
-                    or not invoice.invoice_date
-                    or invoice.invoice_date >= invoice.company_id.sii_start_date
+                    or not invoice.date
+                    or invoice.date >= invoice.company_id.sii_start_date
                 )
             ):
                 invoice.sii_enabled = (

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -790,11 +790,13 @@ class AccountMove(models.Model):
     @api.depends(
         "company_id",
         "company_id.sii_enabled",
+        "company_id.sii_start_date",
         "journal_id",
         "journal_id.sii_enabled",
         "move_type",
         "fiscal_position_id",
         "fiscal_position_id.aeat_active",
+        "invoice_date",
     )
     def _compute_sii_enabled(self):
         """Compute if the invoice is enabled for the SII"""
@@ -803,6 +805,11 @@ class AccountMove(models.Model):
                 invoice.company_id.sii_enabled
                 and invoice.journal_id.sii_enabled
                 and invoice.is_invoice()
+                and (
+                    not invoice.company_id.sii_start_date
+                    or not invoice.invoice_date
+                    or invoice.invoice_date >= invoice.company_id.sii_start_date
+                )
             ):
                 invoice.sii_enabled = (
                     invoice.fiscal_position_id

--- a/l10n_es_aeat_sii_oca/models/res_company.py
+++ b/l10n_es_aeat_sii_oca/models/res_company.py
@@ -59,6 +59,10 @@ class ResCompany(models.Model):
         help="Check it to use connector instead of sending the invoice "
         "directly when it's validated",
     )
+    sii_start_date = fields.Date(
+        help="If this field is set, the sii won't be enabled on invoices with lower "
+        "invoice date. If not set, the sii can be enabled on all invoice dates"
+    )
     send_mode = fields.Selection(
         selection=[
             ("auto", "On validate"),

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -531,3 +531,14 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.assertEqual(reversal.sii_refund_type, "I")
         self.assertTrue(reversal.sii_refund_type_required)
         self.assertFalse(reversal.supplier_invoice_number_refund_required)
+
+    def test_start_date(self):
+        self.company.sii_start_date = "2018-01-01"
+        invoice1 = self._create_invoice_for_sii("out_invoice")
+        invoice1.invoice_date = "2019-01-01"
+        self.assertTrue(invoice1.sii_enabled)
+        invoice2 = self._create_invoice_for_sii("out_invoice")
+        invoice2.invoice_date = "2017-01-01"
+        self.assertFalse(invoice2.sii_enabled)
+        self.company.sii_start_date = False
+        self.assertTrue(invoice2.sii_enabled)

--- a/l10n_es_aeat_sii_oca/views/res_company_view.xml
+++ b/l10n_es_aeat_sii_oca/views/res_company_view.xml
@@ -15,6 +15,7 @@
                     </group>
                     <group attrs="{'invisible': [('sii_enabled', '=', False)]}">
                         <group name="sii_config">
+                            <field name="sii_start_date" />
                             <field name="sii_test" />
                             <field name="sii_method" />
                             <field name="sii_period" />

--- a/l10n_es_pos_sii/models/pos_order.py
+++ b/l10n_es_pos_sii/models/pos_order.py
@@ -39,7 +39,11 @@ class PosOrder(models.Model):
     def _compute_sii_enabled(self):
         """Compute if the order is enabled for the SII"""
         for order in self:
-            if order.company_id.sii_enabled:
+            if order.company_id.sii_enabled and (
+                not order.company_id.sii_start_date
+                or not order.date_order
+                or order.date_order.date() >= order.company_id.sii_start_date
+            ):
                 order.sii_enabled = (
                     order.fiscal_position_id and order.fiscal_position_id.aeat_active
                 ) or not order.fiscal_position_id

--- a/l10n_es_pos_sii/tests/test_l10n_es_pos_sii.py
+++ b/l10n_es_pos_sii/tests/test_l10n_es_pos_sii.py
@@ -366,3 +366,45 @@ class TestSpainPosSii(TestPoSCommon, TestL10nEsAeatSiiBase):
             ),
             "The session is closed",
         )
+
+    def test_start_date(self):
+        session = self.order.session_id
+        default_partner = session.config_id.default_partner_id
+        pos_order_vals = {
+            "company_id": self.order.company_id.id,
+            "session_id": session.id,
+            "date_order": "2019-01-01 12:00:00",
+            "pricelist_id": default_partner.property_product_pricelist.id,
+            "partner_id": default_partner.id,
+            "lines": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "TPV/0001",
+                        "product_id": self.product21.id,
+                        "price_unit": 100,
+                        "discount": 0.0,
+                        "qty": 1.0,
+                        "tax_ids": [(6, 0, self.product21.taxes_id.ids)],
+                        "price_subtotal": 100,
+                        "price_subtotal_incl": 100 + 21,
+                    },
+                )
+            ],
+            "amount_tax": 21,
+            "amount_total": 100 + 21,
+            "amount_paid": 121,
+            "amount_return": 0,
+        }
+        # enabled because company has not sii_start_date
+        pos_order_enabled = self.env["pos.order"].create(pos_order_vals)
+        self.assertTrue(pos_order_enabled.sii_enabled)
+        # enabled because company has a sii_start_date before date_order
+        self.order.company_id.sii_start_date = "2018-01-01"
+        pos_order_enabled2 = self.env["pos.order"].create(pos_order_vals)
+        self.assertTrue(pos_order_enabled2.sii_enabled)
+        # disabled because company has a sii_start_date after date_order
+        self.order.company_id.sii_start_date = "2020-01-01"
+        pos_order_not_enabled = self.env["pos.order"].create(pos_order_vals)
+        self.assertFalse(pos_order_not_enabled.sii_enabled)


### PR DESCRIPTION
Cherry-pick de https://github.com/OCA/l10n-spain/pull/4216 para añadir un campo de fecha de inicio del sii en la compañía, de modo que no se puedan enviar facturas anteriores a esa fecha.
Se incluye también para pos_order.