### PR TITLE
[17.0][FIX] l10n_es_facturae: Don't test thing outside module

### DIFF
--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -423,7 +423,6 @@ class CommonTest(CommonTestBase):
             domain = [("id", "=", refund_result["res_id"])]
         refund_inv = self.env["account.move"].search(domain)
         self.assertTrue(refund_inv)
-        self.assertIn(motive, refund_inv.ref)
         self.assertEqual(refund_inv.facturae_refund_reason, "01")
         refund_inv.action_post()
         refund_inv.name = "2998/99999"


### PR DESCRIPTION
This module doesn't transfer the motive text to the move, so it's better to not test that kind of things inside here, as any external change (like now) will make this to fail.

@Tecnativa 