### PR TITLE
[14.0][IMP] l10n_es_facturae: validate partner address fields

### DIFF
--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -130,7 +130,7 @@ class AccountMove(models.Model):
     def _get_valid_move_statuses(self):
         return ["posted"]
 
-    def validate_facturae_fields(self):
+    def validate_facturae_fields(self):  # noqa: C901
         lines = self.line_ids.filtered(
             lambda r: not r.display_type and not r.exclude_from_invoice_tab
         )
@@ -145,10 +145,26 @@ class AccountMove(models.Model):
             raise ValidationError(_("Company vat not provided"))
         if len(self.partner_id.vat) < 3:
             raise ValidationError(_("Partner vat is too small"))
-        if not self.partner_id.state_id:
-            raise ValidationError(_("Partner state not provided"))
         if len(self.company_id.vat) < 3:
             raise ValidationError(_("Company vat is too small"))
+        for kind, partner in [
+            (_("Partner"), self.partner_id),
+            (_("Company"), self.company_id.partner_id),
+        ]:
+            if not partner.country_id:
+                raise ValidationError(
+                    _("%(kind)s country not provided") % {"kind": kind}
+                )
+            if not partner.state_id:
+                raise ValidationError(_("%(kind)s state not provided") % {"kind": kind})
+            if not partner.street:
+                raise ValidationError(
+                    _("%(kind)s street not provided") % {"kind": kind}
+                )
+            if not partner.zip:
+                raise ValidationError(_("%(kind)s zip not provided") % {"kind": kind})
+            if not partner.city:
+                raise ValidationError(_("%(kind)s city not provided") % {"kind": kind})
         if not self.payment_mode_id:
             raise ValidationError(_("Payment mode is required"))
         if self.payment_mode_id.facturae_code:

--- a/l10n_es_facturae/reports/report_facturae.py
+++ b/l10n_es_facturae/reports/report_facturae.py
@@ -20,6 +20,23 @@ from odoo.exceptions import UserError
 _logger = logging.getLogger(__name__)
 
 
+class ReportFacturaeUnsigned(models.AbstractModel):
+    _name = "report.l10n_es_facturae.template_facturae"
+    _inherit = "report.report_xml.abstract"
+    _description = "Account Move Facturae"
+
+    def _get_report_values(self, docids, data=None):
+        result = super()._get_report_values(docids, data=data)
+        result["docs"] = self.env["account.move"].browse(docids)
+        return result
+
+    @api.model
+    def generate_report(self, ir_report, docids, data=None):
+        move = self.env["account.move"].browse(docids).ensure_one()
+        move.validate_facturae_fields()
+        return super().generate_report(ir_report, docids, data=data)
+
+
 class ReportFacturae(models.AbstractModel):
     _name = "report.l10n_es_facturae.facturae_signed"
     _inherit = "report.report_xml.abstract"

--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -66,7 +66,22 @@ class CommonTest(TestL10nEsAeatCertificateBase):
         )
         main_company = self.env.ref("base.main_company")
         main_company.vat = "ESA12345674"
-        main_company.partner_id.country_id = self.env.ref("base.uk")
+        self.uk_state = self.env["res.country.state"].create(
+            {
+                "name": "London",
+                "code": "LDN",
+                "country_id": self.env.ref("base.uk").id,
+            }
+        )
+        main_company.partner_id.write(
+            {
+                "country_id": self.env.ref("base.uk").id,
+                "state_id": self.uk_state.id,
+                "street": "Main Street, 1",
+                "zip": "08001",
+                "city": "London",
+            }
+        )
         self.env["res.currency.rate"].search(
             [("currency_id", "=", main_company.currency_id.id)]
         ).write({"company_id": False})
@@ -388,6 +403,38 @@ class CommonTest(TestL10nEsAeatCertificateBase):
             self.wizard.with_context(
                 active_ids=self.move.ids, active_model="account.move"
             ).create_facturae_file()
