### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: Clave BienInversión se fusiona en otros IVAs con el mismo tipo impositivo

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -66,7 +66,7 @@ class AccountMove(models.Model):
                 "[1]-Real property with cadastral code located within "
                 "the Spanish territory except Basque Country or Navarra",
             ),
-            ("2", "[2]-Real property located in the " "Basque Country or Navarra"),
+            ("2", "[2]-Real property located in the Basque Country or Navarra"),
             (
                 "3",
                 "[3]-Real property in any of the above situations "
@@ -277,7 +277,7 @@ class AccountMove(models.Model):
                 if not self._merge_tax_dict(
                     base_dict["DetalleIVA"],
                     tax_dict,
-                    "TipoImpositivo",
+                    ["TipoImpositivo", "BienInversion"],
                     ["BaseImponible", "CuotaSoportada"],
                 ):
                     base_dict["DetalleIVA"].append(tax_dict)

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -479,10 +479,21 @@ class SiiMixin(models.AbstractModel):
         )
 
     @api.model
-    def _merge_tax_dict(self, vat_list, tax_dict, comp_key, merge_keys):
-        """Helper method for merging values in an existing tax dictionary."""
+    def _merge_tax_dict(self, vat_list, tax_dict, comp_keys, merge_keys):
+        """Helper method for merging values in an existing tax dictionary.
+
+        :param vat_list: List of tax dictionaries to check for merge.
+        :param tax_dict: Tax dictionary to merge.
+        :param comp_keys: List of keys to compare for matching.
+        :param merge_keys: List of keys whose values should be summed.
+        """
         for existing_dict in vat_list:
-            if existing_dict.get(comp_key, "-99") == tax_dict.get(comp_key, "-99"):
+            match = True
+            for key in comp_keys:
+                if existing_dict.get(key, "-99") != tax_dict.get(key, "-99"):
+                    match = False
+                    break
+            if match:
                 for key in merge_keys:
                     existing_dict[key] += tax_dict[key]
                 return True
@@ -581,7 +592,7 @@ class SiiMixin(models.AbstractModel):
                     if not self._merge_tax_dict(
                         sub,
                         tax_dict,
-                        "TipoImpositivo",
+                        ["TipoImpositivo"],
                         ["BaseImponible", "CuotaRepercutida"],
                     ):
                         sub.append(tax_dict)
@@ -625,7 +636,7 @@ class SiiMixin(models.AbstractModel):
                     if not self._merge_tax_dict(
                         sub,
                         tax_dict,
-                        "TipoImpositivo",
+                        ["TipoImpositivo"],
                         ["BaseImponible", "CuotaRepercutida"],
                     ):
                         sub.append(tax_dict)

--- a/l10n_es_aeat_sii_oca/tests/json/sii_in_invoice_p_iva21_bc_p_iva21_bi_dict.json
+++ b/l10n_es_aeat_sii_oca/tests/json/sii_in_invoice_p_iva21_bc_p_iva21_bi_dict.json
@@ -1,0 +1,34 @@
+{
+  "IDFactura": {
+    "FechaExpedicionFacturaEmisor": "01-01-2020",
+    "NumSerieFacturaEmisor": "sup0008",
+    "IDEmisorFactura": {"NIF": "F35999705"}
+  },
+  "FacturaRecibida": {
+    "TipoFactura": "F1",
+    "Contraparte": {"NombreRazon": "Test partner", "NIF": "F35999705"},
+    "DescripcionOperacion": "/",
+    "ClaveRegimenEspecialOTrascendencia": "01",
+    "ImporteTotal": 201.66,
+    "FechaRegContable": "01-10-2020",
+    "DesgloseFactura": {
+      "DesgloseIVA": {
+        "DetalleIVA": [
+          {
+            "TipoImpositivo": "21.0",
+            "BaseImponible": 83.33,
+            "CuotaSoportada": 17.5
+          },
+          {
+            "TipoImpositivo": "21.0",
+            "BaseImponible": 83.33,
+            "CuotaSoportada": 17.5,
+            "BienInversion": "S"
+          }
+        ]
+      }
+    },
+    "CuotaDeducible": 35.0
+  },
+  "PeriodoLiquidacion": {"Periodo": "01", "Ejercicio": 2020}
+}

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -348,6 +348,17 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
                 },
                 True,
             ),
+            # In invoice with same rate but different investment goods
+            (
+                "in_invoice",
+                [(100, ["p_iva21_bc"]), (100, ["p_iva21_bi"])],
+                {
+                    "ref": "sup0008",
+                    "sii_account_registration_date": "2020-10-01",
+                    "currency_id": self.usd.id,
+                },
+                False,
+            ),
         ]
         for inv_type, lines, extra_vals, is_dua in mapping:
             invoice = self._create_and_test_invoice_sii_dict(


### PR DESCRIPTION
Issue: https://github.com/OCA/l10n-spain/issues/4957

MT-14523 @moduon

@ArantxaSudon @OCA/local-spain-maintainers por favor revisad