### PR TITLE
[16.0][IMP] l10n_es_verifactu_oca: fecha de operación

### DIFF
--- a/l10n_es_verifactu_oca/i18n/es.po
+++ b/l10n_es_verifactu_oca/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-28 10:22+0000\n"
-"PO-Revision-Date: 2025-11-28 10:22+0000\n"
+"POT-Creation-Date: 2025-11-30 21:00+0000\n"
+"PO-Revision-Date: 2025-11-30 21:00+0000\n"
 "Last-Translator: Mario Montes <admin@syci.es>\n"
 "Language-Team: \n"
 "Language: \n"
@@ -1769,6 +1769,23 @@ msgstr "número de factura"
 #, python-format
 msgid "third-party number"
 msgstr "número de terceros"
+
+#. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/account_move.py:0
+#, python-format
+msgid "- The operation date cannot be greater than the invoice date."
+msgstr "- La fecha de operación no puede ser mayor que la fecha de factura."
+
+#. module: l10n_es_verifactu_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_form
+msgid "Operation date"
+msgstr "Fecha de operación"
+
+#. module: l10n_es_verifactu_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_form
+msgid "Fill this field if the operation date is earlier than the invoice date."
+msgstr "Rellene este campo si la fecha de operación es anterior a la fecha de factura."
 
 #~ msgid "Cancelled"
 #~ msgstr "Cancelada"

--- a/l10n_es_verifactu_oca/i18n/l10n_es_verifactu_oca.pot
+++ b/l10n_es_verifactu_oca/i18n/l10n_es_verifactu_oca.pot
@@ -1726,3 +1726,20 @@ msgstr ""
 #, python-format
 msgid "third-party number"
 msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/account_move.py:0
+#, python-format
+msgid "- The operation date cannot be greater than the invoice date."
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_form
+msgid "Operation date"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_form
+msgid "Fill this field if the operation date is earlier than the invoice date."
+msgstr ""

--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -226,6 +226,8 @@ class AccountMove(models.Model):
             "NombreRazonEmisor": self.company_id.name[0:120],
             "TipoFactura": verifactu_doc_type,
         }
+        if self.date and self.date != self.invoice_date:
+            inv_dict["FechaOperacion"] = self._get_verifactu_date(self.date)
         if self.move_type == "out_refund":
             inv_dict["TipoRectificativa"] = self.verifactu_refund_type
             if self.verifactu_refund_type == "I":
@@ -521,6 +523,10 @@ class AccountMove(models.Model):
             suffixes.append(_("- There are some inconsistent taxes on lines."))
         if not self._check_all_taxes_mapped():
             suffixes.append(_("- It does not have all taxes mapped."))
+        if self.date and self.invoice_date and self.date > self.invoice_date:
+            suffixes.append(
+                _("- The operation date cannot be greater than the invoice date.")
+            )
         return super()._check_verifactu_configuration(suffixes=suffixes)
 
     def _check_inconsistent_taxes(self):

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -5,7 +5,7 @@
 # Copyright 2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from hashlib import sha256
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -508,3 +508,45 @@ class TestVerifactuSendResponse(TestVerifactuCommon):
             activity,
             "A warning activity should be created for 'AceptadoConErrores' response",
         )
+
+
+class TestVerifactuOperationDate(TestVerifactuCommon):
+    def test_operation_date_validation(self):
+        """Test that operation date cannot be greater than invoice date."""
+        self._activate_certificate(self.certificate_password)
+        invoice = self._create_test_invoice()
+        invoice.aeat_state = "not_sent"
+        invoice.date = invoice.invoice_date + timedelta(days=1)
+
+        with self.assertRaisesRegex(
+            UserError, "The operation date cannot be greater than the invoice date"
+        ):
+            invoice.action_post()
+
+    def test_operation_date_in_dict(self):
+        """Test that FechaOperacion is included when date < invoice_date."""
+        self._activate_certificate(self.certificate_password)
+        invoice = self._create_test_invoice()
+        operation_date = invoice.invoice_date - timedelta(days=1)
+        invoice.date = operation_date
+        self._prepare_invoice_for_verifactu(invoice)
+
+        res_dict = invoice._get_verifactu_invoice_dict_out()
+        inv_dict = res_dict["RegistroAlta"]
+
+        self.assertIn("FechaOperacion", inv_dict)
+        self.assertEqual(
+            inv_dict["FechaOperacion"], operation_date.strftime("%d-%m-%Y")
+        )
+
+    def test_operation_date_not_in_dict_when_equal(self):
+        """Test that FechaOperacion is NOT included when date == invoice_date."""
+        self._activate_certificate(self.certificate_password)
+        invoice = self._create_test_invoice()
+        invoice.date = invoice.invoice_date
+        self._prepare_invoice_for_verifactu(invoice)
+
+        res_dict = invoice._get_verifactu_invoice_dict_out()
+        inv_dict = res_dict["RegistroAlta"]
+
+        self.assertNotIn("FechaOperacion", inv_dict)

--- a/l10n_es_verifactu_oca/views/account_move_view.xml
+++ b/l10n_es_verifactu_oca/views/account_move_view.xml
@@ -24,6 +24,14 @@
                     attrs="{'invisible': ['|','|',('verifactu_enabled', '=', False), ('state', 'not in', ['posted','cancel']), ('aeat_state','not in', ('sent', 'sent_w_errors', 'cancel_w_errors', 'cancel_incorrect'))]}"
                 />
             </button>
+            <xpath expr="//field[@name='invoice_date']" position="after">
+                <field
+                    name="date"
+                    string="Operation date"
+                    attrs="{'invisible': ['|', ('verifactu_enabled', '=', False), ('move_type', 'not in', ('out_invoice', 'out_refund'))]}"
+                    help="Fill this field if the operation date is earlier than the invoice date."
+                />
+            </xpath>
             <notebook position="inside">
                 <field
                     name="verifactu_enabled"


### PR DESCRIPTION
Propone un modo de gestionar la fecha de operación de forma acorde con Odoo: la factura se registra en una fecha y el asiento contable en otra. De este modo, aparece correctamente en el libro de IVA, en los modelos 303 y similares, donde debe figurar.