### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_match: Look for vendor bill properly

### DIFF
--- a/l10n_es_aeat_sii_match/models/aeat_sii_match_report.py
+++ b/l10n_es_aeat_sii_match/models/aeat_sii_match_report.py
@@ -4,6 +4,7 @@
 
 import copy
 import json
+from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
 from zeep.helpers import serialize_object
@@ -11,6 +12,8 @@ from zeep.helpers import serialize_object
 from odoo import _, api, exceptions, fields, models
 from odoo.exceptions import UserError
 from odoo.modules.registry import Registry
+
+from odoo.addons.l10n_es_aeat.models.aeat_mixin import AEAT_DATE_FORMAT
 
 SII_VERSION = "1.1"
 
@@ -162,13 +165,23 @@ class SiiMatchReport(models.Model):
                     limit=1,
                 )
             else:
+                invoice_date = invoice["IDFactura"]["FechaExpedicionFacturaEmisor"]
+                invoice_date = datetime.strptime(invoice_date, AEAT_DATE_FORMAT)
                 odoo_invoice = self.env["account.move"].search(
                     [
                         ("ref", "=", name),
+                        ("invoice_date", "=", invoice_date),
                         ("move_type", "in", ["in_invoice", "in_refund"]),
                     ],
-                    limit=1,
                 )
+                if len(odoo_invoice) > 1:
+                    vat = invoice["IDFactura"]["IDEmisorFactura"].get("NIF", "NO_VALID")
+                    for rec in odoo_invoice:
+                        if vat in rec.partner_id.vat:
+                            odoo_invoice = rec
+                            break
+                    else:
+                        odoo_invoice = False  # Don't match with any of them
             if odoo_invoice and odoo_invoice.id not in list(matched_invoices.keys()):
                 matched_invoices[odoo_invoice.id] = invoice
             else:


### PR DESCRIPTION
On vendor bills, the invoice number may be repeated across different vendors, returning an incorrect matching. For minimizing this, we first look for invoices with the same date, and if more than one match, then we iterate for finding the one matching (maybe partially) the VAT.

We are not including the VAT comparison on the initial search, because you may have other identifier set on the partner, and then not returning any result at all, so we reserve this check only in case of multiple match.

@Tecnativa 