### PR TITLE
[17.0][FIX] l10n_es_partner: Force context to calculate complete_name with comercial

### DIFF
--- a/l10n_es_partner/migrations/17.0.1.0.0/post-migration.py
+++ b/l10n_es_partner/migrations/17.0.1.0.0/post-migration.py
@@ -1,0 +1,8 @@
+# Copyright 2025 Tecnativa - Pilar Vargas
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["res.partner"].search([("comercial", "!=", False)])._compute_complete_name()

--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -43,6 +43,19 @@ class ResPartner(models.Model):
                 }
         return name
 
+    @api.depends("comercial")
+    def _compute_complete_name(self):
+        # We are enforcing the new context,
+        # because complete name field will remove the context
+        res = super()._compute_complete_name()
+        for partner in self:
+            partner.complete_name = partner.with_context(
+                display_commercial=not self.env.context.get(
+                    "no_display_commercial", False
+                )
+            )._get_complete_name()
+        return res
+
     @api.model
     def _commercial_fields(self):
         res = super()._commercial_fields()

--- a/l10n_es_partner/tests/test_l10n_es_partner.py
+++ b/l10n_es_partner/tests/test_l10n_es_partner.py
@@ -72,18 +72,18 @@ class TestL10nEsPartner(common.TransactionCase):
             }
         )
         self.assertEqual(partner2.display_name, "Nombre comercial (Empresa de prueba)")
-        self.assertEqual(partner2.complete_name, "Empresa de prueba")
+        self.assertEqual(partner2.complete_name, "Nombre comercial (Empresa de prueba)")
         self.assertEqual(
             partner2.with_context(show_address=True).display_name,
             "Nombre comercial (Empresa de prueba)\nMy street",
         )
-        # We will enforce the computation, but nothing should change
+        # We will enforce the computation
         partner2.with_context(
             show_address=True, display_commercial=True
         )._compute_complete_name()
-        self.assertEqual(partner2.complete_name, "Empresa de prueba")
         partner2.write({"comercial": "Nuevo nombre"})
         self.assertEqual(partner2.display_name, "Nuevo nombre (Empresa de prueba)")
+        self.assertEqual(partner2.complete_name, "Nuevo nombre (Empresa de prueba)")
         names = dict(
             [
                 (


### PR DESCRIPTION
bp https://github.com/OCA/l10n-spain/pull/4658/

complete_name is the field used to sort res.partner, but when calculated without context, the stored value ignored the sales rep name, producing an inconsistent visual order in the tree views when sorting by contact. The context is forced during the compute to include the sales rep in companies and contacts. In addition, a migration script is added to recalculate the affected records as it is a stored field.

@Tecnativa TT59646

@victoralmau @pedrobaeza please review