### PR TITLE
[15.0][IMP]l10n_es_verifactu_oca: añadido causas de exención

### DIFF
--- a/l10n_es_verifactu_oca/data/verifactu_map_data.xml
+++ b/l10n_es_verifactu_oca/data/verifactu_map_data.xml
@@ -20,10 +20,7 @@
                 ref('l10n_es.account_tax_template_s_iva0s'),
                 ref('l10n_es.account_tax_template_s_iva4s'),
                 ref('l10n_es.account_tax_template_s_iva5s'),
-                ref('l10n_es.account_tax_template_s_iva0_ic'),
-                ref('l10n_es.account_tax_template_s_iva0_sp_i'),
-                ref('l10n_es.account_tax_template_s_iva0_e'),
-                ref('l10n_es.account_tax_template_s_iva_e'),
+                ref('l10n_es.account_tax_template_s_iva7-5s'),
                 ref('l10n_es.account_tax_template_s_iva0'),
             ])]"
         />
@@ -47,7 +44,12 @@
     </record>
     <record id="verifactu_map_line_N1" model="verifactu.map.line">
         <field name="code">N1</field>
-        <field name="taxes" eval="[(6, 0, [])]" />
+        <field
+            name="taxes"
+            eval="[(6, 0, [
+                ref('l10n_es.account_tax_template_s_iva_ns_b'),
+        ])]"
+        />
         <field name="verifactu_map_id" ref="verifactu_map" />
         <field name="name">Operación No Sujeta artículo 7, 14, otros.</field>
     </record>
@@ -57,8 +59,9 @@
         <field
             name="taxes"
             eval="[(6, 0, [
-                ref('l10n_es.account_tax_template_s_iva_ns_b'),
                 ref('l10n_es.account_tax_template_s_iva_ns'),
+                ref('l10n_es.account_tax_template_s_iva_e'),
+                ref('l10n_es.account_tax_template_s_iva0_sp_i'),
             ])]"
         />
         <field name="verifactu_map_id" ref="verifactu_map" />
@@ -116,5 +119,57 @@
         />
         <field name="verifactu_map_id" ref="verifactu_map" />
         <field name="name">Bases no incluidas en ImporteTotal</field>
+    </record>
+
+    <record id="verifactu_map_line_E1" model="verifactu.map.line">
+        <field name="code">E1</field>
+        <field name="taxes" eval="[]" />
+        <field name="verifactu_map_id" ref="verifactu_map" />
+        <field name="name">Exenta por el artículo 20</field>
+    </record>
+
+    <record id="verifactu_map_line_E2" model="verifactu.map.line">
+        <field name="code">E2</field>
+        <field
+            name="taxes"
+            eval="[(6, 0, [
+                ref('l10n_es.account_tax_template_s_iva0_e'),
+        ])]"
+        />
+        <field name="verifactu_map_id" ref="verifactu_map" />
+        <field name="name">Exenta por el artículo 21</field>
+    </record>
+
+    <record id="verifactu_map_line_E3" model="verifactu.map.line">
+        <field name="code">E3</field>
+        <field name="taxes" eval="[]" />
+        <field name="verifactu_map_id" ref="verifactu_map" />
+        <field name="name">Exenta por el artículo 22</field>
+    </record>
+
+    <record id="verifactu_map_line_E4" model="verifactu.map.line">
+        <field name="code">E4</field>
+        <field name="taxes" eval="[]" />
+        <field name="verifactu_map_id" ref="verifactu_map" />
+        <field name="name">Exenta por los artículos 23 y 24</field>
+    </record>
+
+    <record id="verifactu_map_line_E5" model="verifactu.map.line">
+        <field name="code">E5</field>
+        <field
+            name="taxes"
+            eval="[(6, 0, [
+                ref('l10n_es.account_tax_template_s_iva0_ic'),
+        ])]"
+        />
+        <field name="verifactu_map_id" ref="verifactu_map" />
+        <field name="name">Exenta por el artículo 25</field>
+    </record>
+
+    <record id="verifactu_map_line_E6" model="verifactu.map.line">
+        <field name="code">E6</field>
+        <field name="taxes" eval="[]" />
+        <field name="verifactu_map_id" ref="verifactu_map" />
+        <field name="name">Exenta por otros</field>
     </record>
 </odoo>

