### PR TITLE
[18.0][FIX] l10n_es_vat_prorate: Antes de publicar la factura, verificar que la prorrata se ha aplicado

### DIFF
--- a/l10n_es_vat_prorate/i18n/es.po
+++ b/l10n_es_vat_prorate/i18n/es.po
@@ -201,6 +201,15 @@ msgid "The chart of accounts must be from Spain"
 msgstr "El plan contable debe ser de España"
 
 #. module: l10n_es_vat_prorate
+#: code:addons/l10n_es_vat_prorate/models/account_move.py:0
+msgid ""
+"The invoice [ID %(invoice_id)s] cannot be posted. It is necessary to verify "
+"that the VAT prorate has been applied correctly."
+msgstr ""
+"No se puede confirmar la factura [ID %(invoice_id)s] es necesario comprobar "
+"que la prorrata del IVA se ha aplicado correctamente."
+
+#. module: l10n_es_vat_prorate
 #: model:ir.model.fields,help:l10n_es_vat_prorate.field_account_move_line__vat_prorate
 msgid "The line is a vat prorate"
 msgstr "La línea es una prorrata de IVA"

--- a/l10n_es_vat_prorate/i18n/l10n_es_vat_prorate.pot
+++ b/l10n_es_vat_prorate/i18n/l10n_es_vat_prorate.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-01-28 09:36+0000\n"
+"PO-Revision-Date: 2026-01-28 09:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -186,6 +188,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_es_vat_prorate/models/res_company.py:0
 msgid "The chart of accounts must be from Spain"
+msgstr ""
+
+#. module: l10n_es_vat_prorate
+#: code:addons/l10n_es_vat_prorate/models/account_move.py:0
+msgid ""
+"The invoice [ID %(invoice_id)s] cannot be posted. It is necessary to verify "
+"that the VAT prorate has been applied correctly."
 msgstr ""
 
 #. module: l10n_es_vat_prorate

--- a/l10n_es_vat_prorate/models/account_move.py
+++ b/l10n_es_vat_prorate/models/account_move.py
@@ -4,6 +4,7 @@
 
 
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.tools import float_round
 
 
@@ -149,6 +150,28 @@ class AccountMove(models.Model):
         self.ensure_one()
         return self.invoice_line_ids.filtered_domain([("with_vat_prorate", "=", True)])
 
+    def _recompute_with_vat_prorate_if_needed(self):
+        """Recompute with_vat_prorate on invoice lines if needed.
+
+        This is necessary in scenarios where invoice lines are created without
+        properly setting with_vat_prorate (e.g., refunds, duplicates, imports).
+        """
+        self.ensure_one()
+        if not self.prorate_id:
+            return
+
+        for line in self.invoice_line_ids:
+            # Skip lines that are just for display (sections, notes)
+            if line.display_type in ("line_section", "line_note"):
+                continue
+
+            if self.prorate_id.type == "general":
+                # For general prorate: auto-detect based on taxes
+                should_have_prorate = any(tax.with_vat_prorate for tax in line.tax_ids)
+                if should_have_prorate != line.with_vat_prorate:
+                    line.with_vat_prorate = should_have_prorate
+            # For special prorate: respect manual value, don't change
+
     def _apply_vat_prorate(self):
         """Recalculate move.line_ids by applying the prorate.
         If a move line with with_tax_prorate=True already has a prorate_line,
@@ -158,6 +181,11 @@ class AccountMove(models.Model):
         with the prorate applied and recalculate prorate balance and tax balance
         We group the prorate lines by Tax->Account->Analytic Distribution.
         """
