### PR TITLE
[18.0] [FIX] l10n_es_atc_mod420: Restore code of city field

### DIFF
--- a/l10n_es_atc_mod420/models/mod420.py
+++ b/l10n_es_atc_mod420/models/mod420.py
@@ -254,7 +254,7 @@ class L10nEsAtcMod420Report(models.Model):
                     "Please select a different payment type."
                 )
             )
-        if not self.company_id.city_id.zipcode:
+        if not self.company_id.city_id.code:
             messages.append(
                 _(
                     "- Please set the code in the city: %s",

--- a/l10n_es_atc_mod420/reports/mod420_report.xml
+++ b/l10n_es_atc_mod420/reports/mod420_report.xml
@@ -21,7 +21,7 @@
                     t-att-CP="doc.company_id.zip"
                     t-att-SVP="doc.company_id.atc_public_way"
                     t-att-NVP="(doc.company_id.street or '').upper()"
-                    t-att-CMU="doc.company_id.city_id.zipcode"
+                    t-att-CMU="doc.company_id.city_id.code"
                 />
             </IDE>
             <t

--- a/l10n_es_atc_mod420/tests/test_l10n_es_atc_mod420.py
+++ b/l10n_es_atc_mod420/tests/test_l10n_es_atc_mod420.py
@@ -434,7 +434,7 @@ class TestL10nEsAtcMod420Base(TestL10nEsAeatModBase):
         cls.palmas_city = cls.env["res.city"].create(
             {
                 "name": "Las Palmas de Gran Canaria",
-                "zipcode": "35016",
+                "code": "35016",
                 "state_id": cls.env.ref("base.state_es_gc").id,
                 "country_id": cls.env.ref("base.es").id,
             }


### PR DESCRIPTION
Con este cambio restablecemos el uso del campo code de la ciudad para mejorar la funcionalidad como se ha comentado en este PR https://github.com/OCA/l10n-spain/pull/4388#discussion_r2452150551