### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: Incluir el impuesto exento no sujeto en el sitio correcto

### DIFF
--- a/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
+++ b/l10n_es_aeat_sii_oca/data/aeat_sii_map_data.xml
@@ -107,6 +107,7 @@
                 ref('s_iva0_e'),
                 ref('s_iva0_ic'),
                 ref('s_iva0_nsd'),
+                ref('s_iva0_ns'),
             ])]"
         />
         <field name="sii_map_id" ref="aeat_sii_map" />
@@ -366,12 +367,7 @@
         model="aeat.sii.map.lines"
     >
         <field name="code">BaseNotIncludedInTotal</field>
-        <field
-            name="tax_xmlid_ids"
-            eval="[(6, 0, [
-          ref('s_iva0_ns'),
-        ])]"
-        />
+        <field name="tax_xmlid_ids" eval="[(6, 0, [])]" />
         <field name="sii_map_id" ref="aeat_sii_map" />
         <field name="name">Bases no incluidas en ImporteTotal</field>
     </record>

--- a/l10n_es_aeat_sii_oca/tests/json/sii_out_invoice_s_iva10b_s_iva0_ns_dict.json
+++ b/l10n_es_aeat_sii_oca/tests/json/sii_out_invoice_s_iva10b_s_iva0_ns_dict.json
@@ -23,11 +23,19 @@
                 }
               ]
             }
+          },
+          "Exenta": {
+            "DetalleExenta": [
+              {
+                "BaseImponible": 200.0,
+                "CausaExencion": "E5"
+              }
+            ]
           }
         }
       }
     },
-    "ImporteTotal": 110.0,
+    "ImporteTotal": 310.0,
     "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
   }
 }

--- a/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_s_iva0_ns_dict.json
+++ b/l10n_es_vat_prorate/tests/json/sii_out_invoice_s_iva10b_s_iva0_ns_dict.json
@@ -23,11 +23,19 @@
                 }
               ]
             }
+          },
+          "Exenta": {
+            "DetalleExenta": [
+              {
+                "BaseImponible": 200.0,
+                "CausaExencion": "E5"
+              }
+            ]
           }
         }
       }
     },
-    "ImporteTotal": 110.0,
+    "ImporteTotal": 310.0,
     "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"}
   }
 }


### PR DESCRIPTION
Migración de este PR https://github.com/OCA/l10n-spain/pull/3022