### PR TITLE
[18.0][FIX] Fix l10n_es_vat_book: Recálculo sin caché

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -339,7 +339,6 @@ class L10nEsVatBook(models.Model):
             self._account_move_line_domain(taxes=taxes, account=account)
         )
 
-    @ormcache("self.id")
     def get_pos_partner_ids(self):
         return (
             self.env["res.partner"]


### PR DESCRIPTION
Cuándo se calcula el libro de IVA, se marca un partner cómo cliente anónimo y se recalcula, el partner sigue apareciendo con un error.

Esto se debe a la caché, el método get_pos_partner_ids tiene el decorador @ormcache("self.id").

Si lo eliminamos o lo comentamos, lo calcula correctamente.

cc https://github.com/APSL 2518

@miquelalzanillas @lbarry-apsl @BernatObrador @peluko00 @javierobcn @ppyczko please review