### PR TITLE
[18.0][FIX] l10n_es_partner: Enable searching by the commercial field in the search view

### DIFF
--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -55,3 +55,14 @@ class ResPartner(models.Model):
         if "comercial" not in self._rec_names_search:
             self._rec_names_search.append("comercial")
         return super().name_search(name=name, args=args, operator=operator, limit=limit)
+
+    @api.model
+    def get_views(self, views, options=None):
+        res = super().get_views(views, options)
+        # Inject the commercial field into the domain when searching by complete_name
+        if "search" in res["views"]:
+            res["views"]["search"]["arch"] = res["views"]["search"]["arch"].replace(
+                "'|', ('complete_name', 'ilike', self)",
+                "'|','|',('complete_name','ilike',self),('comercial','ilike',self)",
+            )
+        return res


### PR DESCRIPTION
The field used in the search view is `complete_name`, but this field cannot be inherited because, in this line of code: https://github.com/odoo/odoo/blob/5238a24752de83ef347755dc6c2d5f9c6f3e6772/odoo/addons/base/models/res_partner.py#L381

Odoo calls the `_get_complete_name` function without context.

When a user searches in the Contacts menu by the commercial name, no results are found. With this commit, we inject an additional domain when a search for `complete_name` is performed, enabling results to be found by the commercial name.
TT58890
@Tecnativa @pedrobaeza @juancarlosonate-tecnativa @mpascuall @david-s73 could you please review this?
