### PR TITLE
[18.0][IMP] delivery_gls_asm: raise UserError when validating picking with a PickUp Service

### DIFF
--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -273,7 +273,17 @@ class DeliveryCarrier(models.Model):
         result = []
         for picking in pickings:
             if picking.carrier_id.gls_is_pickup_service:
-                continue
+                service_name = dict(
+                    picking.carrier_id._fields["gls_asm_service"].selection
+                ).get(picking.carrier_id.gls_asm_service)
+                raise UserError(
+                    _(
+                        "The service %s is a pickup service. "
+                        "If you want to record a pickup, please first use the "
+                        "'Send Pickup' button in the picking."
+                    )
+                    % service_name
+                )
             vals = self._prepare_gls_asm_shipping(picking)
             if len(vals.get("referencia_c", "")) > 15:
                 raise UserError(
@@ -343,7 +353,12 @@ class DeliveryCarrier(models.Model):
         result = []
         for picking in pickings:
             if not picking.carrier_id.gls_is_pickup_service:
-                continue
+                service_name = dict(
+                    picking.carrier_id._fields["gls_asm_service"].selection
+                ).get(picking.carrier_id.gls_asm_service)
+                raise UserError(
+                    _("The service %s is not a pickup service.") % service_name
+                )
             vals = self._prepare_gls_asm_pickup(picking)
             vals.update({"tracking_number": False, "exact_price": 0})
             response = gls_request._send_pickup(vals)


### PR DESCRIPTION
Cuando se valida un picking donde el carrier tiene como servicio uno de los "Pick-up service" por ejemplo: _RECOGIDA ECONOMY_ , aparece un error 
![Kooha-2025-12-30-13-58-37 (2)](https://github.com/user-attachments/assets/4507340f-5374-49df-95aa-b9cfd7d02d66)

La propuesta es mejorar la visualización del error:
<img width="1124" height="183" alt="image" src="https://github.com/user-attachments/assets/d644aa38-f356-49b5-b115-459d8543bef3" />
