### PR TITLE
[18.0][IMP] l10n_es_aeat_sii_oca: Replace line feeds by spaces in SII description

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -672,7 +672,7 @@ class AccountMove(models.Model):
                         "invoice_line_ids.ref"
                     )
                     names = [unidecode(x) for x in names if x]  # Avoid "ugly" chars
-                    description += " - ".join(filter(None, names))
+                    description += " - ".join(filter(None, names)).replace("\n", " ")
             invoice.sii_description = (description or "")[:500] or "/"
 
     @api.depends(


### PR DESCRIPTION
Although the field is now a single-line string, Odoo encodes line feeds as `\n` when computing the SII description from the invoice lines, so when sending that to the AEAT, they are not kept as is in the end.

On that cases, doing the SII match contrast, they will say there's no exact match due to that.

Let's replace the line feeds by spaces in advance to avoid this problem.

@Tecnativa 