### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: get the invoice dict inside the main try

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -9,7 +9,7 @@ import json
 from unidecode import unidecode
 
 from odoo import api, exceptions, fields, models
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import UserError
 from odoo.modules.registry import Registry
 from odoo.tools.float_utils import float_compare
 
@@ -823,13 +823,9 @@ class SiiMixin(models.AbstractModel):
             doc_vals = {
                 "aeat_header_sent": json.dumps(header, indent=4),
             }
-            # add this extra try except in case _get_aeat_invoice_dict fails
-            # if not, get the value doc_dict for the next try and except below
+            inv_dict = False
             try:
                 inv_dict = document._get_aeat_invoice_dict()
-            except Exception as fault:
-                raise ValidationError(fault) from fault
-            try:
                 mapping_key = document._get_mapping_key()
                 serv = document._connect_aeat(mapping_key)
                 doc_vals["aeat_content_sent"] = json.dumps(inv_dict, indent=4)
@@ -891,10 +887,11 @@ class SiiMixin(models.AbstractModel):
                         "aeat_send_failed": True,
                         "aeat_send_error": repr(fault)[:60],
                         "sii_return": repr(fault),
-                        "aeat_content_sent": json.dumps(inv_dict, indent=4),
                         "sii_send_date": False,
                     }
                 )
+                if inv_dict:
+                    doc_vals["aeat_content_sent"] = json.dumps(inv_dict, indent=4)
                 document.write(doc_vals)
                 new_cr.commit()
                 new_cr.close()


### PR DESCRIPTION
If not, the error is reraised, and the SII sending in batch is aborted, so the rest of the invoices are not ever sent meanwhile.

Looking for the roots of this code, it was introduced when extracting the SII mixin:

https://github.com/OCA/l10n-spain/commit/4e2dee275030c97602faadf900c61cb

but not related to it, and the comment of the justification doesn't seem correct. This raise was previously captured by the second existing try, that was provoking another problem and removed in #4807.

As now the dict may not exist, we adapt the exception save to that condition.

@Tecnativa TT61482