### PR TITLE
[14.0][FIX] l10n_es_verifactu_oca: Corrección del valor de document_name al crear el registro verifactu.invoice.entry

### DIFF
--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -303,7 +303,7 @@ class VerifactuMixin(models.AbstractModel):
                     "verifactu_chaining_id": chaining.id,
                     "model": self._name,
                     "document_id": self.id,
-                    "document_name": self.name,
+                    "document_name": self._get_document_serial_number(),
                     "previous_invoice_entry_id": previous_invoice_entry_id,
                     "company_id": self.company_id.id,
                     "document_hash": "",


### PR DESCRIPTION
Si se aplica el verifactu sobre otros modelos en los cuales la numeración enviada a hacienda es distinta a la del campo name las respuestas recibidas no quedarán relacionadas. 