### PR TITLE
[18.0][FIX] delivery_gls_asm: Disable tests

### DIFF
--- a/delivery_gls_asm/tests/__init__.py
+++ b/delivery_gls_asm/tests/__init__.py
@@ -1,1 +1,2 @@
-from . import test_delivery_gls_asm
+# The GLS service is very unstable and not reliable, so let's disable it for now
+# from . import test_delivery_gls_asm


### PR DESCRIPTION
The GLS test service is very unstable and not reliable, so we get continuous false negatives. With this, the tests are not complying with their purpose.

I usually prefer to test real services instead of mocks, but not having something reliable in the other part, we can't sacrifice the general workflows. Converting the tests to use mocks is not possible right now due to the heavy refactoring work, so let's just disable them for now.

@Tecnativa