### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: Ensure processed invoices are marked as so

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -918,11 +918,27 @@ class AccountMove(models.Model):
                 ("sii_send_date", "<=", fields.Datetime.now()),
             ]
         )
-        if documents:
-            batch = self._get_sii_batch()
-            documents = all_documents[:batch]
-            remaining_documents = all_documents - documents
-            documents.confirm_one_document()
+        if not documents:
+            return remaining_documents
+        batch = self._get_sii_batch()
+        documents = all_documents[:batch]
+        remaining_documents = all_documents - documents
+        for doc in documents:
+            try:
+                with self.env.cr.savepoint():
+                    doc.confirm_one_document()
+            except Exception as fault:
+                new_cr = Registry(self.env.cr.dbname).cursor()
+                env = api.Environment(new_cr, self.env.uid, self.env.context)
+                doc_vals = {
+                    "aeat_send_failed": True,
+                    "aeat_send_error": repr(fault)[:60],
+                    "sii_send_date": False,
+                }
+                invoice = env["account.move"].browse(doc.id)
+                invoice.write(doc_vals)
+                new_cr.commit()
+                new_cr.close()
         return remaining_documents
 
     @api.model


### PR DESCRIPTION
Cuando desde la vista lista de facturas seleccionas muchas facturas y le das a enviar al SII, si alguna de ellas da un error de Odoo el resto se siguen enviando bien pero no quedan registradas en Odoo. Por tanto no sabemos cuáles se han enviado y cuáles no. Si le damos otra vez puede que AEAT nos devuelva error de factura duplicada.

Pongo el PR en borrador porque quizás la solución es un poco overkill :smile: . Abierto a sugerencias.