### PR TITLE
[18.0][IMP] l10n_es_verifactu_oca: create response line also when no verifactu response

### DIFF
--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
@@ -346,6 +346,32 @@ class VerifactuInvoiceEntry(models.Model):
         self, response=False, header=False, verifactu_response=False
     ):
         create_response_activity = False
+        if not verifactu_response:
+            for rec in self:
+                if rec.document:
+                    vals = {
+                        "entry_id": rec.id,
+                        "model": rec.model,
+                        "document_id": rec.document_id,
+                        "response": _("Connection error - no response from VERI*FACTU"),
+                        "entry_response_id": response.id,
+                        "send_state": "not_sent",
+                        "error_code": "CONNECTION_ERROR",
+                    }
+                    response_line = (
+                        self.env["verifactu.invoice.entry.response.line"]
+                        .sudo()
+                        .create(vals)
+                    )
+                    rec.document.last_verifactu_response_line_id = response_line
+                    rec.last_response_line_id = response_line
+                    rec.document.write(
+                        {
+                            "aeat_send_failed": True,
+                            "aeat_send_error": _("Connection error with VERI*FACTU"),
+                        }
+                    )
+            return create_response_activity
         # the returned object doesn't have `get` method, so use this form
         verifactu_response_lines = (
             "RespuestaLinea" in verifactu_response

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -374,6 +374,30 @@ class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):
                 "Invoice send be marked as failed after VERI*FACTU processing.",
             )
 
+    def test_send_invoices_to_verifactu_connection_error(self):
+        self._activate_certificate(self.certificate_password)
+        self.invoice.action_post()
+        with patch(
+            "odoo.addons.l10n_es_verifactu_oca.models."
+            "verifactu_invoice_entry.VerifactuInvoiceEntry._connect_verifactu"
+        ) as mock_connect:
+            mock_service = MagicMock()
+            mock_service.RegFactuSistemaFacturacion.return_value = {}
+            mock_connect.return_value = mock_service
+            self.env["verifactu.invoice.entry"]._cron_send_documents_to_verifactu()
+
+            self.assertEqual(
+                self.invoice.aeat_state,
+                "not_sent",
+                "Invoice should be marked as not sent after connection error.",
+            )
+            self.assertTrue(self.invoice.aeat_send_failed)
+            self.assertEqual(
+                self.invoice.aeat_send_error, "Connection error with VERI*FACTU"
+            )
+            last_line = self.invoice.last_verifactu_response_line_id
+            self.assertEqual(last_line.error_code, "CONNECTION_ERROR")
+
     def test_send_invoices_to_verifactu_duplicated(self):
         self._activate_certificate(self.certificate_password)
         self.invoice.action_post()

--- a/l10n_es_verifactu_oca/views/verifactu_invoice_entry_response_view.xml
+++ b/l10n_es_verifactu_oca/views/verifactu_invoice_entry_response_view.xml
@@ -57,7 +57,7 @@
                                 </group>
                             </group>
                         </page>
-                        <page string="Details">
+                        <page string="Response lines">
                             <field name="response_line_ids" readonly="1">
                                 <list>
                                     <field name="entry_id" column_invisible="1" />


### PR DESCRIPTION
La idea es que en caso de error de conexión con Verifactu, podamos visualizar desde la factura que hay un error de conexión.

<img width="1234" height="476" alt="image" src="https://github.com/user-attachments/assets/83deaeac-9011-497a-af31-bf26daaee047" />
<img width="1228" height="890" alt="image" src="https://github.com/user-attachments/assets/32e7bae4-8144-479f-a091-ccda335200e2" />

<img width="1243" height="834" alt="image" src="https://github.com/user-attachments/assets/d3292b76-8b12-4c30-b1c8-fa8df2a92285" />
