### PR TITLE
[18.0] [FIX] l10n_es_verifactu_oca: Fix report layout conflict with stock picking address

### DIFF
--- a/l10n_es_verifactu_oca/views/report_invoice.xml
+++ b/l10n_es_verifactu_oca/views/report_invoice.xml
@@ -14,7 +14,7 @@
     </template>
     <template id="address_layout" inherit_id="web.address_layout" priority="1000">
         <div t-attf-class="address row mb-4" position="attributes">
-            <attribute name="t-if">not verifactu_invoice</attribute>
+            <attribute name="t-if">address and not verifactu_invoice</attribute>
         </div>
         <div t-attf-class="address row mb-4" position="after">
             <div t-if="verifactu_invoice" class="row" id="verifactu_row">


### PR DESCRIPTION
El cambio para mover el QR al encabezado del informe provocó que aparezca este bloque en el el report "stock.report_picking".
Origen del error: https://github.com/OCA/l10n-spain/pull/4384
Línea:
https://github.com/OCA/l10n-spain/blob/84ac9d1e30b8c561bc549c324195743a278d1f29/l10n_es_verifactu_oca/views/report_invoice.xml#L15-L18

Para replicar el error, imprimir albarán en estado "Ready"
<img width="1258" height="679" alt="image" src="https://github.com/user-attachments/assets/ffd868a0-22ef-4d87-9a18-80ff9e3882db" />
<img width="779" height="383" alt="image" src="https://github.com/user-attachments/assets/89c37573-7fa2-4454-a393-607bf7ae106f" />

Después del fix:
<img width="789" height="449" alt="image" src="https://github.com/user-attachments/assets/40d439ff-e79c-4b65-96f1-64531068bc23" />
