### PR TITLE
[18.0][FIX] l10n_es_pos_sii: Adjust tax calculation for tax included

### DIFF
--- a/l10n_es_pos_sii/models/pos_order.py
+++ b/l10n_es_pos_sii/models/pos_order.py
@@ -123,19 +123,24 @@ class PosOrder(models.Model):
         for line in self.lines:
             if not line.tax_ids_after_fiscal_position:
                 continue
+            if line.tax_ids_after_fiscal_position.filtered("price_include"):
+                # Due to the way Odoo computes taxes and totals in PoS orders, the
+                # most similar option for getting proper base and amount information
+                # is to round by line
+                rounding_method = "round_per_line"
+            else:
+                rounding_method = line.company_id.tax_calculation_rounding_method
             line_taxes = line.tax_ids_after_fiscal_position.sudo().compute_all(
                 line.price_unit * (1 - (line.discount or 0.0) / 100.0),
-                line.order_id.pricelist_id.currency_id or self.session_id.currency_id,
+                line.order_id.currency_id,
                 line.qty,
                 product=line.product_id,
                 partner=self._aeat_get_partner(),
+                rounding_method=rounding_method,
             )
             for line_tax in line_taxes["taxes"]:
                 tax = self.env["account.tax"].browse(line_tax["id"])
-                taxes.setdefault(
-                    tax,
-                    {"tax": tax, "amount": 0.0, "base": 0.0},
-                )
+                taxes.setdefault(tax, {"tax": tax, "amount": 0.0, "base": 0.0})
                 taxes[tax]["amount"] += line_tax["amount"]
                 taxes[tax]["base"] += line_tax["base"]
         return taxes


### PR DESCRIPTION
When taxes are included in the price, and the tax rounding is set to global, there's a chance of not getting the expected results through the bare call to `compute_all` method due to rounding inaccuracies.

As we can't follow the same approach as the invoices, as they rely on the generation of the move lines for computing everything, the most similar option is to round each line.

Let's see one example:

Line 1: 15 € with 21% VAT included
Line 2: 15 € with 21% VAT included
Total: 30 €

These are the amounts returned from the method:

- Base amount: 12.396694214876034
- Tax amount: 2.6

Curiously, the tax amount seems rounded, but the base not.

Summing both lines, we get:

Base amount: 24.79338843 > 24.79
Tax amount: 5.2
Total: 29.99

Passing the parameter to round by line, the base is round to 12.40 (the same as shown in the order backend in the line), and then the sum is correct: 24.80 + 5.2

Tested in several cases, and it seems to be correct in all of them. It has been limited to the cases where the tax is included in the price for not having impact at all in the rest of the cases.

@Tecnativa TT63335