### PR TITLE
[FIX] l10n_es_aeat_mod130: Support multi-company environments

### DIFF
--- a/l10n_es_aeat_mod130/models/mod130.py
+++ b/l10n_es_aeat_mod130/models/mod130.py
@@ -222,9 +222,10 @@ class L10nEsAeatMod130Report(models.Model):
         self.ensure_one()
         aml_obj = self.env["account.move.line"]
         date_start = "%s-01-01" % self.year
+                # Get company_ids from context for multi-company support
+                company_ids = self.env.context.get('allowed_company_ids', [self.company_id.id])
         extra_domain = [
-            ("company_id", "=", self.company_id.id),
-            ("date", ">=", date_start),
+            ("company_id", "in", company_ids),            ("date", ">=", date_start),
             ("date", "<=", self.date_end),
         ]
         groups = aml_obj.read_group(


### PR DESCRIPTION
The module was not working correctly in multi-company environments. The _calc_ingresos_gastos_retenciones method only searched for accounting entries in self.company_id.id, ignoring the allowed_company_ids context.

This caused calculations to return 0.00 when users switched companies in the UI.

Changed the domain filter to use 'in' operator with allowed_company_ids from context, falling back to company_id for backward compatibility.