### PR TITLE
[18.0][FIX] l10n_es_vat_prorate: Error when duplicate vendor bill with prorate

### DIFF
--- a/l10n_es_vat_prorate/models/account_move.py
+++ b/l10n_es_vat_prorate/models/account_move.py
@@ -14,10 +14,12 @@ class AccountMove(models.Model):
         "res.company.vat.prorate",
         compute="_compute_prorate_id",
         store=True,
+        copy=False,
     )
     with_special_vat_prorate = fields.Boolean(
         compute="_compute_prorate_id",
         store=True,
+        copy=False,
     )
 
     @api.depends("company_id", "date", "invoice_date")
@@ -267,6 +269,7 @@ class AccountMoveLine(models.Model):
         compute="_compute_with_vat_prorate",
         store=True,
         readonly=False,
+        copy=False,
     )
 
     prorate_line_ids = fields.Many2many(
@@ -274,6 +277,7 @@ class AccountMoveLine(models.Model):
         relation="account_move_line_prorate_move_line_rel",
         column1="account_move_line_id",
         column2="prorate_move_line_id",
+        copy=False,
     )
 
     @api.depends("move_id.prorate_id", "company_id")


### PR DESCRIPTION
Before fix you cannot duplicate vendor bill, a raise happened "You can't delete a posted journal item. Don’t play games with your accounting records; reset the journal entry to draft before deleting it." This happened because the field `prorate_line_ids` was copied to new bill.

<img width="1270" height="679" alt="image" src="https://github.com/user-attachments/assets/0644825c-bef8-4b39-a790-61f5f4d1e587" />

In addition, copy to false is added to fields from move and move line to run always the compute methods when duplicate or refund

@Andrii9090 @Shide @Gelojr can you review please?

MT-12497 @moduon