### PR TITLE
[19.0][IMP] l10n_es_aeat_sii_oca: Missing fw ports

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -673,7 +673,7 @@ class AccountMove(models.Model):
                     )
                     names = [unidecode(x) for x in names if x]  # Avoid "ugly" chars
                     description += " - ".join(filter(None, names)).replace("\n", " ")
-            invoice.sii_description = (description or "")[:500] or "/"
+            invoice.sii_description = description or "/"  # shrink to 500 by the field
 
     @api.depends(
         "company_id",

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -672,7 +672,7 @@ class AccountMove(models.Model):
                         "invoice_line_ids.ref"
                     )
                     names = [unidecode(x) for x in names if x]  # Avoid "ugly" chars
-                    description += " - ".join(filter(None, names))
+                    description += " - ".join(filter(None, names)).replace("\n", " ")
             invoice.sii_description = (description or "")[:500] or "/"
 
     @api.depends(

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -38,6 +38,7 @@ class SiiMixin(models.AbstractModel):
     sii_description = fields.Char(
         string="SII computed description",
         compute="_compute_sii_description",
+        size=500,
         default="/",
         store=True,
         readonly=False,

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -46,7 +46,7 @@ class SiiMixin(models.AbstractModel):
     aeat_state = fields.Selection(
         selection_add=SII_STATES,
     )
-    sii_csv = fields.Char(string="SII CSV", copy=False, readonly=True)
+    sii_csv = fields.Char(string="SII CSV", copy=False, readonly=True, index=True)
     sii_return = fields.Text(string="SII Return", copy=False, readonly=True)
     sii_refund_type = fields.Selection(
         selection=[


### PR DESCRIPTION
Forward-ports of #4990, #4492 and #5044

- **Replace line feeds by spaces in SII description:**
 
  Although the field is now a single-line string, Odoo encodes line feeds as `\n` when computing the SII description from the invoice lines, so when sending that to the AEAT, they are not kept as is in the end.

  On that cases, doing the SII match contrast, they will say there's no
exact match due to that.

  Let's replace the line feeds by spaces in advance to avoid this problem.

- **CSV index: For improving the SII match searches.**

- **Apply SII description size:**

  Instead of doing it by code, let's restrict it at field level, so any assignation outside the main compute also restricts the size of the field, or if not, we will have an AEAT returning code saying:

  ```
  Campo inválido "DescripcionOperacion"
  ```
  
@Tecnativa 