### PR TITLE
[16.0][FIX] l10n_es_aeat_mod190: Add non-existent method _compute_representante_legal_vat()

### DIFF
--- a/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
+++ b/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
@@ -503,6 +503,11 @@ class L10nEsAeatMod190ReportLine(models.Model):
             item.partner_vat = item.partner_id._parse_aeat_vat_info()[2]
 
     @api.depends("partner_id")
+    def _compute_representante_legal_vat(self):
+        for item in self.filtered(lambda x: x.partner_id):
+            item.representante_legal_vat = item.partner_id.representante_legal_vat
+
+    @api.depends("partner_id")
     def _compute_codigo_provincia(self):
         for item in self:
             code = SPANISH_STATES.get(item.partner_id.state_id.code)


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/l10n-spain/pull/4485

Añadir método olvidado `_compute_representante_legal_vat()`

Relacionado con https://github.com/OCA/l10n-spain/pull/3559

Por favor @pedrobaeza puedes revisarlo?

@Tecnativa