### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: No error if no description

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -681,7 +681,7 @@ class AccountMove(models.Model):
                     names = invoice.mapped("invoice_line_ids.name") or invoice.mapped(
                         "invoice_line_ids.ref"
                     )
-                    names = [unidecode(x) for x in names]  # Avoid "ugly" chars
+                    names = [unidecode(x) for x in names if x]  # Avoid "ugly" chars
                     description += " - ".join(filter(None, names))
             invoice.sii_description = (description or "")[:500] or "/"
 


### PR DESCRIPTION
When initializing an invoice, there are no descriptions, and unidecode gives an error, so let's avoid putting the conditional.

Follow-up of #4865

@Tecnativa 