### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_oca: Don't retry forever

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -643,6 +643,7 @@ class AccountMove(models.Model):
             inv_vals = {
                 "aeat_send_failed": True,
                 "aeat_send_error": False,
+                "sii_send_date": False,
             }
             try:
                 inv_dict = invoice._get_cancel_sii_invoice_dict()
@@ -940,6 +941,7 @@ class AccountMove(models.Model):
             try:
                 with self.env.cr.savepoint():
                     doc.confirm_one_document()
+                    doc.sii_send_date = False
             except Exception as fault:
                 new_cr = Registry(self.env.cr.dbname).cursor()
                 env = api.Environment(new_cr, self.env.uid, self.env.context)


### PR DESCRIPTION
Backport of #4723 

In the case an invoice is accepted with errors, the sending date is not reset, and the system is trying to send it on each cron run, which is not correct. With accepted invoices, there's no problem, as they are not selected anymore for being sent.

Let's reset anyway for both cases the sending date for avoiding this hammering.

@Tecnativa