### PR TITLE
[17.0][FIX] l10n_es_pos_sii: Fix tests

### DIFF
--- a/l10n_es_pos_sii/tests/test_l10n_es_pos_sii.py
+++ b/l10n_es_pos_sii/tests/test_l10n_es_pos_sii.py
@@ -4,6 +4,7 @@
 
 import json
 
+from odoo import Command
 from odoo.tests import tagged
 from odoo.tools.misc import file_path
 
@@ -83,6 +84,28 @@ class TestSpainPosSii(TestPoSCommon, TestL10nEsAeatSiiBase):
         self._create_session_closed()
         self.session = self.PosSession.search([], limit=1, order="id desc")
         self.order = self.session.order_ids[:1]
+
+    @classmethod
+    def _create_invoice(cls, move_type):
+        return cls.env["account.move"].create(
+            {
+                "company_id": cls.company.id,
+                "partner_id": cls.partner.id,
+                "invoice_date": "2018-02-01",
+                "move_type": move_type,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": cls.product.id,
+                            "account_id": cls.account_expense.id,
+                            "name": "Test line",
+                            "price_unit": 100,
+                            "quantity": 1,
+                        },
+                    )
+                ],
+            }
+        )
 
     def _create_session_closed(self):
         cash = self.cash_pm1


### PR DESCRIPTION
Este PR corrige el error detectado en https://github.com/OCA/l10n-spain/pull/4767
`AttributeError: type object 'TestSpainPosSii' has no attribute 'partner_a' `
Se ha aplicado el mismo cambio que en el commit https://github.com/OCA/l10n-spain/commit/db0fb6121cc48bd9b90d4d99ccc187f9e785a92e#diff-9ffe4db9f53c810ba35a024a6cc8d278d3e2641c7738c1f309496ff694add35c durante la migración a 18.0
@Tecnativa 
@victoralmau @pedrobaeza 