### PR TITLE
[17.0][FIX] l10n_es_intrastat_report: Fix wizard view visualization to avoid scroll

### DIFF
--- a/l10n_es_intrastat_report/wizards/l10n_es_intrastat_code_import.xml
+++ b/l10n_es_intrastat_report/wizards/l10n_es_intrastat_code_import.xml
@@ -12,7 +12,7 @@
                 <separator position="replace">
                     <group>
                         <p
-                            colspan="4"
+                            colspan="2"
                         >This wizard will import Spanish Product HS Codes from the local copy and set company Instrastat type defaults at company level.</p>
                     </group>
                 </separator>


### PR DESCRIPTION
Corrección de la visualización de la vista del wizard para evitar scroll.

**Antes**
<img width="1275" height="318" alt="antes" src="https://github.com/user-attachments/assets/daee9c75-5fde-4d32-a9bc-81fa01fa0451" />

**Despues**
<img width="1260" height="304" alt="despues" src="https://github.com/user-attachments/assets/b7d2b85f-5045-4527-8323-799ac01637ff" />


Por favor @pedrobaeza puedes revisarlo?

@Tecnativa TT62349