### PR TITLE
[17.0][FIX] l10n_es_aeat: Take into account mapped country codes when get countr_code from vat prefix

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -97,8 +97,10 @@ class ResPartner(models.Model):
         self.ensure_one()
         vat_number = self.vat or ""
         prefix = vat_number[:2].upper()
-        if self._map_aeat_country_code(prefix) in self._get_aeat_europe_codes():
-            country_code = prefix
+        aeat_country_code = self._map_aeat_country_code(prefix)
+        if aeat_country_code in self._get_aeat_europe_codes():
+            # Return mapped vats like Greece. Take into account mapped countries
+            country_code = aeat_country_code
             vat_number = vat_number[2:]
             identifier_type = "02"
         else:


### PR DESCRIPTION
En este método se extrae el country_code del prefijo del vat pero no se tiene en cuenta el mapeo de algunos vat como el Griego.. 
Por ejemplo para un NIF con el formato ELnnnnn se devuelve como country_code EL en lugar de GR

@Tecnativa TT60396

ping @carlosdauden @christian-ramos-tecnativa @victoralmau 