### PR TITLE
[18.0][IMP] l10n_es_facturae: Clean XML file when it is not signed

### DIFF
--- a/l10n_es_facturae/reports/__init__.py
+++ b/l10n_es_facturae/reports/__init__.py
@@ -1,1 +1,2 @@
-from . import report_facturae
+from . import report_template_facturae
+from . import report_facturae_signed

--- a/l10n_es_facturae/reports/report_facturae_signed.py
+++ b/l10n_es_facturae/reports/report_facturae_signed.py
@@ -17,20 +17,18 @@ from lxml import etree
 
 from odoo import api, models, tools
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import cleanup_xml_node
 
 _logger = logging.getLogger(__name__)
 
 
-class ReportFacturae(models.AbstractModel):
-    _name = "report.l10n_es_facturae.facturae_signed"
-    _inherit = "report.report_xml.abstract"
-    _description = "Account Move Facturae Signed"
+class ReportFacturaeSigned(models.AbstractModel):
+    """As the name is report.{module}.{template}, this model is used as
+    a base to generate the signed facturae XML.
+    """
 
-    def _get_report_values(self, docids, data=None):
-        result = super()._get_report_values(docids, data=data)
-        result["docs"] = self.env["account.move"].browse(docids)
-        return result
+    _name = "report.l10n_es_facturae.facturae_signed"
+    _inherit = "report.l10n_es_facturae.template_facturae"
+    _description = "Account Move Facturae Signed"
 
     @api.model
     def generate_report(self, ir_report, docids, data=None):
@@ -40,10 +38,6 @@ class ReportFacturae(models.AbstractModel):
         xml_facturae, content_type = super().generate_report(
             ir_report, docids, data=data
         )
-        # Quitamos espacios en blanco, para asegurar que el XML final quede
-        # totalmente libre de ellos.
-        tree = cleanup_xml_node(xml_facturae)
-        xml_facturae = etree.tostring(tree, xml_declaration=True, encoding="UTF-8")
         self._validate_facturae(move, xml_facturae)
         public_crt, private_key = (
             self.env["l10n.es.aeat.certificate"]

--- a/l10n_es_facturae/reports/report_template_facturae.py
+++ b/l10n_es_facturae/reports/report_template_facturae.py
@@ -1,0 +1,33 @@
+# Copyright 2021 Creu Blanca
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from lxml import etree
+
+from odoo import api, models
+from odoo.tools import cleanup_xml_node
+
+
+class ReportFacturae(models.AbstractModel):
+    """As the name is report.{module}.{template}, this model is used as
+    a base to generate the unsigned facturae XML.
+    """
+
+    _name = "report.l10n_es_facturae.template_facturae"
+    _inherit = "report.report_xml.abstract"
+    _description = "Account Move Facturae Template without signature"
+
+    def _get_report_values(self, docids, data=None):
+        result = super()._get_report_values(docids, data=data)
+        result["docs"] = self.env["account.move"].browse(docids)
+        return result
+
+    @api.model
+    def generate_report(self, ir_report, docids, data=None):
+        xml_facturae, content_type = super().generate_report(
+            ir_report, docids, data=data
+        )
+        # Quitamos espacios en blanco, para asegurar que el XML final quede
+        # totalmente libre de ellos.
+        tree = cleanup_xml_node(xml_facturae)
+        xml_facturae = etree.tostring(tree, xml_declaration=True, encoding="UTF-8")
+        return xml_facturae, content_type


### PR DESCRIPTION
Otherwise, when creating the XML file without signature, extra empty tags are added, but they shouldn't exist.

Before:

<img width="690" height="353" alt="image" src="https://github.com/user-attachments/assets/7066fdfa-01f1-4837-940d-dfe520899461" />

After:

<img width="1076" height="233" alt="image" src="https://github.com/user-attachments/assets/54b550ef-233e-4790-a3ef-a83e162da8ca" />
