### PR TITLE
[16.0][IMP] l10n_es_igic: New 1% IGIC Taxes.

### DIFF
--- a/l10n_es_dua_igic/data/fiscal_position_taxes_dua.xml
+++ b/l10n_es_dua_igic/data/fiscal_position_taxes_dua.xml
@@ -13,6 +13,11 @@
         <field name="tax_src_id" ref="l10n_es_igic.account_tax_template_igic_sop_0" />
         <field name="tax_dest_id" ref="account_tax_template_p_atc_dua0" />
     </record>
+    <record id="fptt_atc_dua_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_atc_dua" />
+        <field name="tax_src_id" ref="l10n_es_igic.account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="account_tax_template_p_atc_dua0" />
+    </record>
     <record id="fptt_atc_dua_3_inv" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_atc_dua" />
         <field

--- a/l10n_es_igic/data/account_fiscal_position_template_canary_data.xml
+++ b/l10n_es_igic/data/account_fiscal_position_template_canary_data.xml
@@ -61,6 +61,11 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0" />
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_i_0" />
     </record>
+    <record id="fptt_extra_canary_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_extra_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_i_1" />
+    </record>
     <record id="fptt_extra_canary_3_inv" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_extra_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_sop_3_inv" />
@@ -127,6 +132,14 @@
     >
         <field name="position_id" ref="fp_extra_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_r_0" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_ex_0" />
+    </record>
+    <record
+        id="fptt_extra_ventas_canary_1"
+        model="account.fiscal.position.tax.template"
+    >
+        <field name="position_id" ref="fp_extra_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_r_1" />
         <field name="tax_dest_id" ref="account_tax_template_igic_ex_0" />
     </record>
     <record
@@ -200,6 +213,16 @@
         <field name="position_id" ref="fp_recargo_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0" />
         <field name="tax_dest_id" ref="account_tax_template_igic_p_re0" />
+    </record>
+    <record id="fptt_recargo_canary_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_recargo_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_i_1" />
+    </record>
+    <record id="fptt_recargo_canary_1_2" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_recargo_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_p_re01" />
     </record>
     <record id="fptt_recargo_canary_3_inv" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_recargo_canary" />
@@ -359,6 +382,16 @@
         <field name="tax_src_id" ref="account_tax_template_igic_r_0" />
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf9" />
     </record>
+    <record id="fptt_irpf9sale_canary_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_irpf9_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_r_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_1" />
+    </record>
+    <record id="fptt_irpf9sale_canary_1_2" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_irpf9_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_r_1" />
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf9" />
+    </record>
     <record id="fptt_irpf9sale_canary_3" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_irpf9_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_r_3" />
@@ -446,6 +479,16 @@
     <record id="fptt_irpf9_canary_0_2" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_irpf9_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0" />
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf9" />
+    </record>
+    <record id="fptt_irpf9_canary_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_irpf9_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_1" />
+    </record>
+    <record id="fptt_irpf9_canary_1_2" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_irpf9_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf9" />
     </record>
     <record id="fptt_irpf9_canary_3_inv" model="account.fiscal.position.tax.template">
@@ -591,6 +634,19 @@
         <field name="tax_src_id" ref="account_tax_template_igic_r_0" />
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf15" />
     </record>
+    <record id="fptt_irpf15sale_canary_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_irpf15_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_r_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_1" />
+    </record>
+    <record
+        id="fptt_irpf15sale_canary_1_2"
+        model="account.fiscal.position.tax.template"
+    >
+        <field name="position_id" ref="fp_irpf15_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_r_1" />
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf15" />
+    </record>
     <record id="fptt_irpf15sale_canary_3" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_irpf15_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_r_3" />
@@ -692,6 +748,18 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0" />
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf15" />
     </record>
+
+    <record id="fptt_irpf15_canary_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_irpf15_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_1" />
+    </record>
+    <record id="fptt_irpf15_canary_1_2" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_irpf15_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf15" />
+    </record>
+
     <record id="fptt_irpf15_canary_3_inv" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_irpf15_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_sop_3_inv" />
@@ -844,6 +912,19 @@
         <field name="tax_src_id" ref="account_tax_template_igic_r_0" />
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf19a" />
     </record>
+    <record id="fptt_irpf19asale_canary_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_irpf19a_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_r_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_r_1" />
+    </record>
+    <record
+        id="fptt_irpf19asale_canary_1_2"
+        model="account.fiscal.position.tax.template"
+    >
+        <field name="position_id" ref="fp_irpf19a_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_r_1" />
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_s_irpf19a" />
+    </record>
     <record id="fptt_irpf19asale_canary_3" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_irpf19a_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_r_3" />
@@ -954,6 +1035,17 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0" />
         <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf19a" />
     </record>
+    <record id="fptt_irpf19a_canary_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_irpf19a_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_1" />
+    </record>
+    <record id="fptt_irpf19a_canary_1_2" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_irpf19a_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="l10n_es.account_tax_template_p_irpf19a" />
+    </record>
+
     <record id="fptt_irpf19a_canary_3_inv" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_irpf19a_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_sop_3_inv" />
