### PR TITLE
[16.0] [IMP] l10n_es_ticketbai*: several minor improvements

### DIFF
--- a/l10n_es_ticketbai/i18n/es.po
+++ b/l10n_es_ticketbai/i18n/es.po
@@ -4,18 +4,16 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0+e\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-10 11:59+0000\n"
-"PO-Revision-Date: 2023-09-03 07:57+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
+"POT-Creation-Date: 2025-11-03 21:57+0000\n"
+"PO-Revision-Date: 2025-11-03 21:57+0000\n"
+"Last-Translator: \n"
 "Language-Team: \n"
-"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_l10n_es_aeat_certificate
@@ -36,12 +34,12 @@ msgstr "Revocación de movimiento en cuenta"
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_invoice_refund_origin__account_refund_invoice_id
 msgid "Account Refund Invoice"
-msgstr "Cuenta de reembolso de factura"
+msgstr "Factura rectificativa"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_l10n_es_aeat_certificate__tbai_p12_friendlyname
 msgid "Alias"
-msgstr "Alias"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_refund_key__r4
@@ -56,12 +54,12 @@ msgstr "Art. 80.1, 80.2, 80.6 y errores fundados de derecho"
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_refund_key__r2
 msgid "Art. 80.3"
-msgstr "Art. 80.3"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_refund_key__r3
 msgid "Art. 80.4"
-msgstr "Art. 80.4"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__res_company__tbai_description_method__auto
@@ -76,8 +74,6 @@ msgid ""
 "BOE-A-1992-28740. Ley 37/1992, de 28 de diciembre, del Impuesto sobre el "
 "Valor Añadido. Artículo 80. Modificación de la base imponible."
 msgstr ""
-"BOE-A-1992-28740. Ley 37/1992, de 28 de diciembre, del Impuesto sobre el "
-"Valor Añadido. Artículo 80. Modificación de la base imponible."
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_refund_type__i
@@ -182,7 +178,7 @@ msgstr "Número de serie de dispositivo"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_exemption_key__display_name
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_regime_key__display_name
 msgid "Display Name"
-msgstr "Mostrar nombre"
+msgstr "Nombre mostrado"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_line__tbai_enabled
@@ -195,7 +191,7 @@ msgstr "Habilitar TicketBAI"
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_invoice_refund_origin__expedition_date
 msgid "Expedition Date"
-msgstr "Fecha de la factura"
+msgstr "Fecha expedición"
 
 #. module: l10n_es_ticketbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
@@ -246,7 +242,7 @@ msgstr "Agrupar por"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_exemption_key__id
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_regime_key__id
 msgid "ID"
-msgstr "Identificador"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_invoice__invoice_id
@@ -277,7 +273,7 @@ msgstr "Diario"
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_account_move
 msgid "Journal Entry"
-msgstr "Asiento contable"
+msgstr "Asientos contables"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_account_move_line
@@ -298,7 +294,7 @@ msgstr "Clave/Tipo"
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_exemption_key____last_update
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_vat_regime_key____last_update
 msgid "Last Modified on"
-msgstr "Última modificación el"
+msgstr "Última modificación en"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_fp_tbai_tax__write_uid
@@ -332,9 +328,20 @@ msgstr "Enlace entre la factura del cliente y su sustituta."
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__res_company__tbai_description_method__manual
 msgid "Manual"
-msgstr "Manual"
+msgstr ""
 
 #. module: l10n_es_ticketbai
+#: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
+msgid "Mark as Cancel"
+msgstr "Marcar como Cancelada"
+
+#. module: l10n_es_ticketbai
+#: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
+msgid "Mark as Sent"
+msgstr "Marcar como Enviada"
+
+#. module: l10n_es_ticketbai
+#: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.view_move_form_inherit
 msgid "Messages"
 msgstr "Mensajes"
