### PR TITLE
[18.0][FIX] l10n_es_pos_sii: Initialize aeat_state

### DIFF
--- a/l10n_es_pos_sii/models/pos_order.py
+++ b/l10n_es_pos_sii/models/pos_order.py
@@ -57,6 +57,13 @@ class PosOrder(models.Model):
             else:
                 record.sii_refund_type = False
 
+    @api.model
+    def _process_order(self, pos_order, existing_order):
+        # Inject proper value for aeat_state
+        if not existing_order:
+            pos_order["aeat_state"] = "not_sent"
+        return super()._process_order(pos_order, existing_order)
+
     def _is_sii_type_breakdown_required(self, taxes_dict):
         """As these are simplified invoices, we don't break taxes.
 


### PR DESCRIPTION
Due to the way PoS orders are created from the JS app, the records are created with null in aeat_state field, so they are sent to the SII with A1 (modification) key instead of A0 (creation) one.

Let's force in the creation the value for not having this problem.

@Tecnativa TT60223