--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -285,7 +285,7 @@ class AccountMove(models.Model):
                 }
         return {"PrimerRegistro": "S"}
 
-    def _get_verifactu_tax_dict(self, tax_line, tax_lines):
+    def _get_verifactu_tax_dict(self, tax_line, tax_lines, operation_type):
         """Get the VERI*FACTU tax dictionary for the passed tax line.
 
         :param self: Single invoice record.
@@ -294,6 +294,11 @@ class AccountMove(models.Model):
             (like REQ).
         :return: A dictionary with the corresponding VERI*FACTU tax values.
         """
+        if operation_type in ("N1", "N2", "exempt"):
+            tax_dict = {
+                "BaseImponibleOimporteNoSujeto": tax_line["base"],
+            }
+            return tax_dict
         tax = tax_line["tax"]
         tax_base_amount = tax_line["base"]
         if tax.amount_type == "group":
@@ -311,19 +316,6 @@ class AccountMove(models.Model):
         if req_tax:
             tax_dict["TipoRecargoEquivalencia"] = req_tax.amount
             tax_dict["CuotaRecargoEquivalencia"] = tax_lines[req_tax]["amount"]
-        return tax_dict
-
-    def _get_verifactu_tax_dict_ns(self, tax_line):
-        """Get the VERI*FACTU tax dictionary for the passed tax line.
-
-        :param self: Single invoice record.
-        :param tax_line: Tax line that is being analyzed.
-        :return: A dictionary with the corresponding VERI*FACTU tax values.
-        """
-        tax_base_amount = tax_line["base"]
-        tax_dict = {
-            "BaseImponibleOimporteNoSujeto": tax_base_amount,
-        }
         return tax_dict
 
     def _get_verifactu_tax_req(self, tax):
@@ -355,6 +347,12 @@ class AccountMove(models.Model):
         taxes_N1 = self._get_verifactu_taxes_map(["N1"], document_date)
         taxes_N2 = self._get_verifactu_taxes_map(["N2"], document_date)
         taxes_RE = self._get_verifactu_taxes_map(["RE"], document_date)
+        taxes_E1 = self._get_verifactu_taxes_map(["E1"], document_date)
+        taxes_E2 = self._get_verifactu_taxes_map(["E2"], document_date)
+        taxes_E3 = self._get_verifactu_taxes_map(["E3"], document_date)
+        taxes_E4 = self._get_verifactu_taxes_map(["E4"], document_date)
+        taxes_E5 = self._get_verifactu_taxes_map(["E5"], document_date)
+        taxes_E6 = self._get_verifactu_taxes_map(["E6"], document_date)
         taxes_not_in_total = self._get_verifactu_taxes_map(
             ["TaxNotIncludedInTotal"], document_date
         )
@@ -365,26 +363,44 @@ class AccountMove(models.Model):
         breakdown_taxes = taxes_S1 + taxes_S2 + taxes_N1 + taxes_N2
         not_in_amount_total = 0.0
         not_in_taxes = 0.0
+        exempt_taxes = taxes_E1 + taxes_E2 + taxes_E3 + taxes_E4 + taxes_E5 + taxes_E6
         for tax_line in tax_lines.values():
             tax = tax_line["tax"]
             if tax in taxes_not_in_total:
                 not_in_amount_total += tax_line["amount"]
             elif tax in base_not_in_total:
                 not_in_amount_total += tax_line["base"]
