### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_oca: mig script escape %

### DIFF
--- a/l10n_es_aeat_sii_oca/migrations/17.0.1.0.0/post-migration.py
+++ b/l10n_es_aeat_sii_oca/migrations/17.0.1.0.0/post-migration.py
@@ -11,7 +11,7 @@ def migrate(env, version):
         UPDATE account_move am
         SET sii_send_date = job.eta,
             sii_needs_cancel = CASE
-                WHEN job.func_string LIKE '%cancel_one_invoice()' THEN True
+                WHEN job.func_string LIKE '%%cancel_one_invoice()' THEN True
             ELSE
                 False
             END


### PR DESCRIPTION
Newer psycopg2 versions are stricter when parsing % characters.

A simple showcase of the problem

With psycopg2 2.9.9 (strict)

```python
>>> openupgrade.logged_query(env.cr, "select name from res_partner where name ilike '%fixme'")
2026-06-12 09:19:20,570 1 ERROR odoo odoo.sql_db: bad query: select name from res_partner where name ilike '%fixme'
ERROR: tuple index out of range 
IndexError: tuple index out of range

>>> openupgrade.logged_query(env.cr, "select name from res_partner where name ilike '%%fixme'")
2026-06-12 09:19:15,341 1 DEBUG odoo OpenUpgrade: 0 rows affected after 0:00:00.009709 running select name from res_partner where name ilike '%fixme' 
0
```


With psycopg2 2.9.2 (tolerant)

```python
>>> openupgrade.logged_query(env.cr, "select name from res_partner where name ilike '%fixme'")
2026-06-12 09:18:28,699 1 DEBUG odoo OpenUpgrade: 0 rows affected after 0:00:00.027295 running select name from res_partner where name ilike '%fixme' 
0

>>> openupgrade.logged_query(env.cr, "select name from res_partner where name ilike '%%fixme'")
2026-06-12 09:18:55,896 1 DEBUG odoo OpenUpgrade: 0 rows affected after 0:00:00.029270 running select name from res_partner where name ilike '%%fixme' 
0
```

cc @moduon MT-13217

please take a look @yajo @pedrobaeza @EmilioPascual 