### PR TITLE
[18.0][FIX] l10n_es_aeat_mod303_vat_prorate: Add other exempt taxes

### DIFF
--- a/l10n_es_aeat_mod303_vat_prorate/models/mod303.py
+++ b/l10n_es_aeat_mod303_vat_prorate/models/mod303.py
@@ -197,7 +197,14 @@ class L10nEsAeatMod303Report(models.Model):
         taxed = -sum(move_lines.mapped("balance"))
         # Get base amount of exempt operations
         mapline_vals["tax_xmlid_ids"] = [
-            (4, self.env.ref("l10n_es_aeat_mod303.s_iva0").id)
+            (4, self.env.ref(f"l10n_es_aeat_mod303.{x}").id)
+            for x in [
+                "s_iva0",
+                "s_iva0_art22",
+                "s_iva0_art23",
+                "s_iva0_nsd",
+                "s_iva0_ns",
+            ]
         ]
         map_line = MapLine.new(mapline_vals)
         move_lines = self._get_tax_lines(date_from, date_to, map_line)

--- a/l10n_es_aeat_mod303_vat_prorate/tests/test_l10n_es_aeat_mod303_vat_prorate.py
+++ b/l10n_es_aeat_mod303_vat_prorate/tests/test_l10n_es_aeat_mod303_vat_prorate.py
@@ -237,3 +237,66 @@ class TestL10nEsAeatMod303VatProrate(TestL10nEsAeatMod303Base):
         self.model303.button_compute()
         self.assertEqual(self.model303.vat_prorate_percent, 67)
         self.assertEqual(self.model303.casilla_44, 0)
+
+    def test_button_compute_other_exempt(self):
+        self.company.write(
+            {
+                "with_vat_prorate": True,
+                "vat_prorate_ids": [
+                    Command.create({"date": "2024-01-01", "vat_prorate": 10})
+                ],
+            }
+        )
+        self._invoice_purchase_create(
+            "2024-01-01",
+            {
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Compra 100€ + IVA 21%",
+                            "account_id": self.accounts["600000"].id,
+                            "price_unit": 100,
+                            "quantity": 1,
+                            "with_vat_prorate": True,
+                            "tax_ids": [
+                                Command.link(t.id)
+                                for t in self._get_taxes("P_IVA21_BC")
+                            ],
+                        }
+                    ),
+                ]
+            },
+        )
+        self._invoice_sale_create(
+            "2024-01-01",
+            {
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Venta 200€ + IVA 21%",
+                            "account_id": self.accounts["700000"].id,
+                            "price_unit": 200,
+                            "quantity": 1,
+                            "tax_ids": [
+                                Command.link(t.id) for t in self._get_taxes("S_IVA21B")
+                            ],
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "name": "Venta 100€ exento art. 22",
+                            "account_id": self.accounts["700000"].id,
+                            "price_unit": 100,
+                            "quantity": 1,
+                            "tax_ids": [
+                                Command.link(t.id)
+                                for t in self._get_taxes("S_IVA0_ART22")
+                            ],
+                        }
+                    ),
+                ]
+            },
+        )
+        self.model303.button_compute()
+        self.assertEqual(self.model303.vat_prorate_percent, 67)
+        self.assertEqual(self.model303.casilla_44, 0)


### PR DESCRIPTION
Añado a la lista de los impuestos exentos otros que también deberían ser considerados para el cálculo de la prorrata.

@Tecnativa TT60315
@pedrobaeza @victoralmau 