### PR TITLE
[18.0][IMP] payment_redsys: Define a specific string for the redsys_secret_key field to avoid lot warning

### DIFF
--- a/payment_redsys/models/payment_provider.py
+++ b/payment_redsys/models/payment_provider.py
@@ -38,7 +38,7 @@ class PaymentProvider(models.Model):
         "Product Description", required_if_provider="redsys"
     )
     redsys_secret_key = fields.Char(
-        "Secret Key", required_if_provider="redsys", groups="base.group_system"
+        required_if_provider="redsys", groups="base.group_system"
     )
     redsys_terminal = fields.Char(
         "Terminal", default="1", required_if_provider="redsys"

--- a/payment_redsys/views/payment_provider.xml
+++ b/payment_redsys/views/payment_provider.xml
@@ -11,7 +11,11 @@
                 <group invisible="code  != 'redsys'">
                     <field name="redsys_merchant_name" required="code == 'redsys'" />
                     <field name="redsys_merchant_code" required="code == 'redsys'" />
-                    <field name="redsys_secret_key" required="code == 'redsys'" />
+                    <field
+                        name="redsys_secret_key"
+                        string="Secret Key"
+                        required="code == 'redsys'"
+                    />
                     <field name="redsys_terminal" required="code == 'redsys'" />
                     <field name="redsys_currency" required="code == 'redsys'" />
                     <field name="redsys_transaction_type" required="code == 'redsys'" />


### PR DESCRIPTION
Define a specific string for the `redsys_secret_key` field to avoid lot warning

`WARNING prod odoo.addons.base.models.ir_model: Two fields (stripe_secret_key, redsys_secret_key) of payment.provider() have the same label: Secret Key. [Modules: payment_stripe and payment_redsys]`

Please @pedrobaeza can you review it?

@Tecnativa