### PR TITLE
[17.0][FIX] l10n_es_aeat_mod592: No indicar Régimen fiscal en algunos casos

### DIFF
--- a/l10n_es_aeat_mod592/models/mod592_acquirer.py
+++ b/l10n_es_aeat_mod592/models/mod592_acquirer.py
@@ -116,5 +116,7 @@ class L10nEsAeatmod592LineAcquirer(models.Model):
         self.ensure_one()
         data = super()._get_csv_report_info()
         data["product_description"] = ""  # Campo ignorado para adquirientes
-        data["fiscal_acquirer"] = self.fiscal_acquirer
+        data["fiscal_acquirer"] = (
+            self.fiscal_acquirer if self.concept not in ("2", "3") else ""
+        )  # En algunos casos no se debe indicar
         return self._get_csv_report_info_mapped(data)


### PR DESCRIPTION
FWP de 16.0: https://github.com/OCA/l10n-spain/pull/4465

No indicar Régimen fiscal en algunos casos

En algunos casos ((2) Envío fuera del territorio español + 	(3) Inadecuación o destrucción) no se debe indicar el dato de Régimen fiscal

Por favor @pedrobaeza puedes revisarlo?

@Tecnativa TT58497