### PR TITLE
[16.0][FIX] l10n_es_aeat_mod369: deduplicate OSS taxes in 369 map

### DIFF
--- a/l10n_es_aeat_mod369/models/mod369.py
+++ b/l10n_es_aeat_mod369/models/mod369.py
@@ -148,47 +148,58 @@ class L10nEsAeatMod369Report(models.Model):
         oss_map_lines = self.env.context.get("oss_map_lines", {})
         if map_line in oss_map_lines:
             oss_taxes_map = self.env.context.get("oss_taxes_map", {})
-            return oss_taxes_map.get(map_line.field_number, {}).get(
-                "tax", self.env["account.tax"]
-            )
+            tax_data = oss_taxes_map.get(map_line.field_number, {})
+            return tax_data.get("taxes", tax_data.get("tax", self.env["account.tax"]))
         return super().get_taxes_from_map(map_line)
 
     def _get_oss_taxes_map(self):
         oss_taxes = self.env["account.tax"].search(
             [("oss_country_id", "!=", False), ("company_id", "=", self.company_id.id)]
         )
-        oss_countries = {}
+        # Group taxes by (oss_country_id, amount) so duplicate OSS taxes
+        # (same country and rate) share one slot but all IDs are available
+        # for the move line domain search
+        oss_country_rates = {}
         for tax in oss_taxes:
-            oss_countries.setdefault(tax.oss_country_id, self.env["account.tax"])
-            oss_countries[tax.oss_country_id] |= tax
+            key = (tax.oss_country_id, tax.amount)
+            if key not in oss_country_rates:
+                oss_country_rates[key] = self.env["account.tax"]
+            oss_country_rates[key] |= tax
+        # Rebuild per-country unique rates preserving country order
+        oss_countries = {}
+        for (country, _amount), taxes in oss_country_rates.items():
+            oss_countries.setdefault(country, [])
+            oss_countries[country].append(taxes)
         oss_taxes_map = {}
         line_number = 1
         previous_country = False
         previous_tax_count = 0
-        for country, taxes in oss_countries.items():
+        for country, tax_groups in oss_countries.items():
             if previous_country and country != previous_country:
                 line_number += 8 - (previous_tax_count * 2)
                 previous_tax_count = 0
-            for tax in taxes:
+            for taxes in tax_groups:
+                tax = taxes[:1]
                 previous_tax_count += 1
+                entry = {"tax": tax, "taxes": taxes, "country": country}
                 oss_taxes_map.update(
                     {
                         # Goods + spain (base)
-                        line_number: {"tax": tax, "country": country},
+                        line_number: entry,
                         # Goods + spain (amount)
-                        line_number + 1: {"tax": tax, "country": country},
+                        line_number + 1: entry,
                         # Goods + outside spain (base)
-                        line_number + 224: {"tax": tax, "country": country},
+                        line_number + 224: entry,
                         # Goods + outside spain (amount)
-                        line_number + 225: {"tax": tax, "country": country},
+                        line_number + 225: entry,
                         # Services + spain (base)
-                        line_number + 448: {"tax": tax, "country": country},
+                        line_number + 448: entry,
                         # Services + spain (amount)
-                        line_number + 449: {"tax": tax, "country": country},
+                        line_number + 449: entry,
                         # Services + outside spain (base)
-                        line_number + 672: {"tax": tax, "country": country},
+                        line_number + 672: entry,
                         # Services + outside spain (amount)
-                        line_number + 673: {"tax": tax, "country": country},
+                        line_number + 673: entry,
                     }
                 )
                 line_number += 2

--- a/l10n_es_aeat_mod369/models/mod369.py
+++ b/l10n_es_aeat_mod369/models/mod369.py
@@ -170,17 +170,13 @@ class L10nEsAeatMod369Report(models.Model):
         for (country, _amount), taxes in oss_country_rates.items():
             oss_countries.setdefault(country, [])
             oss_countries[country].append(taxes)
