### PR TITLE
[16.0][FIX] l10n_es_verifactu_oca: Remove ES prefix from Spanish NIF

### DIFF
--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -467,6 +467,10 @@ class AccountMove(models.Model):
             identifier = "NO_DISPONIBLE"
             identifier_type = "06"
         if identifier_type == "":
+            # For Spanish NIF, ensure "ES" prefix is removed if present
+            # This can happen when VAT is stored with country prefix (e.g., "ESB12345678")
+            if identifier.startswith("ES") and len(identifier) > 2:
+                identifier = identifier[2:]
             return {"IDDestinatario": {"NombreRazon": receiver.name, "NIF": identifier}}
         if (
             receiver._map_aeat_country_code(country_code)


### PR DESCRIPTION
## Summary

This PR fixes issue #4623 where Verifactu rejects invoices when the customer's VAT has the "ES" prefix.

**Problem:**
When a customer's VAT is stored with the country prefix (e.g., "ESB12345678" instead of "B12345678"), the module sends it to Verifactu as-is. Verifactu rejects this because it expects the NIF without the "ES" prefix for Spanish customers.

This commonly happens when external connectors (like Prestashop) import customers with the full EU VAT format.

**Solution:**
Added validation in `_get_verifactu_receiver_dict()` to remove the "ES" prefix from the identifier when:
- The identifier type is empty (indicating a Spanish NIF)
- The identifier starts with "ES" and has more than 2 characters

## Changes

- `l10n_es_verifactu_oca/models/account_move.py`: Added ES prefix removal logic

## Test plan

- [ ] Create a customer with VAT "ESB12345678" (with ES prefix)
- [ ] Create and confirm an invoice for this customer
- [ ] Send the invoice to Verifactu
- [ ] Verify the NIF is sent as "B12345678" (without ES prefix)
- [ ] Verify the invoice is accepted by Verifactu

Closes #4623