### PR TITLE
[17.0][FIX] l10n_es_aeat_mod303: tener en cuenta redondeo en comprobaciones cuotas compensación

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -524,9 +524,22 @@ class L10nEsAeatMod303Report(models.Model):
     def check_qty(self):
         if self.filtered(
             lambda x: (
-                x.cuota_compensar < 0
-                or x.remaining_cuota_compensar < 0
-                or (x.potential_cuota_compensar - x.cuota_compensar) < 0
+                float_compare(
+                    x.cuota_compensar, 0, precision_digits=x.currency_id.decimal_places
+                )
+                < 0
+                or float_compare(
+                    x.remaining_cuota_compensar,
+                    0,
+                    precision_digits=x.currency_id.decimal_places,
+                )
+                < 0
+                or float_compare(
+                    x.potential_cuota_compensar,
+                    x.cuota_compensar,
+                    precision_digits=x.currency_id.decimal_places,
+                )
+                < 0
             )
         ):
             raise exceptions.ValidationError(


### PR DESCRIPTION
En casos límite, como puede ser establecer la compensación pendiente como exactamente la cuota a compensar aplicada, podía impedir la operación por problemas de redondeo.