### PR TITLE
[16.0][IMP] l10n_es_sigaus_stock_picking_report_valued: Remove the SIGAUS total block.

### DIFF
--- a/l10n_es_sigaus_stock_picking_report_valued/models/stock_picking.py
+++ b/l10n_es_sigaus_stock_picking_report_valued/models/stock_picking.py
@@ -39,3 +39,9 @@ class StockPicking(models.Model):
             pick.picking_total_with_sigaus = (
                 pick.sigaus_amount_total + pick.amount_total
             )
+
+    def _get_report_valued_total_amount(self):
+        total = super()._get_report_valued_total_amount()
+        if self.sale_id and self.sale_id.is_sigaus:
+            total += self.sigaus_amount_total or 0.0
+        return total

--- a/l10n_es_sigaus_stock_picking_report_valued/report/report_deliveryslip.xml
+++ b/l10n_es_sigaus_stock_picking_report_valued/report/report_deliveryslip.xml
@@ -7,7 +7,7 @@
     >
         <xpath expr="//span[@t-field='o.amount_untaxed']/../../../.." position="after">
             <t
-                t-if="o.valued and o.sale_id and o.sale_id.is_sigaus and o.move_line_ids and is_outgoing"
+                t-if="o.valued and o.sale_id and o.sale_id.is_sigaus and o.move_line_ids and is_outgoing and abs(o.sigaus_amount_total) >= o.currency_id.rounding"
             >
                 <table class="table table-sm mt32" name="sigaus_valued">
                     <thead>
@@ -32,22 +32,6 @@
                         </tr>
                     </tbody>
                 </table>
-                <div class="col-6 ms-auto">
-                    <table
-                        class="table table-sm"
-                        style="background-color: rgba(0, 0, 0, 0.2);"
-                        name="sigaus_total"
-                    >
-                        <tr>
-                            <td>
-                                <strong>Total Picking</strong>
-                            </td>
-                            <td class="text-end">
-                                <strong t-field="o.picking_total_with_sigaus" />
-                            </td>
-                        </tr>
-                    </table>
-                </div>
             </t>
         </xpath>
     </template>

--- a/l10n_es_sigaus_stock_picking_report_valued/tests/test_l10n_es_sigaus_stock_picking_report_valued.py
+++ b/l10n_es_sigaus_stock_picking_report_valued/tests/test_l10n_es_sigaus_stock_picking_report_valued.py
@@ -82,3 +82,42 @@ class TestL10nEsSigausStockPickingReportValued(TestL10nEsSigausCommon):
         self.assertAlmostEqual(
             picking.picking_total_with_sigaus, sale.amount_total, places=2
         )
+
+    def test_get_report_valued_total_amount_with_sigaus(self):
+        sale = self.env["sale.order"].create(
+            {
+                "company_id": self.company.id,
+                "partner_id": self.partner.id,
+                "date_order": "2023-01-01",
+                "fiscal_position_id": self.fiscal_position_sigaus.id,
+                "is_sigaus": True,
+                "order_line": [
+                    (
+                        0,
+                        False,
+                        {
+                            "product_id": self.product_sigaus_in_product.id,
+                            "product_uom_qty": 10,
+                            "price_unit": 2,
+                            "tax_id": [self.tax.id],
+                        },
+                    )
+                ],
+            }
+        )
+        sale.action_confirm()
+        picking = sale.picking_ids
+        line = picking.move_line_ids
+        line.write({"qty_done": 10})
+        line._compute_sale_order_line_fields()
+        picking._compute_amount_all()
+        picking._compute_sigaus_amount()
+        total = picking._get_report_valued_total_amount()
+        base_total = picking.amount_total or 0.0
+        expected_total = base_total + picking.sigaus_amount_total
+        self.assertAlmostEqual(
+            total,
+            expected_total,
+            places=2,
+            msg="Valued picking total must include SIGAUS amount when sale is SIGAUS",
+        )


### PR DESCRIPTION
@HaraldPanten @Jaimermaccione 

- Remove the SIGAUS total block.  Now the stock_picking_report_valued module now includes logic to add totals through the `get_report_valued_total_amount method` (OCA/stock-logistics-reporting#457)

[T-9158]