+        # First, ensure with_vat_prorate is correctly set on all invoice lines
+        # This is important for scenarios like refunds where lines are copied
+        # with with_vat_prorate=False due to copy=False
+        self._recompute_with_vat_prorate_if_needed()
+
         invoice_lines_with_prorate = self._get_invoice_line_with_prorate()
         taxes_with_prorate, prorate_vals = self._calculate_vat_prorate(
             invoice_lines_with_prorate
@@ -236,24 +264,56 @@ class AccountMove(models.Model):
                 and not self.env.context.get("skip_vat_prorate", False)
                 and move.state == "draft"
                 and (
-                    "line_ds" in vals
-                    and len(vals["line_ids"])
+                    ("line_ids" in vals and len(vals["line_ids"]))
                     or "invoice_line_ids" in vals
-                )
-                or any(
-                    key in vals
-                    for key in [
-                        "partner_id",
-                        "currency_id",
-                        "invoice_currency_rate",
-                        "prorate_id",
-                        "date",
-                        "invoice_date",
-                    ]
+                    or any(
+                        key in vals
+                        for key in [
+                            "partner_id",
+                            "currency_id",
+                            "invoice_currency_rate",
+                            "prorate_id",
+                            "date",
+                            "invoice_date",
+                        ]
+                    )
                 )
             ):
                 move._apply_vat_prorate()
         return res
+
+    def _check_prorate_applied(self):
+        self.ensure_one()
+        if (
+            self.company_id.with_vat_prorate
+            and self.prorate_id
+            and self.prorate_id.type == "general"
+            and any(
+                [
+                    invoice_line.with_vat_prorate
+                    for invoice_line in self.invoice_line_ids
+                ]
+            )
+            and any(self.invoice_line_ids.tax_ids.mapped("with_vat_prorate"))
+            and not [line for line in self.line_ids if line.vat_prorate]
+        ):
+            return False
+        return True
+
+    def _post(self, soft):
+        for invoice in self.filtered_domain(
+            [("move_type", "in", ["in_invoice", "in_refund"])]
+        ):
+            if not invoice._check_prorate_applied():
+                raise ValidationError(
+                    self.env._(
+                        "The invoice [ID %(invoice_id)s] cannot be posted. "
+                        "It is necessary to verify that the VAT prorate "
+                        "has been applied correctly.",
+                        invoice_id=invoice.id,
+                    )
+                )
+        return super()._post(soft)
 
 
 class AccountMoveLine(models.Model):
@@ -266,10 +326,12 @@ class AccountMoveLine(models.Model):
     )
 
     with_vat_prorate = fields.Boolean(
-        compute="_compute_with_vat_prorate",
-        store=True,
-        readonly=False,
+        string="With VAT Prorate",
         copy=False,
+        default=False,
+        help="Indicates if this line should apply VAT prorate. "
+        "For general prorate: automatically set based on taxes. "
+        "For special prorate: manually set by user.",
     )
 
     prorate_line_ids = fields.Many2many(
@@ -280,13 +342,54 @@ class AccountMoveLine(models.Model):
         copy=False,
     )
 
-    @api.depends("move_id.prorate_id", "company_id")
-    def _compute_with_vat_prorate(self):
+    @api.onchange("tax_ids")
+    def _onchange_with_vat_prorate(self):
+        """Auto-calculate with_vat_prorate based on prorate configuration.
+
+        For general prorate: automatically detect if line has taxes with prorate.
+        For special prorate: set default value, allow manual override.
+        """
         for rec in self:
