### PR TITLE
[17.0][FIX] l10n_aeat_mod347: Add to context default_report_id

### DIFF
--- a/l10n_es_aeat_mod347/models/mod347.py
+++ b/l10n_es_aeat_mod347/models/mod347.py
@@ -186,6 +186,7 @@ class L10nEsAeatMod347Report(models.Model):
             "name": _("Partner records"),
             "view_mode": "tree,form",
             "res_model": "l10n.es.aeat.mod347.partner_record",
+            "context": dict(self.env.context, default_report_id=self.id),
             "type": "ir.actions.act_window",
         }
 

--- a/l10n_es_aeat_mod347/views/mod347_view.xml
+++ b/l10n_es_aeat_mod347/views/mod347_view.xml
@@ -98,6 +98,7 @@
                         <page string="Partner info">
                             <group>
                                 <group>
+                                    <field name="report_id" invisible="1" />
                                     <field name="partner_id" />
                                     <field name="check_ok" invisible="1" />
                                     <field


### PR DESCRIPTION
Para poder crear "Registros de empresas" de modelo 347 desde la vista `view_l10n_es_aeat_mod347_partner_record_tree` y relacionarlos con el informe falta pasar por el contexto `report_id`.

@victoralmau @pedrobaeza podéis revisar?

<img width="1532" height="1098" alt="image" src="https://github.com/user-attachments/assets/cbf0ecd1-a26d-4625-93a0-9f6318c6c01d" />
<img width="1263" height="839" alt="image" src="https://github.com/user-attachments/assets/ba148243-9ce2-420d-bb72-1a94fe245b62" />


@Tecnativa
TT61015