### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_oca: Homogenize actions on error

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -680,6 +680,7 @@ class AccountMove(models.Model):
                     {
                         "aeat_send_failed": True,
                         "aeat_send_error": repr(fault)[:60],
+                        "sii_send_date": False,
                         "sii_return": repr(fault),
                     }
                 )
@@ -946,6 +947,7 @@ class AccountMove(models.Model):
                     "aeat_send_failed": True,
                     "aeat_send_error": repr(fault)[:60],
                     "sii_send_date": False,
+                    "sii_return": repr(fault),
                 }
                 invoice = env["account.move"].browse(doc.id)
                 invoice.write(doc_vals)


### PR DESCRIPTION
When an exception happens, it was not the same for cancel communication than for normal one:

- The representation of the exception is not fully logged.
- The sending date is not reset.

This homogenizes the behavior on both.

@Tecnativa TT60254