### PR TITLE
[17.0][IMP] l10n_es_account_asset: Corrected amount after non deductible

### DIFF
--- a/l10n_es_account_asset/README.rst
+++ b/l10n_es_account_asset/README.rst
@@ -36,6 +36,8 @@ las regulaciones españolas:
 -  Añade la opción de trasladar la depreciación al final del periodo.
 -  Añade un campo de fecha de comienzo de amortizacion para definir una
    distinta a la de compra.
+-  Gestiona los impuestos no deducibles y prorrata de IVA, incrementando
+   el valor amortizable en los activos generados desde la factura.
 
 **Table of contents**
 

--- a/l10n_es_account_asset/__manifest__.py
+++ b/l10n_es_account_asset/__manifest__.py
@@ -1,13 +1,13 @@
 # Copyright 2015 AvanzOSC - Ainara Galdona
 # Copyright 2016 Tecnativa - Antonio Espinosa
 # Copyright 2021 Tecnativa - João Marques
-# Copyright 2012-2023 Tecnativa - Pedro M. Baeza
+# Copyright 2012,2023,2025 Tecnativa - Pedro M. Baezas
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Gestión de activos fijos para España",
     "version": "17.0.1.0.0",
-    "depends": ["account_asset_management"],
+    "depends": ["account_asset_management", "l10n_es_aeat"],
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/l10n-spain",

--- a/l10n_es_account_asset/models/__init__.py
+++ b/l10n_es_account_asset/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import account_asset
 from . import account_asset_profile
+from . import account_move

--- a/l10n_es_account_asset/models/account_move.py
+++ b/l10n_es_account_asset/models/account_move.py
@@ -1,0 +1,26 @@
+# Copyright 2025 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _prepare_asset_vals(self, aml):
+        # Adapt purchase value for taking into account non deductible amounts
+        # As we only know the deductible amount at invoice level, we get the general
+        # tax info, and then apply the percentage corresponding to this line
+        res = super()._prepare_asset_vals(aml)
+        main_vals = aml.move_id._get_aeat_tax_info()
+        amount = aml.balance
+        for tax in aml.tax_ids:
+            tax_vals = main_vals[tax]
+            vals = {}
+            aml._process_aeat_tax_base_info(vals, tax, 1)
+            if tax_vals["amount"] != tax_vals["deductible_amount"]:
+                ratio = vals[tax]["base"] / tax_vals["base"]
+                diff = tax_vals["amount"] - tax_vals["deductible_amount"]
+                amount += diff * ratio
+        res["purchase_value"] = amount
+        return res

--- a/l10n_es_account_asset/readme/DESCRIPTION.md
+++ b/l10n_es_account_asset/readme/DESCRIPTION.md
@@ -6,3 +6,5 @@ las regulaciones españolas:
 - Añade la opción de trasladar la depreciación al final del periodo.
 - Añade un campo de fecha de comienzo de amortizacion para definir una
   distinta a la de compra.
+- Gestiona los impuestos no deducibles y prorrata de IVA, incrementando el valor
+  amortizable en los activos generados desde la factura.

--- a/l10n_es_account_asset/static/description/index.html
+++ b/l10n_es_account_asset/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -377,6 +378,8 @@ las regulaciones españolas:</p>
 <li>Añade la opción de trasladar la depreciación al final del periodo.</li>
 <li>Añade un campo de fecha de comienzo de amortizacion para definir una
 distinta a la de compra.</li>
+<li>Gestiona los impuestos no deducibles y prorrata de IVA, incrementando
+el valor amortizable en los activos generados desde la factura.</li>
 </ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
@@ -425,7 +428,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/l10n_es_account_asset/tests/__init__.py
+++ b/l10n_es_account_asset/tests/__init__.py
@@ -1,4 +1,4 @@
-# (c) 2015 Ainara Galdona - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from . import test_create_asset_from_invoice
 from . import test_l10n_es_account_asset

--- a/l10n_es_account_asset/tests/test_create_asset_from_invoice.py
+++ b/l10n_es_account_asset/tests/test_create_asset_from_invoice.py
@@ -1,0 +1,61 @@
+# Copyright 2025 Tecnativa - Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import Command
+
+from odoo.addons.l10n_es_aeat.tests.test_l10n_es_aeat_mod_base import (
+    TestL10nEsAeatModBase,
+)
+
+
+class TestCreateAssetFromInvoice(TestL10nEsAeatModBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
+        cls.product = cls.env["product.product"].create({"name": "Test product"})
+        cls.journal = cls.env["account.journal"].create(
+            {"name": "Test asset journal", "code": "TSTA", "type": "general"}
+        )
+        cls.profile = cls.env["account.asset.profile"].create(
+            {
+                "name": "Test asset category",
+                "account_expense_depreciation_id": cls.env.ref(
+                    f"account.{cls.company.id}_account_common_681"
+                ).id,
+                "account_asset_id": cls.env.ref(
+                    f"account.{cls.company.id}_account_common_213"
+                ).id,
+                "account_depreciation_id": cls.env.ref(
+                    f"account.{cls.company.id}_account_common_2813"
+                ).id,
+                "journal_id": cls.journal.id,
+                "method_number": 3,
+            }
+        )
+        tax = cls.env.ref(f"account.{cls.company.id}_account_tax_template_p_iva0_nd")
+        line_vals = {
+            "product_id": cls.product.id,
+            "name": "Test line",
+            "price_unit": 54.23,
+            "account_id": cls.profile.account_asset_id.id,
+            "asset_profile_id": cls.profile.id,
+            "quantity": 1,
+            "tax_ids": [Command.link(tax.id)],
+        }
+        line_vals2 = line_vals.copy()
+        line_vals2["price_unit"] = 114.67
+        invoice_vals = {
+            "company_id": cls.company.id,
+            "partner_id": cls.partner.id,
+            "invoice_date": "2025-11-01",
+            "move_type": "in_invoice",
+            "invoice_line_ids": [Command.create(line_vals), Command.create(line_vals2)],
+        }
+        cls.invoice = cls.env["account.move"].create(invoice_vals)
+
+    def test_create_asset_from_invoice_non_deductible(self):
+        self.invoice.action_post()
+        lines = self.invoice.invoice_line_ids
+        self.assertEqual(lines[0].asset_id.purchase_value, 65.62)  # 54.23 * 1.21
+        self.assertEqual(lines[1].asset_id.purchase_value, 138.75)  # 114.67 * 1.21


### PR DESCRIPTION
Forward-port of #4562 

When a tax is non deductible (because it's directly non deductible VAT, or due to the VAT prorate), the amount to depreciate should be increased with this non deductible amount, which was not taken into account before this commit.

For achieving this without requiring glue modules, we are now depending on `l10n_es_aeat`, which is a reasonable trade-off, as almost all the instances with this module will have the other installed as well.

As we only know the deductible amount at invoice level, we get the general tax info, and then apply the percentage corresponding to each line.

It includes a new test for covering this case.

@Tecnativa 