### PR TITLE
[16.0][FIX] payment_redsys: robust return flow

### DIFF
--- a/payment_redsys/__manifest__.py
+++ b/payment_redsys/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Pasarela de pago Redsys",
     "category": "Payment Acquirer",
     "summary": "Payment Acquirer: Redsys Implementation",
-    "version": "16.0.1.0.4",
+    "version": "16.0.1.0.5",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-spain",
     "depends": ["payment"],

--- a/payment_redsys/controllers/main.py
+++ b/payment_redsys/controllers/main.py
@@ -9,6 +9,8 @@ import pprint
 from odoo import http
 from odoo.http import request
 
+from odoo.addons.payment.controllers.post_processing import PaymentPostProcessing
+
 _logger = logging.getLogger(__name__)
 
 
@@ -29,16 +31,37 @@ class RedsysController(http.Controller):
         auth="public",
         csrf=False,
     )
-    def redsys_return(self, **post):
+    def redsys_return(self, tx_ref=None, **post):
         """Redsys."""
         _logger.info(
-            "Redsys: entering form_feedback with post data %s", pprint.pformat(post)
+            "Redsys: entering form_feedback with post data %s tx_ref=%s",
+            pprint.pformat(post),
+            tx_ref,
         )
         if post:
             request.env["payment.transaction"].sudo()._handle_notification_data(
                 "redsys", post
             )
-            return request.redirect("/payment/status")
+        # Re-attach the transaction to the user's session in case the
+        # cross-site round-trip through Redsys dropped the session cookie
+        # (browser SameSite policies behave differently on the POST/GET
+        # combinations Redsys uses to redirect back to UrlOk).
+        if tx_ref:
+            tx = (
+                request.env["payment.transaction"]
+                .sudo()
+                .search(
+                    [("provider_code", "=", "redsys"), ("reference", "=", tx_ref)],
+                    limit=1,
+                )
+            )
+            if tx:
+                PaymentPostProcessing.monitor_transactions(tx)
+        # Always redirect to /payment/status so the user never gets a
+        # blank page when Redsys delivers an empty GET to UrlOk (some
+        # 3DS challenge flows do that when MerchantUrl == UrlOk and the
+        # server-to-server notification has already been processed).
+        return request.redirect("/payment/status")
 
     @http.route(
         ["/payment/redsys/result/<page>"],

--- a/payment_redsys/models/payment_provider.py
+++ b/payment_redsys/models/payment_provider.py
@@ -151,7 +151,16 @@ class PaymentProvider(models.Model):
                 and self.redsys_merchant_description[:125]
             ),
             "Ds_Merchant_ConsumerLanguage": (self.redsys_merchant_lang or "001"),
-            "Ds_Merchant_UrlOk": "%s/payment/redsys/result/redsys_result_ok" % base_url,
+            # Include the transaction reference in UrlOk so the return
+            # controller can re-attach it to the user's session, even when
+            # the cross-site round-trip drops the original session cookie.
+            "Ds_Merchant_UrlOk": (
+                "%s/payment/redsys/return?tx_ref=%s"
+                % (
+                    callback_url or base_url,
+                    urllib.parse.quote(tx_values.get("reference") or ""),
+                )
+            )[:250],
             "Ds_Merchant_UrlKo": "%s/payment/redsys/result/redsys_result_ko" % base_url,
             "Ds_Merchant_Paymethods": self.redsys_pay_method or "T",
         }

--- a/payment_redsys/tests/test_redsys.py
+++ b/payment_redsys/tests/test_redsys.py
@@ -2,6 +2,7 @@
 # Copyright 2023 Planesnet - Luis Planes, Laia Espinosa, Raul Solana
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import base64
 import json
 import logging
 
@@ -163,3 +164,17 @@ class RedsysTest(RedsysCommon):
         post_data = self._prepare_post_data(values)
         tx._handle_notification_data("redsys", post_data)
         self.assertEqual(tx.state, "error", "Redsys: response error")
+
+    def test_url_ok_contains_tx_ref(self):
+        """UrlOk must carry tx_ref so the return controller can re-attach
+        the transaction to the user's session when the cross-site
+        round-trip drops the original session cookie."""
+        tx = self._create_transaction(flow="redirect", reference="tx-20260526161009")
+        rendering_values = tx._get_specific_rendering_values(
+            {"reference": tx.reference, "amount": self.amount}
+        )
+        merchant_parameters = json.loads(
+            base64.b64decode(rendering_values["Ds_MerchantParameters"]).decode()
+        )
+        self.assertIn("tx_ref=", merchant_parameters["Ds_Merchant_UrlOk"])
+        self.assertIn("tx-20260526161009", merchant_parameters["Ds_Merchant_UrlOk"])


### PR DESCRIPTION
## Summary

Two bugs in the return flow that combined to break the user-visible side
of the payment, while the server-to-server notification correctly confirmed
the transaction. Symptoms in production: blank screen after paying, or the
generic "we could not find your payment" message in `/payment/status`, even
though the `payment.transaction` was already `done` in the database.

### Bug 1 — Blank screen on empty UrlOk

The `redsys_return` controller only returned a redirect when POST data
was present. When Redsys redirects the browser to UrlOk with no body
(a frequent case in some 3DS challenge variants when `MerchantUrl == UrlOk`
and the S2S notification has already been processed), the route returned
`None` and the browser rendered a blank page. The controller now always
redirects to `/payment/status`.

### Bug 2 — User session lost across the cross-site round-trip

`/payment/status/poll` filters by `request.session['__payment_monitored_tx_ids__']`.
Some browser SameSite policies drop the Odoo session cookie on the
POST/GET combinations Redsys uses to redirect back to UrlOk, so the user
arrives at `/payment/status` with an empty monitored-tx list and sees the
"we could not find your payment" message.

`Ds_Merchant_UrlOk` is switched from the passive
`/payment/redsys/result/redsys_result_ok` endpoint (which just bounced
to `/payment/status` without telling it which transaction to look at)
to `/payment/redsys/return?tx_ref=<reference>`; the return controller
uses `tx_ref` to re-attach the transaction to the user's current
session via `PaymentPostProcessing.monitor_transactions` before
redirecting.

## Tests

One new test in `tests/test_redsys.py`:

- `test_url_ok_contains_tx_ref` — UrlOk includes `?tx_ref=<reference>`.

Manifest bumped to `16.0.1.0.5`.

## Test plan

- [x] `odoo --test-tags /payment_redsys -i payment_redsys` on a clean DB — all tests pass.
- [x] Reproduced and validated against the Redsys sandbox with a real 3DS challenge: empty GET on UrlOk, fresh incognito session. Before the patch: blank screen / "could not find" / `tx.state = draft`. After the patch: redirect to `/payment/status` showing the `done_msg`, `tx.state = done`.