@@ -343,19 +350,14 @@ msgstr "Mensajes"
 #: model:ir.model.fields,help:l10n_es_ticketbai.field_res_company__tbai_description_method
 msgid ""
 "Method for the TicketBAI invoices description, can be one of these:\n"
-"- Automatic: the description will be the join of the invoice   lines "
-"description\n"
+"- Automatic: the description will be the join of the invoice   lines description\n"
 "- Fixed: the description write on the below field 'TBAI   Description'\n"
-"- Manual (by default): It will be necessary to manually enter   the "
-"description on each invoice"
+"- Manual (by default): It will be necessary to manually enter   the description on each invoice"
 msgstr ""
 "Método para la descripción de facturas TicketBAI, puede ser uno de éstos:\n"
-"- Automático: la descripción será la unión de las descripciones de las "
-"lineas de la factura\n"
-"- Predefinido: la descripción escrita en el campo de abajo 'Descripción "
-"TBAI'\n"
-"- Manual (por defecto): Es necesario insertar la descripción de la factura "
-"manualmente en cada factura"
+"- Automático: la descripción será la unión de las descripciones de las lineas de la factura\n"
+"- Predefinido: la descripción escrita en el campo de abajo 'Descripción TBAI'\n"
+"- Manual (por defecto): Es necesario insertar la descripción de la factura manualmente en cada factura"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_tax_map__name
@@ -444,8 +446,8 @@ msgid ""
 "Refunded Invoice %(name)s Number Prefix %(prefix)s longer than expected. "
 "Should be 20 characters max.!"
 msgstr ""
-"Factura rectificativa %(name)s. Prefijo %(prefix)s más largo de lo esperado. "
-"Debería de contener 20 caracteres como máximo!"
+"Factura rectificativa %(name)s. Prefijo %(prefix)s más largo de lo esperado."
+" Debería de contener 20 caracteres como máximo!"
 
 #. module: l10n_es_ticketbai
 #. odoo-python
@@ -462,6 +464,11 @@ msgstr ""
 #: model:ir.model,name:l10n_es_ticketbai.model_account_resequence_wizard
 msgid "Remake the sequence of Journal Entries."
 msgstr "Haz de nuevo la secuencia de asientos de diario."
+
+#. module: l10n_es_ticketbai
+#: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
+msgid "Response"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_account_bank_statement_line__tbai_response_ids
@@ -482,12 +489,12 @@ msgstr "Enviar facturas a hacienda TicketBAI"
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields.selection,name:l10n_es_ticketbai.selection__account_move__tbai_refund_key__r5
 msgid "Simplified Invoice"
-msgstr "Factura simplificada"
+msgstr "Factura Simplificada"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_info__software
 msgid "Software"
-msgstr "Software"
+msgstr ""
 
 #. module: l10n_es_ticketbai
 #. odoo-python
@@ -536,7 +543,7 @@ msgstr "Impuesto"
 #: model:ir.model.constraint,message:l10n_es_ticketbai.constraint_account_fp_tbai_tax_template_position_tax_uniq
 #, python-format
 msgid "Tax must be unique per fiscal position!"
-msgstr "El impuesto debe ser único por posición fiscal!"
+msgstr "El impuesto debe ser único por posición fiscal."
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,field_description:l10n_es_ticketbai.field_tbai_tax_map__tax_template_ids
@@ -596,11 +603,11 @@ msgstr "Plantilla de posición fiscal"
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,help:l10n_es_ticketbai.field_res_company__tbai_description
 msgid ""
-"The description for invoices. Only used when the field TicketBAI Description "
-"Method is 'Fixed'."
+"The description for invoices. Only used when the field TicketBAI Description"
+" Method is 'Fixed'."
 msgstr ""
-"Descripción de las facturas. Utilizado cuando el campo Método de descripción "
-"TicketBAI es 'Predefinido'."
+"Descripción de las facturas. Utilizado cuando el campo Método de descripción"
+" TicketBAI es 'Predefinido'."
 
 #. module: l10n_es_ticketbai
 #: model:ir.model.fields,help:l10n_es_ticketbai.field_tbai_invoice_refund_origin__number
