### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: Send cancellations if previously sent

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -264,7 +264,12 @@ class SiiMixin(models.AbstractModel):
             lambda document: (
                 document.sii_enabled
                 and document.state in self._get_valid_document_states()
-                and document.aeat_state not in ["sent", "cancelled"]
+                and (
+                    (document.aeat_state != "sent" and not document.sii_needs_cancel)
+                    or (
+                        document.aeat_state != "cancelled" and document.sii_needs_cancel
+                    )
+                )
             )
         )
 


### PR DESCRIPTION
Forward-port of #4592 

The filtering was not done correctly for cancel operations if they were on "sent" state.

@Tecnativa