### PR TITLE
[18.0][IMP] l10n_es_aeat_sii_oca: Send now option

### DIFF
--- a/l10n_es_aeat_sii_oca/i18n/es.po
+++ b/l10n_es_aeat_sii_oca/i18n/es.po
@@ -844,6 +844,11 @@ msgstr "Enviar ahora"
 
 #. module: l10n_es_aeat_sii_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii_oca.invoice_sii_form
+msgid "Send now to SII"
+msgstr "Enviar ahora al SII"
+
+#. module: l10n_es_aeat_sii_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii_oca.invoice_sii_form
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii_oca.view_wizard_send_sii
 msgid "Send to SII"
 msgstr "Enviar al SII"

--- a/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
+++ b/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
@@ -755,6 +755,11 @@ msgstr ""
 
 #. module: l10n_es_aeat_sii_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii_oca.invoice_sii_form
+msgid "Send now to SII"
+msgstr ""
+
+#. module: l10n_es_aeat_sii_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii_oca.invoice_sii_form
 #: model_terms:ir.ui.view,arch_db:l10n_es_aeat_sii_oca.view_wizard_send_sii
 msgid "Send to SII"
 msgstr ""

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -258,14 +258,23 @@ class SiiMixin(models.AbstractModel):
             return False
         return True
 
-    def send_sii(self):
-        documents = self.filtered(
+    def _sii_filter_to_send(self):
+        """Helper method to filter documents to send to SII."""
+        return self.filtered(
             lambda document: (
                 document.sii_enabled
                 and document.state in self._get_valid_document_states()
                 and document.aeat_state not in ["sent", "cancelled"]
             )
         )
+
+    def send_sii_now(self):
+        documents = self._sii_filter_to_send()
+        if documents:
+            documents._process_sii_send(send_date=fields.Datetime.now())
+
+    def send_sii(self):
+        documents = self._sii_filter_to_send()
         if not documents._cancel_send_to_sii():
             raise UserError(
                 self.env._(
@@ -274,25 +283,25 @@ class SiiMixin(models.AbstractModel):
                 )
             )
         if documents:
-            documents.with_context(bypass_sii_send=True)._process_sii_send()
-            sii_send_cron = self.env.ref("l10n_es_aeat_sii_oca.invoice_send_to_sii")
-            self.env["ir.cron.trigger"].sudo().create(
-                {"cron_id": sii_send_cron.id, "call_at": fields.Datetime.now()}
-            )
+            documents._process_sii_send()
 
-    def _process_sii_send(self):
+    def _process_sii_send(self, send_date=None):
         """Process document sending to the SII. Adds general checks from
         configuration parameters and document availability for SII."""
-        for record in self:
-            company = record.company_id
-            sii_sending_time = company._get_sii_sending_time()
-            record.sii_send_date = sii_sending_time
+        if send_date:
+            self.sii_send_date = send_date
+        else:
+            for record in self:
+                record.sii_send_date = record.company_id._get_sii_sending_time()
         # Create trigger if any company needs to send doc to SII now
         # so the sending to SII cron is executed as soon as possible
-        if self.company_id.filtered(
-            lambda company: company.send_mode == "auto"
-            or (company.send_mode == "delayed" and company.delay_time == 0.0)
-        ) and not self.env.context.get("bypass_sii_send", False):
+        if (
+            self.company_id.filtered(
+                lambda company: company.send_mode == "auto"
+                or (company.send_mode == "delayed" and company.delay_time == 0.0)
+            )
+            or send_date
+        ):
             sii_send_cron = self.env.ref("l10n_es_aeat_sii_oca.invoice_send_to_sii")
             self.env["ir.cron.trigger"].sudo().create(
                 {"cron_id": sii_send_cron.id, "call_at": fields.Datetime.now()}

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -83,8 +83,8 @@
                             <button
                                 type="object"
                                 class="oi oi-arrow-right oe_link"
-                                name="send_sii"
-                                string="Send to SII"
+                                name="send_sii_now"
+                                string="Send now to SII"
                             />
                         </div>
                         <field


### PR DESCRIPTION
Forward-port of #4408 

If the sending to SII is delayed, there's no mechanism right now to make the sending immediate, which was the original intention of the inline button next to the sending date.

Now the button has been explicitly labelled, and the code adapted for being able to do this immediate sending.

@Tecnativa 