### PR TITLE
[16.0][FIX] l10n_es_sigaus_stock_picking_report_valued: Fix rounding of valued picking total when adding SIGAUS amounts

### DIFF
--- a/l10n_es_sigaus_stock_picking_report_valued/models/stock_picking.py
+++ b/l10n_es_sigaus_stock_picking_report_valued/models/stock_picking.py
@@ -41,7 +41,8 @@ class StockPicking(models.Model):
             )
 
     def _get_report_valued_total_amount(self):
+        currency = self.currency_id or self.company_id.currency_id
         total = super()._get_report_valued_total_amount()
         if self.sale_id and self.sale_id.is_sigaus:
             total += self.sigaus_amount_total or 0.0
-        return total
+        return currency.round(total)


### PR DESCRIPTION
@HaraldPanten @Jaimermaccione 

- Closing this PR as the issue is addressed with a different approach in another PR https://github.com/OCA/stock-logistics-reporting/pull/467