### PR TITLE
[16.0][FIX]l10n_es_aeat_sii_oca: arreglar error del sii en un corner case de céntimos con impuestos incluídos

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -212,6 +212,7 @@ class AccountMove(models.Model):
         if req_tax:
             tax_dict["TipoRecargoEquivalencia"] = req_tax.amount
             tax_dict["CuotaRecargoEquivalencia"] = tax_lines[req_tax]["amount"]
+        tax_dict = self._clean_sii_tax_dict(tax, self.move_type, tax_dict)
         return tax_dict
 
     def _get_document_amount_total(self):

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -10,7 +10,7 @@ import logging
 from odoo import _, api, exceptions, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.modules.registry import Registry
-from odoo.tools.float_utils import float_compare
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 from odoo.addons.l10n_es_aeat.models.aeat_mixin import round_by_keys
 
@@ -422,7 +422,8 @@ class SiiMixin(models.AbstractModel):
         else:
             tax_type = abs(tax.amount)
         tax_dict = {"TipoImpositivo": str(tax_type), "BaseImponible": tax_base_amount}
-        if self._get_mapping_key() in ["out_invoice", "out_refund"]:
+        mapping_key = self._get_mapping_key()
+        if mapping_key in ["out_invoice", "out_refund"]:
             key = "CuotaRepercutida"
         else:
             key = "CuotaSoportada"
@@ -432,6 +433,7 @@ class SiiMixin(models.AbstractModel):
         if req_tax:
             tax_dict["TipoRecargoEquivalencia"] = req_tax.amount
             tax_dict["CuotaRecargoEquivalencia"] = tax_lines[req_tax]["amount"]
+        tax_dict = self._clean_sii_tax_dict(tax, mapping_key, tax_dict)
         return tax_dict
 
     def _get_no_taxable_cause(self):
@@ -740,6 +742,40 @@ class SiiMixin(models.AbstractModel):
             ],
         )
         return inv_dict
+
+    def _clean_sii_tax_dict(self, tax, move_type, tax_dict):
+        """
+        Clean tax dict for corner cases that produces SII rejections.
+        :param tax: tax record
+        :param move_type: invoice move type
+        :param tax_dict: tax dict to clean
+        :return: cleaned tax dict
+
+        Corner case 1:
+            - document with amount_total 0.0
+            - amount_untaxed -0.1 and amount_tax 0.1 or
+              0.1 amount_untaxed and -0.1 amount_tax due to rounding issues.
+            (example in test_get_invoice_data_tax_price_included_corner_case)
+            It should be sent with 0.0 values to avoid SII rejection with error:
+            1231:'El campo CuotaRepercutida y BaseImponible deben tener el mismo signo.'
+        """
+        if tax.price_include:
+            base_amount = round(tax_dict.get("BaseImponible", 0.0), 2)
+            key = (
+                "CuotaRepercutida"
+                if move_type in ["out_invoice", "out_refund"]
+                else "CuotaSoportada"
+            )
+            tax_amount = round(tax_dict.get(key, 0.0), 2)
+
+            if (
+                float_compare(abs(base_amount), 0.01, precision_digits=2) == 0
+                and float_compare(abs(tax_amount), 0.01, precision_digits=2) == 0
+                and float_is_zero(base_amount + tax_amount, precision_digits=2)
+            ):
+                tax_dict[key] = 0.0
+                tax_dict["BaseImponible"] = 0.0
+        return tax_dict
 
     def _get_account_registration_date(self):
         """Hook method to allow the setting of the account registration date

--- a/l10n_es_aeat_sii_oca/tests/json/sii_out_invoice_s_iva21s_s_iva21s_s_iva21s_s_iva21s_dict.json
+++ b/l10n_es_aeat_sii_oca/tests/json/sii_out_invoice_s_iva21s_s_iva21s_s_iva21s_s_iva21s_dict.json
@@ -1,0 +1,35 @@
+{
+  "IDFactura": {
+    "IDEmisorFactura": {"NIF": "U2687761C"},
+    "NumSerieFacturaEmisor": "TEST001",
+    "FechaExpedicionFacturaEmisor": "01-01-2020"
+  },
+  "PeriodoLiquidacion": {"Ejercicio": 2020, "Periodo": "01"},
+  "FacturaExpedida": {
+    "TipoFactura": "F1",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "DescripcionOperacion": "/",
+    "TipoDesglose": {
+      "DesgloseTipoOperacion": {
+        "PrestacionServicios": {
+          "Sujeta": {
+            "NoExenta": {
+              "TipoNoExenta": "S1",
+              "DesgloseIVA": {
+                "DetalleIVA": [
+                  {
+                    "TipoImpositivo": "21.0",
+                    "BaseImponible": 0.0,
+                    "CuotaRepercutida": 0.0
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "ImporteTotal": 0.0,
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
+  }
+}

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -545,3 +545,35 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.company.sii_start_date = False
         self.assertTrue(invoice2.sii_enabled)
         self.assertTrue(invoice2.filtered_domain([("sii_enabled", "=", True)]))
+
+    def test_get_invoice_data_tax_price_included_corner_case(self):
+        xml_id = "l10n_es.{}_account_tax_template_{}".format(
+            self.company.id, "s_iva21s"
+        )
+        tax = self.env.ref(xml_id)
+        tax.price_include = True
+        mapping = [
+            (
+                "out_invoice",
+                [
+                    (-45, ["s_iva21s"]),
+                    (15, ["s_iva21s"]),
+                    (15, ["s_iva21s"]),
+                    (15, ["s_iva21s"]),
+                ],
+                {},
+            ),
+            (
+                "out_invoice",
+                [
+                    (45, ["s_iva21s"]),
+                    (-15, ["s_iva21s"]),
+                    (-15, ["s_iva21s"]),
+                    (-15, ["s_iva21s"]),
+                ],
+                {},
+            ),
+        ]
+        for inv_type, lines, extra_vals in mapping:
+            self._create_and_test_invoice_sii_dict(inv_type, lines, extra_vals)
+        return


### PR DESCRIPTION
Arregla error del sii en un corner case de céntimos que sucede en algunas facturas con impuestos incluídos en el precio.

Para reproducir el caso, se reproduce tanto en una factura de venta o compra como en un pos_order. Lo que sucede es que se envía en el desglose de impuestos una base con un céntimo positivo y una cuota con un céntimo negativo, o viceversa.
Por lo que el sii devuelve el error 1231:  'El campo CuotaRepercutida y BaseImponible deben tener el mismo signo.',

Ejemplo: con un iva 21% impuestos incluídos en el precio
<img width="1154" height="759" alt="image" src="https://github.com/user-attachments/assets/252900bf-bff5-4a0a-8eb7-e79ab1499918" />


<img width="537" height="281" alt="image" src="https://github.com/user-attachments/assets/d74663f9-303c-4acb-9527-d5aa3d60012e" />

mismo caso pero inverso, base negativa, impuesto positivo
<img width="1152" height="713" alt="image" src="https://github.com/user-attachments/assets/f85d8508-7704-4855-9085-7579dae6c60c" />



<img width="828" height="76" alt="image" src="https://github.com/user-attachments/assets/46055b5d-1865-4453-ae10-88c1cbc42163" />
