### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_oca: Start date against accounting date

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -806,7 +806,7 @@ class AccountMove(models.Model):
         "move_type",
         "fiscal_position_id",
         "fiscal_position_id.aeat_active",
-        "invoice_date",
+        "date",
         "invoice_line_ids",
     )
     def _compute_sii_enabled(self):
@@ -836,8 +836,8 @@ class AccountMove(models.Model):
                     )
                     and (
                         not invoice.company_id.sii_start_date
-                        or not invoice.invoice_date
-                        or invoice.invoice_date >= invoice.company_id.sii_start_date
+                        or not invoice.date
+                        or invoice.date >= invoice.company_id.sii_start_date
                     )
                 )
             else:


### PR DESCRIPTION
Partial forward-port of #4436 

The correct field to check if sii is enabled on invoices is "date" not "invoice_date".

@Tecnativa