### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: Raise exception is partner has not a vat but has a aeat_identification

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -368,6 +368,9 @@ class SiiMixin(models.AbstractModel):
             if (
                 (gen_type != 3 or country_code == "ES")
                 and not partner.vat
+                and not (
+                    partner.aeat_identification_type and partner.aeat_identification
+                )
                 and not is_simplified_invoice
             ):
                 raise UserError(self.env._("The partner has not a VAT configured."))


### PR DESCRIPTION
Forward-port of #4710

@Tecnativa 