### PR TITLE
[18.0][IMP] l10n_es_aeat_sii_oca: multiple improvements

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_journal.py
+++ b/l10n_es_aeat_sii_oca/models/account_journal.py
@@ -11,3 +11,24 @@ class AccountJournal(models.Model):
         related="company_id.sii_enabled", string="Company enable SII"
     )
     sii_enabled = fields.Boolean(string="Enable SII", default=True)
+
+    def _fill_sale_purchase_dashboard_data(self, dashboard_data):
+        res = super()._fill_sale_purchase_dashboard_data(dashboard_data)
+        for journal in self.filtered(
+            lambda journal: journal.type in ("sale", "purchase")
+        ):
+            domain_not_send = [
+                ("journal_id", "=", journal.id),
+                ("aeat_state", "=", "not_sent"),
+                ("sii_enabled", "=", True),
+            ]
+            domain_fail = [
+                ("journal_id", "=", journal.id),
+                ("aeat_send_failed", "=", True),
+                ("sii_enabled", "=", True),
+            ]
+            journal_dict = dashboard_data[journal.id]
+            AccountMove = self.env["account.move"]
+            journal_dict["number_not_sent"] = AccountMove.search_count(domain_not_send)
+            journal_dict["number_aeat_failed"] = AccountMove.search_count(domain_fail)
+        return res

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -298,7 +298,11 @@ class SiiMixin(models.AbstractModel):
             self.sii_send_date = send_date
         else:
             for record in self:
