### PR TITLE
[16.0][FIX] l10n_es_verifactu_oca: better matching an exception control in responses

### DIFF
--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
@@ -305,8 +305,24 @@ class VerifactuInvoiceEntry(models.Model):
         try:
             serv = rec._connect_verifactu()
             res = serv.RegFactuSistemaFacturacion(header, registro_factura_list)
-        except Exception as AEATError:
-            res = {AEATError}
+        except Exception as fault:
+            # Capture the fault regardless of its type: SOAP faults expose a
+            # `message` (and sometimes a `path`) attribute, plain Python errors
+            # do not. Falling back to the exception itself keeps the traceback
+            # visible in the response instead of storing an empty payload.
+            fault_message = str(getattr(fault, "message", None) or fault)
+            if hasattr(fault, "path"):
+                fault_message += " | Path: %s" % fault.path
+            res = {fault_message}
+            for rec in self:
+                if rec.document and hasattr(rec.document, "message_post"):
+                    rec.document.message_post(
+                        body=_(
+                            "Error from VERI*FACTU: %(error_message)s",
+                            error_message=fault_message,
+                        ),
+                        message_type="comment",
+                    )
             create_exception = True
         response_name = ""
         response = (
@@ -357,39 +373,51 @@ class VerifactuInvoiceEntry(models.Model):
             ).sorted(lambda x: x.create_date, reverse=True)
             if not matching_entries:
                 continue
-            verifactu_invoice_entry = matching_entries[0]  # Assume one match
-            document = verifactu_invoice_entry.document
-            previous_response_line = document.last_verifactu_response_line_id
-            send_state = VERIFACTU_STATE_MAPPING[
-                verifactu_response_line["EstadoRegistro"]
-            ]
-            if verifactu_invoice_entry.entry_type == "cancel":
-                send_state = VERIFACTU_CANCEL_STATE_MAPPING[
-                    verifactu_response_line["EstadoRegistro"]
-                ]
-            vals = {
-                "entry_id": verifactu_invoice_entry.id,
-                "model": verifactu_invoice_entry.model,
-                "document_id": verifactu_invoice_entry.document_id,
-                "response": verifactu_response_line,
-                "entry_response_id": response.id,
-                "send_state": send_state,
-                "error_code": "CodigoErrorRegistro" in verifactu_response_line
-                and str(verifactu_response_line["CodigoErrorRegistro"])
-                or "",
-            }
-            response_line = (
-                self.env["verifactu.invoice.entry.response.line"].sudo().create(vals)
-            )
-            document.last_verifactu_response_line_id = response_line
-            verifactu_invoice_entry.last_response_line_id = response_line
-            self._process_response_line_doc_vals(
-                verifactu_response=verifactu_response,
-                verifactu_response_line=verifactu_response_line,
-                response_line=response_line,
-                previous_response_line=previous_response_line,
-                header_sent=header,
-            )
-            if send_state not in ("sent", "cancel"):
-                create_response_activity = True
+            try:
+                with self.env.cr.savepoint():
+                    verifactu_invoice_entry = matching_entries[0]
+                    document = verifactu_invoice_entry.document
+                    previous_response_line = document.last_verifactu_response_line_id
+                    send_state = VERIFACTU_STATE_MAPPING[
+                        verifactu_response_line["EstadoRegistro"]
+                    ]
+                    if verifactu_invoice_entry.entry_type == "cancel":
+                        send_state = VERIFACTU_CANCEL_STATE_MAPPING[
+                            verifactu_response_line["EstadoRegistro"]
+                        ]
+                    vals = {
+                        "entry_id": verifactu_invoice_entry.id,
+                        "model": verifactu_invoice_entry.model,
+                        "document_id": verifactu_invoice_entry.document_id,
+                        "response": verifactu_response_line,
+                        "entry_response_id": response.id,
+                        "send_state": send_state,
+                        "error_code": "CodigoErrorRegistro" in verifactu_response_line
+                        and str(verifactu_response_line["CodigoErrorRegistro"])
+                        or "",
+                    }
+                    response_line = (
+                        self.env["verifactu.invoice.entry.response.line"]
+                        .sudo()
+                        .create(vals)
+                    )
+                    document.last_verifactu_response_line_id = response_line
+                    verifactu_invoice_entry.last_response_line_id = response_line
+                    self._process_response_line_doc_vals(
+                        verifactu_response=verifactu_response,
+                        verifactu_response_line=verifactu_response_line,
+                        response_line=response_line,
+                        previous_response_line=previous_response_line,
+                        header_sent=header,
+                    )
+                    if send_state not in ("sent", "cancel"):
+                        create_response_activity = True
+            except Exception as fault:
+                document = matching_entries[0].document
+                msg = _(
+                    "Error on VERI*FACTU response processing: %(error_message)s",
+                    error_message=repr(fault)[:60],
+                )
+                if document and hasattr(document, "message_post"):
+                    document.message_post(body=msg, message_type="comment")
         return create_response_activity

