### PR TITLE
[16.0] [FIX] l10n_es_ticketbai_api, l10n_es_ticketbai: fix a operaciones de recargo de equivalencia y regimen simplificado

### DIFF
--- a/l10n_es_ticketbai/models/account_tax.py
+++ b/l10n_es_ticketbai/models/account_tax.py
@@ -204,12 +204,10 @@ class AccountTax(models.Model):
         return res
 
     def tbai_get_value_op_recargo_equiv_o_reg_simpl(self, invoice_id):
-        re_invoice_tax = self.tbai_get_associated_re_tax(invoice_id)
-        if re_invoice_tax or invoice_id.company_id.tbai_vat_regime_simplified:
-            res = "S"
-        else:
-            res = "N"
-        return res
+        is_surcharge_or_simplified = (
+            invoice_id.company_id.is_operation_in_surcharge_equivalence_or_simplified_regime()  # noqa: B950
+        )
+        return "S" if is_surcharge_or_simplified else "N"
 
     def tbai_get_invoice_base_balace_for_tax_group(self, invoice_id):
         base = 0

--- a/l10n_es_ticketbai_api/models/res_company.py
+++ b/l10n_es_ticketbai_api/models/res_company.py
@@ -175,3 +175,10 @@ class ResCompany(models.Model):
                 ("Version", self.tbai_software_version),
             ]
         )
+
+    def is_operation_in_surcharge_equivalence_or_simplified_regime(self):
+        self.ensure_one()
+        return (
+            self.partner_id.property_account_position_id.tbai_vat_regime_key.code
+            in ("51", "52")
+        )

--- a/l10n_es_ticketbai_api/models/ticketbai_invoice_tax.py
+++ b/l10n_es_ticketbai_api/models/ticketbai_invoice_tax.py
@@ -261,6 +261,7 @@ class TicketBaiTax(models.Model):
                     or record.surcharge_or_simplified_regime
                     != SurchargeOrSimplifiedRegimeType.S.value
                 )
+                and record.tbai_invoice_id.company_id.is_operation_in_surcharge_equivalence_or_simplified_regime()  # noqa: B950
             ):
                 raise exceptions.ValidationError(
                     _(


### PR DESCRIPTION
El contexto completo está acá #4874.

El fix determina el valor **'S'** de la clave **OperacionEnRecargoDeEquivalenciaORegimenSimplificado** (en el xml asociado a una factura ticketbai) teniendo en cuenta el régimen de IVA del emisor de la factura y el antiguo comportamiento vinculado a los impuestos.


@BinhexTeam T9758