### PR TITLE
[16.0][FIX] l10n_es_intrastat_report: correct country code for Greece

### DIFF
--- a/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
+++ b/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
@@ -224,6 +224,30 @@ class IntrastatProductComputationLine(models.Model):
             res["partner_vat"] = self.partner_vat
         return res
 
+    @api.depends("src_dest_country_id")
+    def _compute_src_dest_country_code(self):
+        res = super()._compute_src_dest_country_code()
+        for record in self.filtered(lambda rec: rec.src_dest_country_id):
+            code = record.src_dest_country_code
+            iso_code = record.partner_id._map_aeat_country_iso_code(
+                record.src_dest_country_id
+            )
+            if iso_code and iso_code != code:
+                record.src_dest_country_code = iso_code
+        return res
+
+    @api.depends("product_origin_country_id")
+    def _compute_product_origin_country_code(self):
+        res = super()._compute_product_origin_country_code()
+        for record in self.filtered(lambda rec: rec.product_origin_country_id):
+            code = record.product_origin_country_code
+            iso_code = record.partner_id._map_aeat_country_iso_code(
+                record.product_origin_country_id
+            )
+            if iso_code and iso_code != code:
+                record.product_origin_country_code = iso_code
+        return res
+
 
 class IntrastatProductDeclarationLine(models.Model):
     _inherit = "intrastat.product.declaration.line"

--- a/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
+++ b/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
@@ -290,3 +290,17 @@ class TestL10nIntraStatReport(AccountTestInvoicingCommon):
             items = line.split(";")
             self.assertTrue(items[0] in ("PT", "FR"))
             self.assertEqual(items[6], self.hs_code.local_code)
+
+    def test_intrastat_greece_declaration(self):
+        """Test that intrastat declaration for Greece works as expected."""
+        partner_greece = self.env["res.partner"].create(
+            {"name": "Test Partner Greece", "country_id": self.env.ref("base.gr").id}
+        )
+        invoice = self._create_invoice_for_intrastat(
+            "out_invoice", partner_greece, self.fiscal_position_b2b
+        )
+        report_dispatches = self._create_declaration("dispatches")
+        report_dispatches.action_gather()
+        computation_lines = report_dispatches.computation_line_ids
+        self.assertIn(invoice.id, computation_lines.mapped("invoice_id").ids)
+        self.assertIn("EL", computation_lines.mapped("src_dest_country_code"))


### PR DESCRIPTION
When a declaration line is computed and the country is Greece, it gets GR country code, but the correct code is EL. 
Call the function https://github.com/OCA/l10n-spain/blob/b1d71ec1b9b8fb0ff84b6c6bef8eec26ed45418d/l10n_es_aeat/models/res_partner.py#L77 to get the iso code