### PR TITLE
[19.0][FIX] l10n_es_partner: Fix local path to data_banks.csv

### DIFF
--- a/l10n_es_partner/wizard/l10n_es_partner_wizard.py
+++ b/l10n_es_partner/wizard/l10n_es_partner_wizard.py
@@ -9,6 +9,7 @@ import os
 import tempfile
 
 from odoo import fields, models, tools
+from odoo.modules.module import get_module_path
 
 from ..gen_src.gen_data_banks import gen_bank_data_csv
 
@@ -72,7 +73,8 @@ class L10nEsPartnerImportWizard(models.TransientModel):
             self.env["res.bank"].load(fieldnames, data)
 
     def import_local(self):
-        path = os.path.join("l10n_es_partner", "wizard", "data_banks.csv")
+        module_path = get_module_path("l10n_es_partner")
+        path = os.path.join(module_path, "wizard", "data_banks.csv")
         if path and os.path.exists(path):
             self._load_csv_data(path)
         else:


### PR DESCRIPTION
We need a full path to import data from a CSV file. I used Odoo’s `get_module_path` function to get the full path of the module.

@pedrobaeza @victoralmau ping
@Tecnativa