### PR TITLE
[18.0][FIX] l10n_es_intrastat_report: Convertir valores a 2 decimales

### DIFF
--- a/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
+++ b/l10n_es_intrastat_report/models/l10n_es_intrastat_product_declaration.py
@@ -96,6 +96,7 @@ class IntrastatProductDeclaration(models.Model):
 
     def _generate_csv_line(self, line):
         state_code = line.intrastat_state_id.code
+        qweb_f_float = self.env["ir.qweb.field.float"].with_context(lang="es_ES")
         vals = (
             # Estado destino/origen
             line.src_dest_country_code,
@@ -116,13 +117,17 @@ class IntrastatProductDeclaration(models.Model):
             # Régimen estadístico
             False,
             # Masa neta
-            str(line.weight).replace(".", ","),
+            qweb_f_float.value_to_html(line.weight, {"precision": 2}).replace(".", ""),
             # Unidades suplementarias
             str(line.suppl_unit_qty).replace(".", ","),
             # Valor
-            str(line.amount_company_currency).replace(".", ","),
+            qweb_f_float.value_to_html(
+                line.amount_company_currency, {"precision": 2}
+            ).replace(".", ""),
             # Valor estadístico
-            str(line.amount_company_currency).replace(".", ","),
+            qweb_f_float.value_to_html(
+                line.amount_company_currency, {"precision": 2}
+            ).replace(".", ""),
         )
         # Nº IVA-VIES asignado a la contraparte de la operación
         if self.declaration_type == "dispatches" and int(self.year) >= 2022:

--- a/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
+++ b/l10n_es_intrastat_report/tests/test_l10n_es_intrastat_report.py
@@ -4,6 +4,7 @@
 from datetime import datetime
 
 from odoo.tests import Form, tagged
+from odoo.tools import mute_logger
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
@@ -248,6 +249,7 @@ class TestL10nIntraStatReport(AccountTestInvoicingCommon):
             self.assertEqual(items[6], self.hs_code.local_code)
 
     # TODO: Remove if a test is added in intrastat_product to test it
+    @mute_logger("odoo.models.unlink")
     def test_report_creation_dispatches_notes_and_lines(self):
         # Generate report
         self.product.origin_country_id = False
@@ -275,6 +277,13 @@ class TestL10nIntraStatReport(AccountTestInvoicingCommon):
             self.assertNotIn(expected_note, report_dispatches.note)
 
     def test_report_creation_arrivals(self):
+        # You must enable the language to check the values at the end
+        self.env.ref("base.lang_es").active = True
+        # We change the invoice amount to verify the values at the end
+        for invoice in self.invoices["arrivals"]["invoices"]:
+            invoice.button_draft()
+            invoice.invoice_line_ids.price_unit = 1000
+            invoice.action_post()
         # Generate report
         report_arrivals = self._create_declaration("arrivals")
         report_arrivals.action_gather()
@@ -296,6 +305,8 @@ class TestL10nIntraStatReport(AccountTestInvoicingCommon):
             self.invoices["arrivals"][self.partner_1.country_id],
             self.invoices["arrivals"][self.partner_2.country_id],
         )
+        # We change the weight to check the value of the csv later
+        report_arrivals.declaration_line_ids.weight = 1000
         csv_result = report_arrivals._generate_csv()
         csv_lines = csv_result.decode("utf-8").rstrip().splitlines()
         self.assertEqual(len(csv_lines), 2)
@@ -303,3 +314,6 @@ class TestL10nIntraStatReport(AccountTestInvoicingCommon):
             items = line.split(";")
             self.assertTrue(items[0] in ("PT", "FR"))
             self.assertEqual(items[6], self.hs_code.local_code)
+            self.assertEqual(items[9], "1000,00")
+            self.assertEqual(items[11], "2000,00")
+            self.assertEqual(items[12], "2000,00")


### PR DESCRIPTION
FWP de 17.0: https://github.com/OCA/l10n-spain/pull/4950

Convertir valores a 2 decimales

Relacionado con https://github.com/OCA/intrastat-extrastat/commit/ee34b6dd6e34e84ebc87c8ac26c512f3fdbdeeff

@Tecnativa TT61896