### PR TITLE
[17.0][IMP] l10n_es_vat_book: tax group compatibility

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -277,13 +277,18 @@ class L10nEsVatBook(models.Model):
         for i, tax in enumerate(move_line.tax_ids):
             res = {}
             move_line._process_aeat_tax_base_info(res, tax, sign)
+            tax_base = (
+                res[tax]["base"]
+                if tax.amount_type != "group"
+                else list(res.values())[0]["base"]
+            )
             if i == 0:
-                vat_book_line["base_amount"] += res[tax]["base"]
+                vat_book_line["base_amount"] += tax_base
             if tax not in implied_taxes:
                 continue
             key = self.get_book_line_tax_key(move_line, tax)
             value = tax_lines.setdefault(key, default_dict | {"tax_id": tax.id})
-            value["base_amount"] += res[tax]["base"]
+            value["base_amount"] += tax_base
             value["base_move_line_ids"].append((4, move_line.id))
             # For later matching special taxes
             value["other_tax_ids"] = (move_line.tax_ids - tax).ids
@@ -392,6 +397,24 @@ class L10nEsVatBook(models.Model):
             if line_key not in moves_dic:
                 moves_dic[line_key] = self._prepare_book_line_vals(move_line, line_type)
             self.upsert_book_line_tax(move_line, moves_dic[line_key], taxes)
+
+        for move_id in list(moves_dic):
+            for tax_key in list(moves_dic[move_id]["tax_lines"]):
+                tax_line = moves_dic[move_id]["tax_lines"][tax_key]
+                tax = self.env["account.tax"].browse(tax_line["tax_id"])
+                if tax.amount_type == "group":
+                    sign = -1
+                    if line_type in ["received", "rectification_received"]:
+                        sign = 1
+                    res = {}
+                    move_line._process_aeat_tax_fee_info(res, tax, sign)
+                    for sub_tax in res.keys():
+                        if sub_tax.l10n_es_type != "ignore":
+                            moves_dic[move_id]["tax_lines"][(move_id, sub_tax.id)][
+                                "base_amount"
+                            ] += tax_line["base_amount"]
+                    moves_dic[move_id]["tax_lines"].pop(tax_key)
+
         lines_values = []
         for line_vals in moves_dic.values():
             tax_lines = line_vals.pop("tax_lines")

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -27,6 +27,7 @@ class TestL10nEsAeatVatBookBase(TestL10nEsAeatModBase):
         "P_REQ05": (270, 1.35),
         "P_REQ014": (280, 3.92),
         "P_REQ52": (290, 15.08),
+        "P_IVA10_IBC_GROUP": (10, 0.1),
     }
 
 
@@ -78,7 +79,7 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatVatBookBase):
             self.assertEqual(line.base_amount, 0.0)
             self.assertEqual(line.tax_amount, 0.0)
         # Check tax summary for received invoices
-        self.assertEqual(len(vat_book.received_tax_summary_ids), 6)
+        self.assertEqual(len(vat_book.received_tax_summary_ids), 7)
         rec_summaries = sorted(
             vat_book.received_tax_summary_ids,
             key=lambda line: line.tax_amount,
@@ -108,6 +109,11 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatVatBookBase):
         line = rec_summaries[5]
         self.assertAlmostEqual(line.base_amount, 270)
         self.assertAlmostEqual(line.tax_amount, 1.35)
+        # DUA - (1r desglose) 10% EX G (Bienes)
+        line = rec_summaries[6]
+        self.assertAlmostEqual(line.base_amount, 10)
+        self.assertAlmostEqual(line.tax_amount, 1.0)
+
         # Let's dig into this tax detail for checking the deductible amount
         tax_line = vat_book.received_line_ids.tax_line_ids.filtered(
             lambda x: "account_tax_template_p_iva0_nd" in x.tax_id.get_external_id()


### PR DESCRIPTION
Solution to issue https://github.com/OCA/l10n-spain/issues/4652 . 
**Dado que el módulo se va a refactorizar, se deja este PR en Draft, para el resto de casos que se necesite utilizar el libro de IVA con impuestos agrupados (DUA). Actualmente esta solución es viable, pero se debería de realizar más optima, esto se realizará en la refactorización. Por el momento, este PR no se mergeará para no relentizar el cálculo del libro de IVA.**