### PR TITLE
[17.0][IMP] delivery_dhl_parcel: add Pre 13:30 and insured shipment options

### DIFF
--- a/delivery_dhl_parcel/README.rst
+++ b/delivery_dhl_parcel/README.rst
@@ -182,6 +182,7 @@ Contributors
 - `Tecnativa <https://www.tecnativa.com>`__:
 
   - Víctor Martínez
+  - Cristina Hidalgo
 
 Maintainers
 -----------

--- a/delivery_dhl_parcel/i18n/delivery_dhl_parcel.pot
+++ b/delivery_dhl_parcel/i18n/delivery_dhl_parcel.pot
@@ -294,6 +294,44 @@ msgid "Server not reachable, please try again later"
 msgstr ""
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_pre_1330
+msgid "Pre 13:30"
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_pre_1330
+msgid "Activates Feature 714 for Pre 13:30 time-definite delivery."
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_insurance
+msgid "Insured shipment"
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_insurance
+msgid ""
+"If checked, the shipment will be declared as insured. It assumes there is a "
+"sale order linked and it will use the picking lines total as the declared "
+"insurance value."
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_insurance_expenses
+msgid "Insurance expenses"
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_insurance_expenses__p
+msgid "Paid by sender"
+msgstr ""
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_insurance_expenses__d
+msgid "Paid by recipient"
+msgstr ""
+
+#. module: delivery_dhl_parcel
 #: model:ir.model,name:delivery_dhl_parcel.model_delivery_carrier
 msgid "Shipping Methods"
 msgstr ""

--- a/delivery_dhl_parcel/i18n/es.po
+++ b/delivery_dhl_parcel/i18n/es.po
@@ -312,6 +312,47 @@ msgid "Server not reachable, please try again later"
 msgstr "El servidor no responde, por favor vuelve a intentarlo más tarde"
 
 #. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_pre_1330
+msgid "Pre 13:30"
+msgstr "Pre 13:30"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_pre_1330
+msgid "Activates Feature 714 for Pre 13:30 time-definite delivery."
+msgstr "Activa la Feature 714 para la entrega antes de las 13:30."
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_insurance
+msgid "Insured shipment"
+msgstr "Envío asegurado"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,help:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_insurance
+msgid ""
+"If checked, the shipment will be declared as insured. It assumes there is a "
+"sale order linked and it will use the picking lines total as the declared "
+"insurance value."
+msgstr ""
+"Si está marcado, el envío se declarará como asegurado. Se asume que hay un "
+"pedido de venta vinculado y se usará el total de las líneas del albarán como "
+"valor declarado del seguro."
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields,field_description:delivery_dhl_parcel.field_delivery_carrier__dhl_parcel_insurance_expenses
+msgid "Insurance expenses"
+msgstr "Gastos del seguro"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_insurance_expenses__p
+msgid "Paid by sender"
+msgstr "Pagados por el remitente"
+
+#. module: delivery_dhl_parcel
+#: model:ir.model.fields.selection,name:delivery_dhl_parcel.selection__delivery_carrier__dhl_parcel_insurance_expenses__d
+msgid "Paid by recipient"
+msgstr "Pagados por el destinatario"
+
+#. module: delivery_dhl_parcel
 #: model:ir.model,name:delivery_dhl_parcel.model_delivery_carrier
 msgid "Shipping Methods"
 msgstr "Métodos de envío"

--- a/delivery_dhl_parcel/models/delivery_carrier.py
+++ b/delivery_dhl_parcel/models/delivery_carrier.py
@@ -56,6 +56,23 @@ class DeliveryCarrier(models.Model):
             "It will also exclude this carrier from the e-commerce checkout."
         ),
     )
+    dhl_parcel_pre_1330 = fields.Boolean(
+        string="Pre 13:30",
+        help="Activates Feature 714 for Pre 13:30 time-definite delivery.",
+    )
+    dhl_parcel_insurance = fields.Boolean(
+        string="Insured shipment",
+        help=(
+            "If checked, the shipment will be declared as insured. It assumes "
+            "there is a sale order linked and it will use the picking lines "
+            "total as the declared insurance value."
+        ),
+    )
+    dhl_parcel_insurance_expenses = fields.Selection(
+        selection=[("P", "Paid by sender"), ("D", "Paid by recipient")],
+        string="Insurance expenses",
+        default="P",
+    )
 
     def dhl_parcel_get_tracking_link(self, picking):
         """Provide tracking link for the customer"""
@@ -162,6 +179,28 @@ class DeliveryCarrier(models.Model):
                     "CODCurrency": sale.currency_id.name,
                 }
             )
+        if self.dhl_parcel_insurance and picking.move_ids:
+            insurance_amount = sum(
+                move.sale_line_id.currency_id.round(
+                    move.sale_line_id.price_reduce_taxexcl * move.quantity
+                )
+                for move in picking.move_ids
+                if move.sale_line_id
+            )
+            currency = (
+                picking.sale_id.currency_id.name
+                if picking.sale_id
+                else picking.company_id.currency_id.name
+            )
+            vals.update(
+                {
+                    "InsuranceAmount": insurance_amount,
+                    "InsuranceExpenses": self.dhl_parcel_insurance_expenses,
+                    "InsuranceCurrency": currency,
+                }
+            )
+        if self.dhl_parcel_pre_1330:
+            vals["Features"] = [{"Key": "714"}]
         return vals
 
     def dhl_parcel_send_shipping(self, pickings):

--- a/delivery_dhl_parcel/readme/CONTRIBUTORS.md
+++ b/delivery_dhl_parcel/readme/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
   - Ethan Hildick
 - [Tecnativa](https://www.tecnativa.com):
   - Víctor Martínez
+  - Cristina Hidalgo

--- a/delivery_dhl_parcel/static/description/index.html
+++ b/delivery_dhl_parcel/static/description/index.html
@@ -556,6 +556,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Víctor Martínez</li>
+<li>Cristina Hidalgo</li>
 </ul>
 </li>
 </ul>

--- a/delivery_dhl_parcel/views/delivery_carrier_view.xml
+++ b/delivery_dhl_parcel/views/delivery_carrier_view.xml
@@ -39,6 +39,13 @@
                         </group>
                         <group>
                             <field name="dhl_parcel_cash_on_delivery" />
+                            <field name="dhl_parcel_pre_1330" />
+                            <field name="dhl_parcel_insurance" />
+                            <field
+                                name="dhl_parcel_insurance_expenses"
+                                invisible="not dhl_parcel_insurance"
+                                required="dhl_parcel_insurance"
+                            />
                             <field
                                 name="dhl_parcel_last_end_day_report"
                                 filename="dhl_parcel_last_end_day_report_name"


### PR DESCRIPTION
Add Pre 13:30 and insured shipment options to DHL Parcel carrier configuration.

- New boolean field `dhl_parcel_pre_1330`: activates Feature 714 in the DHL API for time-definite delivery before 13:30.
- New boolean field `dhl_parcel_insurance`: marks the shipment as insured, sending `InsuranceAmount`, `InsuranceExpenses` and `InsuranceCurrency` to the API using the linked sale order total as declared value.
- New selection field `dhl_parcel_insurance_expenses`: who pays the insurance (sender/recipient), only visible when insurance is enabled.

Users can configure 4 separate DHL carriers to cover all combinations: DHL Regular, DHL Pre 13:30, DHL Regular Insured, DHL Pre 13:30 Insured.

@Tecnativa TT61250
@pedrobaeza @christian-ramos-tecnativa 