### PR TITLE
[18.0][FIX] l10n_es_aeat_mod369: Place menu inside AEAT submenu

### DIFF
--- a/l10n_es_aeat_mod369/views/mod369_view.xml
+++ b/l10n_es_aeat_mod369/views/mod369_view.xml
@@ -160,7 +160,7 @@
     </record>
     <menuitem
         id="menu_aeat_mod369_report"
-        parent="l10n_es_aeat.menu_root_aeat"
+        parent="l10n_es_aeat.menu_l10n_es_aeat_submenu"
         action="action_l10n_es_aeat_mod369_report"
         sequence="369"
         name="AEAT 369 model"


### PR DESCRIPTION
It was in the root.

@Tecnativa 