### PR TITLE
[17.0][FIX] l10n_es_atc_mod4*: Freeze time in tests for avoiding 2026 problem

### DIFF
--- a/l10n_es_atc_mod417/tests/test_l10n_es_atc_mod417.py
+++ b/l10n_es_atc_mod417/tests/test_l10n_es_atc_mod417.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime
 
 import requests
+from freezegun import freeze_time
 from lxml import etree
 
 from odoo.exceptions import UserError
@@ -568,6 +569,7 @@ class TestL10nEsAeatmod417(TestL10nEsAtcmod417Base):
         self.model417.button_cancel()
         self.assertEqual(self.model417.state, "cancelled")
 
+    @freeze_time("2025-01-01")
     def test_model_417_declaration_xml(self):
         """
         Test the generation of the .xml file
@@ -614,6 +616,7 @@ class TestL10nEsAeatmod417(TestL10nEsAtcmod417Base):
         self.assertEqual(res_node[0].attrib["IMP"], "78385")
         self.assertEqual(res_node[0].attrib["FPA"], "5")
 
+    @freeze_time("2025-01-01")
     def test_model_417_declaration_pdf(self):
         """
         Test the generation of the .pdf file
@@ -640,6 +643,7 @@ class TestL10nEsAeatmod417(TestL10nEsAtcmod417Base):
                 test_l10n_es_atc_report=True
             ).action_generar_mod417()
 
+    @freeze_time("2025-01-01")
     def test_model_417_declaration_dec(self):
         """
         Test the generation of the .dec file

--- a/l10n_es_atc_mod420/tests/test_l10n_es_atc_mod420.py
+++ b/l10n_es_atc_mod420/tests/test_l10n_es_atc_mod420.py
@@ -7,6 +7,7 @@ import logging
 from datetime import datetime
 
 import requests
+from freezegun import freeze_time
 from lxml import etree
 
 from odoo.exceptions import UserError
@@ -567,6 +568,7 @@ class TestL10nEsAeatMod420(TestL10nEsAtcMod420Base):
         self.model420.button_cancel()
         self.assertEqual(self.model420.state, "cancelled")
 
+    @freeze_time("2025-01-01")
     def test_model_420_declaration_xml(self):
         """
         Test the generation of the .xml file
@@ -613,6 +615,7 @@ class TestL10nEsAeatMod420(TestL10nEsAtcMod420Base):
         self.assertEqual(res_node[0].attrib["IMP"], "78385")
         self.assertEqual(res_node[0].attrib["FPA"], "5")
 
+    @freeze_time("2025-01-01")
     def test_model_420_declaration_pdf(self):
         """
         Test the generation of the .pdf file
@@ -645,6 +648,7 @@ class TestL10nEsAeatMod420(TestL10nEsAtcMod420Base):
                 test_l10n_es_atc_report=True
             ).action_generar_mod420()
 
+    @freeze_time("2025-01-01")
     def test_model_420_declaration_dec(self):
         """
         Test the generation of the .dec file

--- a/l10n_es_atc_mod425/tests/test_l10n_es_atc_mod425.py
+++ b/l10n_es_atc_mod425/tests/test_l10n_es_atc_mod425.py
@@ -5,6 +5,7 @@
 import logging
 
 import requests
+from freezegun import freeze_time
 from lxml import etree
 
 from odoo.exceptions import UserError
@@ -522,6 +523,7 @@ class TestL10nEsAeatMod425(TestL10nEsAtcMod425Base):
         self.model425.button_cancel()
         self.assertEqual(self.model425.state, "cancelled")
 
+    @freeze_time("2025-01-01")
     def test_model_425_declaration_xml(self):
         """
         Test the generation of the .xml file
@@ -582,6 +584,7 @@ class TestL10nEsAeatMod425(TestL10nEsAtcMod425Base):
         self.assertEqual(len(res_node), 1)
         self.assertEqual(res_node[0].attrib["TOT"], "2134000")
 
+    @freeze_time("2025-01-01")
     def test_model_425_declaration_pdf(self):
         """
         Test the generation of the .pdf file
@@ -612,6 +615,7 @@ class TestL10nEsAeatMod425(TestL10nEsAtcMod425Base):
                 test_l10n_es_atc_report=True
             ).action_generar_mod425()
 
+    @freeze_time("2025-01-01")
     def test_model_425_declaration_dec(self):
         """
         Test the generation of the .dec file


### PR DESCRIPTION
Backport of #4694

It seems the ATC libraries are still not prepared for 2026, so let's freeze for now the tests on 2025. When they switch, we will probably need to reset this.

@Tecnativa