### PR TITLE
[18.0][FIX][DRAFT] l10n_es_pos_sii: add sii date compute on order paid

### DIFF
--- a/l10n_es_pos_sii/models/pos_order.py
+++ b/l10n_es_pos_sii/models/pos_order.py
@@ -186,3 +186,10 @@ class PosOrder(models.Model):
     @api.model
     def _send_to_sii(self):
         self._send_to_sii_valid()
+
+    def action_pos_order_paid(self):
+        res = super().action_pos_order_paid()
+        company = self.company_id
+        if self.sii_enabled and company.sii_method == "auto":
+            self._process_sii_send()
+        return res


### PR DESCRIPTION
Actualmente, en los pedidos del TPV no se está rellenando el campo fecha para el envío al SII, ya que no se llama a la función `_process_sii_send` que introduce esta información. En facturas esto se realiza durante la validación, por lo que considero que lo mas cercano sería al realizar el pago en el TPV.

@Tecnativa TT59666
@pedrobaeza 