-            if tax in breakdown_taxes:
-                operation_type = self._get_verifactu_operation_type(
-                    tax_line, taxes_S1, taxes_S2, taxes_N1, taxes_N2
-                )
+            if tax in breakdown_taxes or tax in exempt_taxes:
                 tax_dict = {
                     "Impuesto": self.verifactu_tax_key,
                     "ClaveRegimen": self.verifactu_registration_key_code,
-                    "CalificacionOperacion": operation_type,
                 }
-                if operation_type not in ("N1", "N2"):
-                    new_tax_dict = self._get_verifactu_tax_dict(tax_line, tax_lines)
-                    tax_dict.update(new_tax_dict)
+                operation_type = self._get_verifactu_operation_type(
+                    tax_line, taxes_S1, taxes_S2, taxes_N1, taxes_N2
+                )
+                if operation_type != "exempt":
+                    tax_dict.update(
+                        {
+                            "CalificacionOperacion": operation_type,
+                        }
+                    )
                 else:
-                    tax_dict.update(self._get_verifactu_tax_dict_ns(tax_line))
+                    tax_dict.update(
+                        {
+                            "OperacionExenta": self._get_verifactu_exempt_cause(
+                                tax_line,
+                                taxes_E1,
+                                taxes_E2,
+                                taxes_E3,
+                                taxes_E4,
+                                taxes_E5,
+                            )
+                        }
+                    )
+                new_tax_dict = self._get_verifactu_tax_dict(
+                    tax_line, tax_lines, operation_type
+                )
+                tax_dict.update(new_tax_dict)
                 taxes_dict["DetalleDesglose"].append(tax_dict)
             elif tax in excluded_taxes:
                 not_in_taxes += tax_line["amount"]
@@ -416,7 +432,31 @@ class AccountMove(models.Model):
             return "N1"
         elif tax in taxes_N2:
             return "N2"
-        return "S1"
+        return "exempt"
+
+    def _get_verifactu_exempt_cause(
+        self, tax_line, taxes_E1, taxes_E2, taxes_E3, taxes_E4, taxes_E5
+    ):
+        """
+        E1	Exenta por el artículo 20
+        E2	Exenta por el artículo 21
+        E3	Exenta por el artículo 22
+        E4	Exenta por los artículos 23 y 24
+        E5	Exenta por el artículo 25
+        E6	Exenta por otros
+        """
+        tax = tax_line["tax"]
+        if tax in taxes_E1:
+            return "E1"
+        elif tax in taxes_E2:
+            return "E2"
+        elif tax in taxes_E3:
+            return "E3"
+        elif tax in taxes_E4:
+            return "E4"
+        elif tax in taxes_E5:
+            return "E5"
+        return "E6"
 
     def _get_verifactu_receiver_dict(self):
         self.ensure_one()

--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
@@ -296,9 +296,8 @@ class VerifactuInvoiceEntry(models.Model):
         try:
             serv = rec._connect_verifactu()
             res = serv.RegFactuSistemaFacturacion(header, registro_factura_list)
