### PR TITLE
[17.0][IMP] l10n_es_account_statement_import_n43: Add exclude pattern

### DIFF
--- a/l10n_es_account_statement_import_n43/i18n/es.po
+++ b/l10n_es_account_statement_import_n43/i18n/es.po
@@ -60,6 +60,11 @@ msgstr ""
 "archivo."
 
 #. module: l10n_es_account_statement_import_n43
+#: model:ir.model.fields,field_description:l10n_es_account_statement_import_n43.field_account_journal__n43_exclude_pattern
+msgid "Exclude pattern for N43 Import"
+msgstr "Patrón de exclusion para importación N43"
+
+#. module: l10n_es_account_statement_import_n43
 #. odoo-python
 #: code:addons/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py:0
 #, python-format

--- a/l10n_es_account_statement_import_n43/i18n/l10n_es_account_statement_import_n43.pot
+++ b/l10n_es_account_statement_import_n43/i18n/l10n_es_account_statement_import_n43.pot
@@ -50,6 +50,11 @@ msgid ""
 msgstr ""
 
 #. module: l10n_es_account_statement_import_n43
+#: model:ir.model.fields,field_description:l10n_es_account_statement_import_n43.field_account_journal__n43_exclude_pattern
+msgid "Exclude pattern for N43 Import"
+msgstr ""
+
+#. module: l10n_es_account_statement_import_n43
 #. odoo-python
 #: code:addons/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py:0
 #, python-format

--- a/l10n_es_account_statement_import_n43/models/account_journal.py
+++ b/l10n_es_account_statement_import_n43/models/account_journal.py
@@ -23,6 +23,11 @@ class AccountJournal(models.Model):
         default="all",
         required=True,
     )
+    n43_exclude_pattern = fields.Char(
+        string="Exclude pattern for N43 import",
+        help="Fill this field if you want to exclude some lines of the N43 according "
+        "this regexp pattern.",
+    )
 
     def _get_bank_statements_available_import_formats(self):
         res = super()._get_bank_statements_available_import_formats()

--- a/l10n_es_account_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
+++ b/l10n_es_account_statement_import_n43/tests/test_l10n_es_account_bank_statement_import_n43.py
@@ -109,3 +109,11 @@ class L10nEsAccountStatementImportN43(common.TransactionCase):
             [("statement_id.journal_id", "=", self.journal.id)]
         )
         self.assertEqual(statements[0].date, fields.Date.to_date("2016-05-26"))
+
+    def test_import_n43_excluded_patern(self):
+        self.journal.n43_exclude_pattern = r".*TEST PARTNER 2.*"
+        self.import_wizard.import_file_button()
+        st_lines = self.env["account.bank.statement.line"].search(
+            [("statement_id.journal_id", "=", self.journal.id)]
+        )
+        self.assertEqual(len(st_lines), 2)

--- a/l10n_es_account_statement_import_n43/views/account_journal_views.xml
+++ b/l10n_es_account_statement_import_n43/views/account_journal_views.xml
@@ -8,6 +8,7 @@
                 <group string="Norm 43 options" invisible="type != 'bank'">
                     <field name="n43_date_type" />
                     <field name="n43_partner_search" />
+                    <field name="n43_exclude_pattern" />
                 </group>
             </xpath>
         </field>

--- a/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py
+++ b/l10n_es_account_statement_import_n43/wizards/account_statement_import_n43.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
+import re
 from datetime import datetime
 
 from odoo import _, api, exceptions, fields, models
@@ -409,9 +410,12 @@ class AccountStatementImport(models.TransientModel):
         return CURRENCY_ISO4217_MAP.get(iso_currency)
 
     def _complete_stmts_vals(self, stmts_vals, journal, account_number):
-        """Match partner_id if if hasn't been deducted yet."""
+        """Match partner_id if it hasn't been deducted yet & discard excluded lines."""
         res = super()._complete_stmts_vals(stmts_vals, journal, account_number)
+        pattern = journal.n43_exclude_pattern
+        pattern = re.compile(pattern) if pattern else False
         for st_vals in res:
+            transactions = []
             for line_vals in st_vals["transactions"]:
                 if line_vals.get("n43_line"):
                     n43_line = line_vals.pop("n43_line")
@@ -422,9 +426,18 @@ class AccountStatementImport(models.TransientModel):
                     line_vals["date"] = fields.Date.to_string(
                         n43_line.get(journal.n43_date_type or "fecha_valor")
                     )
+                    if (
+                        pattern
+                        and not pattern.match(line_vals["payment_ref"])
+                        or not pattern
+                    ):
+                        transactions.append(line_vals)
+                else:
+                    transactions.append(line_vals)
                 # This can't be used, as Odoo doesn't present the lines
                 # that already have a counterpart account as final
                 # verification, making this very counter intuitive to the user
                 # line_vals['account_id'] = self._get_n43_account(
                 #     line_vals['raw_data'], journal).id
+            st_vals["transactions"] = transactions
         return res


### PR DESCRIPTION
You may be interested in not importing certain statement lines if they come from complicated operations like third party payment providers with several charges/incomes, and you are interested in importing them by other means.

This commit includes a new field at journal level for defining an excluding pattern that allows this.

@Tecnativa TT59339