### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: sii_send_date, sii_needs_cancel no copy

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -96,8 +96,8 @@ class SiiMixin(models.AbstractModel):
         "greater o equal to 100 000 000,00 euros.",
         compute="_compute_macrodata",
     )
-    sii_send_date = fields.Datetime(string="SII Send Date", index=True)
-    sii_needs_cancel = fields.Boolean(readonly=True)
+    sii_send_date = fields.Datetime(string="SII Send Date", index=True, copy=False)
+    sii_needs_cancel = fields.Boolean(readonly=True, copy=False)
 
     def _compute_sii_refund_type(self):
         self.sii_refund_type = False


### PR DESCRIPTION
Make sure the field is not copied when duplicating invoices since it can be problematic in companies with the automatic SII method.