### PR TITLE
[18.0][FIX] l10n_es_aeat_mod111 & mod216 & mod347 & mod130: Don't use ascii, recover ' ' on bool_no or positive_sign

### DIFF
--- a/l10n_es_aeat_mod111/data/aeat_export_mod111_data.xml
+++ b/l10n_es_aeat_mod111/data/aeat_export_mod111_data.xml
@@ -498,7 +498,7 @@
         <field name="export_type">boolean</field>
         <field name="size">1</field>
         <field name="bool_yes">X</field>
-        <field name="bool_no" />
+        <field name="bool_no" eval="' '" />
         <field name="alignment">left</field>
     </record>
     <record id="aeat_mod111_sub01_export_line_43" model="aeat.model.export.config.line">
@@ -524,7 +524,7 @@
         <field name="export_type">boolean</field>
         <field name="size">1</field>
         <field name="bool_yes">X</field>
-        <field name="bool_no" />
+        <field name="bool_no" eval="' '" />
         <field name="alignment">left</field>
     </record>
     <record id="aeat_mod111_sub01_export_line_45" model="aeat.model.export.config.line">
@@ -723,7 +723,7 @@
         <field
             name="name"
         >Fin de Registro. Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
-        <field name="expression">${"\r\n".encode("ascii")}</field>
+        <field name="expression">${"\r\n"}</field>
         <field name="export_type">string</field>
         <field name="size">2</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod130/data/aeat_export_mod130_data.xml
+++ b/l10n_es_aeat_mod130/data/aeat_export_mod130_data.xml
@@ -380,7 +380,7 @@
         <field name="export_type">boolean</field>
         <field name="size">1</field>
         <field name="bool_yes">X</field>
-        <field name="bool_no" />
+        <field name="bool_no" eval="' '" />
         <field name="alignment">left</field>
     </record>
 

--- a/l10n_es_aeat_mod216/data/2016/aeat_export_mod216_data.xml
+++ b/l10n_es_aeat_mod216/data/2016/aeat_export_mod216_data.xml
@@ -209,7 +209,7 @@
         <field name="export_type">boolean</field>
         <field name="size">1</field>
         <field name="bool_yes">X</field>
-        <field name="bool_no" />
+        <field name="bool_no" eval="' '" />
         <field name="alignment">left</field>
     </record>
     <record id="aeat_mod216_sub01_export_line_21" model="aeat.model.export.config.line">
@@ -375,7 +375,7 @@
         <field
             name="name"
         >Fin de Registro. Constante CRLF (Hexadecimal 0D0A, Decimal 1310)</field>
-        <field name="expression">${"\r\n".encode("ascii")}</field>
+        <field name="expression">${"\r\n"}</field>
         <field name="export_type">string</field>
         <field name="size">2</field>
         <field name="alignment">left</field>

--- a/l10n_es_aeat_mod347/data/aeat_export_mod347_data.xml
+++ b/l10n_es_aeat_mod347/data/aeat_export_mod347_data.xml
@@ -145,7 +145,7 @@
         <field name="expression">${object.total_amount}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -169,7 +169,7 @@
         <field name="expression">${object.total_real_estate_amount}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>

--- a/l10n_es_aeat_mod347/data/aeat_export_mod347_partner_data.xml
+++ b/l10n_es_aeat_mod347/data/aeat_export_mod347_partner_data.xml
@@ -176,7 +176,7 @@
         <field name="expression">${object.amount}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -191,7 +191,7 @@
         <field name="export_type">boolean</field>
         <field name="size">1</field>
         <field name="bool_yes">X</field>
-        <field name="bool_no" />
+        <field name="bool_no" eval="' '" />
         <field name="alignment">left</field>
     </record>
     <!--             99          Arrendamiento local negocio -->
@@ -203,7 +203,7 @@
         <field name="export_type">boolean</field>
         <field name="size">1</field>
         <field name="bool_yes">X</field>
-        <field name="bool_no" />
+        <field name="bool_no" eval="' '" />
         <field name="alignment">left</field>
     </record>
     <!--             100-114     Importe percibido en metálico -->
@@ -235,7 +235,7 @@
         <field name="expression">${object.real_estate_transmissions_amount}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -267,7 +267,7 @@
         <field name="expression">${object.first_quarter}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -289,7 +289,7 @@
         >${object.first_quarter_real_estate_transmission}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -306,7 +306,7 @@
         <field name="expression">${object.second_quarter}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -328,7 +328,7 @@
         >${object.second_quarter_real_estate_transmission}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -345,7 +345,7 @@
         <field name="expression">${object.third_quarter}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -367,7 +367,7 @@
         >${object.third_quarter_real_estate_transmission}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -384,7 +384,7 @@
         <field name="expression">${object.fourth_quarter}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -406,7 +406,7 @@
         >${object.fourth_quarter_real_estate_transmission}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>
@@ -434,7 +434,7 @@
         <field name="export_type">boolean</field>
         <field name="size">1</field>
         <field name="bool_yes">X</field>
-        <field name="bool_no" />
+        <field name="bool_no" eval="' '" />
         <field name="alignment">left</field>
     </record>
     <!--             282         'X' si son operaciones con inversión de sujeto pasivo -->
@@ -446,7 +446,7 @@
         <field name="export_type">boolean</field>
         <field name="size">1</field>
         <field name="bool_yes">X</field>
-        <field name="bool_no" />
+        <field name="bool_no" eval="' '" />
         <field name="alignment">left</field>
     </record>
     <!--             283         'X' si son operaciones vinculadas al régimen de -->
@@ -461,7 +461,7 @@
         <field name="export_type">boolean</field>
         <field name="size">1</field>
         <field name="bool_yes">X</field>
-        <field name="bool_no" />
+        <field name="bool_no" eval="' '" />
         <field name="alignment">left</field>
     </record>
     <!--             284-299     Importe de la operaciones anuales de criterio de caja -->
@@ -475,7 +475,7 @@
         <field name="fixed_value">0</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>

--- a/l10n_es_aeat_mod347/data/aeat_export_mod347_real_state_data.xml
+++ b/l10n_es_aeat_mod347/data/aeat_export_mod347_real_state_data.xml
@@ -136,7 +136,7 @@
         <field name="expression">${object.amount}</field>
         <field name="export_type">float</field>
         <field name="apply_sign" eval="True" />
-        <field name="positive_sign" />
+        <field name="positive_sign" eval="' '" />
         <field name="negative_sign">N</field>
         <field name="size">16</field>
         <field name="decimal_size">2</field>


### PR DESCRIPTION
Si dejamos el ascii, en los ficheros nos añade un B' al final que hace que no sea aceptado por la AEAT.
Además, se cargaba espacios en blanco por culpa del pre-commit que se lo comió.

@pedrobaeza 