### PR TITLE
[18.0][IMP] l10n_es_facturae: Include registration data

### DIFF
--- a/l10n_es_facturae/models/res_company.py
+++ b/l10n_es_facturae/models/res_company.py
@@ -15,3 +15,10 @@ class ResCompany(models.Model):
         string="Hide Facturae discount",
         help="The unit price will be recalculated applying the discount",
     )
+    facturae_registration_book = fields.Char(size=20)
+    facturae_registration_location = fields.Char(size=20)
+    facturae_registration_sheet = fields.Char(size=20)
+    facturae_registration_folio = fields.Char(size=20)
+    facturae_registration_section = fields.Char(size=20)
+    facturae_registration_volume = fields.Char(size=20)
+    facturae_registration_additional = fields.Char(size=20)

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -123,7 +123,19 @@
         <LegalEntity t-if="buyer_type == 'J'">
             <CorporateName t-length="80" t-out="partner.name" />
             <TradeName t-length="40" t-out="partner.name" />
-            <RegistrationData />
+            <RegistrationData>
+                <Book t-out="company.facturae_registration_book" />
+                <RegisterOfCompaniesLocation
+                    t-out="company.facturae_registration_location"
+                />
+                <Sheet t-out="company.facturae_registration_sheet" />
+                <Folio t-out="company.facturae_registration_folio" />
+                <Section t-out="company.facturae_registration_section" />
+                <Volume t-out="company.facturae_registration_volume" />
+                <AdditionalRegistrationData
+                    t-out="company.facturae_registration_additional"
+                />
+            </RegistrationData>
             <t t-call="l10n_es_facturae.address_contact" />
         </LegalEntity>
         <Individual t-if="buyer_type == 'F'">

--- a/l10n_es_facturae/views/res_company.xml
+++ b/l10n_es_facturae/views/res_company.xml
@@ -16,6 +16,21 @@
                         <field name="facturae_version" />
                         <field name="facturae_hide_discount" />
                     </group>
+                    <group string="Registration data">
+                        <field name="facturae_registration_book" string="Book" />
+                        <field
+                            name="facturae_registration_location"
+                            string="Location"
+                        />
+                        <field name="facturae_registration_sheet" string="Sheet" />
+                        <field name="facturae_registration_folio" string="Folio" />
+                        <field name="facturae_registration_section" string="Section" />
+                        <field name="facturae_registration_volume" string="Volume" />
+                        <field
+                            name="facturae_registration_additional"
+                            string="Additional information"
+                        />
+                    </group>
                 </page>
             </notebook>
         </field>


### PR DESCRIPTION
Forward-port of #4528 and #4529 

More and more, some organizations in FACe are asking for this data for validating the invoices uploaded to it, so let's introduce this information at company level to fill it optionally.

No need to worry about empty elements, as they are auto-cleaned.

@Tecnativa TT58981