@@ -1112,6 +1204,11 @@
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0" />
         <field name="tax_dest_id" ref="account_tax_template_igic_ISP0" />
     </record>
+    <record id="fptt_ispn_p_igic1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_ispn_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_ISP1" />
+    </record>
     <record id="fptt_ispn_p_igic3_inv" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_ispn_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_sop_3_inv" />
@@ -1177,6 +1274,11 @@
         <field name="tax_src_id" ref="account_tax_template_igic_r_0" />
         <field name="tax_dest_id" ref="account_tax_template_igic_s_ISP0" />
     </record>
+    <record id="fptt_ispn_s_igic1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_ispn_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_r_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_s_ISP0" />
+    </record>
     <record id="fptt_ispn_s_igic3" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_ispn_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_r_3" />
@@ -1213,6 +1315,11 @@
         <field name="tax_src_id" ref="account_tax_template_igic_r_0" />
         <field name="tax_dest_id" ref="account_tax_template_igic_cmino" />
     </record>
+    <record id="fptt_cmino_s_igic1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_retailer_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_r_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_cmino" />
+    </record>
     <record id="fptt_cmino_s_igic3" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_retailer_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_r_3" />
@@ -1247,6 +1354,11 @@
         <field name="position_id" ref="fp_retailer_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_sop_0" />
         <field name="tax_dest_id" ref="account_tax_template_igic_sop_cmino" />
+    </record>
+    <record id="fptt_cmino_p_igic1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_retailer_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_sop_1" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_sop_1_cmino" />
     </record>
     <record id="fptt_cmino_p_igic3" model="account.fiscal.position.tax.template">
         <field name="position_id" ref="fp_retailer_canary" />
@@ -1285,6 +1397,11 @@
     >
         <field name="position_id" ref="fp_lease_canary" />
         <field name="tax_src_id" ref="account_tax_template_igic_r_0" />
+        <field name="tax_dest_id" ref="account_tax_template_igic_re_ex" />
+    </record>
+    <record id="fpl_extra_ventas_canary_1" model="account.fiscal.position.tax.template">
+        <field name="position_id" ref="fp_lease_canary" />
+        <field name="tax_src_id" ref="account_tax_template_igic_r_1" />
         <field name="tax_dest_id" ref="account_tax_template_igic_re_ex" />
     </record>
     <record id="fpl_extra_ventas_canary_3" model="account.fiscal.position.tax.template">

--- a/l10n_es_igic/data/account_tax_data.xml
+++ b/l10n_es_igic/data/account_tax_data.xml
@@ -26,6 +26,38 @@
                   ]"
         />
     </record>
+    <record id="account_tax_template_igic_r_1" model="account.tax.template">
+        <field
+            name="sequence"
+            eval="0"
+        /> <!-- Para que sea el impuesto por defecto de ventas -->
+        <field name="type_tax_use">sale</field>
+        <field name="name">IGIC 1%</field>
+        <field name="chart_template_id" ref="account_chart_template_common_canary" />
+        <field name="amount" eval="1" />
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_1" />
+        <field
+            name="invoice_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4777'),
+                          }),
+                  ]"
+        />
+        <field
+            name="refund_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4777'),
+                          }),
+                  ]"
+        />
+    </record>
     <record id="account_tax_template_igic_r_3" model="account.tax.template">
         <field name="type_tax_use">sale</field>
         <field name="name">IGIC 3%</field>
@@ -319,6 +351,35 @@
         />
     </record>
 
+    <record id="account_tax_template_igic_sop_1_cmino" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IGIC 1% Soportado (Comercio minorista)</field>
+        <field name="chart_template_id" ref="account_chart_template_common_canary" />
+        <field name="amount" eval="1.0" />
+        <field name="amount_type">division</field>
+        <field name="tax_group_id" ref="tax_group_igic_cmino" />
+        <field
+            name="invoice_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                  ]"
+        />
+        <field
+            name="refund_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                  ]"
+        />
+    </record>
+
     <record id="account_tax_template_igic_sop_3_cmino" model="account.tax.template">
         <field name="type_tax_use">purchase</field>
         <field name="name">IGIC 3% Soportado (Comercio minorista)</field>
@@ -544,6 +605,34 @@
             eval="[(5, 0, 0),
                    (0, 0, {'repartition_type': 'base',}),
                    (0, 0, {'repartition_type': 'tax',}),
+                  ]"
+        />
+    </record>
+    <record id="account_tax_template_igic_sop_1" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IGIC 1% Soportado (Operaciones corrientes)</field>
+        <field name="chart_template_id" ref="account_chart_template_common_canary" />
+        <field eval="1.0" name="amount" />
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_1" />
+        <field
+            name="invoice_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                  ]"
+        />
+        <field
+            name="refund_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
                   ]"
         />
     </record>
@@ -935,6 +1024,34 @@
                   ]"
         />
     </record>
+        <record id="account_tax_template_igic_sop_i_1" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IGIC 1% Importaciones (Operaciones corrientes)</field>
+        <field name="chart_template_id" ref="account_chart_template_common_canary" />
+        <field eval="1" name="amount" />
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_1" />
+        <field
+            name="invoice_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                  ]"
+        />
+        <field
+            name="refund_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                  ]"
+        />
+    </record>
     <record id="account_tax_template_igic_sop_i_3" model="account.tax.template">
         <field name="type_tax_use">purchase</field>
         <field name="name">IGIC 3% Importaciones (Operaciones corrientes)</field>
