### PR TITLE
[18.0][IMP] l10n_es_mod390_vat_prorate: Page 12. Prorates

### DIFF
--- a/l10n_es_aeat_mod390_vat_prorate/data/aeat.model.export.config.line.csv
+++ b/l10n_es_aeat_mod390_vat_prorate/data/aeat.model.export.config.line.csv
@@ -1,3 +1,9 @@
-id,alignment,apply_sign,bool_no,bool_yes,conditional_expression,decimal_size,export_config_id:id,export_type,expression,fixed_value,name,sequence,size,subconfig_id:id
-"l10n_es_aeat_mod390.aeat_mod390_2024_sub04_export_line_43","right","True",,,,"2","l10n_es_aeat_mod390.aeat_mod390_2024_sub04_export_config","float",${object.casilla_522},,"5. Operaciones Reg. Gral. - IVA deducible - Regularización por aplicación porcentaje definitivo de prorrata [522]","43","17",
-"l10n_es_aeat_mod390.aeat_mod390_2025_sub04_export_line_43","right","True",,,,"2","l10n_es_aeat_mod390.aeat_mod390_2025_sub04_export_config","float",${object.casilla_522},,"5. Operaciones Reg. Gral. - IVA deducible - Regularización por aplicación porcentaje definitivo de prorrata [522]","43","17",
+id,fixed_value,expression
+"l10n_es_aeat_mod390.aeat_mod390_2024_sub04_export_line_43",,${object.casilla_522}
+"l10n_es_aeat_mod390.aeat_mod390_2025_sub04_export_line_43",,${object.casilla_522}
+"l10n_es_aeat_mod390.aeat_mod390_2019_sub07_export_line_17",,${object.main_activity}
+"l10n_es_aeat_mod390.aeat_mod390_2019_sub07_export_line_18",,${object.cnae}
+"l10n_es_aeat_mod390.aeat_mod390_2019_sub07_export_line_19",,${object.casilla_115}
+"l10n_es_aeat_mod390.aeat_mod390_2019_sub07_export_line_20",,${object.casilla_116}
+"l10n_es_aeat_mod390.aeat_mod390_2019_sub07_export_line_21",,${object.type_prorate}
+"l10n_es_aeat_mod390.aeat_mod390_2019_sub07_export_line_22",,${object.vat_prorate_percent}

--- a/l10n_es_aeat_mod390_vat_prorate/models/mod390.py
+++ b/l10n_es_aeat_mod390_vat_prorate/models/mod390.py
@@ -15,16 +15,46 @@ class L10nEsAeatMod390Report(models.Model):
     )
     with_vat_prorate = fields.Boolean(related="company_id.with_vat_prorate")
     vat_prorate_percent = fields.Float(
-        string="Definitive VAT prorate percentage",
-        default=100,
+        string="[118] % Prorrata",
+        default=0,
         readonly=True,
+        help="se hará constar en esta casilla el porcentaje definitivo en función de "
+        "las operaciones del ejercicio correspondientes a la actividad de que se "
+        "trate.",
+    )
+    cnae = fields.Char(string="[114] C.N.A.E.", size=3)
+    casilla_115 = fields.Float(
+        string="[115] Importe total de las operaciones",
+        help="Se hará constar el importe total de las entregas de bienes y prestaciones"
+        " de servicios realizadas por el sujeto pasivo, incluidas aquellas que no "
+        "originan el derecho a deducir, correspondientes a la actividad de que se "
+        "trate.",
+    )
+    casilla_116 = fields.Float(
+        string="[116] Importe de las operaciones con derecho a deducción",
+        help="Se hará constar el importe total de las entregas de bienes y prestaciones"
+        " de servicios que originen el derecho a la deducción, realizadas por el sujeto"
+        " pasivo, correspondientes a la actividad de que se trate.",
+    )
+    type_prorate = fields.Selection(
+        selection=[("G", "General"), ("E", "Special")],
+        string="[117] Tipo",
+        compute="_compute_type_prorate",
+        store=True,
+        readonly=True,
+        help="Se consignará una “G” si aplica la prorrata general o una “E” si es la "
+        "prorrata especial la que aplica el sujeto pasivo.",
     )
 
