### PR TITLE
[18.0][FIX] l10n_es_verifactu_oca: Change field name reversal_move_id -> reversal_move_ids

### DIFF
--- a/l10n_es_verifactu_oca/wizards/account_move_reversal.py
+++ b/l10n_es_verifactu_oca/wizards/account_move_reversal.py
@@ -11,6 +11,6 @@ class AccountMoveReversal(models.TransientModel):
     def reverse_moves(self):
         res = super().reverse_moves()
         self.move_ids.filtered(lambda mov: mov.move_type == "out_invoice").mapped(
-            "reversal_move_id"
+            "reversal_move_ids"
         ).write({"verifactu_refund_type": "I"})
         return res


### PR DESCRIPTION
In this commit (https://github.com/odoo/odoo/commit/26d57934f7a656fe5267d7931e0601c43a18d270), the field 'reversal_move_id' in the model 'account.move' was renamed to 'reversal_move_ids'.

@moduon