### PR TITLE
[15.0][FIX] l10n_es_aeat_mod303: Error generación asiento contable cuando sale a pagar pero se compensa parcialmente con ejercicios anteriores

### DIFF
--- a/l10n_es_aeat_mod303/i18n/es.po
+++ b/l10n_es_aeat_mod303/i18n/es.po
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.6.2\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report__casilla_46
@@ -308,6 +308,13 @@ msgstr "Compañía"
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report__partner_bank_id
 msgid "Company bank account used for the presentation"
 msgstr "Cuenta bancaria de la compañía usada para la presentación"
+
+#. module: l10n_es_aeat_mod303
+#. odoo-python
+#: code:addons/l10n_es_aeat_mod303/models/mod303.py:0
+#, python-format
+msgid "Compensation from previous periods"
+msgstr "Compensación de períodos previos"
 
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report__contact_email

--- a/l10n_es_aeat_mod303/i18n/l10n_es_aeat_mod303.pot
+++ b/l10n_es_aeat_mod303/i18n/l10n_es_aeat_mod303.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-01-02 11:29+0000\n"
+"PO-Revision-Date: 2025-01-02 11:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -292,6 +294,13 @@ msgstr ""
 #. module: l10n_es_aeat_mod303
 #: model:ir.model.fields,help:l10n_es_aeat_mod303.field_l10n_es_aeat_mod303_report__partner_bank_id
 msgid "Company bank account used for the presentation"
+msgstr ""
+
+#. module: l10n_es_aeat_mod303
+#. odoo-python
+#: code:addons/l10n_es_aeat_mod303/models/mod303.py:0
+#, python-format
+msgid "Compensation from previous periods"
 msgstr ""
 
 #. module: l10n_es_aeat_mod303

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -519,7 +519,7 @@ class L10nEsAeatMod303Report(models.Model):
                         - fields.Date.to_date(mod303.date_start)
                     ),
                 )
-                if prev_report.remaining_cuota_compensar > 0:
+                if prev_report.remaining_cuota_compensar >= 0:
                     amount = prev_report.remaining_cuota_compensar
                     if prev_report.result_type == "C":
                         amount -= prev_report.resultado_liquidacion

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -597,6 +597,27 @@ class L10nEsAeatMod303Report(models.Model):
             map_line,
         )
 
+    def _prepare_regularization_extra_move_lines(self):
+        """Include behavior for the regularization of the fees to compensate."""
+        lines = super()._prepare_regularization_extra_move_lines()
+        if not (self.result_type in {"I", "G", "U"} and self.cuota_compensar):
+            return lines
+        code = ("%s%%" % _ACCOUNT_PATTERN_MAP.get("C", "4700"),)
+        compensation_account_id = self.env["account.account"].search(
+            [("code", "=like", code[0]), ("company_id", "=", self.company_id.id)],
+            limit=1,
+        )
+        lines.append(
+            {
+                "name": _("Compensation from previous periods"),
+                "account_id": compensation_account_id.id,
+                "partner_id": self.env.ref("l10n_es_aeat.res_partner_aeat").id,
+                "debit": 0.0,
+                "credit": self.cuota_compensar,
+            }
+        )
+        return lines
+
 
 class L10nEsAeatMod303ReportActivityCode(models.Model):
     _name = "l10n.es.aeat.mod303.report.activity.code"

--- a/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
+++ b/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
@@ -452,6 +452,23 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
         cls._invoice_sale_create("2017-01-12")
         sale = cls._invoice_sale_create("2017-01-13")
         cls._invoice_refund(sale, "2017-01-14")
