### PR TITLE
[18.0][IMP] delivery_gls_asm: Fine-tuning of cancel_shipment button visibility

### DIFF
--- a/delivery_gls_asm/views/stock_picking_views.xml
+++ b/delivery_gls_asm/views/stock_picking_views.xml
@@ -16,7 +16,7 @@
                     class="fa fa-arrow-right oe_link"
                     name="cancel_shipment"
                     string="Cancel"
-                    invisible="not carrier_tracking_ref or delivery_type != 'gls_asm' or state == 'done'"
+                    invisible="not carrier_tracking_ref or not gls_carrier_is_pickup_service or state == 'done'"
                 />
             </xpath>
             <xpath expr="//div[@name='tracking']" position="after">


### PR DESCRIPTION
Display this button only when the carrier has the pickup service enabled, according to this feature.

Esto se agrego en el commit https://github.com/OCA/l10n-spain/commit/c07fdf868653f7ec4d9b9dff63d0f15c5bbd1039 de V14 pero se muestra siempre que sea GLS, mas solo deberia mostrarse cuando este activo el servicio de pickup. Provocando que con modulos como este https://github.com/OCA/delivery-carrier/pull/1070 se vean 2 botones para Cancelar el envio. Esto no evita que cuando sea pickup, igual aparezcan 2 botones si se instalan ambos modulos, pero al menos se minimiza el issue visual
@Tecnativa @pedrobaeza @sergio-teruel pueden darle una mirada a este PR por favor