### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_oca: No double savepoint + commit

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -638,6 +638,7 @@ class AccountMove(models.Model):
 
     def _cancel_invoice_to_sii(self):
         for invoice in self.filtered(lambda i: i.state in ["cancel"]):
+            # TODO: Move communication code to sii.mixin
             serv = invoice._connect_aeat(invoice.move_type)
             header = invoice._get_aeat_header(cancellation=True)
             inv_vals = {
@@ -938,23 +939,7 @@ class AccountMove(models.Model):
         documents = all_documents[:batch]
         remaining_documents = all_documents - documents
         for doc in documents:
-            try:
-                with self.env.cr.savepoint():
-                    doc.confirm_one_document()
-                    doc.sii_send_date = False
-            except Exception as fault:
-                new_cr = Registry(self.env.cr.dbname).cursor()
-                env = api.Environment(new_cr, self.env.uid, self.env.context)
-                doc_vals = {
-                    "aeat_send_failed": True,
-                    "aeat_send_error": repr(fault)[:60],
-                    "sii_send_date": False,
-                    "sii_return": repr(fault),
-                }
-                invoice = env["account.move"].browse(doc.id)
-                invoice.write(doc_vals)
-                new_cr.commit()
-                new_cr.close()
+            doc.confirm_one_document()
         return remaining_documents
 
     @api.model

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -839,6 +839,7 @@ class SiiMixin(models.AbstractModel):
                         "sii_account_registration_date"
                     ] = document._get_account_registration_date()
                 doc_vals["sii_return"] = res
+                doc_vals["sii_send_date"] = False
                 send_error = False
                 if res_line["CodigoErrorRegistro"]:
                     send_error = "{} | {}".format(


### PR DESCRIPTION
Before this commit, there was a savepoint + commit in case of exception in `account.move`, but also in the method `_send_document_to_sii`, that is called from `sii.mixin`, which is not needed, and provoking that when there's a real exception (like XML schema not compliant), you get the `SerializationError: couldn't serialize access due to concurrent...` error.

Removing the upper savepoint and commit on exception, solves the problem.

The code has also been adjusted for resetting `sii_send_date` in the proper method, and annotated a TODO refactoring for moving the cancellation code to the mixin.

@Tecnativa TT60762