### PR TITLE
[18.0][IMP] delivery_gls_asm: Fix tests by forcing service to 37 [ECONOMY]

### DIFF
--- a/delivery_gls_asm/tests/__init__.py
+++ b/delivery_gls_asm/tests/__init__.py
@@ -1,1 +1,1 @@
-# from . import test_delivery_gls_asm
+from . import test_delivery_gls_asm

--- a/delivery_gls_asm/tests/test_delivery_gls_asm.py
+++ b/delivery_gls_asm/tests/test_delivery_gls_asm.py
@@ -22,6 +22,7 @@ class TestDeliveryGlsAsm(BaseCommon):
                 "delivery_type": "gls_asm",
                 "product_id": cls.shipping_product.id,
                 "prod_environment": False,
+                "gls_asm_service": "37",
             }
         )
         cls.product = cls.env["product.product"].create(


### PR DESCRIPTION
Cuando usamos el servicio por defecto "COURIER", GLS devuelve error:
<img width="638" height="213" alt="image" src="https://github.com/user-attachments/assets/61560e00-de5d-428c-907f-f71ab5d5c0e1" />

Por lo contrario, el sevicio "37 - ECONOMY" sí que funciona

Así que con este cambio podemos volver a habilitar los tests que desactivamos en https://github.com/OCA/l10n-spain/pull/4090