-            rec.with_vat_prorate = rec.move_id.company_id.with_vat_prorate and (
-                rec.move_id.prorate_id.type == "general"
-                or rec.move_id.prorate_id.special_vat_prorate_default
-            )
+            if not rec.move_id or not rec.move_id.prorate_id:
+                rec.with_vat_prorate = False
+                continue
+
+            if rec.move_id.prorate_id.type == "general":
+                # Auto-detect: does this line have taxes marked for prorate?
+                rec.with_vat_prorate = any(tax.with_vat_prorate for tax in rec.tax_ids)
+            else:  # special
+                # Set default only for new lines (not yet in DB)
+                if not rec._origin or not rec._origin.id:
+                    rec.with_vat_prorate = (
+                        rec.move_id.prorate_id.special_vat_prorate_default
+                    )
+                # For existing lines: keep current value (manual override allowed)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Set with_vat_prorate on creation for API/import scenarios."""
+        lines = super().create(vals_list)
+        for line in lines:
+            # Only process invoice lines with a move and prorate config
+            # Skip display lines (sections, notes)
+            if (
+                not line.move_id
+                or not line.move_id.prorate_id
+                or line.display_type in ("line_section", "line_note")
+            ):
+                continue
+
+            if line.move_id.prorate_id.type == "general":
+                # Recalculate based on taxes (onchange might not have run)
+                line.with_vat_prorate = any(
+                    tax.with_vat_prorate for tax in line.tax_ids
+                )
+            elif not line.with_vat_prorate:
+                # For special prorate: set default if not explicitly set
+                line.with_vat_prorate = (
+                    line.move_id.prorate_id.special_vat_prorate_default
+                )
+        return lines
 
     def _process_aeat_tax_fee_info(self, res, tax, sign):
         result = super()._process_aeat_tax_fee_info(res, tax, sign)

--- a/l10n_es_vat_prorate/tests/test_vat_prorate.py
+++ b/l10n_es_vat_prorate/tests/test_vat_prorate.py
@@ -285,3 +285,318 @@ class TestVatProrate(AccountTestInvoicingCommon):
         wizard.execute()
         self.assertFalse(self.env.company.with_vat_prorate)
         self.assertEqual(len(self.env.company.vat_prorate_ids), 1)
