### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: send to sii action wizard

### DIFF
--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -552,3 +552,32 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
             }
         )
         self.assertFalse(invoice.sii_enabled)
+
+    def test_send_sii_wizard(self):
+        invoice = self._create_invoice("out_invoice")
+        invoice_sii_failed = self._create_invoice("out_invoice")
+        invoice_sii_modified = self._create_invoice("out_invoice")
+        (invoice + invoice_sii_failed + invoice_sii_modified).action_post()
+        (invoice + invoice_sii_failed + invoice_sii_modified).write(
+            {"sii_send_date": False}
+        )
+        invoice_sii_failed.write({"aeat_send_failed": True})
+        invoice_sii_modified.write({"aeat_state": "sent_modified"})
+        wizard = (
+            self.env["wizard.send.sii"]
+            .with_context(
+                active_model="account.move",
+                active_ids=[invoice_sii_failed.id, invoice_sii_modified.id, invoice.id],
+            )
+            .create({})
+        )
+        self.assertEqual(wizard.not_send_without_errors_number, 1)
+        self.assertEqual(wizard.with_errors_number, 1)
+        self.assertEqual(wizard.modified_number, 1)
+        self.assertFalse(invoice.sii_send_date)
+        self.assertFalse(invoice_sii_failed.sii_send_date)
+        self.assertFalse(invoice_sii_modified.sii_send_date)
+        wizard.action_confirm()
+        self.assertTrue(invoice.sii_send_date)
+        self.assertTrue(invoice_sii_failed.sii_send_date)
+        self.assertTrue(invoice_sii_modified.sii_send_date)

--- a/l10n_es_aeat_sii_oca/wizards/account_move_send_sii.py
+++ b/l10n_es_aeat_sii_oca/wizards/account_move_send_sii.py
@@ -8,7 +8,7 @@ class SendSIIWizard(models.TransientModel):
     _name = "wizard.send.sii"
     _description = "Send SII Wizard"
 
-    sending_number = fields.Integer()
+    moves_to_send = fields.Integer()
     not_send_without_errors_number = fields.Integer()
     with_errors_number = fields.Integer()
     modified_number = fields.Integer()
@@ -26,9 +26,14 @@ class SendSIIWizard(models.TransientModel):
         modified = account_moves.filtered(
             lambda a: a.aeat_state in ["sent_modified", "cancelled_modified"]
         )
+        moves_to_send = account_moves.filtered(
+            lambda a: a.sii_enabled
+            and a.state in a._get_valid_document_states()
+            and a.aeat_state not in ["sent", "cancelled"]
+        )
         res.update(
             {
-                "sending_number": len(account_moves),
+                "moves_to_send": len(moves_to_send),
                 "not_send_without_errors_number": len(not_send_without_errors),
                 "with_errors_number": len(with_errors),
                 "modified_number": len(modified),

--- a/l10n_es_aeat_sii_oca/wizards/account_move_send_sii_views.xml
+++ b/l10n_es_aeat_sii_oca/wizards/account_move_send_sii_views.xml
@@ -21,12 +21,12 @@
                 <p
                     class="alert alert-warning"
                     role="alert"
-                    invisible="sending_number == 0"
+                    invisible="moves_to_send == 0"
                 >
                     <field
-                        name="sending_number"
+                        name="moves_to_send"
                         widget="statinfo"
-                        string="of the selected invoices are being processed to be sent to the SII. If you confirm, they will be resent."
+                        string="of the selected invoices are being processed to be sent to the SII. If you confirm, they will be sent."
                     />
                 </p>
                 <p


### PR DESCRIPTION
Forward-port of #4161 

Before this fix, the sending to SII wizard which opens through the list view selecting several invoices didn't work.

Besides, the value of the field sending_number for indicating the number of invoices to be sent through connector makes no sense now.

@Tecnativa 