### PR TITLE
[IMP] avoid warning:

### DIFF
--- a/payment_redsys/models/payment_provider.py
+++ b/payment_redsys/models/payment_provider.py
@@ -42,7 +42,7 @@ class PaymentProvider(models.Model):
         "Terminal", default="1", required_if_provider="redsys"
     )
     redsys_currency = fields.Char(
-        "Currency", default="978", required_if_provider="redsys"
+        "Redsys Currency", default="978", required_if_provider="redsys"
     )
     redsys_transaction_type = fields.Char(
         "Transtaction Type", default="0", required_if_provider="redsys"


### PR DESCRIPTION
Two fields (redsys_currency, main_currency_id) of payment.provider() have the same label: Currency. [Modules: payment_redsys and payment]