### PR TITLE
[FIX][17.0] l10n_es_aeat_mod347: Remove old_not_in_mod347 column

### DIFF
--- a/l10n_es_aeat_mod347/migrations/17.0.1.5.0/post-migration.py
+++ b/l10n_es_aeat_mod347/migrations/17.0.1.5.0/post-migration.py
@@ -9,7 +9,10 @@ from odoo import SUPERUSER_ID, api
 def migrate(cr, version):
     if not openupgrade.column_exists(cr, "res_partner", "not_in_mod347"):
         return  # Already migrated in 16
+    if not openupgrade.column_exists(cr, "res_partner", "old_not_in_mod347"):
+        return  # Already migrated in 16
     env = api.Environment(cr, SUPERUSER_ID, {})
     openupgrade.convert_to_company_dependent(
         env, "res.partner", "old_not_in_mod347", "not_in_mod347"
     )
+    openupgrade.drop_columns(cr, [("res_partner", "old_not_in_mod347")])

--- a/l10n_es_aeat_mod347/migrations/17.0.1.5.0/pre-migration.py
+++ b/l10n_es_aeat_mod347/migrations/17.0.1.5.0/pre-migration.py
@@ -7,6 +7,8 @@ from openupgradelib import openupgrade
 def migrate(cr, version):
     if not openupgrade.column_exists(cr, "res_partner", "not_in_mod347"):
         return  # Already migrated in 16
+    if openupgrade.column_exists(cr, "res_partner", "old_not_in_mod347"):
+        return  # Already migrated in 16
     openupgrade.rename_columns(
         cr, {"res_partner": [("not_in_mod347", "old_not_in_mod347")]}
     )


### PR DESCRIPTION
- Comprueba si la columna `old_not_in_mod347` existe antes de renombrarla (porque en el [script de post-migración](https://github.com/OCA/l10n-spain/blob/16.0/l10n_es_aeat_mod347/migrations/16.0.1.11.5/post-migration.py#L11-L13) a 16.0.1.11.5 no se ha borrado)
- Elimina la columna `old_not_in_mod347` una vez que la migración ha terminado.

MT-9962 @moduon @pedrobaeza @EmilioPascual porfa revisad 😄 
