### PR TITLE
[19.0][FIX] l10n_es_aeat: Pestaña AEAT en compañía invisible si el país no es España

### DIFF
--- a/l10n_es_aeat/views/res_company_view.xml
+++ b/l10n_es_aeat/views/res_company_view.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="base.view_company_form" />
         <field name="arch" type="xml">
             <notebook position="inside">
-                <page name="aeat" string="AEAT">
+                <page name="aeat" string="AEAT" invisible="country_code != 'ES'">
                     <group>
                         <group name="aeat_config">
                             <field name="tax_agency_id" />


### PR DESCRIPTION
La pestaña AEAT en compañía sólo debe ser visible si el país es España.

Ahora está así
<img width="535" height="349" alt="image" src="https://github.com/user-attachments/assets/cc7f8e92-91c6-448b-bda4-ddb951035d31" />

Con el cambio queda así:
<img width="610" height="247" alt="image" src="https://github.com/user-attachments/assets/ee50721e-f0b3-4425-bcfb-2e358e1c2126" />
<img width="540" height="252" alt="image" src="https://github.com/user-attachments/assets/bb7c7421-8ab3-4360-8d37-291fb390324c" />

@ArantxaSudon @OCA/local-spain-maintainers por favor revisad. Gracias

MT-14056 @moduon