### PR TITLE
[18.0][FIX] l10n_es_intrastat_report: Fix tests (related to the default value of the Intrastat field)

### DIFF
--- a/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
+++ b/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
@@ -195,9 +195,9 @@ class TestL10nIntraStatReport(AccountTestInvoicingCommon):
         self.assertTrue(fp_es_b2b.vat_required)
         self.assertEqual(fp_es_b2c.intrastat, "b2c")
         self.assertFalse(fp_es_b2c.vat_required)
-        self.assertFalse(fp_es_ok.intrastat)
+        self.assertEqual(fp_es_ok.intrastat, "no")
         self.assertFalse(fp_es_ok.vat_required)
-        self.assertFalse(fp_not_es_ok.intrastat)
+        self.assertEqual(fp_not_es_ok.intrastat, "no")
         self.assertFalse(fp_not_es_ok.vat_required)
 
     def _check_move_lines_present(self, original, target):


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/l10n-spain/pull/4922

Fix tests (related to the default value of the Intrastat field)

Related to https://github.com/OCA/intrastat-extrastat/pull/342

Locked by:
- [x] `intrastat_base`: https://github.com/OCA/intrastat-extrastat/pull/342

Please @pedrobaeza can you review it?

@Tecnativa