+
+    def test_missing_address_fields(self):
+        self.move.action_post()
+        cases = [
+            ("country_id", "country"),
+            ("state_id", "state"),
+            ("street", "street"),
+            ("zip", "zip"),
+            ("city", "city"),
+        ]
+        for label, partner in [
+            ("Partner", self.move.partner_id),
+            ("Company", self.main_company.partner_id),
+        ]:
+            original_facturae = partner.facturae
+            for field, field_label in cases:
+                original = partner[field]
+                partner.write({"facturae": False, field: False})
+                try:
+                    with self.assertRaises(exceptions.ValidationError) as cm:
+                        self.move.validate_facturae_fields()
+                    self.assertIn(
+                        "%s %s not provided" % (label, field_label),
+                        str(cm.exception),
+                    )
+                finally:
+                    partner.write(
+                        {
+                            field: original.id if hasattr(original, "id") else original,
+                            "facturae": original_facturae,
+                        }
+                    )
 
     def test_signature(self):
         self._activate_certificate(self.certificate_password)

--- a/l10n_es_facturae_efact/tests/test_efact.py
+++ b/l10n_es_facturae_efact/tests/test_efact.py
@@ -161,7 +161,22 @@ class EDIBackendTestCase(TestL10nEsAeatCertificateBase, SavepointComponentRegist
         )
         main_company = self.env.ref("base.main_company")
         main_company.vat = "ESA12345674"
-        main_company.partner_id.country_id = self.env.ref("base.uk")
+        self.uk_state = self.env["res.country.state"].create(
+            {
+                "name": "London",
+                "code": "LDN",
+                "country_id": self.env.ref("base.uk").id,
+            }
+        )
+        main_company.partner_id.write(
+            {
+                "country_id": self.env.ref("base.uk").id,
+                "state_id": self.uk_state.id,
+                "street": "Main Street, 1",
+                "zip": "08001",
+                "city": "London",
+            }
+        )
         self.env["res.currency.rate"].search(
             [("currency_id", "=", main_company.currency_id.id)]
         ).write({"company_id": False})

--- a/l10n_es_facturae_face/tests/test_facturae_face.py
+++ b/l10n_es_facturae_face/tests/test_facturae_face.py
@@ -84,7 +84,22 @@ class EDIBackendTestCase(TestL10nEsAeatCertificateBase, SavepointComponentRegist
         )
         main_company = self.env.ref("base.main_company")
         main_company.vat = "ESA12345674"
-        main_company.partner_id.country_id = self.env.ref("base.uk")
+        self.uk_state = self.env["res.country.state"].create(
+            {
+                "name": "London",
+                "code": "LDN",
+                "country_id": self.env.ref("base.uk").id,
+            }
+        )
+        main_company.partner_id.write(
+            {
+                "country_id": self.env.ref("base.uk").id,
+                "state_id": self.uk_state.id,
+                "street": "Main Street, 1",
+                "zip": "08001",
+                "city": "London",
+            }
+        )
         self.env["res.currency.rate"].search(
             [("currency_id", "=", main_company.currency_id.id)]
         ).write({"company_id": False})


### PR DESCRIPTION
## Summary

- Fix: when the seller or buyer partner has empty address fields, `validate_facturae_fields()` now raises a clear `ValidationError` per missing field BEFORE the QWeb render runs.
- Without this check the render crashed deep inside `report_qweb_parameter`'s `t-length` directive with `TypeError: 'bool' object is not subscriptable` — caused by `(value)[:N]` slicing `False` when a Char field is empty in Odoo.
- Fields now validated on both partners (seller and buyer): `country_id`, `state_id`, `street`, `zip`, `city`.
- The previous one-line `partner_id.state_id` check is folded into the new loop, so state is also validated on the seller partner (it was buyer-only before).

## Test plan

- [x] `pre-commit run --files l10n_es_facturae/models/account_move.py` passes locally.
- [ ] CI green.
- [ ] Manual: clear `city` on a seller's company partner, attempt to generate Factura-E → `ValidationError` raised before render with a clear message naming the missing field. Restore the city → Factura-E generates as before.