### PR TITLE
[16.0][IMP] l10n_es_aeat_mod347: Incluir prestaciones de servicios extracomunitarios

### DIFF
--- a/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
+++ b/l10n_es_aeat_mod347/data/tax_code_map_mod347_data.xml
@@ -107,6 +107,7 @@
                 ref('l10n_es.account_tax_template_s_iva5b'),
                 ref('l10n_es.account_tax_template_s_iva7-5s'),
                 ref('l10n_es.account_tax_template_s_iva7-5b'),
+                ref('l10n_es.account_tax_template_s_iva_e'),
                 ref('l10n_es.account_tax_template_s_req0'),
                 ref('l10n_es.account_tax_template_s_req026'),
                 ref('l10n_es.account_tax_template_s_req062'),


### PR DESCRIPTION
PR relacionado a https://github.com/OCA/l10n-spain/issues/4816

Se pasará a versiones superiores

@HaraldPanten 

T-9309