--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
@@ -352,7 +352,9 @@ class VerifactuInvoiceEntry(models.Model):
         )
         for verifactu_response_line in verifactu_response_lines:
             invoice_num = verifactu_response_line["IDFactura"]["NumSerieFactura"]
-            matching_entries = self.filtered(lambda r: r.document_name == invoice_num)
+            matching_entries = self.filtered(
+                lambda r: r.document_name == invoice_num
+            ).sorted(lambda x: x.create_date, reverse=True)
             if not matching_entries:
                 continue
             verifactu_invoice_entry = matching_entries[0]  # Assume one match

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -461,6 +461,97 @@ class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):
         self.invoice.invoice_line_ids.price_unit = 130000000
         self.assertTrue(self.invoice.verifactu_macrodata)
 
+    def test_send_invoices_to_verifactu_with_fault_exception(self):
+        """
+        Test that when VERI*FACTU raises an exception with a path attribute,
+        the exception is caught and stored in invoice.
+        """
+        self._activate_certificate(self.certificate_password)
+        self.invoice.action_post()
+        with patch(
+            "odoo.addons.l10n_es_verifactu_oca.models."
+            "verifactu_invoice_entry.VerifactuInvoiceEntry._connect_verifactu"
+        ) as mock_connect:
+            mock_service = MagicMock()
+            # Create a mock exception with both message and path attributes
+            fault_exception = Exception("SOAP Fault")
+            fault_exception.message = (
+                "Expected at least 1 items (minOccurs check) 0 items found."
+            )
+            fault_exception.path = [
+                "RegFactuSistemaFacturacion",
+                "RegistroFactura",
+                "Desglose",
+                "DetalleDesglose",
+            ]
+
+            mock_service.RegFactuSistemaFacturacion.side_effect = fault_exception
+            mock_connect.return_value = mock_service
+
+            # Execute the cron job - this should catch the exception
+            self.env["verifactu.invoice.entry"]._cron_send_documents_to_verifactu()
+
+            # Verify that a response was created with the exception info
+            response = self.env["verifactu.invoice.entry.response"].search(
+                [], order="id desc", limit=1
+            )
+            self.assertTrue(
+                response, "A response should be created even when exception occurs"
+            )
+
+            # Check that the response contains the error message with path information
+            self.assertIn(
+                "Expected at least 1 items (minOccurs check) 0 items found.",
+                str(response.response),
+            )
+            self.assertIn("Path:", str(response.response))
+            self.assertIn("DetalleDesglose", str(response.response))
+
+            # Verify that the document has an error message posted
+            messages = self.invoice.message_ids.filtered(
+                lambda m: "Error from VERI*FACTU" in m.body
+            )
+            self.assertTrue(
+                messages, "An error message should be posted to the invoice"
+            )
+            self.assertIn("Path:", messages[0].body)
+
+    def test_send_invoices_to_verifactu_with_plain_exception(self):
+        """
+        Test that a plain Python exception (no `message`/`path` attribute,
+        e.g. a network error) is still captured in the response payload and
+        posted to the invoice chatter, instead of being silently dropped.
+        """
+        self._activate_certificate(self.certificate_password)
+        self.invoice.action_post()
+        with patch(
+            "odoo.addons.l10n_es_verifactu_oca.models."
+            "verifactu_invoice_entry.VerifactuInvoiceEntry._connect_verifactu"
+        ) as mock_connect:
+            mock_service = MagicMock()
+            mock_service.RegFactuSistemaFacturacion.side_effect = RuntimeError(
+                "connection reset by peer"
+            )
+            mock_connect.return_value = mock_service
+
+            self.env["verifactu.invoice.entry"]._cron_send_documents_to_verifactu()
+
+            response = self.env["verifactu.invoice.entry.response"].search(
+                [], order="id desc", limit=1
+            )
+            self.assertTrue(
+                response, "A response should be created even when exception occurs"
+            )
+            # The exception text is captured even without a `message` attribute
+            self.assertIn("connection reset by peer", str(response.response))
+
+            messages = self.invoice.message_ids.filtered(
+                lambda m: "Error from VERI*FACTU" in (m.body or "")
+            )
+            self.assertTrue(
+                messages, "An error message should be posted to the invoice"
+            )
+
 
 class TestVerifactuSendResponse(TestVerifactuCommon):
     def test_create_activity_on_exception(self):
