### PR TITLE
[18.0][FIX] delivery_gls_asm: Prevent an error when the partner has no street

### DIFF
--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -129,8 +129,16 @@ class DeliveryCarrier(models.Model):
         )
         consignee = picking.partner_id
         consignee_entity = picking.partner_id.commercial_partner_id
-        if not sender_partner.street:
+        sender_street = sender_partner.street or ""
+        if sender_partner.street2:
+            sender_street += " " + sender_partner.street2
+        if not sender_street:
             raise UserError(_("Couldn't find the sender street"))
+        consignee_street = consignee.street or ""
+        if consignee.street2:
+            consignee_street += " " + consignee.street2
+        if not consignee_street:
+            raise UserError(_("Couldn't find the consignee street"))
         cash_amount = 0
         if self.gls_asm_cash_on_delivery:
             cash_amount = picking.sale_id.amount_total
@@ -155,7 +163,7 @@ class DeliveryCarrier(models.Model):
             "remite_nombre": escape(
                 sender_partner.name or sender_partner.parent_id.name
             ),
-            "remite_direccion": escape(sender_partner.street or ""),
+            "remite_direccion": escape(sender_street),
             "remite_poblacion": escape(sender_partner.city or ""),
             "remite_provincia": escape(sender_partner.state_id.name or ""),
             "remite_pais": "34",  # [mandatory] always 34=Spain
@@ -171,7 +179,7 @@ class DeliveryCarrier(models.Model):
             "destinatario_nombre": (
                 escape(consignee.name or consignee.commercial_partner_id.name or "")
             ),
-            "destinatario_direccion": escape(consignee.street or ""),
+            "destinatario_direccion": escape(consignee_street),
             "destinatario_poblacion": escape(consignee.city or ""),
             "destinatario_provincia": escape(consignee.state_id.name or ""),
             "destinatario_pais": consignee.country_id.code or "",
@@ -218,9 +226,15 @@ class DeliveryCarrier(models.Model):
             picking.picking_type_id.warehouse_id.partner_id
             or picking.company_id.partner_id
         )
-        if not sender_partner.street:
+        sender_street = sender_partner.street or ""
+        if sender_partner.street2:
+            sender_street += " " + sender_partner.street2
+        if not sender_street:
             raise UserError(_("Couldn't find the sender street"))
-        if not receiving_partner.street:
+        receiving_street = receiving_partner.street or ""
+        if receiving_partner.street2:
+            receiving_street += " " + receiving_partner.street2
+        if not receiving_street:
             raise UserError(_("Couldn't find the consignee street"))
         recipient_phone = self._sanitize_phone_gls(
             receiving_partner.phone or receiving_partner.parent_id.phone or ""
@@ -237,7 +251,7 @@ class DeliveryCarrier(models.Model):
             "remite_nombre": escape(
                 sender_partner.name or sender_partner.parent_id.name
             ),
-            "remite_direccion": escape(sender_partner.street) or "",
+            "remite_direccion": escape(sender_street),
             "remite_poblacion": sender_partner.city or "",
             "remite_provincia": sender_partner.state_id.name or "",
             "remite_pais": (sender_partner.country_id.phone_code or ""),
@@ -254,7 +268,7 @@ class DeliveryCarrier(models.Model):
             "destinatario_nombre": escape(
                 receiving_partner.name or receiving_partner.parent_id.name
             ),
-            "destinatario_direccion": escape(receiving_partner.street) or "",
+            "destinatario_direccion": escape(receiving_street),
             "destinatario_poblacion": receiving_partner.city or "",
             "destinatario_provincia": receiving_partner.state_id.name or "",
             "destinatario_pais": (receiving_partner.country_id.code or ""),


### PR DESCRIPTION
- Include street2 if it is set.
- Apply the same logic in `_prepare_gls_asm_pickup`.

TT63049
@Tecnativa @pedrobaeza @sergio-teruel @christian-ramos-tecnativa Pueden darle una mirada a este PR por favor