### PR TITLE
[16.0][IMP] l10n_es_verifactu_oca: Use Zeep cache for WSDL/schema requests

### DIFF
--- a/l10n_es_verifactu_oca/README.rst
+++ b/l10n_es_verifactu_oca/README.rst
@@ -134,6 +134,8 @@ Contributors
   * Pedro M. Baeza
 * Factor Libre S.L.:
   * Luis J. Salvatierra
+* Batista10:
+  * Ivan Vilata i Balaguer
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
@@ -6,6 +6,7 @@ import json
 
 from requests import Session
 from zeep import Client, Settings
+from zeep.cache import SqliteCache
 from zeep.plugins import HistoryPlugin
 from zeep.transports import Transport
 
@@ -207,7 +208,10 @@ class VerifactuInvoiceEntry(models.Model):
         params = self._connect_verifactu_params_aeat()
         session = Session()
         session.cert = (public_crt, private_key)
-        transport = Transport(session=session)
+        # The cache avoids hammering AEAT and W3 servers
+        # with WSDL and schema requests (which may trigger challenges).
+        cache = SqliteCache(timeout=7200)  # in seconds
+        transport = Transport(session=session, cache=cache)
         history = HistoryPlugin()
         settings = Settings(forbid_entities=False)
         client = Client(

--- a/l10n_es_verifactu_oca/readme/CONTRIBUTORS.rst
+++ b/l10n_es_verifactu_oca/readme/CONTRIBUTORS.rst
@@ -16,3 +16,5 @@
   * Pedro M. Baeza
 * Factor Libre S.L.:
   * Luis J. Salvatierra
+* Batista10:
+  * Ivan Vilata i Balaguer

--- a/l10n_es_verifactu_oca/static/description/index.html
+++ b/l10n_es_verifactu_oca/static/description/index.html
@@ -486,6 +486,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 * Pedro M. Baeza</li>
 <li>Factor Libre S.L.:
 * Luis J. Salvatierra</li>
+<li>Batista10:
+* Ivan Vilata i Balaguer</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Those supplemental files get cached for 2 hours.

This avoids hammering AEAT and W3 servers with WSDL or XML schema requests for each request/response, especially when there are connectivity or data issues.

In particular, since W3 (w3.org) adopted the Cloudflare proxy, this may eventually cause it to serve JavaScript challenges (with "403 Forbidden" status) that Zeep is unable to solve.