-    @api.depends(
-        "company_id.vat_prorate_ids",
-        "company_id.with_vat_prorate",
-        "date_start",
-    )
+    @api.depends("company_id")
+    def _compute_type_prorate(self):
+        for record in self:
+            company_prorates = record._get_company_prorates()
+            type_prorate = False
+            if company_prorates:
+                type_prorate = "G" if company_prorates[:1].type == "general" else "E"
+            record.type_prorate = type_prorate
+
     def _get_company_prorates(self):
         self.ensure_one()
         if self.company_id.with_vat_prorate:
@@ -83,3 +113,14 @@ class L10nEsAeatMod390Report(models.Model):
                 continue
             report._calculate_casilla_522_mod390_vat_prorate()
         return res
+
+    def button_confirm(self):
+        for report in self:
+            if report.with_vat_prorate and not report.vat_prorate_percent:
+                raise exceptions.ValidationError(
+                    self.env._(
+                        "The field [118] % Prorate cannot be 0, please fill it in page "
+                        "12. Prorates"
+                    )
+                )
+        return super().button_confirm()

--- a/l10n_es_aeat_mod390_vat_prorate/views/mod390_views.xml
+++ b/l10n_es_aeat_mod390_vat_prorate/views/mod390_views.xml
@@ -13,7 +13,7 @@
             ref="l10n_es_aeat_mod390.view_l10n_es_aeat_mod390_report_form"
         />
         <field name="arch" type="xml">
-            <field name="casilla_98" position="before">
+            <xpath expr="//field[@name='casilla_598']/parent::group" position="inside">
                 <field
                     name="casilla_522"
                     widget="monetary"
@@ -23,15 +23,42 @@
                     readonly="state == 'done'"
                 />
                 <label for="casilla_522" />
-            </field>
-            <field name="statement_type" position="after">
-                <field
-                    name="vat_prorate_percent"
+            </xpath>
+            <xpath expr="//notebook" position="inside">
+                <page
+                    string="12. Prorates"
+                    name="12_prorates"
                     invisible="not with_vat_prorate"
-                    required="with_vat_prorate or period_type == '0A'"
-                    readonly="state != 'draft'"
-                />
-            </field>
+                >
+                    <group>
+                        <field
+                            name="main_activity"
+                            required="state == 'calculated' and (with_vat_prorate or period_type == '0A')"
+                            readonly="state != 'calculated'"
+                        />
+                        <field
+                            name="cnae"
+                            required="state == 'calculated' and (with_vat_prorate or period_type == '0A')"
+                            readonly="state != 'calculated'"
+                            nolabel="1"
+                        />
+                        <label for="cnae" />
+                        <field name="casilla_115" nolabel="1" />
+                        <label for="casilla_115" />
+                        <field name="casilla_116" nolabel="1" />
+                        <label for="casilla_116" />
+                        <field name="type_prorate" nolabel="1" />
+                        <label for="type_prorate" />
+                        <field
+                            name="vat_prorate_percent"
+                            required="state == 'calculated' and (with_vat_prorate or period_type == '0A')"
+                            readonly="state != 'calculated'"
+                            nolabel="1"
+                        />
+                        <label for="vat_prorate_percent" />
+                    </group>
+                </page>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Añade nuevos campos de la página 12. Prorratas. De momento son editables todos menos el tipo de prorrata.

<img width="765" height="753" alt="image" src="https://github.com/user-attachments/assets/0a9dc8d1-1718-4dde-96f3-c72a88a43cbc" />

Fuente https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/G412/Instrucciones_modelo_390-2025.pdf

MT-13512 @moduon