### PR TITLE
[16.0] [IMP] l10n_es_aeat: mapeo de impuestos creados manualmente para modelos

### DIFF
--- a/l10n_es_aeat/__manifest__.py
+++ b/l10n_es_aeat/__manifest__.py
@@ -45,6 +45,7 @@
         "views/aeat_certificate_view.xml",
         "views/account_journal_view.xml",
         "views/account_move_view.xml",
+        "views/account_tax_view.xml",
     ],
     "installable": True,
     "maintainers": ["pedrobaeza"],

--- a/l10n_es_aeat/models/account_tax.py
+++ b/l10n_es_aeat/models/account_tax.py
@@ -1,11 +1,18 @@
 # Copyright 2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class AccountTax(models.Model):
     _inherit = "account.tax"
+
+    aeat_equivalent_tax_id = fields.Many2one(
+        comodel_name="account.tax",
+        string="Equivalent Tax (for AEAT mapping purposes)",
+        help="This field is for manually created taxes in order to allow to map them"
+        " for AEAT reports",
+    )
 
     def _clear_tax_id_from_tax_template_cache(self):
         Company = self.env["res.company"]
@@ -27,3 +34,15 @@ class AccountTax(models.Model):
         res = super().unlink()
         self._clear_tax_id_from_tax_template_cache()
         return res
+
+    def copy_data(self, default=None):
+        """When duplicating a tax, if it does not contain an equivalent tax,
+        takes itself as base.
+        """
+        vals_list = super().copy_data(default=default)
+        for record, vals in zip(self, vals_list, strict=False):
+            if not vals.get("aeat_equivalent_tax_id"):
+                vals["aeat_equivalent_tax_id"] = (
+                    record.aeat_equivalent_tax_id.id or record.id
+                )
+        return vals_list

--- a/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
@@ -86,7 +86,9 @@ class L10nEsAeatReportTaxMapping(models.AbstractModel):
         return []
 
     def get_taxes_from_map(self, map_line):
-        return self.get_taxes_from_templates(map_line.tax_ids)
+        taxes = self.get_taxes_from_templates(map_line.tax_ids)
+        tax_obj = self.env["account.tax"]
+        return taxes + tax_obj.search([("aeat_equivalent_tax_id", "in", taxes.ids)])
 
     def _get_move_line_domain(self, date_start, date_end, map_line):
         self.ensure_one()

--- a/l10n_es_aeat/views/account_tax_view.xml
+++ b/l10n_es_aeat/views/account_tax_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="account_tax_view_tree" model="ir.ui.view">
+        <field name="model">account.tax</field>
+        <field name="inherit_id" ref="account.view_tax_tree" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="before">
+                <field
+                    name="aeat_equivalent_tax_id"
+                    options="{'no_create': True}"
+                    optional="hide"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="account_tax_view_form" model="ir.ui.view">
+        <field name="model">account.tax</field>
+        <field name="inherit_id" ref="account.view_tax_form" />
+        <field name="arch" type="xml">
+            <field name="tax_group_id" position="after">
+                <field name="aeat_equivalent_tax_id" options="{'no_create': True}" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Back port of #5018 

He adaptado el cambio en el método get_taxes_for_company() del modelo L10nEsAeatMapTaxLine que no existe en 16 para obtener los impuestos equivalentes directamente en la función get_taxes_from_map del modelo L10nEsAeatReportTaxMapping