### PR TITLE
[18.0][FIX] l10n_es_mis_report: Utilizar la expresión adecuada (-balp[651%]) para Ayudas no monetarias

### DIFF
--- a/l10n_es_mis_report/data/mis_report_pyg_sme_sfl.xml
+++ b/l10n_es_mis_report/data/mis_report_pyg_sme_sfl.xml
@@ -162,7 +162,7 @@
         <field name="sequence">110</field>
         <field name="name">es40320</field>
         <field name="description">b) Ayudas no monetarias</field>
-        <field name="expression">-balp[650%]</field>
+        <field name="expression">-balp[651%]</field>
         <field name="auto_expand_accounts">True</field>
         <field
             name="auto_expand_accounts_style_id"


### PR DESCRIPTION
Utilizar la expresión adecuada (-balp[651%]) para Ayudas no monetarias

Relacionado con https://github.com/OCA/l10n-spain/issues/5007