### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_match: Extract company VAT properly

### DIFF
--- a/l10n_es_aeat_sii_match/models/aeat_sii_match_report.py
+++ b/l10n_es_aeat_sii_match/models/aeat_sii_match_report.py
@@ -423,7 +423,7 @@ class SiiMatchReport(models.Model):
             "IDVersionSii": SII_VERSION,
             "Titular": {
                 "NombreRazon": self.company_id.name[0:120],
-                "NIF": self.company_id.vat[2:],
+                "NIF": self.company_id.partner_id._parse_aeat_vat_info()[2],
             },
         }
         return header


### PR DESCRIPTION
Previously, if you don't prefix the VAT company with "ES", the matching fails, as it was unconditionally strip the first 2 characters.

Let's use the existing method that takes into account all the possible cases.

@Tecnativa 