### PR TITLE
[16.0][IMP] l10n_es_verifactu_oca: Add control for ID SIF digits

### DIFF
--- a/l10n_es_verifactu_oca/models/verifactu_chaining.py
+++ b/l10n_es_verifactu_oca/models/verifactu_chaining.py
@@ -18,7 +18,14 @@ class VerifactuChaining(models.Model):
         copy=False,
         readonly=True,
     )
-    sif_id = fields.Char(string="SIF ID", required=True, tracking=True)
+    sif_id = fields.Char(
+        string="SIF ID",
+        required=True,
+        tracking=True,
+        size=2,
+        help="Identifier of the billing software (SIF). "
+        "Must be exactly 2 alphanumeric characters (A,Z, 0,9).",
+    )
     installation_number = fields.Integer(default=1, required=True, tracking=True)
 
     _sql_constraints = [


### PR DESCRIPTION
El campo `sif_id` (IdSistemaInformatico según AEAT) se limita ahora a exactamente 2 caracteres alfanuméricos (A–Z, 0–9). El campo en el protocolo oficial dice:

[ Código de 2 posiciones dado por cada fabricante a su producto SIF, motivo por 
el cual, la unicidad "global" de dicho Id.SIF del producto SIF se consigue considerando también de forma vinculada a él (como si formara parte de él) la identificación de su 
fabricante: NIF o IdOtro de la agrupación/bloque ‘SistemaInformatico’.](https://www.agenciatributaria.es/static_files/AEAT_Desarrolladores/EEDD/IVA/VERI-FACTU/FAQs-Desarrolladores.pdf)

Debemos limitarlo para dar facilidad de configuración y no obtener el fallo:

```
1100 | Valor o tipo incorrecto del campo.: IdSistemaInformatico
``` 

@BinhexTeam