### PR TITLE
[16.0][FIX] l10n_es_aeat_mod390: Calculate casilla 662

### DIFF
--- a/l10n_es_aeat_mod390/README.rst
+++ b/l10n_es_aeat_mod390/README.rst
@@ -126,6 +126,7 @@ Contributors
 * `Moduon <https://www.moduon.team>`_:
 
   * Emilio Pascual
+  * Arantxa Sudón
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_aeat_mod390/models/mod390.py
+++ b/l10n_es_aeat_mod390/models/mod390.py
@@ -849,6 +849,50 @@ class L10nEsAeatMod390Report(models.Model):
         # remaining_cuota_compensar, usamos la suma de las casillas [78]
         return min(total_cuota_compensar, remaining_cuota_compensar)
 
+    @api.model
+    def _calculate_casilla_662(self, reports_303):
+        """Box 662 will be the difference between this year's compensation and what was
+        applied this year that does not come from previous years.
+        - Amount to compensate this year is the sum of the result in 303 reports to
+          compensate this year except the last period
+        - Amount applied this year is the sum of the 78 in 303 reports except the first period.
+        - Compensation previous year is the box 78 of the first period of the year.
+        """
+        # Cuotas aplicadas este año
+        applied_this_year = sum(
+            reports_303.filtered_domain(
+                [("period_type", "not in", ("1T", "01"))]
+            ).mapped("cuota_compensar")
+        )
+        # Compensaciones de este año
+        compensation_this_year = abs(
+            sum(
+                reports_303.filtered_domain(
+                    [("period_type", "not in", ("4T", "12")), ("result_type", "=", "C")]
+                ).mapped("resultado_liquidacion")
+            )
+        )
+        # Compensaciones de años anteriores
+        compensation_previous_years = reports_303.filtered_domain(
+            [("period_type", "in", ("1T", "01"))]
+        )[:1].potential_cuota_compensar
+        # Si lo aplicado este año es menor que compensaciones de años anteriores
+        # significa que no se ha aplicado todo de años anteriores, por lo que
+        # no hay que tenerlo en cuenta para la 662.
+        if applied_this_year < compensation_previous_years:
+            compensation_previous_years = 0
+            # Si la diferencia entre compensaciones del año anterior y lo aplicado
+            # este año es mayor a las compensaciones del año, significa que el total
+            # de lo compensado este año no se ha aplicado porque todavía queda por
+            # aplicar de años anteriores.
+            if compensation_previous_years - applied_this_year > compensation_this_year:
+                applied_this_year = 0
+        # La casilla 662 será la diferencia entre las compensaciones de este año y lo
+        # aplicado este año que no provenga de años anteriores
+        return max(
+            compensation_this_year - applied_this_year - compensation_previous_years, 0
+        )
+
     def calculate(self):
         res = super().calculate()
         for mod390 in self:
@@ -877,19 +921,16 @@ class L10nEsAeatMod390Report(models.Model):
             report_303_last_period = reports_303_this_year.filtered(
                 lambda r: r.period_type in {"4T", "12"}
             )
+            casilla_662 = self._calculate_casilla_662(reports_303_this_year)
             if report_303_last_period:
                 if report_303_last_period[0].result_type == "C":
                     # Si salió a compensar, casilla 97 = casilla 71 del último periodo
                     # del año si fue a compensar
                     casilla_97 = abs(report_303_last_period.resultado_liquidacion)
-                else:
-                    # casilla 662 = casilla 87 del último periodo del año si no se
-                    # incluyo en la casilla 97
-                    casilla_662 = report_303_last_period.remaining_cuota_compensar
-                    if report_303_last_period[0].result_type in {"D", "V", "X"}:
-                        # Si salió a devolver, casilla 98 = casilla 71 del último periodo
-                        # del año si fue a devolver
-                        casilla_98 = abs(report_303_last_period.resultado_liquidacion)
+                elif report_303_last_period[0].result_type in {"D", "V", "X"}:
+                    # Si salió a devolver, casilla 98 = casilla 71 del último periodo
+                    # del año si fue a devolver
+                    casilla_98 = abs(report_303_last_period.resultado_liquidacion)
             mod390.update(
                 {
                     "casilla_85": casilla_85,

--- a/l10n_es_aeat_mod390/readme/CONTRIBUTORS.rst
+++ b/l10n_es_aeat_mod390/readme/CONTRIBUTORS.rst
@@ -20,3 +20,4 @@
 * `Moduon <https://www.moduon.team>`_:
 
   * Emilio Pascual
+  * Arantxa Sudón

--- a/l10n_es_aeat_mod390/static/description/index.html
+++ b/l10n_es_aeat_mod390/static/description/index.html
@@ -474,6 +474,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.moduon.team">Moduon</a>:<ul>
 <li>Emilio Pascual</li>
+<li>Arantxa Sudón</li>
 </ul>
 </li>
 </ul>

--- a/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
+++ b/l10n_es_aeat_mod390/tests/test_l10n_es_aeat_mod390.py
@@ -401,7 +401,11 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 560.85, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 0.0, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
+        # To compensate this year = 674.48
+        # Total compensation applied this year = 0
+        # Compensation from previous years = 0
+        # Then C662 = 674.48
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 674.48, 2)
 
         model303_4T.return_last_period = True
         model303_4T.button_calculate()
@@ -412,7 +416,9 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 200.0, 2)
+        # As 78 in 303 4T increases then all to compensate this year is appliead
+        # Then C662 = 0
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
 
         model303_1T.potential_cuota_compensar = 500.0
         model303_1T.button_calculate()
@@ -422,7 +428,7 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 200.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
 
         model303_1T.potential_cuota_compensar = 1000.0
         model303_1T.button_calculate()
@@ -432,7 +438,7 @@ class TestL10nEsAeatMod390(TestL10nEsAeatMod390Base):
         self.assertAlmostEqual(self.model390_2018.casilla_95, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_97, 0.0, 2)
         self.assertAlmostEqual(self.model390_2018.casilla_98, 1235.33, 2)
-        self.assertAlmostEqual(self.model390_2018.casilla_662, 200.0, 2)
+        self.assertAlmostEqual(self.model390_2018.casilla_662, 0.0, 2)
 
     def test_model_390_using_303_03(self):
         # Check use 303 activated, 303 reports exist and last period is to compensate


### PR DESCRIPTION
En la casilla 662 se deben incluir las cuotas a compensar generadas en este año que no se hayan aplicado en el año.
<img width="612" height="73" alt="image" src="https://github.com/user-attachments/assets/ed061c8b-3cd5-4040-9d21-ca4ec83c6d9b" />
https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/G412/instr390.pdf

Antes del fix sólo se recogía la casilla 87 del último periodo lo que no recogía todos los casos, como que el contenido de la casilla 87 proveniera integra o parcialmente de años anteriores.

@ArantxaSudon revisa por favor.

MT-8899 @moduon