### PR TITLE
[16.0][FIX] l10n_es_aeat_sii_oca: Take into account sii_start_date for sii_enabled search

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -826,12 +826,25 @@ class AccountMove(models.Model):
         condition_2 = [("fiscal_position_id.aeat_active", operator, value)]
         search_ko = (operator == "=" and not value) or (operator == "!=" and value)
         exp_condition = OR if search_ko else AND
+        condition_3 = []
         if not search_ko:
+            for company in self.env.companies.filtered("sii_enabled"):
+                if company.sii_start_date:
+                    condition_3.append(
+                        [
+                            ("company_id", "=", company.id),
+                            ("date", ">=", company.sii_start_date),
+                        ]
+                    )
+                else:
+                    condition_3.append([("company_id", "=", company.id)])
+            if condition_3:
+                condition_3 = OR(condition_3)
             condition_2 = OR([condition_2, [("fiscal_position_id", "=", False)]])
         return AND(
             [
                 [("move_type", "in", invoice_types)],
-                exp_condition([domain, exp_condition([condition_1, condition_2])]),
+                exp_condition([domain, condition_1, condition_2, condition_3]),
             ]
         )
 

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -537,8 +537,11 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         invoice1 = self._create_invoice_for_sii("out_invoice")
         invoice1.invoice_date = "2019-01-01"
         self.assertTrue(invoice1.sii_enabled)
+        self.assertTrue(invoice1.filtered_domain([("sii_enabled", "=", True)]))
         invoice2 = self._create_invoice_for_sii("out_invoice")
         invoice2.invoice_date = "2017-01-01"
         self.assertFalse(invoice2.sii_enabled)
+        self.assertTrue(invoice2.filtered_domain([("sii_enabled", "=", False)]))
         self.company.sii_start_date = False
         self.assertTrue(invoice2.sii_enabled)
+        self.assertTrue(invoice2.filtered_domain([("sii_enabled", "=", True)]))


### PR DESCRIPTION
It was added in #4216 as a config option and in the compute, but not in the search method, so now we have it with all the possible combinations.

It includes some tests as well.

@Tecnativa TT58430