### PR TITLE
[18.0][FIX] l10n_es_verifactu_oca: verifactu mixin macrodata computation

### DIFF
--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -146,11 +146,10 @@ class VerifactuMixin(models.AbstractModel):
 
     def _compute_verifactu_macrodata(self):
         for document in self:
+            amount_total = document._get_verifactu_taxes_and_total()[2]
             document.verifactu_macrodata = (
                 float_compare(
-                    abs(document._get_verifactu_amount_total()),
-                    VERIFACTU_MACRODATA_LIMIT,
-                    precision_digits=2,
+                    abs(amount_total), VERIFACTU_MACRODATA_LIMIT, precision_digits=2
                 )
                 >= 0
             )


### PR DESCRIPTION
Se estaba usando el método `_get_verifactu_amount_total` que se sustituyó por `_get_verifactu_taxes_and_total` y por lo tanto saltaba un error al ejecutarse el método.