### PR TITLE
[16.0][FIX] l10n_es_aeat_mod592: No indicar Régimen fiscal en algunos casos

### DIFF
--- a/l10n_es_aeat_mod592/models/mod592_acquirer.py
+++ b/l10n_es_aeat_mod592/models/mod592_acquirer.py
@@ -119,4 +119,7 @@ class L10nEsAeatmod592LineAcquirer(models.Model):
         data["fiscal_acquirer"] = (
             self.fiscal_acquirer if self.concept not in ("2", "3", "4") else ""
         )  # En algunos casos no se debe indicar
+        data["supplier_document_type"] = (
+            self.supplier_document_type if self.concept != "3" else ""
+        )  # Campo vacío para concepto 3
         return self._get_csv_report_info_mapped(data)

--- a/l10n_es_aeat_mod592/models/mod592_acquirer.py
+++ b/l10n_es_aeat_mod592/models/mod592_acquirer.py
@@ -117,6 +117,6 @@ class L10nEsAeatmod592LineAcquirer(models.Model):
         data = super()._get_csv_report_info()
         data["product_description"] = ""  # Campo ignorado para adquirientes
         data["fiscal_acquirer"] = (
-            self.fiscal_acquirer if self.concept not in ("2", "3") else ""
+            self.fiscal_acquirer if self.concept not in ("2", "3", "4") else ""
         )  # En algunos casos no se debe indicar
         return self._get_csv_report_info_mapped(data)


### PR DESCRIPTION
FWP de 15.0: https://github.com/OCA/l10n-spain/pull/4733

Cambios hechos:
- [x] No indicar Régimen fiscal en algunos casos (4). Relacionado con https://github.com/OCA/l10n-spain/pull/4460
- [x] No indicar Prov./Dest.: Tipo Documento si el concepto es 3

Por favor @pedrobaeza puedes revisarlo?

@Tecnativa TT60323