### PR TITLE
[18.0][FIX] l10n_es_atc_mod420: Freeze time in tests for avoiding 2026 problem

### DIFF
--- a/l10n_es_atc_mod420/tests/test_l10n_es_atc_mod420.py
+++ b/l10n_es_atc_mod420/tests/test_l10n_es_atc_mod420.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime
 
 import requests
+from freezegun import freeze_time
 from lxml import etree
 
 from odoo.exceptions import UserError
@@ -511,6 +512,7 @@ class TestL10nEsAeatMod420(TestL10nEsAtcMod420Base):
             company_form.zip_id = self.palmas_zip
         self.model420.year = datetime.now().year
 
+    @freeze_time("2025-01-01")
     def test_model_420(self):
         _logger.debug("Calculate ATC 420 1T 2017")
         self.model420.button_calculate()
@@ -572,6 +574,7 @@ class TestL10nEsAeatMod420(TestL10nEsAtcMod420Base):
         self.model420.button_cancel()
         self.assertEqual(self.model420.state, "cancelled")
 
+    @freeze_time("2025-01-01")
     def test_model_420_declaration_xml(self):
         """
         Test the generation of the .xml file
@@ -618,6 +621,7 @@ class TestL10nEsAeatMod420(TestL10nEsAtcMod420Base):
         self.assertEqual(res_node[0].attrib["IMP"], "78385")
         self.assertEqual(res_node[0].attrib["FPA"], "5")
 
+    @freeze_time("2025-01-01")
     def test_model_420_declaration_pdf(self):
         """
         Test the generation of the .pdf file
@@ -650,6 +654,7 @@ class TestL10nEsAeatMod420(TestL10nEsAtcMod420Base):
                 test_l10n_es_atc_report=True
             ).action_generar_mod420()
 
+    @freeze_time("2025-01-01")
     def test_model_420_declaration_dec(self):
         """
         Test the generation of the .dec file


### PR DESCRIPTION
It seems the ATC libraries are still not prepared for 2026, so let's freeze for now the tests on 2025. When they switch, we will probably need to reset this.

@Tecnativa 