### PR TITLE
[18.0] [FIX] l10n_es_intrastat_report: Updated template name

### DIFF
--- a/l10n_es_intrastat_report/models/template_es_common.py
+++ b/l10n_es_intrastat_report/models/template_es_common.py
@@ -7,7 +7,7 @@ from odoo.addons.account.models.chart_template import template
 class AccountChartTemplate(models.AbstractModel):
     _inherit = "account.chart.template"
 
-    @template("es_common", model="account.fiscal.position")
+    @template("es_common_mainland", model="account.fiscal.position")
     def _get_fiscal_position(self):
         return {
             "fp_intra_private": {"intrastat": "b2c"},


### PR DESCRIPTION
La plantilla de account.fiscal.position ha sido renombrada a "es_common_mainland" https://github.com/odoo/odoo/commit/7b0d13cd48eae55a89dba9560d5950e8d93c24aa