+        # Invoices for testing partial compensation
+        cls.taxes_sale = {"S_IVA21B": (2000, 420)}
+        cls.taxes_purchase = {"P_IVA21_BC": (500, 105)}
+        cls._invoice_sale_create("2015-01-01")
+        cls._invoice_purchase_create("2015-01-01")
+        cls.taxes_sale = {"S_IVA21B": (100, 21)}
+        cls.taxes_purchase = {"P_IVA21_BC": (4000, 840)}
+        cls._invoice_sale_create("2015-04-01")
+        cls._invoice_purchase_create("2015-04-01")
+        cls.taxes_sale = {"S_IVA21B": (3000, 630)}
+        cls.taxes_purchase = {"P_IVA21_BC": (100, 21)}
+        cls._invoice_sale_create("2015-07-01")
+        cls._invoice_purchase_create("2015-07-01")
+        cls.taxes_sale = {"S_IVA21B": (1350, 283.50)}
+        cls.taxes_purchase = {"P_IVA21_BC": (100, 21)}
+        cls._invoice_sale_create("2015-10-01")
+        cls._invoice_purchase_create("2015-10-01")
 
     def _check_tax_lines(self):
         for field, result in iter(self.taxes_result.items()):
@@ -617,3 +634,140 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
         self.model303.date_end = "2020-03-31"
         self.model303.button_calculate()
         self._check_tax_lines()
+
+    def test_model_303_partial_compensation(self):
+        model303_1T = self.env["l10n.es.aeat.mod303.report"].create(
+            {
+                "name": "3030000020151",
+                "company_id": self.company.id,
+                "company_vat": "1234567890",
+                "contact_name": "Test owner",
+                "statement_type": "N",
+                "support_type": "T",
+                "contact_phone": "911234455",
+                "year": 2015,
+                "period_type": "1T",
+                "date_start": "2015-01-01",
+                "date_end": "2015-03-31",
+                "journal_id": self.journal_misc.id,
+            }
+        )
+        model303_1T.button_calculate()
+        model303_1T.button_confirm()
+        model303_1T.button_post()
+        # Check move lines from 303 1T 2015
+        self.assertRecordValues(
+            model303_1T.move_id.line_ids.sorted("balance"),
+            [
+                {
+                    "account_id": self.accounts["475000"].id,
+                    "debit": 0.0,
+                    "credit": 315.0,
+                },
+                {
+                    "account_id": self.accounts["472000"].id,
+                    "debit": 0.0,
+                    "credit": 105.0,
+                },
+                {
+                    "account_id": self.accounts["477000"].id,
+                    "debit": 420.0,
+                    "credit": 0.0,
+                },
+            ],
+        )
+
+        model303_2T = model303_1T.copy(
+            {
+                "name": "3030000020152",
+                "period_type": "2T",
+                "date_start": "2015-04-01",
+                "date_end": "2015-06-30",
+            }
+        )
+        model303_2T.button_calculate()
+        model303_2T.button_confirm()
+        model303_2T.button_post()
+        account_470 = self.env["account.account"].search(
+            [("company_id", "=", self.company.id), ("code", "=", "470000")]
+        )
+        # Check move lines from 303 2T 2015
+        self.assertRecordValues(
+            model303_2T.move_id.line_ids.sorted("balance"),
+            [
+                {
+                    "account_id": self.accounts["472000"].id,
+                    "debit": 0.0,
+                    "credit": 840.0,
+                },
+                {
+                    "account_id": self.accounts["477000"].id,
+                    "debit": 21.0,
+                    "credit": 0.0,
+                },
+                {"account_id": account_470.id, "debit": 819.0, "credit": 0.0},
+            ],
+        )
+
+        model303_3T = model303_1T.copy(
+            {
+                "name": "3030000020153",
+                "period_type": "3T",
+                "date_start": "2015-07-01",
+                "date_end": "2015-09-30",
+            }
+        )
+        model303_3T.button_calculate()
+        model303_3T.button_confirm()
+        model303_3T.button_post()
+        # Check move lines from 303 3T 2015
+        self.assertRecordValues(
+            model303_3T.move_id.line_ids.sorted("balance"),
+            [
+                {"account_id": account_470.id, "debit": 0.0, "credit": 609.0},
+                {
+                    "account_id": self.accounts["472000"].id,
+                    "debit": 0.0,
+                    "credit": 21.0,
+                },
+                {
+                    "account_id": self.accounts["477000"].id,
+                    "debit": 630.0,
+                    "credit": 0.0,
+                },
+            ],
+        )
+
+        model303_4T = model303_1T.copy(
+            {
+                "name": "3030000020154",
+                "period_type": "4T",
+                "date_start": "2015-10-01",
+                "date_end": "2015-12-31",
+            }
+        )
+        model303_4T.button_calculate()
+        model303_4T.button_confirm()
+        model303_4T.button_post()
+        # Check move lines from 303 4T 2015
+        self.assertRecordValues(
+            model303_4T.move_id.line_ids.sorted("balance"),
+            [
+                {"account_id": account_470.id, "debit": 0.0, "credit": 210.0},
+                {
+                    "account_id": self.accounts["475000"].id,
+                    "debit": 0.0,
+                    "credit": 52.5,
+                },
+                {
+                    "account_id": self.accounts["472000"].id,
+                    "debit": 0.0,
+                    "credit": 21.0,
+                },
+                {
+                    "account_id": self.accounts["477000"].id,
+                    "debit": 283.50,
+                    "credit": 0.0,
+                },
+            ],
+        )

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -396,7 +396,6 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         model303_2T.button_calculate()
         model303_3T.button_calculate()
         model303_4T.button_calculate()
