### PR TITLE
[18.0][IMP] l10n_es_aeat_sii_oca: avoid calling unnecessary write

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -252,6 +252,8 @@ class SiiMixin(models.AbstractModel):
         return header
 
     def _cancel_send_to_sii(self):
+        if not any(self.sudo().mapped("sii_send_date")):
+            return True
         try:
             self.sudo().write({"sii_send_date": False})
         except Exception:


### PR DESCRIPTION
Este write se llama independientemente de si el SII está habilitado para esa factura/compañía y puede generar conflictos a la hora de probar módulos que restringen la modificación de campos en facturas.

@Tecnativa TT59350
@pedrobaeza @victoralmau 