### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_oca: allow deletion when aeat_state is False

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -170,8 +170,8 @@ class SiiMixin(models.AbstractModel):
 
     def _filter_sii_unlink_not_possible(self):
         """Filter records that we do not allow to be deleted, all those
-        that are not in not_sent sii status."""
-        return self.filtered(lambda rec: rec.aeat_state != "not_sent")
+        that are not in not_sent sii status or False."""
+        return self.filtered(lambda rec: rec.aeat_state not in ["not_sent", False])
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_sii(self):


### PR DESCRIPTION
Fixes invoice deletion for records created before `l10n_es_aeat_sii_oca` module activation.

Previously, invoices created before activating `l10n_es_aeat_sii_oca` had `aeat_state = False` and couldn't be deleted. Now deletion is allowed when `aeat_state` is either `'not_sent'` or `False`.