### PR TITLE
[18.0][FIX] l10n_es_aeat_mod347: Fix report style

### DIFF
--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -26,23 +26,23 @@
                 <t t-if="o.amount">
                     <h2>Invoices</h2>
                     <div class="row mt32 mb32">
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col-auto col-2 mw-100 mb-2">
                             <strong>Amount:</strong>
                             <p class="m-0" t-field="o.amount" />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col-auto col-2 mw-100 mb-2">
                             <strong>Amount 1Q:</strong>
                             <p class="m-0" t-field="o.first_quarter" />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col-auto col-2 mw-100 mb-2">
                             <strong>Amount 2Q:</strong>
                             <p class="m-0" t-field="o.second_quarter" />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col-auto col-2 mw-100 mb-2">
                             <strong>Amount 3Q:</strong>
                             <p class="m-0" t-field="o.third_quarter" />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col-auto col-2 mw-100 mb-2">
                             <strong>Amount 4Q:</strong>
                             <p class="m-0" t-field="o.fourth_quarter" />
                         </div>
@@ -124,35 +124,35 @@
                 <t t-if="o.real_estate_transmissions_amount">
                     <h2>Real State Transmissions</h2>
                     <div class="row mt32 mb32">
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col-auto col-2 mw-100 mb-2">
                             <strong>Amount:</strong>
                             <p
                                 class="m-0"
                                 t-field="o.real_estate_transmissions_amount"
                             />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col-auto col-2 mw-100 mb-2">
                             <strong>Amount 1Q:</strong>
                             <p
                                 class="m-0"
                                 t-field="o.first_quarter_real_estate_transmission"
                             />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col-auto col-2 mw-100 mb-2">
                             <strong>Amount 2Q:</strong>
                             <p
                                 class="m-0"
                                 t-field="o.second_quarter_real_estate_transmission"
                             />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col-auto col-2 mw-100 mb-2">
                             <strong>Amount 3Q:</strong>
                             <p
                                 class="m-0"
                                 t-field="o.third_quarter_real_estate_transmission"
                             />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col-auto col-2 mw-100 mb-2">
                             <strong>Amount 4Q:</strong>
                             <p
                                 class="m-0"


### PR DESCRIPTION
- The style of the report had to be modified because if the 'col-3' tag was added to the style, the 'Amount 4Q' option was removed from the report and it was impossible to understand what it said, so it has been changed to 'col-2'

BEFORE:

<img width="786" height="145" alt="image" src="https://github.com/user-attachments/assets/4a2c547b-3d19-451a-90c9-55ae6ba483b7" />

AFTER:

<img width="791" height="152" alt="image" src="https://github.com/user-attachments/assets/d945999a-de73-45a3-b50e-9b1ff75cb0f8" />
