### PR TITLE
[18.0][FIX] l10n_es_vat_book: Excluding mapping should only apply in the map includes an account

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -458,19 +458,13 @@ class L10nEsVatBook(models.Model):
                     if account:
                         accounts.update({tax: account for tax in line_taxes})
                 # Filter in all possible data using sets for improving performance
-                if accounts:
-                    lines = moves.filtered(
-                        lambda line: line.tax_ids & taxes
-                        or (
-                            line.tax_line_id in taxes
-                            and accounts.get(line.tax_line_id, line.account_id)
-                            != line.account_id
-                        )
+                lines = moves.filtered(
+                    lambda line: line.tax_ids & taxes
+                    or (
+                        line.tax_line_id in taxes
+                        and accounts.get(line.tax_line_id) != line.account_id
                     )
-                else:
-                    lines = moves.filtered(
-                        lambda line: (line.tax_ids | line.tax_line_id) & taxes
-                    )
+                )
                 if map_lines:
                     rec.create_vat_book_lines(lines, map_lines[:1].book_type, taxes)
             # Issued

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -24,6 +24,9 @@ class TestL10nEsAeatVatBookBase(TestL10nEsAeatModBase):
         "P_IVA21_SC": (230, 48.3),
         "P_IVA0_ND": (100, 21),
         "P_IVA21_IC_BC": (200, 42),
+        "P_REQ05": (270, 1.35),
+        "P_REQ014": (280, 3.92),
+        "P_REQ52": (290, 15.08),
     }
 
 
@@ -75,19 +78,36 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatVatBookBase):
             self.assertEqual(line.base_amount, 0.0)
             self.assertEqual(line.tax_amount, 0.0)
         # Check tax summary for received invoices
-        self.assertEqual(len(vat_book.received_tax_summary_ids), 3)
+        self.assertEqual(len(vat_book.received_tax_summary_ids), 6)
+        rec_summaries = sorted(
+            vat_book.received_tax_summary_ids,
+            key=lambda line: line.tax_amount,
+            reverse=True,
+        )
         # P_IVA21_SC - 21% IVA soportado (servicios corrientes)
-        line = vat_book.received_tax_summary_ids[0]
+        line = rec_summaries[0]
         self.assertAlmostEqual(line.base_amount, 230)
         self.assertAlmostEqual(line.tax_amount, 48.3)
         # P_IVA21_IC_BC - IVA 21% Adquisición Intracomunitaria. Bienes corrientes
-        line = vat_book.received_tax_summary_ids[1]
+        line = rec_summaries[1]
         self.assertAlmostEqual(line.base_amount, 200)
         self.assertAlmostEqual(line.tax_amount, 42)
         # P_IVA0_ND - 21% IVA Soportado no deducible
-        line = vat_book.received_tax_summary_ids[2]
+        line = rec_summaries[2]
         self.assertAlmostEqual(line.base_amount, 100)
         self.assertAlmostEqual(line.tax_amount, 21)
+        # P_REQ52 - 5.2% Recargo de equivalencia sobre operaciones sujetas a IVA
+        line = rec_summaries[3]
+        self.assertAlmostEqual(line.base_amount, 290)
+        self.assertAlmostEqual(line.tax_amount, 15.08)
+        # P_REQ014 - 1.4% Recargo de equivalencia sobre operaciones sujetas a IVA
+        line = rec_summaries[4]
+        self.assertAlmostEqual(line.base_amount, 280)
+        self.assertAlmostEqual(line.tax_amount, 3.92)
+        # P_REQ05 - 0.5% Recargo de equivalencia sobre operaciones sujetas a IVA
+        line = rec_summaries[5]
+        self.assertAlmostEqual(line.base_amount, 270)
+        self.assertAlmostEqual(line.tax_amount, 1.35)
         # Let's dig into this tax detail for checking the deductible amount
         tax_line = vat_book.received_line_ids.tax_line_ids.filtered(
             lambda x: "account_tax_template_p_iva0_nd" in x.tax_id.get_external_id()


### PR DESCRIPTION
Al haber hecho el cambio por un exclude, si no está definido,  deberíamos aceptarlo.

Nos afectaba al hacer el PR de IGIC.