### PR TITLE
[18.0][IMP] delivery_gls_asm: Do not report a POD error when the delivery is in the parcelshop state and a POD is requested

### DIFF
--- a/delivery_gls_asm/models/delivery_carrier.py
+++ b/delivery_gls_asm/models/delivery_carrier.py
@@ -500,7 +500,16 @@ class DeliveryCarrier(models.Model):
                 }
             )
         except requests.RequestException as ex:
-            picking.write({"pod_error": str(ex)})
+            # If GLS returns a 500 error,
+            # it means that the POD is not available yet.
+            # In that case, we set pod_error to False so it can be retried later.
+            if response.status_code == 500 and picking.gls_shipment_state in [
+                "parcelshop",
+                "parcelshop_confirm",
+            ]:
+                picking.write({"pod_error": False})
+            else:
+                picking.write({"pod_error": str(ex)})
             self.log_xml(
                 f"POD info: {str(pod_info)} Exception: {str(ex)}",
                 "GLS ASM POD Response",


### PR DESCRIPTION
For some reason, the GLS API returns a POD URL when the delivery is in the `parcelshop` state, but the URL is not accessible. Therefore, instead of reporting an error, the exception is silently ignored.

This can be considered a GLS issue, but this workaround avoids reporting a false error until a fix is provided on their side.

TT62522
@Tecnativa @pedrobaeza @carlosdauden @sergio-teruel Pueden darle una mirada a este PR por favor?