### PR TITLE
[18.0][FIX]l10n_es_verifactu_oca: Incorrect signature for reverse_moves

### DIFF
--- a/l10n_es_verifactu_oca/wizards/account_move_reversal.py
+++ b/l10n_es_verifactu_oca/wizards/account_move_reversal.py
@@ -8,8 +8,8 @@ from odoo import models
 class AccountMoveReversal(models.TransientModel):
     _inherit = "account.move.reversal"
 
-    def reverse_moves(self):
-        res = super().reverse_moves()
+    def reverse_moves(self, is_modify=False):
+        res = super().reverse_moves(is_modify=is_modify)
         self.move_ids.filtered(lambda mov: mov.move_type == "out_invoice").mapped(
             "reversal_move_ids"
         ).write({"verifactu_refund_type": "I"})


### PR DESCRIPTION
Forward-port of #4470 

It has changed in this version.

Closes #4463

@Tecnativa 