### PR TITLE
[19.0][FIX] delivery_dhl_parcel: show DHL error message on HTTP errors

### DIFF
--- a/delivery_dhl_parcel/models/dhl_parcel_request.py
+++ b/delivery_dhl_parcel/models/dhl_parcel_request.py
@@ -67,11 +67,11 @@ class DhlParcelRequest:
                 self.env._("Server not reachable, please try again later")
             ) from None
         except requests.exceptions.HTTPError as e:
-            error_message = self.env._(
-                "%(error)s\n%(message)s",
-                error=str(e),
-                message=res.json().get("Message", "") if res and res.text else "",
+            error = str(e)
+            message = (
+                res.json().get("Message", "") if res is not None and res.text else ""
             )
+            error_message = f"{error}\n{message}"
             raise UserError(error_message) from None
         return res
 


### PR DESCRIPTION
When DHL returns an HTTP error response, the connector may omit the error
message returned by the API.

This happens because `requests.Response` objects evaluate to `False` for
4xx/5xx responses, so the previous `if res and res.text` condition skipped
the response body even when DHL returned a JSON payload with a `Message`.

This change checks explicitly that the response is not `None`, allowing the
DHL error message to be included in the `UserError`.


Before:
<img width="697" height="181" alt="image" src="https://github.com/user-attachments/assets/1f7e4828-54d9-4065-adb3-4678f419d8c4" />

After:
<img width="758" height="196" alt="image" src="https://github.com/user-attachments/assets/dcd7bdde-a9fa-44e2-bb77-67b86c241e8b" />
