### PR TITLE
[16.0][IMP] l10n_es_verifactu_oca: Store connection error exception text

### DIFF
--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
@@ -306,8 +306,8 @@ class VerifactuInvoiceEntry(models.Model):
             serv = rec._connect_verifactu()
             res = serv.RegFactuSistemaFacturacion(header, registro_factura_list)
         except Exception as AEATError:
-            res = {AEATError}
-            create_exception = True
+            res = {}
+            create_exception = AEATError
         response_name = ""
         response = (
             self.env["verifactu.invoice.entry.response"]
@@ -319,6 +319,7 @@ class VerifactuInvoiceEntry(models.Model):
                     "invoice_data": json.dumps(registro_factura_list),
                     "response": res,
                     "verifactu_csv": "CSV" in res and res["CSV"] or _("-"),
+                    "connection_error": create_exception and repr(create_exception),
                 }
             )
         )

--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry_response.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry_response.py
@@ -26,6 +26,10 @@ class VerifactuInvoiceEntryResponse(models.Model):
         "entry_response_id",
         string="Response lines",
     )
+    connection_error = fields.Char(
+        readonly=True,
+        help="Message reported by internal connection error exception.",
+    )
 
     def _compute_activity_type_id(self):
         for record in self:

--- a/l10n_es_verifactu_oca/views/verifactu_invoice_entry_response_view.xml
+++ b/l10n_es_verifactu_oca/views/verifactu_invoice_entry_response_view.xml
@@ -46,6 +46,11 @@
                         <page string="Details">
                             <group>
                                 <group name="verifactu1">
+                                    <field
+                                        name="connection_error"
+                                        readonly="1"
+                                        attrs="{'invisible': [('connection_error', '=', False)]}"
+                                    />
                                     <field name="response" readonly="1" />
                                     <field name="header" readonly="1" />
                                     <field name="invoice_data" readonly="1" />


### PR DESCRIPTION
This may help diagnose low-level errors like the connection to the VERI*FACTU server failing, XML-RPC exchange or validation failing, etc. where there is no VF response as such to be stored.

The connection error text is only shown in the VF invoice entry response form view if there was such an error.

Fixes #4952.