@@ -618,7 +625,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.view_move_form_inherit
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.view_partner_property_form_inherit
 msgid "TicketBAI"
-msgstr "TicketBAI"
+msgstr "TiquetBAI"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_account_fp_tbai_tax
@@ -719,8 +726,8 @@ msgid ""
 "TicketBAI Invoice %(name)s Error: the Invoice should have one tax line for "
 "Tax %(tax)s"
 msgstr ""
-"TicketBAI factura %(name)s error: la factura debería tener sólo una línea de "
-"impuesto de factura para el impuesto %(tax)s"
+"TicketBAI factura %(name)s error: la factura debería tener sólo una línea de"
+" impuesto de factura para el impuesto %(tax)s"
 
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_tbai_invoice
@@ -868,24 +875,3 @@ msgid ""
 msgstr ""
 "No puedes dejar de enviar facturas de este diario, al menos una factura ya "
 "ha sido enviada."
-
-#~ msgid "Expected string date format: %dd-%mm-%yyyy"
-#~ msgstr "Formato de fecha esperado: %dd-%mm-%yyyy"
-
-#, python-format
-#~ msgid ""
-#~ "Invoice: number %(name)s prefix %(prefix)s invoice_date %(date)s exists. "
-#~ "Create a credit note from this invoice."
-#~ msgstr ""
-#~ "La factura con número %(name)s , prefijo %(prefix)s y fecha %(date)s "
-#~ "existe. Crea una rectificativa partiendo de esa factura."
-
-#, python-format
-#~ msgid "Refunded Invoice %s Expedition Date"
-#~ msgstr "Factura rectificativa %s fecha"
-
-#~ msgid "Invoices"
-#~ msgstr "Facturas"
-
-#~ msgid "Sequence"
-#~ msgstr "Secuencia"

--- a/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
+++ b/l10n_es_ticketbai/i18n/l10n_es_ticketbai.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-03 21:56+0000\n"
+"PO-Revision-Date: 2025-11-03 21:56+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -329,6 +331,17 @@ msgid "Manual"
 msgstr ""
 
 #. module: l10n_es_ticketbai
+#: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
+msgid "Mark as Cancel"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
+msgid "Mark as Sent"
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
 #: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.view_move_form_inherit
 msgid "Messages"
 msgstr ""
@@ -437,6 +450,11 @@ msgstr ""
 #. module: l10n_es_ticketbai
 #: model:ir.model,name:l10n_es_ticketbai.model_account_resequence_wizard
 msgid "Remake the sequence of Journal Entries."
+msgstr ""
+
+#. module: l10n_es_ticketbai
+#: model_terms:ir.ui.view,arch_db:l10n_es_ticketbai.tbai_invoice_form
+msgid "Response"
 msgstr ""
 
 #. module: l10n_es_ticketbai

--- a/l10n_es_ticketbai/views/ticketbai_invoice_views.xml
+++ b/l10n_es_ticketbai/views/ticketbai_invoice_views.xml
@@ -23,6 +23,20 @@
                         class="btn-primary"
                         groups="account.group_account_manager"
                     />
+                       <button
+                        name="mark_as_sent"
+                        string="Mark as Sent"
+                        type="object"
+                        states="error"
+                        groups="account.group_account_manager"
+                    />
+                    <button
+                        name="cancel"
+                        string="Mark as Cancel"
+                        type="object"
+                        states="error"
+                        groups="account.group_account_manager"
+                    />
                     <field name="state" widget="statusbar" readonly="1" />
                 </header>
                 <sheet>
@@ -74,6 +88,85 @@
                                 style="min-width: 30mm; max-width: 40mm"
                             />
                         </group>
