### PR TITLE
[16.0] [FIX] l10n_es_ticketbai_pos: fix TicketBAI crashes and silent failures

### DIFF
--- a/l10n_es_ticketbai_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/l10n_es_ticketbai_pos/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -71,21 +71,49 @@ odoo.define("l10n_es_ticketbai_pos.PaymentScreen", function (require) {
 
             async validateOrder() {
                 const order = this.currentOrder;
+
                 if (this.env.pos.company.tbai_enabled && !order.is_to_invoice()) {
                     if (!order.tbai_simplified_invoice) {
                         try {
+                            // Start/continue building
                             await order.tbai_build_invoice();
-                            order.tbai_simplified_invoice =
-                                await order.tbai_current_invoice;
-                        } catch (error) {
-                            console.error(
-                                "Error while fetching tbai_current_invoice:",
-                                error
-                            );
-                            // Handle the error appropriately, e.g., show a popup or set a default value
+                            const tbai_inv = await order.tbai_current_invoice;
+
+                            if (!tbai_inv) {
+                                // Validation failed → BLOCK order and inform user
+                                this.showPopup("ErrorPopup", {
+                                    title: this.env._t("TicketBAI"),
+                                    body: this.env._t(
+                                        "Cannot generate TicketBAI simplified invoice.\n\n" +
+                                            "Check:\n" +
+                                            "• Company VAT is set\n" +
+                                            "• Customer has VAT (or foreign ID)\n" +
+                                            "• All products have exactly one tax\n" +
+                                            "• Fiscal position has VAT Regime Key"
+                                    ),
+                                });
+                                // ← BLOCK validation
+                                return;
+                            }
+
+                            order.tbai_simplified_invoice = tbai_inv;
+                        } catch (err) {
+                            console.error("TicketBAI invoice generation failed:", err);
+                            this.showPopup("ErrorPopup", {
+                                title: this.env._t("TicketBAI - Critical Error"),
+                                body: this.env._t(
+                                    "Failed to generate or sign the TicketBAI invoice.\n\n" +
+                                        "Error: %s\n\n" +
+                                        "The order cannot be validated without a valid signed ticket.",
+                                    err.message || err
+                                ),
+                            });
+                            // ← BLOCK validation (required by law)
+                            return;
                         }
                     }
                 }
+
                 await super.validateOrder(...arguments);
             }
         };

--- a/l10n_es_ticketbai_pos/static/src/js/models.js
+++ b/l10n_es_ticketbai_pos/static/src/js/models.js
@@ -69,23 +69,36 @@ odoo.define("l10n_es_ticketbai_pos.models", function (require) {
                 return (tbai_vat_regime_key && tbai_vat_regime_key.code) || null;
             }
             push_single_order(order) {
-                if (this.company.tbai_enabled && order) {
-                    return order.tbai_current_invoice.then((tbai_inv) => {
-                        const tbai_last_invoice_data = {
-                            order: {
-                                simplified_invoice:
-                                    tbai_inv.number_prefix + tbai_inv.number,
-                            },
-                            signature_value: tbai_inv.signature_value,
-                            number: tbai_inv.number,
-                            number_prefix: tbai_inv.number_prefix,
-                            expedition_date: tbai_inv.expedition_date,
-                        };
-                        this.set_tbai_last_invoice_data(tbai_last_invoice_data);
+                if (!this.company.tbai_enabled || !order) {
+                    return super.push_single_order(...arguments);
+                }
+
+                return order.tbai_current_invoice
+                    .then((tbai_inv) => {
+                        if (tbai_inv) {
+                            const tbai_last_invoice_data = {
+                                order: {
+                                    simplified_invoice:
+                                        tbai_inv.number_prefix + tbai_inv.number,
+                                },
+                                signature_value: tbai_inv.signature_value,
+                                number: tbai_inv.number,
+                                number_prefix: tbai_inv.number_prefix,
+                                expedition_date: tbai_inv.expedition_date,
+                            };
+                            this.set_tbai_last_invoice_data(tbai_last_invoice_data);
+                        }
+                        // Even if null → still push the order (it's already validated)
+                        return super.push_single_order(...arguments);
+                    })
+                    .catch((err) => {
+                        console.error(
+                            "push_single_order: TicketBAI processing failed",
+                            err
+                        );
+                        // Do NOT block order sync — but log it
                         return super.push_single_order(...arguments);
                     });
-                }
-                return super.push_single_order(...arguments);
             }
             get_tbai_last_invoice_data() {
                 /**
@@ -280,23 +293,43 @@ odoo.define("l10n_es_ticketbai_pos.models", function (require) {
             }
 
             async tbai_build_invoice() {
-                if (this.tbai_current_invoice.state === "rejected") {
-                    this.tbai_current_invoice = Promise.resolve();
-                }
-                this.tbai_current_invoice = this.tbai_current_invoice.then(async () => {
-                    let tbai_inv = null;
-                    if (this.check_tbai_conf() && !this.to_invoice) {
-                        tbai_inv = new tbai_models.TicketBAISimplifiedInvoice(
-                            {},
-                            {
-                                pos: this.pos,
-                                order: this,
-                            }
-                        );
-                        await tbai_inv.build_invoice();
+                /*
+                 * Reset a previously rejected promise to a safe resolved state.
+                 * Works with both native Promises and jQuery Deferreds (still used in Odoo 16 POS).
+                 */
+                var current = this.tbai_current_invoice;
+                if (current && typeof current.catch === "function") {
+                    try {
+                        await current;
+                    } catch (e) {
+                        /* Absorb */
                     }
+                    if (
+                        (current.state && current.state() === "rejected") ||
+                        (current.isRejected && current.isRejected())
+                    ) {
+                        this.tbai_current_invoice = Promise.resolve(null);
+                    }
+                }
+
+                this.tbai_current_invoice = this.tbai_current_invoice.then(async () => {
+                    if (!this.check_tbai_conf() || this.to_invoice) {
+                        return null;
+                    }
+
+                    const tbai_inv = new tbai_models.TicketBAISimplifiedInvoice(
+                        {},
+                        {
+                            pos: this.pos,
+                            order: this,
+                        }
+                    );
+
+                    await tbai_inv.build_invoice();
                     return tbai_inv;
                 });
+
+                return this.tbai_current_invoice;
             }
         };
     Registries.Model.extend(Order, L10nEsTicketBAIPosOrder);

--- a/l10n_es_ticketbai_pos/static/src/js/tbai_models.js
+++ b/l10n_es_ticketbai_pos/static/src/js/tbai_models.js
@@ -7,13 +7,10 @@
 odoo.define("l10n_es_ticketbai_pos.tbai_models", function (require) {
     "use strict";
 
-    const core = require("web.core");
-    const _t = core._t;
     const field_utils = require("web.field_utils");
 
     const tbai = window.tbai;
     const QRCode = window.QRCode;
-    const {Gui} = require("point_of_sale.Gui");
 
     /* A TicketBAI Simplified Invoice represents a customer's order
     to be exported to the Tax Agency.
@@ -130,12 +127,8 @@ odoo.define("l10n_es_ticketbai_pos.tbai_models", function (require) {
                     );
                     return Promise.resolve();
                 } catch (e) {
-                    console.error(e);
-                    Gui.showPopup("ErrorPopup", {
-                        title: _t("TicketBAI"),
-                        body: e.message,
-                    });
-                    return Promise.reject(e);
+                    console.error("TicketBAI signing/XML generation failed:", e);
+                    throw e;
                 }
             } else {
                 return Promise.reject(


### PR DESCRIPTION
Se corrige la regresión introducida al migrar el módulo de Odoo 15 a 16.  
La “modernización” rompió la cadena segura de Promise original, provocando:

- `TypeError: Cannot read property 'number_prefix' of undefined`
- Fallos silenciosos cuando no se podía generar una factura TicketBAI (facturas con factura, NIF ausente, errores de firma, etc.)

**Cambios**

- `js/models.js` – Garantiza que `tbai_build_invoice()` siempre devuelva una promesa que se resuelve en un objeto de factura válido o `null` (nunca `undefined`) y que maneja correctamente las promesas rechazadas.
- `js/models.js` – Hace que `push_single_order()` sea seguro cuando no se genera factura (elimina el error).
- `js/Screens/PaymentScreen/PaymentScreen.js` – Asegura que cualquier error de TicketBAI (validación, generación XML, firma, etc.) muestre un popup claro y bloquee la validación del pedido (requisito legal).
- `js/tbai_models.js` – Elimina la llamada incorrecta a popup desde la capa de modelo; los errores ahora se propagan al componente de interfaz.

**Resultado:** desaparecen los errores de ejecución, todos los fallos son visibles para el cajero y los pedidos sin TicketBAI firmado válido quedan correctamente bloqueados. El comportamiento vuelve a ser idéntico a la versión estable de Odoo 15, manteniendo la sintaxis moderna con async/await.


@BinhexTeam T17055