### PR TITLE
[17.0][FIX] l10n_es_account_statement_import_n43: Remove invalid creation_context field

### DIFF
--- a/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py
+++ b/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py
@@ -390,7 +390,6 @@ class AccountStatementImport(models.TransientModel):
             "transactions": transactions,
             "balance_start": n43 and n43[0]["saldo_ini"] or 0.0,
             "balance_end_real": n43 and n43[-1]["saldo_fin"] or 0.0,
-            "creation_context": {"skip_retrieve_partner": True},
         }
         return (
             self._get_currency_iso4217(int(n43[0]["divisa"])),


### PR DESCRIPTION
The creation_context field does not exist in the standard account.bank.statement model in Odoo 17.0, causing a ValueError when importing N43 bank statement files.

This field was likely a remnant from a previous version or planned functionality that was never implemented. Removing it allows N43 imports to work correctly without affecting functionality, as the field was not used anywhere else in the module.

Fixes #4596