### PR TITLE
[18.0][FIX] l10n_es_vat_book_oss: line amount tax set to zero when the vat book is installed

### DIFF
--- a/l10n_es_vat_book_oss/models/__init__.py
+++ b/l10n_es_vat_book_oss/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import account_move
 from . import aeat_vat_book_map_lines
+from . import l10n_es_vat_book

--- a/l10n_es_vat_book_oss/models/account_move.py
+++ b/l10n_es_vat_book_oss/models/account_move.py
@@ -10,9 +10,13 @@ class AccountMoveLine(models.Model):
     def _process_aeat_tax_fee_info(self, res, tax, sign):
         # Nullify tax fee for OSS taxes
         result = super()._process_aeat_tax_fee_info(res, tax, sign)
-        oss_taxes = self.env["account.tax"].search(
-            [("oss_country_id", "!=", False), ("company_id", "=", self.company_id.id)]
-        )
-        if tax in oss_taxes:
-            res[tax]["amount"] = 0
+        if self.env.context.get("calculate_vat_book", False):
+            oss_taxes = self.env["account.tax"].search(
+                [
+                    ("oss_country_id", "!=", False),
+                    ("company_id", "=", self.company_id.id),
+                ]
+            )
+            if tax in oss_taxes:
+                res[tax]["amount"] = 0
         return result

--- a/l10n_es_vat_book_oss/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book_oss/models/l10n_es_vat_book.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Tecnativa - Christian Ramos
+# Copyright 2026 Tecnativa - Sergio Teruel
+# License AGPL-3 - See https://www.gnu.org/licenses/agpl-3.0
+
+from odoo import models
+
+
+class L10nEsVatBook(models.Model):
+    _inherit = "l10n.es.vat.book"
+
+    def _calculate_vat_book(self):
+        return super(
+            L10nEsVatBook, self.with_context(calculate_vat_book=True)
+        )._calculate_vat_book()


### PR DESCRIPTION
cc @Tecnativa 

Cuando se envían al SII facturas con impuestos OSS el modulo l10n_es_vat_book_oss establece al campo "amount" de la línea del impuesto a cero, esto hace que el valor no se reste de la clave "ImporteTotal" del diccionario que se envia al SII provocando el error:

` 'DescripcionErrorRegistro': 'Cuando el importe total está cumplimentado, debe ser igual a la suma de las bases imponibles más las cuotas repercutidas, más las cuotas recargo equivalencia del bloque Sujeta No Exenta, más la suma de las bases imponibles del bloque Sujeta Exenta, más la suma del ImportePorArticulos7_14_Otros, más la suma del ImporteTAIReglasLocalizacion',
`

ping @carlosdauden @acysos @christian-ramos-tecnativa 

