### PR TITLE
[17.0][FIX] l10n_es_aeat_mod349: Solve error where rectifications for other periods do not have the original amount

### DIFF
--- a/l10n_es_aeat_mod349/models/mod349.py
+++ b/l10n_es_aeat_mod349/models/mod349.py
@@ -233,7 +233,9 @@ class Mod349(models.Model):
                 original_details = original_details.filtered(
                     lambda d, report=report: d.report_id == report
                 )
-                origin_amount = sum(original_details.mapped("amount_untaxed"))
+                origin_amount = (
+                    original_details.partner_record_id.total_operation_amount
+                )
                 period_type = report.period_type
                 year = str(report.year)
                 # If there are intermediate periods between the original
@@ -285,9 +287,9 @@ class Mod349(models.Model):
                     period_type = month
             key = (partner, op_key, period_type, year)
             key_vals = data.setdefault(
-                key, {"original_amount": 0, "refund_details": refund_detail_obj}
+                key,
+                {"original_amount": origin_amount, "refund_details": refund_detail_obj},
             )
-            key_vals["original_amount"] += origin_amount
             key_vals["refund_details"] += refund_details
         for key, key_vals in data.items():
             partner, op_key, period_type, year = key

--- a/l10n_es_aeat_mod349/tests/test_l10n_es_aeat_mod349.py
+++ b/l10n_es_aeat_mod349/tests/test_l10n_es_aeat_mod349.py
@@ -318,6 +318,59 @@ class TestL10nEsAeatMod349Base(TestL10nEsAeatModBase):
         self.assertEqual(model349_3.partner_refund_ids.total_origin_amount, 200)
         self.assertEqual(model349_3.partner_refund_ids.total_operation_amount, 100)
 
+    def test_model_349_refund_with_multiple_origin_invoices(self):
+        # Create 2 vendor bill and 1 refunds in different periods
+        self._invoice_purchase_create("2017-01-01")
+        inv = self._invoice_purchase_create("2017-01-01")
+        self._invoice_refund(inv, "2017-02-01", price_unit=50.0)
+        # Create model
+        model349_model = self.env["l10n.es.aeat.mod349.report"].with_user(
+            self.account_manager
+        )
+        model349_1 = model349_model.create(
+            {
+                "name": "3490000000001",
+                "company_id": self.company.id,
+                "company_vat": "1234567890",
+                "contact_name": "Test owner",
+                "statement_type": "N",
+                "support_type": "T",
+                "contact_phone": "911234455",
+                "year": 2017,
+                "period_type": "01",
+                "date_start": "2017-01-01",
+                "date_end": "2017-01-31",
+            }
+        )
+        # Calculate
+        _logger.debug("Calculate AEAT 349 January 2017")
+        model349_1.button_calculate()
+        self.assertEqual(model349_1.total_partner_records, 1)
+        self.assertEqual(model349_1.partner_record_ids.total_operation_amount, 600)
+
+        model349_2 = model349_model.create(
+            {
+                "name": "3490000000002",
+                "company_id": self.company.id,
+                "company_vat": "1234567890",
+                "contact_name": "Test owner",
+                "statement_type": "N",
+                "support_type": "T",
+                "contact_phone": "911234455",
+                "year": 2017,
+                "period_type": "02",
+                "date_start": "2017-02-01",
+                "date_end": "2017-02-28",
+            }
+        )
+        # Calculate
+        _logger.debug("Calculate AEAT 349 February 2017")
+        model349_2.button_calculate()
+        self.assertEqual(model349_2.total_partner_records, 0)
+        self.assertEqual(model349_2.total_partner_refunds, 1)
+        self.assertEqual(model349_2.partner_refund_ids.total_origin_amount, 600)
+        self.assertEqual(model349_2.partner_refund_ids.total_operation_amount, 500)
+
     def test_mod349_errors(self):
         # Add some test data
         self.customer.write(


### PR DESCRIPTION
Missing fw-port from #3830

@Tecnativa