### PR TITLE
[16.0][IMP] l10n_es_verifactu_oca: manejo de rechazos, visibilidad de botones y bloqueo de borrado

### DIFF
--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -618,3 +618,9 @@ class AccountMove(models.Model):
                 )
                 rec.verifactu_registration_date = datetime.now()
                 rec._generate_verifactu_chaining(entry_type=entry_type)
+
+    def unlink(self):
+        for rec in self:
+            if rec.verifactu_enabled:
+                raise UserError(_("You can not delete VERI*FACTU enabled invoices"))
+        return super().unlink()

--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -97,6 +97,14 @@ class AccountMove(models.Model):
                     domain, limit=1
                 )
 
+    # pylint: disable=missing-return
+    def _compute_show_reset_to_draft_button(self):
+        """Allow reset to draft only for incorrect AEAT state."""
+        super()._compute_show_reset_to_draft_button()
+        for document in self:
+            if document.aeat_state == "incorrect" and document.state == "cancel":
+                document.show_reset_to_draft_button = True
+
     def _get_verifactu_document_type(self):
         invoice_type = ""
         if self.move_type in ["out_invoice", "out_refund"]:
@@ -501,7 +509,10 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         res = super()._post(soft=soft)
         for record in self.sorted(lambda inv: inv.name):
-            if record.verifactu_enabled and record.aeat_state == "not_sent":
+            if record.verifactu_enabled and record.aeat_state in (
+                "not_sent",
+                "incorrect",
+            ):
                 record._check_verifactu_configuration()
                 record.verifactu_registration_date = datetime.now()
                 record._generate_verifactu_chaining()
@@ -577,9 +588,18 @@ class AccountMove(models.Model):
             self.verifactu_registration_date = datetime.now()
             self._generate_verifactu_chaining(entry_type=entry_type)
 
+    def _filter_verifactu_locked(self):
+        return self.filtered(
+            lambda inv: inv.verifactu_enabled
+            and (
+                inv.aeat_state not in ("not_sent", "incorrect")
+                or inv.verifactu_pending_to_send
+            )
+        )
+
     def write(self, vals):
         for invoice in self.filtered(
-            lambda x: x.is_invoice() and x.aeat_state != "not_sent"
+            lambda x: x.is_invoice() and x.aeat_state not in ("not_sent", "incorrect")
         ):
             if invoice.move_type in ["out_invoice", "out_refund"]:
                 if "invoice_date" in vals:
@@ -591,18 +611,14 @@ class AccountMove(models.Model):
         return super().write(vals)
 
     def button_cancel(self):
-        invoices_sent = self.filtered(
-            lambda inv: inv.verifactu_enabled and inv.aeat_state != "not_sent"
-        )
-        if invoices_sent and not self.env.context.get("verifactu_cancel"):
+        invoices_sent_or_pending = self._filter_verifactu_locked()
+        if invoices_sent_or_pending and not self.env.context.get("verifactu_cancel"):
             raise UserError(_("You can not cancel invoices sent to VERI*FACTU."))
         return super().button_cancel()
 
     def button_draft(self):
-        invoices_sent = self.filtered(
-            lambda inv: inv.verifactu_enabled and inv.aeat_state != "not_sent"
-        )
-        if invoices_sent:
+        invoices_sent_or_pending = self._filter_verifactu_locked()
+        if invoices_sent_or_pending:
             raise UserError(_("You can not set to draft invoices sent to VERI*FACTU."))
         return super().button_draft()
 
@@ -610,8 +626,7 @@ class AccountMove(models.Model):
         for rec in self:
             if (
                 rec.aeat_state in ("sent_w_errors", "incorrect")
-                and rec.last_verifactu_invoice_entry_id
-                and not rec.last_verifactu_invoice_entry_id.send_state == "not_sent"
+                and not rec.verifactu_pending_to_send
             ):
                 entry_type = (
                     "modify" if rec.aeat_state == "sent_w_errors" else "register"

--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -133,6 +133,12 @@ class VerifactuMixin(models.AbstractModel):
         help="Optional internal reason to cancel this invoice"
         "in VERI*FACTU. This reason is not sent to VERI*FACTU",
     )
+    verifactu_pending_to_send = fields.Boolean(
+        string="VERI*FACTU pending to send",
+        compute="_compute_verifactu_pending_to_send",
+        store=True,
+        copy=False,
+    )
 
     @api.depends("last_verifactu_response_line_id.send_state")
     def _compute_aeat_state(self):
@@ -141,6 +147,15 @@ class VerifactuMixin(models.AbstractModel):
                 document.aeat_state = (
                     document.last_verifactu_response_line_id.send_state
                 )
+
+    @api.depends("last_verifactu_invoice_entry_id.send_state")
+    def _compute_verifactu_pending_to_send(self):
+        for document in self:
+            document.verifactu_pending_to_send = (
+                document.verifactu_enabled
+                and document.last_verifactu_invoice_entry_id
+                and document.last_verifactu_invoice_entry_id.send_state == "not_sent"
+            )
 
     @api.model
     def _get_verifactu_reference_models(self):

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -509,6 +509,31 @@ class TestVerifactuSendResponse(TestVerifactuCommon):
             "A warning activity should be created for 'AceptadoConErrores' response",
         )
 
