### PR TITLE
[16.0][FIX] l10n_es_vat_book: Use real invoice date

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -230,14 +230,16 @@ class L10nEsVatBook(models.Model):
         ext_ref = ""
         invoice = move_line.move_id
         partner = move_line.partner_id
+        invoice_date = move_line.date
         if invoice:
             if invoice.is_invoice():
                 partner = invoice.commercial_partner_id
+                invoice_date = invoice.invoice_date
             ref = invoice.name
             ext_ref = invoice.ref
         return {
             "line_type": line_type,
-            "invoice_date": move_line.date,
+            "invoice_date": invoice_date,
             "partner_id": partner.id,
             "vat_number": partner.vat,
             "move_id": invoice.id,


### PR DESCRIPTION
We are using the accounting date for putting the invoice date, which is incorrect, as we should reflect the real invoice date.

Example before the correction:
<img width="1008" height="275" alt="image" src="https://github.com/user-attachments/assets/3b563ac0-e953-439f-8a7a-e01bf4af4fde" />

-----

<img width="1383" height="251" alt="image" src="https://github.com/user-attachments/assets/f9f5cb3f-7f04-46af-9fa2-e6e213a1b77e" />

@Tecnativa TT58027