### PR TITLE
[16.0][FIX] l10n_es_igic_verifactu_oca: Mapeos impuestos IGIC a las nuevas claves de Exención

### DIFF
--- a/l10n_es_igic_verifactu_oca/data/atc_verifactu_map_data.xml
+++ b/l10n_es_igic_verifactu_oca/data/atc_verifactu_map_data.xml
@@ -13,6 +13,7 @@
                 (4, ref('l10n_es_igic.account_tax_template_igic_r_9_5')),
                 (4, ref('l10n_es_igic.account_tax_template_igic_r_15')),
                 (4, ref('l10n_es_igic.account_tax_template_igic_r_20')),
+                (4, ref('l10n_es_igic.account_tax_template_igic_cmino')),
             ]"
         />
     </record>
@@ -27,13 +28,20 @@
         />
     </record>
 
-    <!-- Operación No Sujeta artículo 7, 14, otros. -->
-    <record id="l10n_es_verifactu_oca.verifactu_map_line_N1" model="verifactu.map.line">
+    <record id="l10n_es_verifactu_oca.verifactu_map_line_E2" model="verifactu.map.line">
+        <field
+            name="taxes"
+            eval="[
+                (4, ref('l10n_es_igic.account_tax_template_igic_ex_0')),
+            ]"
+        />
+    </record>
+
+    <record id="l10n_es_verifactu_oca.verifactu_map_line_E6" model="verifactu.map.line">
         <field
             name="taxes"
             eval="[
                 (4, ref('l10n_es_igic.account_tax_template_igic_re_ex')),
-                (4, ref('l10n_es_igic.account_tax_template_igic_ex_0')),
             ]"
         />
     </record>


### PR DESCRIPTION
Corregido los mapeos de impuestos del IGIC en las nuevas claves de exención de VERI*FACTU según #4499 . 

### Nota legal y de cumplimiento

Este cambio mantiene la conformidad con la normativa aplicable al sistema
VERI*FACTU, conforme a lo establecido en:

- Real Decreto 1007/2023, de 5 de diciembre, por el que se aprueba el
  Reglamento que establece los requisitos que deben adoptar los sistemas
  informáticos o electrónicos que soporten los procesos de facturación.
- Real Decreto 254/2025, de 1 de abril, que modifica el anterior.

La modificación tiene carácter exclusivamente técnico y no altera la
estructura, integridad ni trazabilidad de los registros de facturación
ni el cumplimiento de las obligaciones establecidas por la AEAT.

@BinhexTeam