### PR TITLE
[18.0][FIX] l10n_es_aeat: Find properly the XML-ID for non deductible

### DIFF
--- a/l10n_es_aeat/models/account_move.py
+++ b/l10n_es_aeat/models/account_move.py
@@ -82,5 +82,6 @@ class AccountMoveLine(models.Model):
             amount = self.balance * sign
             res[tax]["amount"] += amount
             # Don't add it here if non deductible
-            if tax.tax_group_id.get_external_id() != "l10n_es.tax_group_iva_nd":
+            group = tax.tax_group_id
+            if not group.get_external_id()[group.id].endswith("_tax_group_iva_nd"):
                 res[tax]["deductible_amount"] += amount


### PR DESCRIPTION
Forward-port of #4573 

The tax groups are now by company and bound to `account` module, so let's change the compare condition.

@Tecnativa