@@ -570,4 +661,45 @@ class TestVerifactuSendResponse(TestVerifactuCommon):
         self.assertTrue(
             activity,
             "A warning activity should be created for 'AceptadoConErrores' response",
+        )
+
+    @patch(
+        "odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry."
+        "VerifactuInvoiceEntry._connect_verifactu"
+    )
+    def test_response_line_processing_is_isolated(self, mock_connect):
+        """
+        A failure while processing one response line is isolated by a
+        savepoint: the batch does not crash, the error is posted to the
+        invoice chatter and the partially-created response line is rolled back.
+        """
+        self._activate_certificate(self.certificate_password)
+        self.invoice.action_post()
+        mock_service = MagicMock()
+        mock_service.RegFactuSistemaFacturacion.return_value = (
+            self.mock_verifactu_response("", "OK")
+        )
+        mock_connect.return_value = mock_service
+
+        with patch(
+            "odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry."
+            "VerifactuInvoiceEntry._process_response_line_doc_vals",
+            side_effect=RuntimeError("boom while processing response line"),
+        ):
+            # Must not raise even though the line processing blows up.
+            self.env["verifactu.invoice.entry"]._cron_send_documents_to_verifactu()
+
+        messages = self.invoice.message_ids.filtered(
+            lambda m: "Error on VERI*FACTU response processing" in (m.body or "")
+        )
+        self.assertTrue(
+            messages,
+            "The processing error should be posted to the invoice chatter",
+        )
+        # The response line created inside the savepoint must be rolled back.
+        lines = self.env["verifactu.invoice.entry.response.line"].search(
+            [("document_id", "=", self.invoice.id)]
+        )
+        self.assertFalse(
+            lines, "The response line must be rolled back on processing failure"
         )


### PR DESCRIPTION
- alineación con matching de v 14.0/15.0 (https://github.com/OCA/l10n-spain/pull/4520  https://github.com/OCA/l10n-spain/pull/4533)

- mejora el matching de las respuestas y además controla excepciones. En caso de que durante el procesamiento de las respuestas diera por ejemplo un errror de python en alguna de las facturas, se guarda en la mensajería de la propia factura, similar a esto.
<img width="1825" height="285" alt="image" src="https://github.com/user-attachments/assets/52303e1a-4eb7-4c09-b558-82bcb1361189" />

o si no se envía porque una de las facturas del bloque que se está enviando no está cumpliendo el esquema, muestra el error que devuelve AEAT, aunque AEAT no especifica cual de las facturas es la que no cumple, pero al menos se sabe lo que está pasando
<img width="1809" height="290" alt="image" src="https://github.com/user-attachments/assets/6360a59b-12a4-4964-9e14-a72b35299e2f" />

