### PR TITLE
[16.0][FIX] l10n_es_aeat_mod347: Fix attribute error

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -552,7 +552,7 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
             if record.partner_state_code and not record.partner_state_code.isdigit():
                 errors.append(_("State code can only contain digits"))
             if not (record.partner_vat or record.partner_country_code != "ES"):
-                errors.append(self.env._("VAT must be defined for Spanish Contacts"))
+                errors.append(_("VAT must be defined for Spanish Contacts"))
             if (record.operation_key == "E" and not record.bdns_number) or (
                 record.operation_key == "E"
                 and record.bdns_number
@@ -560,7 +560,7 @@ class L10nEsAeatMod347PartnerRecord(models.Model):
             ):
                 # BDSN can have a maximum of 6 digits
                 errors.append(
-                    self.env._(
+                    _(
                         "BDNS Call Number is mandatory for operation key E and it must"
                         " have 6 digits"
                     )


### PR DESCRIPTION
El siguiente commit es para arreglar el error de atributo al generar un modelo 347. La funcionalidad añadida en el https://github.com/OCA/l10n-spain/pull/4795 no existe en la versión 16.0 solo posteriores.

Error: 
<img width="927" height="784" alt="image" src="https://github.com/user-attachments/assets/1649b22d-7a67-4415-b3f3-6fce7732029e" />