@@ -1322,6 +1439,44 @@
                   ]"
         />
     </record>
+    <record id="account_tax_template_igic_ISP1" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IGIC 1% Compra con Inversión del Sujeto Pasivo</field>
+        <field name="amount_type">percent</field>
+        <field name="amount" eval="1" />
+        <field name="chart_template_id" ref="account_chart_template_common_canary" />
+        <field name="tax_group_id" ref="tax_group_igic_1" />
+        <field
+            name="invoice_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4777'),
+                          }),
+                  ]"
+        />
+        <field
+            name="refund_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                   (0, 0, {'factor_percent': -100,
+                           'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4777'),
+                          }),
+                  ]"
+        />
+    </record>
     <record id="account_tax_template_igic_ISP3" model="account.tax.template">
         <field name="type_tax_use">purchase</field>
         <field name="name">IGIC 3% Compra con Inversión del Sujeto Pasivo</field>
@@ -1574,6 +1729,34 @@
                   ]"
         />
     </record>
+    <record id="account_tax_template_igic_p_re01" model="account.tax.template">
+        <field name="type_tax_use">purchase</field>
+        <field name="name">IGIC 0,10% Compras (Recargo a la importación)</field>
+        <field name="chart_template_id" ref="account_chart_template_common_canary" />
+        <field name="amount" eval="0.1" />
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_re_01" />
+        <field
+            name="invoice_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                  ]"
+        />
+        <field
+            name="refund_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                  ]"
+        />
+    </record>
     <record id="account_tax_template_igic_p_re03" model="account.tax.template">
         <field name="type_tax_use">purchase</field>
         <field name="name">IGIC 0,30% Compras (Recargo a la importación)</field>
@@ -1743,4 +1926,32 @@
         />
     </record>
 
+    <record id="account_tax_template_s_req01" model="account.tax.template">
+        <field name="type_tax_use">sale</field>
+        <field name="name">0.1% Recargo Equivalencia</field>
+        <field name="chart_template_id" ref="account_chart_template_common_canary" />
+        <field name="amount" eval="0.1" />
+        <field name="amount_type">percent</field>
+        <field name="tax_group_id" ref="tax_group_igic_re_01" />
+        <field
+            name="invoice_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                  ]"
+        />
+        <field
+            name="refund_repartition_line_ids"
+            eval="[(5, 0, 0),
+                   (0, 0, {'repartition_type': 'base',}),
+                   (0, 0, {'repartition_type': 'tax',
+                           'account_id':
+                           ref('l10n_es_igic.account_common_canary_4727'),
+                          }),
+                  ]"
+        />
+    </record>
 </odoo>

--- a/l10n_es_igic/data/account_tax_group_data.xml
+++ b/l10n_es_igic/data/account_tax_group_data.xml
@@ -5,6 +5,10 @@
         <field name="name">IGIC 0%</field>
         <field name="country_id" ref="base.es" />
     </record>
+    <record id="tax_group_igic_1" model="account.tax.group">
+        <field name="name">IGIC 1%</field>
+        <field name="country_id" ref="base.es" />
+    </record>
     <record id="tax_group_igic_3" model="account.tax.group">
         <field name="name">IGIC 3%</field>
         <field name="country_id" ref="base.es" />
@@ -35,6 +39,10 @@
     </record>
     <record id="tax_group_igic_re_0" model="account.tax.group">
         <field name="name">IGIC Recargo de Equivalencia 0%</field>
+        <field name="country_id" ref="base.es" />
+    </record>
+    <record id="tax_group_igic_re_01" model="account.tax.group">
+        <field name="name">IGIC Recargo de Equivalencia 0,1%</field>
         <field name="country_id" ref="base.es" />
     </record>
     <record id="tax_group_igic_re_03" model="account.tax.group">


### PR DESCRIPTION
Según el boletín oficial de Canarias existen nuevos impuestos a crear para el módulo del IGIC: https://www.gobiernodecanarias.org/boc/2025/256/4414.html

1. El Tipo del 1% (Combustibles y Petróleo)

- Es el cambio más radical. Hasta ahora, el IGIC funcionaba con tipos del 0, 3, 7, 9.5, 15 y 20%. El 1% es un valor numérico nuevo en la escala del impuesto.
- A qué se aplica: Petróleo y derivados (gasolinas, gasóleos, etc.).
- Por qué no está en Odoo 17: Porque el módulo de localización española (l10n_es_igic) se basa en la normativa anterior donde estos productos iban al 0%.

2. Recargo del 0,1% (Margen Mayorista)

- Este es un nuevo porcentaje de recargo diseñado exclusivamente para acompañar al nuevo IGIC del 1% en las importaciones de combustible realizadas por comerciantes minoristas. Las plantillas de Odoo suelen traer el 0.3%, 0.7%, etc., pero el 0.1% es nuevo de este año.