### PR TITLE
[18.0][FIX] l10n_es_aeat_mod123: Tax 'Retenciones IRPF 19% (Compra consejero de sociedad)' added to tax mapping

### DIFF
--- a/l10n_es_aeat_mod123/data/2024/l10n.es.aeat.map.tax.line.csv
+++ b/l10n_es_aeat_mod123/data/2024/l10n.es.aeat.map.tax.line.csv
@@ -1,5 +1,5 @@
 "id","field_number","field_type","inverse","map_parent_id:id","name","sum_type","tax_xmlid_ids/id","to_regularize","move_type"
 "aeat_mod123_2024_map_line_04","04","base",1,"aeat_mod123_2024_map","Dividendos y otras rentas de participación en fondos propios de entidades - Base de Retenciones e ingresos a cuenta","both","p_rp19,p_rrD19,p_irpf24_rdc",1,"regular"
-"aeat_mod123_2024_map_line_05","05","base",1,"aeat_mod123_2024_map","Resto de rentas - Base de Retenciones e ingresos a cuenta","both",,1,"regular"
+"aeat_mod123_2024_map_line_05","05","base",1,"aeat_mod123_2024_map","Resto de rentas - Base de Retenciones e ingresos a cuenta","both",p_irpf19cs,1,"regular"
 "aeat_mod123_2024_map_line_07","07","amount",0,"aeat_mod123_2024_map","Dividendos y otras rentas de participación en fondos propios de entidades - Retenciones e ingresos a cuenta","credit","p_rp19,p_rrD19,p_irpf24_rdc",1,"regular"
-"aeat_mod123_2024_map_line_08","08","amount",0,"aeat_mod123_2024_map","Resto de rentas - Retenciones e ingresos a cuenta","credit",,1,"regular"
+"aeat_mod123_2024_map_line_08","08","amount",0,"aeat_mod123_2024_map","Resto de rentas - Retenciones e ingresos a cuenta","credit",p_irpf19cs,1,"regular"

--- a/l10n_es_aeat_mod123/data/l10n.es.aeat.map.tax.line.tax.csv
+++ b/l10n_es_aeat_mod123/data/l10n.es.aeat.map.tax.line.tax.csv
@@ -2,3 +2,4 @@ id,name
 p_rp19,account_tax_template_p_rp19
 p_rrD19,account_tax_template_p_rrD19
 p_irpf24_rdc,account_tax_template_p_irpf24_rdc
+p_irpf19cs,account_tax_template_p_irpf19cs


### PR DESCRIPTION
Las Retenciones IRPF 19% no se han metido en el mapeo de impuestos como en v16: https://github.com/OCA/l10n-spain/pull/3625

Cuando esté fusionado hago cherry-pick a la 17

MT-12991 @moduon @EmilioPascual @pedrobaeza porfa, revisad si queréis 😄 