### PR TITLE
[18.0][IMP] l10n_es_aeat_sii_oca: Make use of upstream simplified flag

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -352,8 +352,10 @@ class SiiMixin(models.AbstractModel):
         return res
 
     def _is_aeat_simplified_invoice(self):
-        """Inheritable method to allow control when an
-        invoice are simplified or normal"""
+        """Inheritable method to control when a invoice is simplified or normal."""
+        # we use the flag added in 17+ as extra check for avoiding to set anything
+        if self.l10n_es_is_simplified:
+            return True
         partner = self._aeat_get_partner()
         return partner.aeat_simplified_invoice
 


### PR DESCRIPTION
Odoo has included an extra flag at invoice level for controlling if the invoice complies with the requirements for being a simplified one, so let's use it as an extra possibility for avoiding to manually set the check on all the partners without VAT and not getting to the amount limit.

@Tecnativa 