### PR TITLE
[18.0][FIX] l10n_es_aeat_mod190: Cálculos diferentes de las retenciones cuando registro_manual está marcado

### DIFF
--- a/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
+++ b/l10n_es_aeat_mod190/models/l10n_es_aeat_mod190_report.py
@@ -95,6 +95,12 @@ class L10nEsAeatMod190Report(models.Model):
                 value += sum(
                     item.mapped("partner_record_ids.retenciones_dinerarias_incap")
                 )
+                value += sum(
+                    item.mapped("partner_record_ids.ingresos_a_cuenta_efectuados")
+                )
+                value += sum(
+                    item.mapped("partner_record_ids.ingresos_a_cuenta_efectuados_incap")
+                )
             else:
                 tax_lines = item.tax_line_ids.filtered(
                     lambda x: x.field_number in {12, 14, 16, 19}


### PR DESCRIPTION
El importe total de las retenciones no está teniendo en cuenta todas las retenciones cuando se marca la casilla registro manual. Debe tener en cuenta también los ingresos a cuenta efectuados.

<img width="1010" height="333" alt="image" src="https://github.com/user-attachments/assets/5d7a9d29-9d05-41d0-90f0-1eb067616499" />

MT-13025 @moduon