### PR TITLE
[18.0][FIX] l10n_es_aeat_mod190: Error when adding Partner

### DIFF
--- a/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
+++ b/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
@@ -2,6 +2,8 @@
 # Copyright 2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from collections import defaultdict
+
 from odoo import _, api, exceptions, fields, models
 
 from odoo.addons.l10n_es_aeat.models.spanish_states_mapping import SPANISH_STATES
@@ -571,24 +573,20 @@ class L10nEsAeatMod190ReportLine(models.Model):
     # Calculo campos SIN incapacidad
     @api.depends("report_id", "report_id.tax_line_ids", "discapacidad")
     def _compute_percepciones(self):
-        tax_data = {}
+        tax_data = defaultdict(lambda: defaultdict(dict))
         domain = []
         if len(self.partner_id) == 1:
             # This should only happen when we are making a small update on
             # 'discapacidad'
             domain.append(("partner_id", "=", self.partner_id.id))
         for report in self.report_id:
-            tax_data[report.id] = {
-                "11": report._get_grouped_data(11, domain),
-                "12": report._get_grouped_data(12, domain),
-                "13": report._get_grouped_data(13, domain),
-                "14": report._get_grouped_data(14, domain),
-                "15": report._get_grouped_data(15, domain),
-                "16": report._get_grouped_data(16, domain),
-                "17": report._get_grouped_data(17, domain),
-                "18": report._get_grouped_data(18, domain),
-                "19": report._get_grouped_data(19, domain),
-            }
+            if report.tax_line_ids:
+                tax_data[report.id] = {
+                    str(line.field_number): report._get_grouped_data(
+                        line.field_number, domain
+                    )
+                    for line in report.tax_line_ids
+                }
         for item in self:
             keys = [
                 (

--- a/l10n_es_aeat_mod190/tests/test_mod190.py
+++ b/l10n_es_aeat_mod190/tests/test_mod190.py
@@ -250,3 +250,32 @@ class TestL10nEsAeatMod190Base(TestL10nEsAeatModBase):
                 with self.assertRaises(AssertionError):
                     # User without permissions can't
                     getattr(supplier_limited_f, field)
+
+    def test_mod190_add_partner_without_tax_lines(self):
+        model190 = self.env["l10n.es.aeat.mod190.report"].create(
+            {
+                "company_id": self.company.id,
+                "company_vat": "1234567890",
+                "contact_name": "Test owner",
+                "contact_phone": "911234455",
+                "year": 2017,
+                "date_start": "2017-01-01",
+                "date_end": "2017-12-31",
+            }
+        )
+        perception_key = self.env["l10n.es.aeat.report.perception.key"].search(
+            [], limit=1
+        )
+        self.assertTrue(perception_key, "At least one perception key should exist")
+        partner_record = self.env["l10n.es.aeat.mod190.report.line"].create(
+            {
+                "report_id": model190.id,
+                "partner_id": self.supplier.id,
+                "aeat_perception_key_id": perception_key.id,
+            }
+        )
+        self.assertTrue(partner_record, "Partner record should be created")
+        self.assertEqual(len(partner_record), 1)
+        self.assertEqual(partner_record.partner_id, self.supplier)
+        self.assertFalse(partner_record.percepciones_dinerarias)
+        self.assertFalse(partner_record.retenciones_dinerarias)


### PR DESCRIPTION
Antes de este fix, a la hora de añadir un socio destinatario durante la creación del reporte, saltaba un error que lo hacía imposible.

https://www.loom.com/share/1f1df1b6ed78452cb1c06c71594690c7

MT-13290 @moduon