-        # model303_4T.cuota_compensar = 0
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2018.casilla_85, 0.0, 2)
@@ -407,15 +406,14 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
 
         model303_4T.return_last_period = True
         model303_4T.button_calculate()
-        model303_4T.potential_cuota_compensar = 674.48
-        model303_4T.cuota_compensar = 674.48
+        model303_4T.potential_cuota_compensar = 874.48
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2018.casilla_85, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 200.0, 2)
 
         model303_1T.potential_cuota_compensar = 500.0
         model303_1T.button_calculate()
@@ -425,7 +423,7 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 200.0, 2)
 
         model303_1T.potential_cuota_compensar = 1000.0
         model303_1T.button_calculate()
@@ -435,7 +433,7 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 200.0, 2)
 
     def test_model_390_using_303_03(self):
         # Check use 303 activated, 303 reports exist and last period is to compensate
@@ -448,7 +446,6 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self._invoice_sale_create("2018-01-01")
         self._invoice_sale_create("2018-04-01")
         self._invoice_sale_create("2018-07-01")
-        self._invoice_sale_create("2018-10-01")
         # Reports 303
         model303_1T = self.env["l10n.es.aeat.mod303.report"].create(
             {
@@ -495,33 +492,31 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         model303_1T.button_calculate()
         model303_2T.button_calculate()
         model303_3T.button_calculate()
-        model303_4T.potential_cuota_compensar = 905.25
-        model303_4T.cuota_compensar = 805.25
         model303_4T.button_calculate()
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
         self.assertAlmostEqual(self.model390_2018.casilla_85, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 2302.12, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_97, 560.85, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 100.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
 
         model303_1T.potential_cuota_compensar = 2000.0
         model303_1T.button_calculate()
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
-        self.assertAlmostEqual(self.model390_2018.casilla_85, 1610.50, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_85, 805.25, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 1496.87, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_97, 560.85, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 100.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
 
         model303_4T.return_last_period = True
         model303_4T.button_calculate()
         self.model390_2018.button_calculate()
         # Check casilla_85, casilla_95, casilla_97, casilla_98, casilla_662
-        self.assertAlmostEqual(self.model390_2018.casilla_85, 1710.5, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_85, 805.25, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_95, 1496.87, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_98, 100.00, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_98, 560.85, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)


### PR DESCRIPTION
from: https://github.com/OCA/l10n-spain/pull/3874
T-8969