### PR TITLE
[16.0][FIX] l10n_es_aeat: Compare properly XML-ID

### DIFF
--- a/l10n_es_aeat/models/account_move.py
+++ b/l10n_es_aeat/models/account_move.py
@@ -84,5 +84,6 @@ class AccountMoveLine(models.Model):
             amount = self.balance * sign
             res[tax]["amount"] += amount
             # Don't add it here if non deductible
-            if tax.tax_group_id.get_external_id() != "l10n_es.tax_group_iva_nd":
+            group = tax.tax_group_id
+            if group.get_external_id()[group.id] != "l10n_es.tax_group_iva_nd":
                 res[tax]["deductible_amount"] += amount


### PR DESCRIPTION
`get_external_id` returns a dictionary with record ID as keys and XML-IDs as values, so we have to access to the XML-ID.

@Tecnativa 