### PR TITLE
[19.0][FIX] l10n_es_partner: Force context to calculate complete_name with comercial

### DIFF
--- a/l10n_es_partner/README.rst
+++ b/l10n_es_partner/README.rst
@@ -34,16 +34,16 @@ Adaptación de los clientes, proveedores y bancos para España
 
 Incluye la siguiente funcionalidad:
 
-- Añade el campo *Nombre comercial* a las empresas y permite buscar por
-  él.
-- Permite definir un patrón del nombre a mostrar a partir del nombre y
-  el nombre comercial de la empresa.
-- Añade los campos nombre largo, NIF y web a los bancos.
-- Añade los datos de los bancos españoles extraídos del registro oficial
-  del Banco de España (http://goo.gl/mtx6ic). El asistente realiza la
-  descarga automática de Internet, pero si por cualquier razón hay algún
-  problema, existe una copia local cuya última actualización fue el
-  26/10/2017.
+-  Añade el campo *Nombre comercial* a las empresas y permite buscar por
+   él.
+-  Permite definir un patrón del nombre a mostrar a partir del nombre y
+   el nombre comercial de la empresa.
+-  Añade los campos nombre largo, NIF y web a los bancos.
+-  Añade los datos de los bancos españoles extraídos del registro
+   oficial del Banco de España (http://goo.gl/mtx6ic). El asistente
+   realiza la descarga automática de Internet, pero si por cualquier
+   razón hay algún problema, existe una copia local cuya última
+   actualización fue el 26/10/2017.
 
 **Table of contents**
 
@@ -79,7 +79,7 @@ Para importar los datos de los bancos españoles hay que ir a Facturación
 Known issues / Roadmap
 ======================
 
-- Take BICs from https://github.com/PeterNotenboom/SwiftCodes.
+-  Take BICs from https://github.com/PeterNotenboom/SwiftCodes.
 
 Bug Tracker
 ===========
@@ -104,21 +104,21 @@ Authors
 Contributors
 ------------
 
-- Jordi Esteve <jesteve@zikzakmedia.com>
-- Ignacio Ibeas <ignacio@acysos.com>
-- Pedro M. Baeza <pedro.baeza@tecnativa.com>
-- Sergio Teruel <sergio@incaser.es>
-- Ismael Calvo <ismael.calvo@factorlibre.com>
-- Carlos Dauden <carlos.dauden@tecnativa.com>
-- Manuel Regidor <manuel.regidor@sygel.es>
-- `APSL - Nagarro <https://apsl.tech>`__:
+-  Jordi Esteve <jesteve@zikzakmedia.com>
+-  Ignacio Ibeas <ignacio@acysos.com>
+-  Pedro M. Baeza <pedro.baeza@tecnativa.com>
+-  Sergio Teruel <sergio@incaser.es>
+-  Ismael Calvo <ismael.calvo@factorlibre.com>
+-  Carlos Dauden <carlos.dauden@tecnativa.com>
+-  Manuel Regidor <manuel.regidor@sygel.es>
+-  `APSL - Nagarro <https://apsl.tech>`__:
 
-  - Javier Antó <janto@apsl.net>
-  - Miquel Pascual <mpascual@apsl.net>
+   -  Javier Antó <janto@apsl.net>
+   -  Miquel Pascual <mpascual@apsl.net>
 
-- `Dixmit <https://www.dixmit.com>`__:
+-  `Dixmit <https://www.dixmit.com>`__:
 
-  - Enric Tobella
+   -  Enric Tobella
 
 Maintainers
 -----------

--- a/l10n_es_partner/__manifest__.py
+++ b/l10n_es_partner/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Adaptación de los clientes, proveedores y bancos para España",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "ZikZak,Acysos,Tecnativa,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "category": "Localisation/Europe",

--- a/l10n_es_partner/migrations/19.0.1.0.1/post-migration.py
+++ b/l10n_es_partner/migrations/19.0.1.0.1/post-migration.py
@@ -1,0 +1,8 @@
+# Copyright 2025 Tecnativa - Pilar Vargas
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["res.partner"].search([("comercial", "!=", False)])._compute_complete_name()

--- a/l10n_es_partner/models/res_partner.py
+++ b/l10n_es_partner/models/res_partner.py
@@ -53,6 +53,19 @@ class ResPartner(models.Model):
                 }
         return name
 
+    @api.depends("comercial")
+    def _compute_complete_name(self):
+        # We are enforcing the new context,
+        # because complete name field will remove the context
+        res = super()._compute_complete_name()
+        for partner in self:
+            partner.complete_name = partner.with_context(
+                display_commercial=not self.env.context.get(
+                    "no_display_commercial", False
+                )
+            )._get_complete_name()
+        return res
+
     @api.model
     def _commercial_fields(self):
         res = super()._commercial_fields()

--- a/l10n_es_partner/static/description/index.html
+++ b/l10n_es_partner/static/description/index.html
@@ -382,11 +382,11 @@ ul.auto-toc {
 <li>Permite definir un patrón del nombre a mostrar a partir del nombre y
 el nombre comercial de la empresa.</li>
 <li>Añade los campos nombre largo, NIF y web a los bancos.</li>
-<li>Añade los datos de los bancos españoles extraídos del registro oficial
-del Banco de España (<a class="reference external" href="http://goo.gl/mtx6ic">http://goo.gl/mtx6ic</a>). El asistente realiza la
-descarga automática de Internet, pero si por cualquier razón hay algún
-problema, existe una copia local cuya última actualización fue el
-26/10/2017.</li>
+<li>Añade los datos de los bancos españoles extraídos del registro
+oficial del Banco de España (<a class="reference external" href="http://goo.gl/mtx6ic">http://goo.gl/mtx6ic</a>). El asistente
+realiza la descarga automática de Internet, pero si por cualquier
+razón hay algún problema, existe una copia local cuya última
+actualización fue el 26/10/2017.</li>
 </ul>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">

--- a/l10n_es_partner/tests/test_l10n_es_partner.py
+++ b/l10n_es_partner/tests/test_l10n_es_partner.py
@@ -80,18 +80,18 @@ class TestL10nEsPartner(common.TransactionCase):
             }
         )
         self.assertEqual(partner2.display_name, "Nombre comercial (Empresa de prueba)")
-        self.assertEqual(partner2.complete_name, "Empresa de prueba")
+        self.assertEqual(partner2.complete_name, "Nombre comercial (Empresa de prueba)")
         self.assertEqual(
             partner2.with_context(show_address=True).display_name,
             "Nombre comercial (Empresa de prueba)\nMy street",
         )
-        # We will enforce the computation, but nothing should change
+        # We will enforce the computation
         partner2.with_context(
             show_address=True, display_commercial=True
         )._compute_complete_name()
-        self.assertEqual(partner2.complete_name, "Empresa de prueba")
         partner2.write({"comercial": "Nuevo nombre"})
         self.assertEqual(partner2.display_name, "Nuevo nombre (Empresa de prueba)")
+        self.assertEqual(partner2.complete_name, "Nuevo nombre (Empresa de prueba)")
         names = dict(
             [
                 (


### PR DESCRIPTION
fwp https://github.com/OCA/l10n-spain/pull/4658

complete_name is the field used to sort res.partner, but when calculated without context, the stored value ignored the sales rep name, producing an inconsistent visual order in the tree views when sorting by contact. The context is forced during the compute to include the sales rep in companies and contacts. In addition, a migration script is added to recalculate the affected records as it is a stored field.

@Tecnativa TT59646

@pedrobaeza @victoralmau please review