### PR TITLE
[16.0][FIX] l10n_es_atc_mod420: Rectificaciones de compra en la 34 y 35

### DIFF
--- a/l10n_es_atc_mod420/data/tax_code_map_mod420_data.xml
+++ b/l10n_es_atc_mod420/data/tax_code_map_mod420_data.xml
@@ -252,22 +252,13 @@
 		<field name="inverse" eval="True" />
 		<field
             name="tax_ids"
-            eval="[(6, False, [ref('l10n_es_igic.account_tax_template_igic_sop_0'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_3'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_5'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_7'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_9_5'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_15'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_20'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_0_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_3_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_5_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_7_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_9_5_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_15_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_20_inv')])]"
+            eval="[(6, False, [ref('l10n_es_igic.account_tax_template_igic_ISP0'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP3'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP7'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP95'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP15'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP20')])]"
         />
-
 	</record>
 	<record id="atc_mod420_map_line_22_sale" model="l10n.es.aeat.map.tax.line">
 		<field name="map_parent_id" ref="atc_mod420_map" />
@@ -298,27 +289,18 @@
 		<field name="move_type">refund</field>
 		<field name="field_type">amount</field>
 		<field name="sum_type">both</field>
-		<field name="inverse" eval="True" />
-		<field name="account_id" ref="l10n_es_igic.account_common_canary_4727" />
+		<field name="inverse" eval="False" />
+        <field name="account_id" ref="l10n_es_igic.account_common_canary_4777" />
 		<field
             name="tax_ids"
-            eval="[(6, False, [ref('l10n_es_igic.account_tax_template_igic_sop_0'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_3'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_5'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_7'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_9_5'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_15'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_20'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_0_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_3_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_5_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_7_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_9_5_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_15_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_20_inv')])]"
+            eval="[(6, False, [ref('l10n_es_igic.account_tax_template_igic_ISP0'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP3'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP7'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP95'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP15'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP20')])]"
         />
 	</record>
-
 
 	<!-- ============== -->
 	<!-- IGIC SOPORTADO -->
@@ -561,7 +543,13 @@
                                 ref('l10n_es_igic.account_tax_template_igic_sop_7_inv'),
                                 ref('l10n_es_igic.account_tax_template_igic_sop_9_5_inv'),
                                 ref('l10n_es_igic.account_tax_template_igic_sop_15_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_20_inv')])]"
+                                ref('l10n_es_igic.account_tax_template_igic_sop_20_inv'),
+								ref('l10n_es_igic.account_tax_template_igic_ISP0'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP3'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP7'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP95'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP15'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP20')])]"
         />
 	</record>
 	<record id="atc_mod420_map_line_35" model="l10n.es.aeat.map.tax.line">
@@ -589,7 +577,13 @@
                                 ref('l10n_es_igic.account_tax_template_igic_sop_7_inv'),
                                 ref('l10n_es_igic.account_tax_template_igic_sop_9_5_inv'),
                                 ref('l10n_es_igic.account_tax_template_igic_sop_15_inv'),
-                                ref('l10n_es_igic.account_tax_template_igic_sop_20_inv')])]"
+                                ref('l10n_es_igic.account_tax_template_igic_sop_20_inv'),
+								ref('l10n_es_igic.account_tax_template_igic_ISP0'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP3'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP7'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP95'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP15'),
+                                ref('l10n_es_igic.account_tax_template_igic_ISP20')])]"
         />
 	</record>
 

--- a/l10n_es_atc_mod420/tests/test_l10n_es_atc_mod420.py
+++ b/l10n_es_atc_mod420/tests/test_l10n_es_atc_mod420.py
@@ -67,11 +67,11 @@ class TestL10nEsAtcMod420Base(TestL10nEsAeatModBase):
         "l10n_es_igic.account_tax_template_igic_sop_i_15_inv": (320, 48),
         "l10n_es_igic.account_tax_template_igic_sop_i_20_inv": (330, 66),
         "l10n_es_igic.account_tax_template_igic_ISP0": (340, 0),
-        "l10n_es_igic.account_tax_template_igic_ISP3": (350, 0),
-        "l10n_es_igic.account_tax_template_igic_ISP7": (360, 0),
-        "l10n_es_igic.account_tax_template_igic_ISP95": (370, 0),
-        "l10n_es_igic.account_tax_template_igic_ISP15": (380, 0),
-        "l10n_es_igic.account_tax_template_igic_ISP20": (390, 0),
+        "l10n_es_igic.account_tax_template_igic_ISP3": (350, 10.5),
+        "l10n_es_igic.account_tax_template_igic_ISP7": (360, 25.2),
+        "l10n_es_igic.account_tax_template_igic_ISP95": (370, 35.15),
+        "l10n_es_igic.account_tax_template_igic_ISP15": (380, 57),
+        "l10n_es_igic.account_tax_template_igic_ISP20": (390, 78),
         "l10n_es_igic.account_tax_template_igic_p_re0": (410, 0),
         "l10n_es_igic.account_tax_template_igic_p_re03": (420, 1.26),
         "l10n_es_igic.account_tax_template_igic_p_re07": (430, 3.01),