+                    </group>
+                    <group
+                        name="tbai_response"
+                        string="Response"
+                        attrs="{'invisible': [('tbai_response_ids', '=', [])]}"
+                    >
+                        <field
+                            name="tbai_response_ids"
+                            nolabel="1"
+                            colspan="2"
+                            options="{'no_create_edit': True}"
+                        >
+                            <form>
+                                <header>
+                                    <field
+                                        name="state"
+                                        widget="statusbar"
+                                        readonly="1"
+                                    />
+                                </header>
+                                <sheet>
+                                    <group name="tbai_response_main_group">
+                                        <field
+                                            name="xml"
+                                            filename="xml_fname"
+                                            readonly="1"
+                                        />
+                                        <field
+                                            name="xml_fname"
+                                            invisible="1"
+                                            class="oe_inline oe_right"
+                                        />
+                                    </group>
+                                    <group
+                                        name="tbai_response_messages_group"
+                                        string="Messages"
+                                    >
+                                        <field
+                                            name="tbai_response_message_ids"
+                                            nolabel="1"
+                                            readonly="1"
+                                        >
+                                            <form>
+                                                <group>
+                                                    <field
+                                                        name="tbai_response_id"
+                                                        invisible="1"
+                                                    />
+                                                    <field name="code" readonly="1" />
+                                                    <field
+                                                        name="description"
+                                                        readonly="1"
+                                                    />
+                                                </group>
+                                            </form>
+                                            <tree create="false" delete="false">
+                                                <field
+                                                    name="tbai_response_id"
+                                                    invisible="1"
+                                                />
+                                                <field name="code" readonly="1" />
+                                                <field
+                                                    name="description"
+                                                    readonly="1"
+                                                />
+                                            </tree>
+                                        </field>
+                                    </group>
+                                </sheet>
+                            </form>
+                            <tree create="false" delete="false">
+                                <field name="create_date" />
+                                <field
+                                    name="tbai_response_message_ids"
+                                    widget="many2many_tags"
+                                />
+                                <field name="state" />
+                            </tree>
+                        </field>
                     </group>
                 </sheet>
             </form>

--- a/l10n_es_ticketbai/views/ticketbai_invoice_views.xml
+++ b/l10n_es_ticketbai/views/ticketbai_invoice_views.xml
@@ -127,6 +127,7 @@
                                     >
                                         <field
                                             name="tbai_response_message_ids"
+                                            colspan="2"
                                             nolabel="1"
                                             readonly="1"
                                         >

--- a/l10n_es_ticketbai_api/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice.py
@@ -681,10 +681,8 @@ class TicketBAIInvoice(models.Model):
                         # successfully sent.
                         # Mark pending invoices as error, except in the following:
                         # - TicketBai (Invoice)
-                        #   - 005: Invoice already registered -> mark as sent.
                         #   - 006: service not available. Retry later.
                         # - AnulaTicketBai (Cancellation)
-                        #   - 011: Invoice already registered -> mark as sent.
                         #   - 012: service not available. Retry later.
                         error = True
                         # TicketBAI Response warning and error codes
@@ -696,12 +694,6 @@ class TicketBAIInvoice(models.Model):
                             == next_pending_invoice.schema
                         ):
                             if (
-                                InvoiceResponseCode.INVOICE_ALREADY_REGISTERED.value
-                                in response_codes
-                            ):
-                                next_pending_invoice.mark_as_sent()
-                                error = False
-                            elif (
                                 InvoiceResponseCode.SERVICE_NOT_AVAILABLE.value
                                 in response_codes
                             ):
@@ -712,12 +704,6 @@ class TicketBAIInvoice(models.Model):
                             == next_pending_invoice.schema
                         ):
                             if (
-                                CancellationResponseCode.INVOICE_ALREADY_CANCELLED.value
-                                in response_codes
-                            ):
-                                next_pending_invoice.mark_as_sent()
-                                error = False
-                            elif (
                                 CancellationResponseCode.SERVICE_NOT_AVAILABLE.value
                                 in response_codes
                             ):

