### PR TITLE
[16.0] [FIX] l10n_es_facturae: decode l10n_es_facturae_attachment_ids

### DIFF
--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -225,7 +225,7 @@ class AccountMove(models.Model):
             description, content_type = attachment.filename.rsplit(".", 1)
             result.append(
                 {
-                    "data": attachment.file,
+                    "data": attachment.file.decode("utf-8"),
                     "content_type": content_type,
                     "encoding": "BASE64",
                     "description": description,

--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -340,6 +340,11 @@ class CommonTest(CommonTestBase):
                 ]
             }
         )
+        # Ensure attachments data is correctly decoded on base64
+        attachments = self.move._get_facturae_move_attachments()
+        for attachment in attachments:
+            self.assertFalse(isinstance(attachment["data"], bytes))
+            self.assertTrue(isinstance(attachment["data"], str))
         generated_facturae = self._create_facturae_file(self.move, force=True)
         self.assertTrue(
             generated_facturae.xpath(


### PR DESCRIPTION
Otherwise we can get this error because data is in bytes:

`The attachment data format is not valid. Ex: <AttachmentData>Base64</AttachmentData> or <anexo>Base64</anexo>
`

I split the test commit from the main commit that contains the change to forward-port easily.