-                record.sii_send_date = record.company_id._get_sii_sending_time()
+                # If the document failed to be sent to SII previously, send it now
+                if record.aeat_send_failed:
+                    record.sii_send_date = fields.Datetime.now()
+                else:
+                    record.sii_send_date = record.company_id._get_sii_sending_time()
         # Create trigger if any company needs to send doc to SII now
         # so the sending to SII cron is executed as soon as possible
         if (

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -600,3 +600,18 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.company.sii_start_date = False
         self.assertTrue(invoice2.sii_enabled)
         self.assertTrue(invoice2.filtered_domain([("sii_enabled", "=", True)]))
+
+    def test_journals_dashboard_data(self):
+        self.company.sii_start_date = "2018-01-01"
+        invoice1 = self._create_invoice("out_invoice")
+        invoice1.invoice_date = "2019-01-01"
+        invoice2 = self._create_invoice("out_invoice")
+        invoice2.invoice_date = "2017-01-01"
+        invoice3 = self._create_invoice("out_invoice")
+        invoice3.invoice_date = "2019-06-01"
+        invoice3.aeat_send_failed = True
+        dashboard_data = {invoice1.journal_id.id: {}}
+        invoice1.journal_id._fill_sale_purchase_dashboard_data(dashboard_data)
+        data = dashboard_data.get(invoice1.journal_id.id, {})
+        self.assertEqual(data.get("number_not_sent"), 4)
+        self.assertEqual(data.get("number_aeat_failed"), 1)

--- a/l10n_es_aeat_sii_oca/views/account_journal_view.xml
+++ b/l10n_es_aeat_sii_oca/views/account_journal_view.xml
@@ -18,4 +18,47 @@
             </xpath>
         </field>
     </record>
+
+    <record id="account_journal_dashboard_kanban_view" model="ir.ui.view">
+        <field name="name">account.journal.dashboard.kanban</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.account_journal_dashboard_kanban_view" />
+        <field name="arch" type="xml">
+            <data>
+                <xpath
+                    expr="//t[@id='account.JournalBodySalePurchase']//div[@name='kanban_primary_right']"
+                    position="inside"
+                >
+                    <div class="row" t-if="dashboard.number_not_sent">
+                        <div class="col overflow-hidden text-start">
+                            <a
+                                type="object"
+                                name="open_action"
+                                context="{'search_default_sii_not_sent': '1'}"
+                                class="text-warning"
+                            >
+                                <span title="Invoices not sent to SII"><t
+                                    t-out="dashboard.number_not_sent"
+                                /> Not sent to SII</span>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="row" t-if="dashboard.number_aeat_failed">
+                        <div class="col overflow-hidden text-start">
+                            <a
+                                type="object"
+                                name="open_action"
+                                context="{'search_default_aeat_send_failed': '1'}"
+                                class="text-danger"
+                            >
+                                <span title="Invoices with SII error"><t
+                                    t-out="dashboard.number_aeat_failed"
+                                /> With error in SII</span>
+                            </a>
+                        </div>
+                    </div>
+                </xpath>
+            </data>
+        </field>
+    </record>
 </odoo>

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -38,8 +38,12 @@
             </button>
             <notebook position="inside">
                 <page string="SII" name="page_sii" invisible="not sii_enabled">
-                    <group string="SII Information" name="group_sii_information">
-                        <field name="sii_description" required="sii_enabled" />
+                    <group string="Information" name="group_sii_information">
+                        <field
+                            name="sii_description"
+                            string="Description"
+                            required="sii_enabled"
+                        />
                         <field name="thirdparty_invoice" />
                         <field
                             name="thirdparty_number"
@@ -48,15 +52,18 @@
                         />
                         <field
                             name="sii_refund_type"
+                            string="Refund type"
                             required="sii_enabled and move_type in ['out_refund','in_refund']"
                             invisible="move_type not in ['out_refund','in_refund']"
                         />
                         <field
                             name="sii_refund_specific_invoice_type"
+                            string="Specific refund type"
                             invisible="move_type != 'out_refund'"
                         />
                         <field
                             name="sii_registration_key"
+                            string="Registration key"
                             groups="account.group_account_invoice"
                             domain="[('type', '=', sii_registration_key_domain)]"
                             required="sii_enabled"
@@ -64,31 +71,39 @@
                         />
                         <field
                             name="sii_registration_key_additional1"
+                            string="Additional registration key 1"
                             groups="account.group_account_invoice"
                             domain="[('type', '=', sii_registration_key_domain)]"
                             widget="selection"
                         />
                         <field
                             name="sii_registration_key_additional2"
+                            string="Additional registration key 2"
                             groups="account.group_account_invoice"
                             domain="[('type', '=', sii_registration_key_domain)]"
                             widget="selection"
                         />
-                        <label for="sii_send_date" />
+                        <label
+                            for="sii_send_date"
+                            string="Send date"
+                            invisible="aeat_state in ['sent','cancelled'] or state != 'posted'"
+                        />
                         <div
                             name="sii_send_date"
-                            invisible="aeat_state in ['sent','cancelled']"
+                            string="Send date"
+                            invisible="aeat_state in ['sent','cancelled'] or state != 'posted'"
                         >
                             <field name="sii_send_date" class="oe_inline text-break" />
                             <button
                                 type="object"
                                 class="oi oi-arrow-right oe_link"
                                 name="send_sii_now"
-                                string="Send now to SII"
+                                string="Send now"
                             />
                         </div>
                         <field
                             name="sii_needs_cancel"
+                            string="Needs cancellation"
                             invisible="state != 'cancel' or aeat_state not in ['sent', 'sent_w_errors', 'sent_modified']"
                         />
                         <field name="sii_enabled" invisible="1" />
@@ -107,27 +122,36 @@
                         />
                     </group>
                     <group
-                        string="SII Result"
+                        string="Result"
                         name="group_sii_result"
                         groups="l10n_es_aeat.group_account_aeat"
                     >
                         <notebook colspan="2">
                             <page name="page_sii_result_general" string="General">
                                 <group>
-                                    <field name="aeat_state" />
+                                    <field name="aeat_state" string="Send state" />
                                     <field
                                         name="sii_account_registration_date"
+                                        string="Account registration date"
                                         invisible="not sii_account_registration_date or move_type not in ['in_invoice', 'in_refund']"
                                     />
                                     <field
+                                        name="sii_account_registration_date"
+                                        invisible="not sii_account_registration_date or move_type not in ['out_invoice', 'out_refund']"
+                                        string="Registration date"
+                                    />
+                                    <field
                                         name="aeat_send_failed"
+                                        string="Send failed"
                                         invisible="not aeat_send_failed"
+                                        readonly="1"
                                     />
                                     <field
                                         name="aeat_send_error"
+                                        string="Send error"
                                         invisible="not aeat_send_failed"
                                     />
-                                    <field name="sii_csv" />
+                                    <field name="sii_csv" string="CSV" />
                                 </group>
                             </page>
                             <page
@@ -136,15 +160,21 @@
                                 groups="base.group_no_one"
                             >
                                 <group>
-                                    <label for="aeat_header_sent" />
+                                    <label
+                                        for="aeat_header_sent"
+                                        string="Header sent"
+                                    />
                                 </group>
                                 <field name="aeat_header_sent" />
                                 <group>
-                                    <label for="aeat_content_sent" />
+                                    <label
+                                        for="aeat_content_sent"
+                                        string="Content sent"
+                                    />
                                 </group>
                                 <field name="aeat_content_sent" />
                                 <group>
-                                    <label for="sii_return" />
+                                    <label for="sii_return" string="Return" />
                                 </group>
                                 <field name="sii_return" />
                             </page>


### PR DESCRIPTION
En este PR se añaden las siguientes mejoras:

- Si la factura está en error, al enviarla de nuevo se crea como envío inmediato. 
  - Esto sobretodo es para evitar que lleguemos al límite de tiempo si la corrección se realiza más tarde y tenemos retardo de días.
- El check de error ahora es readonly. 
  - Esto solo debería ser modificado desde el código.
- Muestreo en el dashboard de los diarios si existen facturas con error con enlace directo.
<img width="615" height="298" alt="image" src="https://github.com/user-attachments/assets/1347f8cf-c0be-4cf4-990d-3e126781a6b7" />

@Tecnativa TT59653
@pedrobaeza 