--- a/l10n_es_ticketbai_pos/models/ticketbai_invoice.py
+++ b/l10n_es_ticketbai_pos/models/ticketbai_invoice.py
@@ -4,7 +4,7 @@ import base64
 
 from lxml import etree
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 from odoo.addons.l10n_es_ticketbai_api.ticketbai.xml_schema import TicketBaiSchema
 
@@ -13,6 +13,22 @@ class TicketBAIInvoice(models.Model):
     _inherit = "tbai.invoice"
 
     pos_order_id = fields.Many2one(comodel_name="pos.order")
+
+    @api.model
+    def mark_chain_as_error(self, invoice_to_error):
+        if invoice_to_error.pos_order_id:
+            # Restore last invoice successfully sent
+            if invoice_to_error.schema == TicketBaiSchema.TicketBai.value:
+                invoice_to_error.pos_order_id.config_id.tbai_last_invoice_id = (
+                    invoice_to_error.previous_tbai_invoice_id
+                )
+            while invoice_to_error:
+                invoice_to_error.error()
+                invoice_to_error = self.search(
+                    [("previous_tbai_invoice_id", "=", invoice_to_error.id)]
+                )
+        else:
+            return super().mark_chain_as_error(invoice_to_error)
 
     def send(self, **kwargs):
         self.ensure_one()

--- a/l10n_es_ticketbai_pos/tests/test_l10n_es_ticketbai_pos.py
+++ b/l10n_es_ticketbai_pos/tests/test_l10n_es_ticketbai_pos.py
@@ -72,6 +72,34 @@ class TestL10nEsTicketBAIPoSOrder(TestL10nEsTicketBAIPoSCommon):
         self.assertTrue(pos_order.account_move.tbai_substitute_simplified_invoice)
         self.assertEqual("pending", pos_order.account_move.tbai_invoice_id.state)
 
+    def test_chaining_and_rejected_by_the_tax_agency(self):
+        self.pos_config.open_ui()
+        pos_order = self.create_pos_order(self.account_billing.id)
+        pos_order.sudo()._tbai_build_invoice()
+        invoice = pos_order.tbai_invoice_id
+        self.assertEqual(self.pos_config.tbai_last_invoice_id, invoice)
+
+        pos_order2 = self.create_pos_order(self.account_billing.id)
+        pos_order2.sudo()._tbai_build_invoice()
+        invoice2 = pos_order2.sudo().tbai_invoice_id
+        self.assertEqual(invoice2.previous_tbai_invoice_id, invoice)
+        self.assertEqual(self.pos_config.tbai_last_invoice_id, invoice2)
+
+        pos_order3 = self.create_pos_order(self.account_billing.id)
+        pos_order3.sudo()._tbai_build_invoice()
+        invoice3 = pos_order3.tbai_invoice_id
+        self.assertEqual(invoice3.previous_tbai_invoice_id, invoice2)
+        self.assertEqual(self.pos_config.tbai_last_invoice_id, invoice3)
+
+        # Simulate 1st invoice sent successfully.
+        # 2nd rejected by the Tax Agency. Mark as an error.
+        # 3rd mark as an error.
+        invoice.sudo().mark_as_sent()
+        self.env["tbai.invoice"].sudo().mark_chain_as_error(invoice2)
+        self.assertEqual(invoice2.state, "error")
+        self.assertEqual(invoice3.state, "error")
+        self.assertEqual(self.pos_config.tbai_last_invoice_id, invoice)
+
     def test_create_refund_invoice_from_pos_order(self):
         self.pos_config.open_ui()
         pos_order = self.create_pos_order(self.account_billing.id)


### PR DESCRIPTION
There are several commits conforming this PR.

- [IMP] l10n_es_ticketbai*: mark duplicate record response on TicketBAI invoice as error.
  It's basically the forwarding port of #4006 (never merged) to v16.
- [FIX] l10n_es_ticketbai_pos: avoid mixing error handling for tbai pos invoices with normal  tbai chains (Fixes #3480)

@BinhexTeam