### PR TITLE
[18.0][FIX] l10n_vat_prorate: No se pueden crear apuntes desde un asiento

### DIFF
--- a/l10n_es_vat_prorate/views/account_move_views.xml
+++ b/l10n_es_vat_prorate/views/account_move_views.xml
@@ -13,16 +13,6 @@
             >
                 <field name="vat_prorate" column_invisible="1" />
             </xpath>
-            <xpath expr="//field[@name='line_ids']/list" position="attributes">
-                <attribute name="decoration-danger">debit==0 and credit == 0</attribute>
-            </xpath>
-            <xpath expr="//form" position="inside">
-                <style>
-                    .o_list_view tbody tr.text-danger.o_data_row {
-                        display: none !important;
-                    }
-                </style>
-            </xpath>
 
             <xpath expr="//field[@name='invoice_line_ids']" position="before">
                 <field name="with_special_vat_prorate" invisible="1" />
@@ -38,10 +28,5 @@
                 />
             </xpath>
         </field>
-    </record>
-    <record model="ir.actions.act_window" id="account.action_account_moves_all">
-        <field
-            name="domain"
-        >[('display_type', 'not in', ('line_section', 'line_note')), ('parent_state', '!=', 'cancel'), '!', '&amp;', ('debit', '=', 0.0), ('credit', '=', 0.0)]</field>
     </record>
 </odoo>


### PR DESCRIPTION
Antes de fix, no era posible crear apuntes desde un asiento.
Al eliminar el atributo `decoration-danger` del campo `line_ids` en la vista `account.view_move_form` (que ocultaba las líneas cuando el débito y el crédito eran 0) — ahora es posible agregar nuevas líneas de apuntes.

https://www.loom.com/share/e6d59f4e79cb414baac16582e4363834
MT-12589

@moduon