-        except Exception as e:
-            _logger.error("Error sending documents to VERI*FACTU: %s", e)
-            res = {}
+        except Exception as AEATError:
+            res = {AEATError}
             create_exception = True
         response_name = ""
         response = (

--- a/l10n_es_verifactu_oca/tests/common.py
+++ b/l10n_es_verifactu_oca/tests/common.py
@@ -21,9 +21,14 @@ class TestVerifactuCommon(TestL10nEsAeatModBase, TestL10nEsAeatCertificateBase):
         cls.fp_registration_key_01 = cls.env.ref(
             "l10n_es_verifactu_oca.verifactu_registration_keys_01"
         )
+        cls.fp_registration_key_02 = cls.env.ref(
+            "l10n_es_verifactu_oca.verifactu_registration_keys_02"
+        )
         cls.fp_nacional.verifactu_registration_key = cls.fp_registration_key_01
         cls.fp_recargo = cls.env.ref(f"l10n_es.{cls.company.id}_fp_recargo")
         cls.fp_recargo.verifactu_registration_key = cls.fp_registration_key_01
+        cls.fp_extra = cls.env.ref(f"l10n_es.{cls.company.id}_fp_extra")
+        cls.fp_extra.verifactu_registration_key = cls.fp_registration_key_02
         cls.partner = cls.env["res.partner"].create(
             {
                 "name": "Test partner",

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_e_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_e_dict.json
@@ -1,0 +1,49 @@
+{
+  "RegistroAlta": {
+    "IDVersion": 1.0,
+    "IDFactura": {
+      "IDEmisorFactura": "G87846952",
+      "NumSerieFactura": "TEST_EXEMPT_002",
+      "FechaExpedicionFactura": "01-01-2026"
+    },
+    "NombreRazonEmisor": "Spanish test company",
+    "TipoFactura": "F1",
+    "DescripcionOperacion": "/",
+    "Destinatarios": {
+      "IDDestinatario": {
+        "NombreRazon": "Test partner",
+        "NIF": "89890001K"
+      }
+    },
+    "Desglose": {
+      "DetalleDesglose": [
+        {
+          "Impuesto": "01",
+          "ClaveRegimen": "01",
+          "BaseImponibleOimporteNoSujeto": 200.0,
+          "OperacionExenta": "E2"
+        }
+      ]
+    },
+    "CuotaTotal": 0.0,
+    "ImporteTotal": 200.0,
+    "Encadenamiento": {
+      "PrimerRegistro": "S"
+    },
+    "SistemaInformatico": {
+      "NombreRazon": "Odoo Developer",
+      "NIF": "A12345674",
+      "NombreSistemaInformatico": "odoo",
+      "IdSistemaInformatico": "11",
+      "Version": "1.0",
+      "NumeroInstalacion": 1,
+      "TipoUsoPosibleSoloVerifactu": "S",
+      "TipoUsoPosibleMultiOT": "S",
+      "IndicadorMultiplesOT": "N",
+      "IDOtro": {
+        "IDType": "",
+        "ID": ""
+      }
+    }
+  }
+}

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_ic_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_ic_dict.json
@@ -1,0 +1,49 @@
+{
+  "RegistroAlta": {
+    "IDVersion": 1.0,
+    "IDFactura": {
+      "IDEmisorFactura": "G87846952",
+      "NumSerieFactura": "TEST_EXEMPT_001",
+      "FechaExpedicionFactura": "01-01-2026"
+    },
+    "NombreRazonEmisor": "Spanish test company",
+    "TipoFactura": "F1",
+    "DescripcionOperacion": "/",
+    "Destinatarios": {
+      "IDDestinatario": {
+        "NombreRazon": "Test partner",
+        "NIF": "89890001K"
+      }
+    },
+    "Desglose": {
+      "DetalleDesglose": [
+        {
+          "Impuesto": "01",
+          "ClaveRegimen": "02",
+          "BaseImponibleOimporteNoSujeto": 200.0,
+          "OperacionExenta": "E5"
+        }
+      ]
+    },
+    "CuotaTotal": 0.0,
+    "ImporteTotal": 200.0,
+    "Encadenamiento": {
+      "PrimerRegistro": "S"
+    },
+    "SistemaInformatico": {
+      "NombreRazon": "Odoo Developer",
+      "NIF": "A12345674",
+      "NombreSistemaInformatico": "odoo",
+      "IdSistemaInformatico": "11",
+      "Version": "1.0",
+      "NumeroInstalacion": 1,
+      "TipoUsoPosibleSoloVerifactu": "S",
+      "TipoUsoPosibleMultiOT": "S",
+      "IndicadorMultiplesOT": "N",
+      "IDOtro": {
+        "IDType": "",
+        "ID": ""
+      }
+    }
+  }
+}

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva_ns_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva_ns_dict.json
@@ -1,0 +1,49 @@
+{
+  "RegistroAlta": {
+    "IDVersion": 1.0,
+    "IDFactura": {
+      "IDEmisorFactura": "G87846952",
+      "NumSerieFactura": "TEST_EXPORT",
+      "FechaExpedicionFactura": "01-01-2026"
+    },
+    "NombreRazonEmisor": "Spanish test company",
+    "TipoFactura": "F1",
+    "DescripcionOperacion": "/",
+    "Destinatarios": {
+      "IDDestinatario": {
+        "NombreRazon": "Test partner",
+        "NIF": "89890001K"
+      }
+    },
+    "Desglose": {
+      "DetalleDesglose": [
+        {
+          "Impuesto": "01",
+          "ClaveRegimen": "02",
+          "CalificacionOperacion": "N2",
+          "BaseImponibleOimporteNoSujeto": 200.0
+        }
+      ]
+    },
+    "CuotaTotal": 0.0,
+    "ImporteTotal": 200.0,
+    "Encadenamiento": {
+      "PrimerRegistro": "S"
+    },
+    "SistemaInformatico": {
+      "NombreRazon": "Odoo Developer",
+      "NIF": "A12345674",
+      "NombreSistemaInformatico": "odoo",
+      "IdSistemaInformatico": "11",
+      "Version": "1.0",
+      "NumeroInstalacion": 1,
+      "TipoUsoPosibleSoloVerifactu": "S",
+      "TipoUsoPosibleMultiOT": "S",
+      "IndicadorMultiplesOT": "N",
+      "IDOtro": {
+        "IDType": "",
+        "ID": ""
+      }
+    }
+  }
+}

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -170,6 +170,63 @@ class TestL10nEsAeatVerifactu(TestVerifactuCommon):
         self.company.verifactu_start_date = False
         self.assertTrue(invoice2.verifactu_enabled)
 
+    def test_verifactu_export_invoice_data(self):
+        mapping = [
+            (
+                "TEST_EXPORT",
+                "out_invoice",
+                [(200, ["s_iva_ns"])],
+                {
+                    "fiscal_position_id": self.fp_extra.id,
+                    "verifactu_registration_key": self.fp_registration_key_02.id,
+                    "verifactu_registration_date": "2026-01-01 19:20:30",
+                },
+            )
+        ]
+        for name, inv_type, lines, extra_vals in mapping:
+            self._create_and_test_invoice_verifactu_dict(
+                name, inv_type, lines, extra_vals
+            )
+
+    def test_verifactu_with_exemption_cause_e5_invoice_data(self):
+        # test exemption cause E5
+        mapping = [
+            (
+                "TEST_EXEMPT_001",
+                "out_invoice",
+                [(200, ["s_iva0_ic"])],
+                {
+                    "fiscal_position_id": self.fp_extra.id,
+                    "verifactu_registration_key": self.fp_registration_key_02.id,
+                    "verifactu_registration_date": "2026-01-01 19:20:30",
+                },
+            )
+        ]
+        for name, inv_type, lines, extra_vals in mapping:
+            self._create_and_test_invoice_verifactu_dict(
+                name, inv_type, lines, extra_vals
+            )
+
+    def test_verifactu_with_exemption_cause_e2_invoice_data(self):
+        # test exemption cause E2
+        mapping_2 = [
+            (
+                "TEST_EXEMPT_002",
+                "out_invoice",
+                [(200, ["s_iva0_e"])],
+                {
+                    "fiscal_position_id": self.fp_nacional.id,
+                    "verifactu_registration_key": self.fp_registration_key_01.id,
+                    "verifactu_registration_date": "2026-01-01 19:20:30",
+                },
+            )
+        ]
+        for name, inv_type, lines, extra_vals in mapping_2:
+            self._create_and_test_invoice_verifactu_dict(
+                name, inv_type, lines, extra_vals
+            )
+        return
+
 
 class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):
     def _get_required_qr_params(self):


### PR DESCRIPTION
- Se modifica el mapeo de impuestos de Veri*Factu y se añaden las claves para la 6 causas posibles de exención.
- Se modifica el contenido a enviar para las operaciones exentas.

@BinhexTeam