+    def test_button_cancel_exception(self):
+        """Test that cancelling a sent invoice raises UserError."""
+        invoice = self._create_and_prepare_invoice()
+        self._generate_invoice_entry(invoice)
+        invoice.last_verifactu_invoice_entry_id.send_state = "sent"
+        invoice._compute_aeat_state()
+
+        with self.assertRaises(UserError):
+            invoice.button_cancel()
+
+        invoice.with_context(verifactu_cancel=True).button_cancel()
+        self.assertEqual(invoice.state, "cancel")
+
+    def test_button_draft_exception(self):
+        """Test that resetting to draft a sent invoice raises UserError."""
+        invoice = self._create_and_prepare_invoice()
+        self._generate_invoice_entry(invoice)
+        invoice.last_verifactu_invoice_entry_id.send_state = "sent"
+        invoice._compute_aeat_state()
+
+        invoice.with_context(verifactu_cancel=True).button_cancel()
+
+        with self.assertRaises(UserError):
+            invoice.button_draft()
+
     def test_unlink_exception(self):
         """Test that deleting a verifactu enabled invoice raises UserError."""
         invoice = self._create_and_prepare_invoice()

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -508,3 +508,10 @@ class TestVerifactuSendResponse(TestVerifactuCommon):
             activity,
             "A warning activity should be created for 'AceptadoConErrores' response",
         )
+
+    def test_unlink_exception(self):
+        """Test that deleting a verifactu enabled invoice raises UserError."""
+        invoice = self._create_and_prepare_invoice()
+
+        with self.assertRaises(UserError):
+            invoice.unlink()

--- a/l10n_es_verifactu_oca/views/account_move_view.xml
+++ b/l10n_es_verifactu_oca/views/account_move_view.xml
@@ -20,14 +20,14 @@
                     string="Re-send to VERI*FACTU"
                     name="resend_verifactu"
                     groups="l10n_es_aeat.group_account_aeat"
-                    attrs="{'invisible': ['|','|',('verifactu_enabled', '=', False), ('state', 'not in', ['posted']), ('aeat_state','not in', ('sent_w_errors', 'incorrect'))]}"
+                    attrs="{'invisible': ['|','|','|',('verifactu_enabled', '=', False), ('state', 'not in', ['posted']), ('aeat_state','not in', ('sent_w_errors', 'incorrect')), ('verifactu_pending_to_send', '=', True)]}"
                 />
                 <button
                     type="object"
                     string="Cancel in VERI*FACTU"
                     name="cancel_verifactu"
                     groups="l10n_es_aeat.group_account_aeat"
-                    attrs="{'invisible': ['|','|',('verifactu_enabled', '=', False), ('state', 'not in', ['posted','cancel']), ('aeat_state','not in', ('sent', 'sent_w_errors', 'cancel_w_errors', 'cancel_incorrect'))]}"
+                    attrs="{'invisible': ['|','|','|',('verifactu_enabled', '=', False), ('state', 'not in', ['posted','cancel']), ('aeat_state','not in', ('sent', 'sent_w_errors', 'cancel_w_errors', 'cancel_incorrect')), ('verifactu_pending_to_send', '=', True)]}"
                 />
             </button>
             <notebook position="inside">
@@ -35,6 +35,7 @@
                     name="verifactu_enabled"
                     invisible="1"
                 /> <!-- To be removed in v18 as not needed -->
+                <field name="verifactu_pending_to_send" invisible="1" />
                 <page
                     string="VERI*FACTU"
                     name="page_aeat"

--- a/l10n_es_verifactu_oca/views/account_move_view.xml
+++ b/l10n_es_verifactu_oca/views/account_move_view.xml
@@ -10,6 +10,12 @@
         <field name="arch" type="xml">
             <button name="button_draft" position="after">
                 <button
+                    name="button_cancel"
+                    string="Cancel Invoice"
+                    type="object"
+                    attrs="{'invisible': ['|', '|', ('verifactu_enabled', '=', False),('aeat_state', '!=', 'incorrect'), ('state', '!=', 'posted')]}"
+                />
+                <button
                     type="object"
                     string="Re-send to VERI*FACTU"
                     name="resend_verifactu"


### PR DESCRIPTION
Incluye:

- Cuando una factura es rechazada por VERIFACTU (ej: por fecha futura), no había forma de corregir ciertos datos para subsanarlo. Ahora se permite cancelar facturas con aeat_state = "incorrect" y pasarlas a borrador nuevamente, desbloqueando la posibilidad de editar datos esenciales para la subsanación.
- Los botones "Re-send to VERIFACTU" y "Cancel in VERIFACTU" seguían visibles aunque ya se hubiesen pulsado, causando confusión. Ahora los botones desaparecen automáticamente cuando hay registros pendientes de envío (verifactu_pending_to_send = True) y evita que el usuario intente ejecutar acciones que quedarían sin efecto mientras hay cambios sin enviar.
- Se bloquea la posibilidad de borrar cualquier factura que esté habilitada para VERIFACTU (incluso en estado borrador).

**NOTA:** He incluido un par de cosas dependientes y una independiente (el bloqueo de eliminación) en este PR para un primer análisis. Os invito a opinar acerca de la necesidad de cada una de estas tres cosas antes de hacer la (o las)  propuestas definitivas.