### PR TITLE
[17.0][FIX] l10n_es_pos_sii: Send orders without closing session

### DIFF
--- a/l10n_es_pos_sii/models/pos_order.py
+++ b/l10n_es_pos_sii/models/pos_order.py
@@ -5,7 +5,7 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
-SII_VALID_POS_ORDER_STATES = ["done"]
+SII_VALID_POS_ORDER_STATES = ["paid", "done"]
 
 
 class PosOrder(models.Model):


### PR DESCRIPTION
Forward-port of #4696 

When the PoS session is still opened, the orders remain in "paid" state, not as "done", so we shouldn't wait till session closing (which may not happened in several days, not complying with the sending limit).

Let's include "done" state in the allowed states for having the sending scheduled right after they are issued.

@Tecnativa TT60063