### PR TITLE
[17.0][FIX] l10n_es_atc_mod420: Co-author missing

### DIFF
--- a/l10n_es_atc_mod420/README.rst
+++ b/l10n_es_atc_mod420/README.rst
@@ -141,6 +141,7 @@ Authors
 -------
 
 * Binhex
+* Tecnativa
 
 Contributors
 ------------

--- a/l10n_es_atc_mod420/__manifest__.py
+++ b/l10n_es_atc_mod420/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "ATC Modelo 420",
     "version": "17.0.1.1.0",
-    "author": "Binhex, Odoo Community Association (OCA)",
+    "author": "Binhex, Tecnativa, Odoo Community Association (OCA)",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-spain",
     "license": "AGPL-3",

--- a/l10n_es_atc_mod420/static/description/index.html
+++ b/l10n_es_atc_mod420/static/description/index.html
@@ -490,6 +490,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-7">Authors</a></h3>
 <ul class="simple">
 <li>Binhex</li>
+<li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">


### PR DESCRIPTION
As developers of all the XML export and migration to 17 in #4187, plus the maintenance of subsequent patches, we should be there as co-authors.

@Tecnativa 