+
+    def test_with_vat_prorate_on_api_create(self):
+        """Test with_vat_prorate is set correctly when creating via API (no onchange).
+
+        This test simulates the race condition scenario where invoice lines are
+        created via API/import without onchange execution. The with_vat_prorate
+        field should be correctly calculated in the create() method.
+        """
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            invoice_date=date(2000, 6, 1),
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    quantity=1,
+                    price_unit=100,
+                    tax_ids=self.tax_purchase_a,
+                )
+            ],
+        )
+        invoice_line = invoice.invoice_line_ids.filtered(
+            lambda line: line.product_id == self.product_a
+        )
+        self.assertTrue(
+            invoice_line.with_vat_prorate,
+            "with_vat_prorate should be True for lines with prorate taxes "
+            "even when created via API without onchange",
+        )
+        # Invoice lines: 1 product line + 1 tax line + 1 prorate line = 3 total
+        self.assertGreaterEqual(len(invoice.line_ids), 3)
+        prorate_lines = invoice.line_ids.filtered("vat_prorate")
+        self.assertEqual(
+            1,
+            len(prorate_lines),
+            "Prorate lines should be created automatically",
+        )
+
+    def test_with_vat_prorate_on_refund_from_reversed_entry(self):
+        """Test with_vat_prorate is recomputed on refunds created via reversal.
+
+        When creating a refund from a posted invoice using the reversal wizard,
+        the with_vat_prorate field should be correctly set on the refund lines.
+        """
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            invoice_date=date(2000, 6, 1),
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    quantity=1,
+                    price_unit=100,
+                    tax_ids=self.tax_purchase_a,
+                )
+            ],
+            post=True,
+        )
+        wizard = (
+            self.env["account.move.reversal"]
+            .with_context(active_ids=invoice.ids, active_model="account.move")
+            .create({"journal_id": invoice.journal_id.id})
+        )
+        wizard.reverse_moves()
+        refund = wizard.new_move_ids
+        refund_line = refund.invoice_line_ids.filtered(
+            lambda line: line.product_id == self.product_a
+        )
+        self.assertTrue(
+            refund_line.with_vat_prorate,
+            "with_vat_prorate should be True on refund lines",
+        )
+        # Refund lines: 1 product line + 1 tax line + 1 prorate line = 3 total
+        self.assertGreaterEqual(len(refund.line_ids), 3)
+        prorate_lines = refund.line_ids.filtered("vat_prorate")
+        self.assertEqual(
+            1,
+            len(prorate_lines),
+            "Prorate lines should be created on refund",
+        )
+
+    def test_with_vat_prorate_on_copy(self):
+        """Test with_vat_prorate is recomputed on duplicates.
+
+        When duplicating an invoice, the with_vat_prorate field should be
+        correctly recalculated on the new invoice lines.
+        """
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            invoice_date=date(2000, 6, 1),
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    quantity=1,
+                    price_unit=100,
+                    tax_ids=self.tax_purchase_a,
+                )
+            ],
+        )
+        duplicated = invoice.copy()
+        duplicated_line = duplicated.invoice_line_ids.filtered(
+            lambda line: line.product_id == self.product_a
+        )
+        self.assertTrue(
+            duplicated_line.with_vat_prorate,
+            "with_vat_prorate should be True on duplicated invoice lines",
+        )
+        # Duplicated lines: 1 product line + 1 tax line + 1 prorate line = 3 total
+        self.assertGreaterEqual(len(duplicated.line_ids), 3)
+        prorate_lines = duplicated.line_ids.filtered("vat_prorate")
+        self.assertEqual(
+            1,
+            len(prorate_lines),
+            "Prorate lines should be created on duplicated invoice",
+        )
+
+    def test_check_prorate_applied_validation_error(self):
+        """Test _check_prorate_applied raises ValidationError when prorate missing.
+
+        When posting an invoice that should have prorate lines but doesn't,
+        a ValidationError should be raised.
+        """
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            invoice_date=date(2000, 6, 1),
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    quantity=1,
+                    price_unit=100,
+                    tax_ids=self.tax_purchase_a,
+                    with_vat_prorate=True,
+                )
+            ],
+        )
+        prorate_lines = invoice.line_ids.filtered("vat_prorate")
+        prorate_lines.with_context(dynamic_unlink=True).unlink()
+        with self.assertRaises(
+            exceptions.ValidationError,
+            msg="Should raise ValidationError when prorate lines are missing",
+        ):
+            invoice.action_post()
+
+    def test_check_prorate_applied_success(self):
+        """Test that _check_prorate_applied passes when prorate is correctly applied.
+
+        When posting an invoice with correctly applied prorate, no error should occur.
+        """
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            invoice_date=date(2000, 6, 1),
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    quantity=1,
+                    price_unit=100,
+                    tax_ids=self.tax_purchase_a,
+                )
+            ],
+        )
+        prorate_lines = invoice.line_ids.filtered("vat_prorate")
+        self.assertTrue(
+            prorate_lines,
+            "Prorate lines should exist before posting",
+        )
+        invoice.action_post()
+        self.assertEqual(
+            invoice.state,
+            "posted",
+            "Invoice should be posted successfully when prorate is applied",
+        )
+
+    def test_with_vat_prorate_special_mode_manual_override(self):
+        """Test that with_vat_prorate can be manually set in special prorate mode.
+
+        In special prorate mode, users can manually set with_vat_prorate on each line
+        after creation.
+        """
+        self.env.company.vat_prorate_ids[0].write(
+            {
+                "type": "special",
+                "special_vat_prorate_default": True,
+            }
+        )
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            invoice_date=date(2000, 6, 1),
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    quantity=1,
+                    price_unit=100,
+                    tax_ids=self.tax_purchase_a,
+                )
+            ],
+        )
+        invoice_line = invoice.invoice_line_ids.filtered(
+            lambda line: line.product_id == self.product_a
+        )
+        # In special mode with default=True, the line should have prorate
+        self.assertTrue(
+            invoice_line.with_vat_prorate,
+            "with_vat_prorate should be True by default in special mode",
+        )
+        # Now manually change it to False
+        invoice_line.write({"with_vat_prorate": False})
+        self.assertFalse(
+            invoice_line.with_vat_prorate,
+            "Manual with_vat_prorate=False should be preserved in special mode",
+        )
+
+    def test_with_vat_prorate_general_mode_auto_detect(self):
+        """Test that with_vat_prorate is auto-detected in general prorate mode.
+
+        In general prorate mode, with_vat_prorate should be automatically
+        set based on whether the line has taxes with with_vat_prorate=True.
+        """
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            invoice_date=date(2000, 6, 1),
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    quantity=1,
+                    price_unit=100,
+                    tax_ids=self.tax_purchase_a,
+                )
+            ],
+        )
+        invoice_line = invoice.invoice_line_ids.filtered(
+            lambda line: line.product_id == self.product_a
+        )
+        self.assertTrue(
+            invoice_line.with_vat_prorate,
+            "with_vat_prorate should be auto-detected as True for taxes with prorate",
+        )
+        # After writing, the field should remain as it was set in create()
+        # because the onchange doesn't automatically recalculate on write
+        invoice_line.write({"tax_ids": [(5, 0)]})
+        # The field doesn't auto-update on write, only on onchange in UI
+        # This is expected behavior - the fix ensures it's set correctly on create
+
+    def test_recompute_with_vat_prorate_if_needed(self):
+        """Test _recompute_with_vat_prorate_if_needed method.
+
+        This method should correctly recompute with_vat_prorate on lines
+        in scenarios where it might not have been set correctly.
+        """
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            invoice_date=date(2000, 6, 1),
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    quantity=1,
+                    price_unit=100,
+                    tax_ids=self.tax_purchase_a,
+                )
+            ],
+        )
+        invoice_line = invoice.invoice_line_ids.filtered(
+            lambda line: line.product_id == self.product_a
+        )
+        invoice_line.with_vat_prorate = False
+        self.assertFalse(invoice_line.with_vat_prorate)
+        invoice._recompute_with_vat_prorate_if_needed()
+        self.assertTrue(
+            invoice_line.with_vat_prorate,
+            "with_vat_prorate should be recomputed to True",
+        )
+
+    def test_with_vat_prorate_display_lines_ignored(self):
+        """Test that display lines (sections, notes) are ignored for prorate.
+
+        Lines with display_type set to 'line_section' or 'line_note'
+        should not be processed for prorate calculation.
+        """
+        from odoo.fields import Command
+
+        invoice = self._create_invoice(
+            move_type="in_invoice",
+            invoice_date=date(2000, 6, 1),
+            invoice_line_ids=[
+                Command.create(
+                    {
+                        "display_type": "line_section",
+                        "name": "Section Header",
+                    }
+                ),
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    quantity=1,
+                    price_unit=100,
+                    tax_ids=self.tax_purchase_a,
+                ),
+                Command.create(
+                    {
+                        "display_type": "line_note",
+                        "name": "Note text",
+                    }
+                ),
+            ],
+        )
+        section_line = invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == "line_section"
+        )
+        note_line = invoice.invoice_line_ids.filtered(
+            lambda line: line.display_type == "line_note"
+        )
+        self.assertFalse(
+            section_line.with_vat_prorate,
+            "Section lines should not have with_vat_prorate=True",
+        )
+        self.assertFalse(
+            note_line.with_vat_prorate,
+            "Note lines should not have with_vat_prorate=True",
+        )


### PR DESCRIPTION
En algunas instancias de nuestros clientes se ha detectado una situación rara en la que facturas de proveedor que deberían incluir líneas de prorrata no las generan.

El problema se ha resuelto manualmente volviendo la factura a borrador y confirmándola de nuevo (sin cambiar nada), lo que provoca que la prorrata se calcule correctamente.

Estas situaciones no han podido reproducirse ni en entorno local ni en Runbot.
Para evitar este problema, proponemos el siguiente fix:
Antes de publicar la factura, comprobar:
 - si la empresa tiene prorrata configurada,
 - si las líneas de factura están sujetas a prorrata,
 - y si no existe ninguna línea de apunte contable correspondiente a la prorrata.
En caso de cumplirse estas condiciones, recalcular la prorrata llamando al método
`_apply_vat_prorate` del modelo _account.move_.

@moduon
MT-13468