### PR TITLE
[18.0][FIX] l10n_es_aeat: Remove undefined computed fields from real estate model

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_real_estate.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_real_estate.py
@@ -85,28 +85,8 @@ class L10nEsAeatRealEstate(models.Model):
     )
     state_id = fields.Many2one(
         comodel_name="res.country.state",
-        compute="_compute_state_id",
-        readonly=False,
-        store=True,
-    )
-    state_code = fields.Char(
-        compute="_compute_state_code",
-        store=True,
-        readonly=False,
-        compute_sudo=True,
-    )
-    city_id = fields.Many2one(
-        comodel_name="res.city",
-        string="City ID",
-        index=True,
-        compute="_compute_city_id",
-        readonly=False,
-        store=True,
     )
     city = fields.Char(
-        compute="_compute_city",
-        store=True,
-        readonly=False,
         size=30,
         required=True,
     )
@@ -153,20 +133,12 @@ class L10nEsAeatRealEstate(models.Model):
         for record in self:
             record.representative_vat = record.partner_id.vat
 
-    @api.depends("city_id")
-    def _compute_city(self):
-        for record in self:
-            if record.city_id and record.city_id.name:
-                record.city = record.city_id.name
-            else:
-                record.city = ""
-
-    @api.depends("state_code")
+    @api.depends("state_id")
     def _compute_check_ok(self):
         self.update({"check_ok": False, "error_text": False})
         for record in self:
             errors = []
-            if not record.state_code:
+            if not record.state_id:
                 errors.append(self.env._("Without state"))
             record.check_ok = not bool(errors)
             record.error_text = bool(errors) and ", ".join(errors)

--- a/l10n_es_aeat/tests/test_l10n_es_aeat_real_estate.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat_real_estate.py
@@ -177,19 +177,18 @@ class TestL10nEsAeatRealEstate(TestL10nEsAeatModBase):
             )
 
     def test_compute_check_ok(self):
-        # Sin state_code → check_ok=False
+        # Sin state_id → check_ok=False
         rec_no_state = self.env["l10n.es.aeat.real_estate"].create(
             self._base_vals("Sin estado")
         )
         self.assertFalse(rec_no_state.check_ok)
         self.assertTrue(rec_no_state.error_text)
 
-        # Con state_code → check_ok=True
+        # Con state_id → check_ok=True
         rec_with_state = self.env["l10n.es.aeat.real_estate"].create(
             {
                 **self._base_vals("Con estado"),
                 "state_id": self.env.ref("base.state_es_m").id,
-                "state_code": "28",
             }
         )
         self.assertTrue(rec_with_state.check_ok)

--- a/l10n_es_aeat/views/l10n_es_aeat_real_estate_view.xml
+++ b/l10n_es_aeat/views/l10n_es_aeat_real_estate_view.xml
@@ -105,7 +105,7 @@
                 <field name="representative_vat" optional="hide" />
                 <field name="reference" />
                 <field name="state_id" optional="hide" />
-                <field name="check_ok" invisible="1" />
+                <field name="check_ok" column_invisible="1" />
                 <field name="company_id" groups="base.group_multi_company" />
             </list>
         </field>


### PR DESCRIPTION
Comentado en el PR original: https://github.com/OCA/l10n-spain/pull/4400/changes#r3350226520