### PR TITLE
[18.0][IMP] l10n_es_vat_book: improve search for Ram consume

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -233,6 +233,7 @@ class L10nEsVatBook(models.Model):
         partner = move_line.partner_id
         invoice_date = move_line.date
         if invoice:
+            invoice = invoice.with_context(prefetch_fields=False)
             if invoice.is_invoice():
                 partner = invoice.commercial_partner_id
                 invoice_date = invoice.invoice_date

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -233,6 +233,7 @@ class L10nEsVatBook(models.Model):
         partner = move_line.partner_id
         invoice_date = move_line.date
         if invoice:
+            invoice = invoice.with_context(prefetch_fields=False)
             if invoice.is_invoice():
                 partner = invoice.commercial_partner_id
                 invoice_date = invoice.invoice_date
@@ -387,6 +388,9 @@ class L10nEsVatBook(models.Model):
     def create_vat_book_lines(self, move_lines, line_type, taxes):
         VatBookLine = self.env["l10n.es.vat.book.line"]
         moves_dic = {}
+        move_lines.move_id.fetch(
+            ["move_type", "commercial_partner_id", "invoice_date", "name", "ref"]
+        )
         for move_line in move_lines:
             line_key = self.get_book_line_key(move_line)
             if line_key not in moves_dic:


### PR DESCRIPTION
The invoice search in the vat book calculation has been modified to optimize performance on large databases.

This change avoids unnecessary prefetch and significantly improving the action's speed and memory consumption.

