### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_oca: Raise exception is partner has not a vat but has a aeat_identification

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -364,6 +364,9 @@ class SiiMixin(models.AbstractModel):
             if (
                 (gen_type != 3 or country_code == "ES")
                 and not partner.vat
+                and not (
+                    partner.aeat_identification_type and partner.aeat_identification
+                )
                 and not is_simplified_invoice
             ):
                 raise UserError(_("The partner has not a VAT configured."))


### PR DESCRIPTION
cc @Tecnativa 

La excepcion de que un contacto no tiene NIF tiene que tener en cuenta si el contacto tiene otra identificacion

ping @christian-ramos-tecnativa @carlosdauden 