### PR TITLE
[16.0][FIX] l10n_es_aeat: use v16 attrs syntax for AEAT page visibility

### DIFF
--- a/l10n_es_aeat/views/res_company_view.xml
+++ b/l10n_es_aeat/views/res_company_view.xml
@@ -8,7 +8,11 @@
         <field name="inherit_id" ref="base.view_company_form" />
         <field name="arch" type="xml">
             <notebook position="inside">
-                <page name="aeat" string="AEAT" invisible="country_code != 'ES'">
+                <page
+                    name="aeat"
+                    string="AEAT"
+                    attrs="{'invisible': [('country_code', '!=', 'ES')]}"
+                >
                     <group>
                         <group name="aeat_config">
                             <field name="tax_agency_id" />


### PR DESCRIPTION
Arreglo de https://github.com/OCA/l10n-spain/pull/4967