### PR TITLE
[18.0][IMP] l10n_es_aeat_sii_oca: Apply SII description size

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -673,7 +673,7 @@ class AccountMove(models.Model):
                     )
                     names = [unidecode(x) for x in names if x]  # Avoid "ugly" chars
                     description += " - ".join(filter(None, names)).replace("\n", " ")
-            invoice.sii_description = (description or "")[:500] or "/"
+            invoice.sii_description = description or "/"  # shrink to 500 by the field
 
     @api.depends(
         "company_id",

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -37,6 +37,7 @@ class SiiMixin(models.AbstractModel):
     sii_description = fields.Char(
         string="SII computed description",
         compute="_compute_sii_description",
+        size=500,
         default="/",
         store=True,
         readonly=False,


### PR DESCRIPTION
Instead of doing it by code, let's restrict it at field level, so any assignation outside the main compute also restricts the size of the field, or if not, we will have an AEAT returning code saying:

```
Campo inválido "DescripcionOperacion"
```

@Tecnativa TT63112