### PR TITLE
[18.0][FIX] l10n_es_aeat_mod303_vat_prorate: error ZeroDivisionError

### DIFF
--- a/l10n_es_aeat_mod303_vat_prorate/i18n/es.po
+++ b/l10n_es_aeat_mod303_vat_prorate/i18n/es.po
@@ -6,21 +6,26 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-17 20:07+0000\n"
-"PO-Revision-Date: 2024-09-02 11:06+0000\n"
-"Last-Translator: Alberto Martínez <alberto.martinez@sygel.es>\n"
+"POT-Creation-Date: 2026-01-12 11:25+0000\n"
+"PO-Revision-Date: 2026-01-12 13:16+0100\n"
+"Last-Translator: Andrii Kompaniiets <andrii@moduon.team>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.6.2\n"
+"X-Generator: Poedit 3.6\n"
 
 #. module: l10n_es_aeat_mod303_vat_prorate
 #: model:ir.model,name:l10n_es_aeat_mod303_vat_prorate.model_l10n_es_aeat_mod303_report
 msgid "AEAT 303 Report"
 msgstr "Modelo AEAT 303"
+
+#. module: l10n_es_aeat_mod303_vat_prorate
+#: model_terms:ir.ui.view,arch_db:l10n_es_aeat_mod303_vat_prorate.l10n_es_aeat_mod303_prorrata_form
+msgid "Calcular prorrata definitiva"
+msgstr ""
 
 #. module: l10n_es_aeat_mod303_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303_vat_prorate.field_l10n_es_aeat_mod303_report__vat_prorate_percent
@@ -29,7 +34,10 @@ msgstr "Porcentaje definitivo de prorrata"
 
 #. module: l10n_es_aeat_mod303_vat_prorate
 #: model:ir.model.fields,help:l10n_es_aeat_mod303_vat_prorate.field_l10n_es_aeat_mod303_report__with_vat_prorate
-msgid "If this option is enabled, all invoice lineswith VAT will be prorated"
+#, fuzzy
+#| msgid ""
+#| "If this option is enabled, all invoice lineswith VAT will be prorated"
+msgid "If this option is enabled, all invoice lines with VAT will be prorated"
 msgstr ""
 "Si esta opción está establecida, todas las líneas de facturas con IVA serán "
 "prorrateadas"
@@ -38,6 +46,16 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303_vat_prorate.field_l10n_es_aeat_mod303_report__prorate_id
 msgid "Prorate"
 msgstr "Prorrata"
+
+#. module: l10n_es_aeat_mod303_vat_prorate
+#. odoo-python
+#: code:addons/l10n_es_aeat_mod303_vat_prorate/models/mod303.py:0
+msgid ""
+"Prorate percentage not found, or it's 0. Please review the company's prorate "
+"adjustments."
+msgstr ""
+"No se encuentra porcentaje de prorrata o es 0. Por favor, revise los ajustes "
+"de prorrata de la compañía."
 
 #. module: l10n_es_aeat_mod303_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303_vat_prorate.field_l10n_es_aeat_mod303_report__prorate_account_id
@@ -75,14 +93,12 @@ msgstr ""
 #. module: l10n_es_aeat_mod303_vat_prorate
 #. odoo-python
 #: code:addons/l10n_es_aeat_mod303_vat_prorate/models/mod303.py:0
-#, python-format
 msgid "VAT prorate percent must be between 0.00 and 100"
 msgstr "El porcentaje de prorrata de IVA debe estar entre 0.00 y 100"
 
 #. module: l10n_es_aeat_mod303_vat_prorate
 #. odoo-python
 #: code:addons/l10n_es_aeat_mod303_vat_prorate/models/mod303.py:0
-#, python-format
 msgid "VAT prorate regularization"
 msgstr "Regularización de prorrata de IVA"
 

--- a/l10n_es_aeat_mod303_vat_prorate/i18n/l10n_es_aeat_mod303_vat_prorate.pot
+++ b/l10n_es_aeat_mod303_vat_prorate/i18n/l10n_es_aeat_mod303_vat_prorate.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-01-12 11:25+0000\n"
+"PO-Revision-Date: 2026-01-12 11:25+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -36,6 +38,14 @@ msgstr ""
 #. module: l10n_es_aeat_mod303_vat_prorate
 #: model:ir.model.fields,field_description:l10n_es_aeat_mod303_vat_prorate.field_l10n_es_aeat_mod303_report__prorate_id
 msgid "Prorate"
+msgstr ""
+
+#. module: l10n_es_aeat_mod303_vat_prorate
+#. odoo-python
+#: code:addons/l10n_es_aeat_mod303_vat_prorate/models/mod303.py:0
+msgid ""
+"Prorate percentage not found, or it's 0. Please review the company's prorate"
+" adjustments."
 msgstr ""
 
 #. module: l10n_es_aeat_mod303_vat_prorate

--- a/l10n_es_aeat_mod303_vat_prorate/models/mod303.py
+++ b/l10n_es_aeat_mod303_vat_prorate/models/mod303.py
@@ -8,6 +8,7 @@ import math
 import re
 
 from odoo import _, api, exceptions, fields, models
+from odoo.tools import float_is_zero
 
 
 class L10nEsAeatMod303Report(models.Model):
@@ -72,6 +73,13 @@ class L10nEsAeatMod303Report(models.Model):
     def _general_prorate_method(self):
         self.ensure_one()
         theoretical_prorate = self.prorate_id.vat_prorate
+        if float_is_zero(theoretical_prorate, precision_digits=2):
+            raise exceptions.ValidationError(
+                self.env._(
+                    "Prorate percentage not found, or it's 0. "
+                    "Please review the company's prorate adjustments."
+                )
+            )
         diff_perc = self.vat_prorate_percent - theoretical_prorate
         if not diff_perc:
             return


### PR DESCRIPTION
Pequeño fix para evitar un ZeroDivisionError.
Por ejemplo, si el usuario crea un informe 303 y posteriormente cambia el año de la línea de prorrata en los ajustes de la empresa, al intentar recalcular ese mismo informe se produce un error ZeroDivisionError, ya que la variable theoretical_prorate tiene un valor igual a 0.
<img width="1895" height="934" alt="Captura desde 2026-01-08 12-46-25" src="https://github.com/user-attachments/assets/8b7efed9-1ddc-4a70-936b-6ea04b69dbb1" />

@moduon MT-13250