### PR TITLE
[18.0] [IMP] l10n_es_facturae: add test to ensure correct attachment decoding

### DIFF
--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -323,6 +323,11 @@ class CommonTest(TestL10nEsAeatCertificateBase, TestL10nEsAeatModBase):
                 ]
             }
         )
+        # Ensure attachments data is correctly decoded on base64
+        attachments = self.move._get_facturae_move_attachments()
+        for attachment in attachments:
+            self.assertFalse(isinstance(attachment["data"], bytes))
+            self.assertTrue(isinstance(attachment["data"], str))
         generated_facturae = self._create_facturae_file(self.move, force=True)
         self.assertTrue(
             generated_facturae.xpath(


### PR DESCRIPTION
Forward port del commit en #4988  que comprueba que los datos del adjuntos que se va a añadir al fichero facturae están en base64.