### PR TITLE
[16.0][IMP] l10n_es_aeat: allow to download Public PEM certificate

### DIFF
--- a/l10n_es_aeat/models/aeat_certificate.py
+++ b/l10n_es_aeat/models/aeat_certificate.py
@@ -26,6 +26,19 @@ class L10nEsAeatCertificate(models.Model):
     public_key = fields.Char(readonly=True)
     show_public_key = fields.Boolean(store=False)
     public_key_data = fields.Text(readonly=True, store=False)
+    public_key_file = fields.Binary(
+        readonly=True,
+        store=False,
+        attachment=False,
+        compute="_compute_public_key",
+        groups="l10n_es_aeat.group_account_aeat",
+    )
+    public_key_filename = fields.Char(
+        readonly=True,
+        store=False,
+        compute="_compute_public_key",
+        groups="l10n_es_aeat.group_account_aeat",
+    )
     private_key = fields.Char(readonly=True)
     company_id = fields.Many2one(
         comodel_name="res.company",
@@ -44,6 +57,30 @@ class L10nEsAeatCertificate(models.Model):
                 f.read(), backend=default_backend()
             )
         self.public_key_data = certificate.public_bytes(Encoding.PEM)
+
+    def get_public_key_pem(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_url",
+            "target": "self",
+            "url": "/web/content/l10n.es.aeat.certificate/%s/public_key_file/%s?download=true"
+            % (self.id, self.public_key_filename),
+        }
+
+    @api.depends("public_key")
+    def _compute_public_key(self):
+        for record in self:
+            if not record.public_key:
+                record.public_key_file = False
+                record.public_key_filename = False
+                continue
+            with open(record.public_key, "rb") as f:
+                certificate = x509.load_pem_x509_certificate(
+                    f.read(), backend=default_backend()
+                )
+            public_key = certificate.public_bytes(Encoding.PEM)
+            record.public_key_filename = f"{record.name}.pem"
+            record.public_key_file = public_key
 
     def load_password_wizard(self):
         self.ensure_one()

--- a/l10n_es_aeat/tests/test_l10n_es_aeat_certificate.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_certificate.py
@@ -147,3 +147,15 @@ class TestL10nEsAeatCertificate(TestL10nEsAeatCertificateBase):
             self.assertEqual(f.public_key_data, self.public_key)
             f.show_public_key = False
             self.assertFalse(f.public_key_data)
+
+    def test_get_public_key_pem(self):
+        self.assertFalse(self.sii_cert.public_key_file)
+        self._activate_certificate(self.certificate_password)
+        action = self.sii_cert.get_public_key_pem()
+        self.assertEqual(action["type"], "ir.actions.act_url")
+        self.assertEqual(
+            "/web/content/l10n.es.aeat.certificate/%s/public_key_file/%s?download=true"
+            % (self.sii_cert.id, self.sii_cert.public_key_filename),
+            action["url"],
+        )
+        self.assertTrue(self.sii_cert.public_key_file)

--- a/l10n_es_aeat/views/aeat_certificate_view.xml
+++ b/l10n_es_aeat/views/aeat_certificate_view.xml
@@ -38,6 +38,14 @@
                         widget="boolean_toggle"
                         options="{'autosave': False}"
                     />
+                    <button
+                        name="get_public_key_pem"
+                        type="object"
+                        string="Download Public Key"
+                        colspan="2"
+                        class="btn-primary"
+                        attrs="{'invisible': [('public_key', '=', False)]}"
+                    />
                 </group>
                 <field name="public_key_data" />
             </form>


### PR DESCRIPTION
Al final he podido hacerlo sin un transient:

<img width="464" height="757" alt="image" src="https://github.com/user-attachments/assets/142f90a9-8174-4133-bacc-86dc02e3b493" />
