### PR TITLE
[15.0][FIX] l10n_es_payment_order_confirming_aef: Select properly the currency

### DIFF
--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -148,7 +148,8 @@ class ConfirmingAEF(object):
         cuenta = self.record.company_partner_bank_id.sanitized_acc_number
         text += self._aef_convert_text(cuenta, 34, "left")
         # 137 - 139 Código divisa
-        text += self._aef_convert_text(self.record.company_currency_id.name, 3)
+        currency = self.record.journal_id.currency_id or self.record.company_currency_id
+        text += self._aef_convert_text(currency.name, 3)
         # 140 - 140 Estandar / Pronto Pago/ Otros
         text += self._aef_convert_text(
             self.record.payment_mode_id.aef_confirming_modality or "", 1


### PR DESCRIPTION
Forward-port of #4243 with #4570 incorporated.

If the journal has a explicit currency, use it.

@Tecnativa 