### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: SII description is not multi-line + offending chars

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -15,6 +15,8 @@
 import json
 import logging
 
+from unidecode import unidecode
+
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 from odoo.modules.registry import Registry
@@ -679,6 +681,7 @@ class AccountMove(models.Model):
                     names = invoice.mapped("invoice_line_ids.name") or invoice.mapped(
                         "invoice_line_ids.ref"
                     )
+                    names = [unidecode(x) for x in names]  # Avoid "ugly" chars
                     description += " - ".join(filter(None, names))
             invoice.sii_description = (description or "")[:500] or "/"
 

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -35,7 +35,7 @@ class SiiMixin(models.AbstractModel):
         comodel_name="res.company",
         string="Company",
     )
-    sii_description = fields.Text(
+    sii_description = fields.Char(
         string="SII computed description",
         compute="_compute_sii_description",
         default="/",

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -5,7 +5,8 @@
 # Copyright 2011,2024 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import json
-import logging
+
+from unidecode import unidecode
 
 from odoo import api, exceptions, fields, models
 from odoo.exceptions import UserError, ValidationError
@@ -13,8 +14,6 @@ from odoo.modules.registry import Registry
 from odoo.tools.float_utils import float_compare
 
 from odoo.addons.l10n_es_aeat.models.aeat_mixin import round_by_keys
-
-_logger = logging.getLogger(__name__)
 
 SII_STATES = [
     ("sent_modified", "Registered in SII but last modifications not sent"),
@@ -797,6 +796,10 @@ class SiiMixin(models.AbstractModel):
         for document in self.filtered(
             lambda i: i.state in self._get_valid_document_states()
         ):
+            # Filter the SII description for avoiding manual invalid inputs
+            text = unidecode(document.sii_description)
+            if text != document.sii_description:
+                document.sii_description = text
             if document.aeat_state == "not_sent":
                 tipo_comunicacion = "A0"
             else:


### PR DESCRIPTION
Using `l10n_es_aeat_sii_match` for comparing results from AEAT with Odoo, I have found that the AEAT is accepting line feeds in the query, but not storing them, replacing the character by spaces, so there's no perfect matching when later comparing them.

Although the computed description is not putting that line breaks (line descriptions are joined with ` - `), someone may edit that descriptions and introduce them, so you will have the problem.

For avoiding the temptation, let's convert the field to one line text.

@Tecnativa 