+        # Sequential allocation. AEAT DR369e21 v1.1 defines each section as a
+        # flat 28-entry list, no per-country slot limit.
         oss_taxes_map = {}
         line_number = 1
-        previous_country = False
-        previous_tax_count = 0
         for country, tax_groups in oss_countries.items():
-            if previous_country and country != previous_country:
-                line_number += 8 - (previous_tax_count * 2)
-                previous_tax_count = 0
             for taxes in tax_groups:
                 tax = taxes[:1]
-                previous_tax_count += 1
                 entry = {"tax": tax, "taxes": taxes, "country": country}
                 oss_taxes_map.update(
                     {
@@ -203,7 +199,6 @@ class L10nEsAeatMod369Report(models.Model):
                     }
                 )
                 line_number += 2
-            previous_country = country
         return oss_taxes_map
 
     def _prepare_tax_line_vals(self, map_line):

--- a/l10n_es_aeat_mod369/tests/test_l10n_es_aeat_mod369.py
+++ b/l10n_es_aeat_mod369/tests/test_l10n_es_aeat_mod369.py
@@ -229,3 +229,65 @@ class TestL10nEsAeatMod369Base(TestL10nEsAeatModBase):
         self.model369.total_amount = 0
         with self.assertRaises(UserError):
             self.create_account_move()
+
+    def test_model_369_duplicate_oss_taxes(self):
+        """Duplicate OSS taxes must not break field_number alignment
+        and move lines using the duplicate tax must be included."""
+        fr_general_tax = self.oss_taxes["FR"][0]
+        # Create a duplicate tax for FR with the same rate (simulates real bug:
+        # e.g. "OSS FR 20%" and "OSS FR 20% [DE]" coexisting)
+        dup_tax = self.env["account.tax"].create(
+            {
+                "name": "OSS FR duplicate [DE]",
+                "amount": fr_general_tax.amount,
+                "amount_type": "percent",
+                "type_tax_use": fr_general_tax.type_tax_use,
+                "oss_country_id": self.oss_countries["FR"].id,
+                "country_id": self.company.country_id.id,
+                "company_id": self.company.id,
+                "service_type": "goods",
+            }
+        )
+        # Create an invoice using the duplicate tax so we can verify
+        # that its move lines are also captured by the 369 report
+        fpo = self.env["account.fiscal.position"].search(
+            [("country_id", "=", self.oss_countries["FR"].id), ("oss_oca", "=", True)],
+            limit=1,
+        )
+        dup_invoice = self._invoice_sale_create(
+            "2017-02-01",
+            {
+                "fiscal_position_id": fpo.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Test duplicate OSS tax",
+                            "account_id": self.accounts["700000"].id,
+                            "price_unit": 200,
+                            "quantity": 1,
+                            "tax_ids": [(6, 0, dup_tax.ids)],
+                        },
+                    ),
+                ],
+            },
+        )
+        self.model369.button_calculate()
+        # Both FR and DE must still have lines in the report
+        fr_lines = self.model369.spain_goods_line_ids.filtered(
+            lambda x: x.country_code == "FR" and not x.is_page_8_line
+        )
+        de_lines = self.model369.spain_goods_line_ids.filtered(
+            lambda x: x.country_code == "DE" and not x.is_page_8_line
+        )
+        self.assertTrue(fr_lines)
+        self.assertTrue(de_lines)
+        # FR amounts must include both the original invoice and the duplicate
+        expected_fr_tax = self.sale_invoices["FR"].amount_tax + dup_invoice.amount_tax
+        self.assertEqual(sum(fr_lines.mapped("amount")), expected_fr_tax)
+        # DE amounts must be unaffected
+        self.assertEqual(
+            sum(de_lines.mapped("amount")),
+            self.sale_invoices["DE"].amount_tax,
+        )


### PR DESCRIPTION
Compatibilidad de impuestos que comparten país y tasa.