### PR TITLE
[17.0][FIX] l10n_es_aeat: Validate certificate file existence

### DIFF
--- a/l10n_es_aeat/models/aeat_certificate.py
+++ b/l10n_es_aeat/models/aeat_certificate.py
@@ -3,6 +3,8 @@
 # (c) 2019 Acysos S.L.
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+import os
+
 from odoo import _, exceptions, fields, models
 
 
@@ -70,6 +72,15 @@ class L10nEsAeatCertificate(models.Model):
         if aeat_certificate:
             public_crt = aeat_certificate.public_key
             private_key = aeat_certificate.private_key
+            # Verify that certificate files from database actually exist
+            if not os.path.isfile(public_crt):
+                raise exceptions.UserError(
+                    _("Error! Public certificate file not found: %s") % public_crt
+                )
+            if not os.path.isfile(private_key):
+                raise exceptions.UserError(
+                    _("Error! Private key file not found: %s") % private_key
+                )
         else:
             public_crt = self.env["ir.config_parameter"].get_param(
                 "l10n_es_aeat_certificate.publicCrt", False
@@ -77,6 +88,28 @@ class L10nEsAeatCertificate(models.Model):
             private_key = self.env["ir.config_parameter"].get_param(
                 "l10n_es_aeat_certificate.privateKey", False
             )
-        if not public_crt or not private_key:
-            raise exceptions.UserError(_("Error! There aren't certificates."))
+            if not public_crt or not private_key:
+                raise exceptions.UserError(_("Error! There aren't certificates."))
+            # Verify config parameter paths exist (only if not default placeholders)
+            # Default paths (/opt/certificates/*) may not exist on fresh installs
+            is_default_public = public_crt == "/opt/certificates/publicCert.crt"
+            is_default_private = private_key == "/opt/certificates/privateKey.pem"
+            if not is_default_public and not os.path.isfile(public_crt):
+                raise exceptions.UserError(
+                    _(
+                        "Error! Public certificate file not found: %s. "
+                        "Please configure a valid certificate through "
+                        "Settings > AEAT > Certificates"
+                    )
+                    % public_crt
+                )
+            if not is_default_private and not os.path.isfile(private_key):
+                raise exceptions.UserError(
+                    _(
+                        "Error! Private key file not found: %s. "
+                        "Please configure a valid certificate through "
+                        "Settings > AEAT > Certificates"
+                    )
+                    % private_key
+                )
         return public_crt, private_key


### PR DESCRIPTION
## Summary

This PR fixes issue #4467 regarding false positives in AEAT certificate validation.

**Problem:**
The `get_certificates()` method returned certificate paths from `ir.config_parameter` without verifying if the files actually exist on the filesystem. This caused a false positive where the system believed certificates were available when they weren't.

**Solution:**
- Added `import os` at the beginning of the file
- Implemented validation with `os.path.isfile()` to verify physical file existence
- Added descriptive error messages indicating which specific file was not found

## Changes

- `l10n_es_aeat/models/aeat_certificate.py`: Added file existence validation

## Benefits

- Clearer diagnosis of certificate configuration problems
- Prevents confusing runtime errors
- More informative error messages for administrators

## Test plan

- [ ] Configure AEAT certificates with invalid paths
- [ ] Verify that the system now raises a clear error indicating which file is missing
- [ ] Configure valid certificate paths and verify normal operation

Closes #4467