### PR TITLE
[IMP] payment_redsys: Avoid warning currency

### DIFF
--- a/l10n_es_atc/models/l10n_es_atc_report.py
+++ b/l10n_es_atc/models/l10n_es_atc_report.py
@@ -35,6 +35,7 @@ ATC_JAR_URL = {}
 class L10nEsAtcReport(models.AbstractModel):
     _inherit = "l10n.es.aeat.report.tax.mapping"
     _name = "l10n.es.atc.report"
+    _description="Report ATC"
 
     output_type = fields.Selection(
         selection=[

--- a/payment_redsys/models/payment_provider.py
+++ b/payment_redsys/models/payment_provider.py
@@ -41,9 +41,7 @@ class PaymentProvider(models.Model):
     redsys_terminal = fields.Char(
         "Terminal", default="1", required_if_provider="redsys"
     )
-    redsys_currency = fields.Char(
-        "Currency", default="978", required_if_provider="redsys"
-    )
+    redsys_currency = fields.Char(default="978", required_if_provider="redsys")
     redsys_transaction_type = fields.Char(
         "Transtaction Type", default="0", required_if_provider="redsys"
     )


### PR DESCRIPTION
Change field redsys_currency without string to avoid warning: Two fields (redsys_currency, main_currency_id) of payment.provider() have the same label: Currency. [Modules: payment_redsys and payment]