### PR TITLE
[17.0][FIX] l10n_es_aeat: Find properly the XML-ID for non deductible

### DIFF
--- a/l10n_es_aeat/models/account_move.py
+++ b/l10n_es_aeat/models/account_move.py
@@ -83,5 +83,5 @@ class AccountMoveLine(models.Model):
             res[tax]["amount"] += amount
             # Don't add it here if non deductible
             group = tax.tax_group_id
-            if group.get_external_id()[group.id] != "l10n_es.tax_group_iva_nd":
+            if not group.get_external_id()[group.id].endswith("_tax_group_iva_nd"):
                 res[tax]["deductible_amount"] += amount


### PR DESCRIPTION
The tax groups are now by company and bound to `account` module, so let's change the compare condition.

@Tecnativa 