### PR TITLE
[16.0][FIX] l10n_es_aeat: Switch the equivalent tax mechanism to other level

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report_tax_mapping.py
@@ -86,9 +86,7 @@ class L10nEsAeatReportTaxMapping(models.AbstractModel):
         return []
 
     def get_taxes_from_map(self, map_line):
-        taxes = self.get_taxes_from_templates(map_line.tax_ids)
-        tax_obj = self.env["account.tax"]
-        return taxes + tax_obj.search([("aeat_equivalent_tax_id", "in", taxes.ids)])
+        return self.get_taxes_from_templates(map_line.tax_ids)
 
     def _get_move_line_domain(self, date_start, date_end, map_line):
         self.ensure_one()

--- a/l10n_es_aeat/models/res_company.py
+++ b/l10n_es_aeat/models/res_company.py
@@ -107,7 +107,10 @@ class ResCompany(models.Model):
             tax_id = self._get_tax_id_from_tax_template(tmpl, self)
             if tax_id:
                 tax_ids.append(tax_id)
-        return self.env["account.tax"].browse(tax_ids)
+        # Add equivalent taxes
+        tax_obj = self.env["account.tax"]
+        extra_taxes = tax_obj.search([("aeat_equivalent_tax_id", "in", tax_ids)])
+        return tax_obj.browse(tax_ids) + extra_taxes
 
     def get_account_from_template(self, account_template):
         """Return company account that match the given account template."""


### PR DESCRIPTION
SII and other modules don't use the mapping mechanism of `l10n.es.aeat.report.tax.mapping`, so we need to put it at other level that is used for all.

Fixup of #5020 

@Tecnativa 