### PR TITLE
[18.0][FIX] l10n_es_verifactu_oca: Current + future invoices must not crash when confirming multiple entries

### DIFF
--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -503,7 +503,7 @@ class AccountMove(models.Model):
 
     def _post(self, soft=True):
         res = super()._post(soft=soft)
-        for record in self.sorted(lambda inv: inv.name):
+        for record in self.sorted(lambda inv: inv.name or ""):
             if record.verifactu_enabled and record.aeat_state == "not_sent":
                 record._check_verifactu_configuration()
                 record.verifactu_registration_date = datetime.now()

--- a/l10n_es_verifactu_oca/tests/test_verifactu_invoice.py
+++ b/l10n_es_verifactu_oca/tests/test_verifactu_invoice.py
@@ -3,6 +3,8 @@
 
 from datetime import date, timedelta
 
+from odoo import Command
+
 from .common import TestVerifactuCommon
 
 
@@ -323,6 +325,38 @@ class TestVerifactuInvoice(TestVerifactuCommon):
             chain_entry1,
             "Second entry should reference first entry as previous",
         )
+
+    def test_post_mixed_current_and_future_invoices(self):
+        """Current + future invoices must not crash on sorting."""
+        vals = {
+            "company_id": self.company.id,
+            "partner_id": self.partner.id,
+            "move_type": "out_invoice",
+            "invoice_line_ids": [
+                Command.create(
+                    {
+                        "product_id": self.product.id,
+                        "account_id": self.account_expense.id,
+                        "name": "Test line",
+                        "price_unit": 100,
+                        "quantity": 1,
+                    },
+                )
+            ],
+        }
+        current = self.env["account.move"].create(
+            {**vals, "invoice_date": "2026-01-01"}
+        )
+        future = self.env["account.move"].create({**vals, "invoice_date": "2099-01-01"})
+        wizard = (
+            self.env["validate.account.move"]
+            .with_context(
+                active_model="account.move",
+                active_ids=(current | future).ids,
+            )
+            .create({})
+        )
+        wizard.validate_move()
 
     def test_invoice_entry_creation(self):
         """Test the VERI*FACTU invoice entry creation."""


### PR DESCRIPTION
Si creamos dos facturas en borrador, una con fecha pasada y una con fecha futura, y intentamos confirmar las dos:

```
odoo.http: Exception during request handling. 
.
.
.
    for record in self.sorted(lambda inv: inv.name):
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                  
 TypeError: '<' not supported between instances of 'str' and 'bool'
```

<img width="1906" height="418" alt="image" src="https://github.com/user-attachments/assets/c7bccf55-0d32-447e-a32f-f6f65bdc6932" />
<img width="1582" height="455" alt="image" src="https://github.com/user-attachments/assets/dbd0b0f3-672a-4dc5-a290-8c562b629c3e" />
<img width="1728" height="439" alt="image" src="https://github.com/user-attachments/assets/24292852-016b-452a-b699-9cfc42d2bae4" />
<img width="846" height="619" alt="image" src="https://github.com/user-attachments/assets/7f9180b4-4090-468b-9813-52ca7f428024" />
