### PR TITLE
[16.0][FIX] l10n_es_vat_book: remove cache decorator

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -339,7 +339,6 @@ class L10nEsVatBook(models.Model):
             self._account_move_line_domain(taxes=taxes, account=account)
         )
 
-    @ormcache("self.id")
     def get_pos_partner_ids(self):
         return (
             self.env["res.partner"]


### PR DESCRIPTION
Backport of #4536

@Tecnativa