@@ -132,19 +132,13 @@ class TestL10nEsAtcMod420Base(TestL10nEsAeatModBase):
                 + (2400 - 240)  # account_tax_template_igic_r_9_5
                 + (2600 - 260)  # account_tax_template_igic_r_15
                 + (2800 - 280)  # account_tax_template_igic_r_20
-                + (200)  # account_tax_template_igic_sop_0
-                + (300 - 30)  # account_tax_template_igic_sop_3
-                + (400 - 40)  # account_tax_template_igic_sop_7
-                + (500 - 50)  # account_tax_template_igic_sop_9_5
-                + (600 - 60)  # account_tax_template_igic_sop_15
-                + (700 - 70)  # account_tax_template_igic_sop_20
-                + (110)  # account_tax_template_igic_sop_0_inv
-                + (120)  # account_tax_template_igic_sop_3_inv
-                + (130)  # account_tax_template_igic_sop_7_inv
-                + (140)  # account_tax_template_igic_sop_9_5_inv
-                + (150)  # account_tax_template_igic_sop_15_inv
-                + (160)
-            )  # account_tax_template_igic_sop_20_inv
+                + 340  # account_tax_template_igic_ISP0,
+                + 350  # account_tax_template_igic_ISP3,
+                + 360  # account_tax_template_igic_ISP7,
+                + 370  # account_tax_template_igic_ISP95,
+                + 380  # account_tax_template_igic_ISP15,
+                + 390  # account_tax_template_igic_ISP20,
+            )
         ),
         # Modificación bases y cuotas - Cuota (Ventas + Compras)
         "22": (
@@ -156,19 +150,13 @@ class TestL10nEsAtcMod420Base(TestL10nEsAeatModBase):
                 + (228 - 22.8)  # account_tax_template_igic_r_9_5
                 + (390 - 39)  # account_tax_template_igic_r_15
                 + (560 - 56)  # account_tax_template_igic_r_20
-                + (0)  # account_tax_template_igic_sop_0
-                + (9 - 0.9)  # account_tax_template_igic_sop_3
-                + (28 - 2.8)  # account_tax_template_igic_sop_7
-                + (47.5 - 4.75)  # account_tax_template_igic_sop_9_5
-                + (90 - 9)  # account_tax_template_igic_sop_15
-                + (140 - 14)  # account_tax_template_igic_sop_20
-                + (0)  # account_tax_template_igic_sop_0_inv
-                + (3.6)  # account_tax_template_igic_sop_3_inv
-                + (9.1)  # account_tax_template_igic_sop_7_inv
-                + (13.3)  # account_tax_template_igic_sop_9_5_inv
-                + (22.5)  # account_tax_template_igic_sop_15_inv
-                + (32)
-            )  # account_tax_template_igic_sop_20_inv
+                + 0  # account_tax_template_igic_ISP0,
+                + 10.5  # account_tax_template_igic_ISP3,
+                + 25.2  # account_tax_template_igic_ISP7,
+                + 35.15  # account_tax_template_igic_ISP95,
+                + 57  # account_tax_template_igic_ISP15,
+                + 78  # account_tax_template_igic_ISP20,
+            )
         ),
         # IGIC deducible en operaciones interiores bienes y servicios corrientes - Base
         "26": (
@@ -348,6 +336,12 @@ class TestL10nEsAtcMod420Base(TestL10nEsAeatModBase):
                 + (150)
                 # account_tax_template_igic_sop_20_inv
                 + (160)
+                + 340  # account_tax_template_igic_ISP0,
+                + 350  # account_tax_template_igic_ISP3,
+                + 360  # account_tax_template_igic_ISP7,
+                + 370  # account_tax_template_igic_ISP95,
+                + 380  # account_tax_template_igic_ISP15,
+                + 390  # account_tax_template_igic_ISP20,
             )
         ),
         # Rectificación de deducciones - Cuota
@@ -378,6 +372,12 @@ class TestL10nEsAtcMod420Base(TestL10nEsAeatModBase):
                 + (22.5)
                 # account_tax_template_igic_sop_20_inv
                 + (32)
+                + 0  # account_tax_template_igic_ISP0,
+                + 10.5  # account_tax_template_igic_ISP3,
+                + 25.2  # account_tax_template_igic_ISP7,
+                + 35.15  # account_tax_template_igic_ISP95,
+                + 57  # account_tax_template_igic_ISP15,
+                + 78  # account_tax_template_igic_ISP20,
             )
         ),
     }


### PR DESCRIPTION
Como se puede ver en el documento siguiente:

https://www3.gobiernodecanarias.org/tributos/atc/w/modelo-420
https://www3.gobiernodecanarias.org/tributos/atc/documents/65729/201004/Instrucciones_modelo_420.pdf/59fbc2b2-7aff-4a68-95ea-4984da563cfc?t=1742821063325

El IGIC de compra va a las casillas 34 y 35, no a las 21 y 22.

