### PR TITLE
[18.0][IMP] l10n_es_pos_sii: Better UI

### DIFF
--- a/l10n_es_pos_sii/views/pos_order.xml
+++ b/l10n_es_pos_sii/views/pos_order.xml
@@ -23,17 +23,32 @@
             <xpath expr="//notebook" position="inside">
                 <page string="SII" name="page_sii" invisible="not sii_enabled">
                     <group string="SII Information" name="group_sii_information">
-                        <field name="sii_description" required="sii_enabled" />
-                        <field name="sii_refund_type" />
-                        <field name="sii_registration_key_domain" invisible="1" />
+                        <field
+                            name="sii_description"
+                            string="Description"
+                            required="sii_enabled"
+                            readonly="aeat_state in ['sent','cancelled']"
+                        />
+                        <field
+                            name="sii_refund_type"
+                            string="Refund type"
+                            invisible="amount_total >= 0"
+                            readonly="aeat_state in ['sent','cancelled']"
+                        />
                         <field
                             name="sii_registration_key"
+                            string="Registration key"
                             groups="l10n_es_aeat.group_account_aeat,account.group_account_invoice"
                             domain="[('type', '=', sii_registration_key_domain)]"
                             required="sii_enabled"
+                            readonly="aeat_state in ['sent','cancelled']"
                             widget="selection"
                         />
-                        <label for="sii_send_date" />
+                        <label
+                            for="sii_send_date"
+                            string="Send date"
+                            invisible="aeat_state in ['sent','cancelled']"
+                        />
                         <div
                             name="sii_send_date"
                             invisible="aeat_state in ['sent','cancelled']"
@@ -55,16 +70,18 @@
                         <notebook colspan="4">
                             <page name="page_sii_result_general" string="General">
                                 <group>
-                                    <field name="aeat_state" />
+                                    <field name="aeat_state" string="State" />
                                     <field
                                         name="aeat_send_failed"
+                                        string="Failed"
                                         invisible="not aeat_send_failed"
                                     />
                                     <field
                                         name="aeat_send_error"
+                                        string="Send error"
                                         invisible="not aeat_send_failed"
                                     />
-                                    <field name="sii_csv" />
+                                    <field name="sii_csv" string="CSV" />
                                 </group>
                             </page>
                             <page
@@ -73,15 +90,21 @@
                                 groups="base.group_no_one"
                             >
                                 <group>
-                                    <label for="aeat_header_sent" />
+                                    <label
+                                        for="aeat_header_sent"
+                                        string="Last header sent"
+                                    />
                                 </group>
                                 <field name="aeat_header_sent" />
                                 <group>
-                                    <label for="aeat_content_sent" />
+                                    <label
+                                        for="aeat_content_sent"
+                                        string="Last content sent"
+                                    />
                                 </group>
                                 <field name="aeat_content_sent" />
                                 <group>
-                                    <label for="sii_return" />
+                                    <label for="sii_return" string="Response" />
                                 </group>
                                 <field name="sii_return" />
                             </page>
@@ -91,7 +114,6 @@
             </xpath>
         </field>
     </record>
-
     <record id="view_pos_order_filter" model="ir.ui.view">
         <field name="name">pos.order.list.select</field>
         <field name="model">pos.order</field>


### PR DESCRIPTION
- Hide fields when not needed, like refund type.
- Put better labels on UI. The current field strings are OK for being differentiated in parts like advanced search, but for the UI, as they are already in the SII tab, are not the best one, so let's adjust them.
- Remove useless auxiliary invisible field (since viewpocalypse).

@Tecnativa