### PR TITLE
[16.0][FIX] l10n_es_aeat_mod303: use invoice_date for report period

### DIFF
--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -606,19 +606,40 @@ class L10nEsAeatMod303Report(models.Model):
         )
 
     def _get_move_line_domain(self, date_start, date_end, map_line):
-        """Changes dates to full year when the summary on last report of the
-        year for the corresponding fields. Only field number is checked as
-        the complete check for not bringing results is done on
-        `_get_tax_lines`.
+        """Filter move lines by ``move_id.invoice_date`` (falling back to
+        ``date`` for entries without an invoice).
+
+        AEAT's Pre-303 / SII matches each received invoice against the period
+        stated on the invoice itself ("período consignado en la factura igual
+        al periodo de autoliquidación"), not against the accounting date. This
+        override keeps that criterion for the 303 only; other AEAT reports
+        (347, 349, 390, Verifactu, SII, IRPF…) still filter by ``date``.
+
+        For the yearly summary fields (79-99 and 125) the date range is
+        extended to the full year; the completeness check is done in
+        ``_get_tax_lines``.
         """
         if 79 <= map_line.field_number <= 99 or map_line.field_number == 125:
             date_start = date_start.replace(day=1, month=1)
             date_end = date_end.replace(day=31, month=12)
-        return super()._get_move_line_domain(
-            date_start,
-            date_end,
-            map_line,
-        )
+        domain = super()._get_move_line_domain(date_start, date_end, map_line)
+        domain = [
+            leaf
+            for leaf in domain
+            if not (isinstance(leaf, (tuple, list)) and leaf[0] == "date")
+        ]
+        domain += [
+            "|",
+            "&",
+            ("move_id.invoice_date", ">=", date_start),
+            ("move_id.invoice_date", "<=", date_end),
+            "&",
+            ("move_id.invoice_date", "=", False),
+            "&",
+            ("date", ">=", date_start),
+            ("date", "<=", date_end),
+        ]
+        return domain
 
     def _prepare_regularization_extra_move_lines(self):
         """Include behavior for the regularization of the fees to compensate."""

--- a/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
+++ b/l10n_es_aeat_mod303/tests/test_l10n_es_aeat_mod303.py
@@ -774,3 +774,137 @@ class TestL10nEsAeatMod303(TestL10nEsAeatMod303Base):
                 },
             ],
         )
+
+
+class TestL10nEsAeatMod303InvoiceDate(TestL10nEsAeatMod303Base):
+    """Tests for the period assignment based on ``invoice_date``.
+
+    AEAT's Pre-303 / SII assigns each received invoice to the period stated
+    on the invoice itself, not to the accounting date. The 303 override of
+    ``_get_move_line_domain`` should therefore filter by ``move_id.invoice_date``
+    when available, falling back to ``date`` for entries without an invoice.
+    """
+
+    taxes_purchase = {"P_IVA21_BC": (1000, 210)}
+    taxes_sale = {"S_IVA21B": (1000, 210)}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Supplier invoice straddling a period boundary:
+        #   invoice_date = 2017-03-30 (Q1), date = 2017-04-05 (Q2)
+        cls.cross_bill = cls._invoice_purchase_create(
+            "2017-03-30", extra_vals={"date": "2017-04-05"}
+        )
+        # Regular supplier invoice fully in Q1 (control case).
+        cls._invoice_purchase_create("2017-02-15")
+        # A sale invoice in Q1 just to have something on the output side.
+        cls._invoice_sale_create("2017-02-15")
+
+    def _purchase_tax_lines_for(self, report):
+        # Field 29 = deductible VAT quota on current domestic operations.
+        return report.tax_line_ids.filtered(lambda x: x.field_number == 29)
+
+    def test_cross_period_bill_goes_to_invoice_date_period(self):
+        """A bill with invoice_date in Q1 and date in Q2 must appear in Q1."""
+        # Sanity: the bill really has divergent dates.
+        self.assertNotEqual(
+            self.cross_bill.invoice_date,
+            self.cross_bill.date,
+            "Test fixture is broken: invoice_date and date should differ",
+        )
+        self.model303.button_calculate()
+        field_29_total = sum(
+            self._purchase_tax_lines_for(self.model303).mapped("amount")
+        )
+        # Q1 must include BOTH purchase invoices' 21% quota: 2 * 210 = 420.
+        self.assertAlmostEqual(
+            field_29_total,
+            420.0,
+            2,
+            "Q1 303 should include the bill whose invoice_date falls in Q1, "
+            "even if the accounting date is in Q2",
+        )
+        # And Q2 must NOT include the cross bill.
+        model303_2t = self.model303.copy(
+            {
+                "name": "9991000000303",
+                "period_type": "2T",
+                "date_start": "2017-04-01",
+                "date_end": "2017-06-30",
+            }
+        )
+        model303_2t.button_calculate()
+        q2_total = sum(self._purchase_tax_lines_for(model303_2t).mapped("amount"))
+        self.assertAlmostEqual(
+            q2_total,
+            0.0,
+            2,
+            "Q2 303 should NOT include a bill whose invoice_date is in Q1",
+        )
+
+    def test_move_without_invoice_date_falls_back_to_date(self):
+        """A journal entry with no invoice_date must be filtered by ``date``."""
+        tax = self._get_taxes("P_IVA21_BC")
+        # Build a manual journal entry with a deductible VAT tax and no
+        # invoice_date. It must live in the period of its accounting ``date``.
+        account_expense = self.accounts["600000"]
+        account_tax = self.accounts["472000"]
+        move = self.env["account.move"].create(
+            {
+                "company_id": self.company.id,
+                "journal_id": self.journal_misc.id,
+                "date": "2017-02-20",
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Manual expense",
+                            "account_id": account_expense.id,
+                            "debit": 1000.0,
+                            "credit": 0.0,
+                            "tax_ids": [(6, 0, tax.ids)],
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Manual VAT",
+                            "account_id": account_tax.id,
+                            "debit": 210.0,
+                            "credit": 0.0,
+                            "tax_line_id": tax.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Balance",
+                            "account_id": self.accounts["410000"].id,
+                            "debit": 0.0,
+                            "credit": 1210.0,
+                        },
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        self.assertFalse(move.invoice_date)
+
+        self.model303.button_calculate()
+        q1_lines = self._purchase_tax_lines_for(self.model303)
+        # Q1 has 3 entries contributing to field 29:
+        #   - cross bill (invoice_date in Q1): 210
+        #   - regular Q1 bill:                 210
+        #   - manual move (date in Q1):        210
+        # Total = 630
+        self.assertAlmostEqual(
+            sum(q1_lines.mapped("amount")),
+            630.0,
+            2,
+            "Manual entry without invoice_date should be filtered by its "
+            "accounting date",
+        )


### PR DESCRIPTION
## Problem

The 303 report assigned each `account.move.line` to the period of its accounting date (`account.move.line.date`), but AEAT's Pre-303 / SII matches each received invoice against the period **stated on the invoice itself**:

> "período consignado en la factura igual al periodo de autoliquidación"
> — [AEAT Pre-303 2025 · IVA deducible](https://sede.agenciatributaria.gob.es/Sede/iva/pre-303/2025/iva-deducible.html)

When `invoice_date` and `date` fall in different quarters (supplier bill entered late, year-end close, rectificativas, etc.), the 303 generated by Odoo diverges from the SII data feed and the taxpayer has to justify the gap manually against AEAT's Pre-303 proposal.

## Fix

Override `_get_move_line_domain` **only** in `l10n_es_aeat_mod303` to filter by `move_id.invoice_date` when available, falling back to `date` for entries without an invoice (manual journal entries, opening balances).

The base class `l10n_es_aeat.report.tax.mapping` is **not** touched — other AEAT reports (347, 349, 390, Verifactu, SII, IRPF…) continue to filter by `date`, so nothing outside the 303 changes. The override is a small, defensive patch: it calls `super()` first, filters out the existing `("date", …)` leaves from the returned domain, and appends an OR with `move_id.invoice_date`.

## Legal basis

- **Art. 75 LIVA** — devengo.
- **Art. 98 LIVA** — nacimiento del derecho a deducir.
- **Art. 99 LIVA** — ejercicio del derecho a deducir; permits deferral up to 4 years but requires the invoice to be recorded in the Libro Registro de Facturas Recibidas before submission. The AEAT SII / Pre-303 operational criterion assumes the invoice is recorded against the period of its own date, which is what this fix enforces.

## Tests

- `test_cross_period_bill_goes_to_invoice_date_period`: a supplier bill with `invoice_date` in Q1 and `date` in Q2 is reported in Q1, not Q2.
- `test_move_without_invoice_date_falls_back_to_date`: a manual journal entry with deductible VAT and no `invoice_date` is filtered by its accounting `date` (backward-compatible behaviour).

## Real-world validation

Validated against a production-sized database (19 existing 303 reports, 2021 → 1T/2026):

- 18 historical reports are **unchanged** by the fix (no bills with `invoice_date` / `date` crossing the period boundary in those quarters).
- The most recent report (1T/2026), where the bug was first noticed, shifts as expected: 35 bills with `invoice_date` in 1T/2026 and `date` in 2T/2026 move into the correct period; `total_deducir` changes from a clearly wrong value to the correct one, matching what AEAT's Pre-303 expects.

## Cash basis

`l10n_es_aeat_mod303_cash_basis` inherits from this module's `_get_move_line_domain`; its own override adds payment-based restrictions on top via `super()`, so the new `invoice_date` filter flows through automatically without any change to that module.