### PR TITLE
[17.0][IMP] l10n_es_verifactu_oca: Exempt causes + better classification

### DIFF
--- a/l10n_es_verifactu_oca/data/verifactu.map.line.csv
+++ b/l10n_es_verifactu_oca/data/verifactu.map.line.csv
@@ -1,8 +1,8 @@
 id,code,name,tax_xmlid_ids:id,verifactu_map_id:id
-"verifactu_map_line_S1","S1","Operación Sujeta y No exenta - Sin inversión del sujeto pasivo.","s_iva21b,s_iva0b,s_iva2b,s_iva4b,s_iva5b,s_iva7-5b,s_iva10b,s_iva21s,s_iva10s,s_iva0s,s_iva2s,s_iva4s,s_iva5s,s_iva7-5s,s_iva0_g_i,s_iva0_sp_i,s_iva0_g_e,s_iva_e","verifactu_map"
+"verifactu_map_line_S1","S1","Operación Sujeta y No exenta - Sin inversión del sujeto pasivo.","s_iva21b,s_iva0b,s_iva2b,s_iva4b,s_iva5b,s_iva7-5b,s_iva10b,s_iva21s,s_iva10s,s_iva0s,s_iva2s,s_iva4s,s_iva5s,s_iva7-5s,s_iva0_g_i,s_iva0_g_e","verifactu_map"
 "verifactu_map_line_S2","S2","Operación Sujeta y No exenta - Con Inversión del sujeto pasivo","s_iva0_isp","verifactu_map"
 "verifactu_map_line_N1","N1","Operación No Sujeta artículo 7, 14, otros.",,"verifactu_map"
-"verifactu_map_line_N2","N2","Operación No Sujeta por Reglas de localización.","s_iva_ns_b,s_iva_ns","verifactu_map"
+"verifactu_map_line_N2","N2","Operación No Sujeta por Reglas de localización.","s_iva_e,s_iva0_sp_i,s_iva_ns_b,s_iva_ns","verifactu_map"
 "verifactu_map_line_RE","RE","Recargo Equivalencia","s_req52,s_req014,s_req062,s_req1,s_req05,s_req026,s_req0","verifactu_map"
 "verifactu_map_line_tax_not_included","TaxNotIncludedInTotal","Impuestos no incluidos en ImporteTotal","s_irpf1,s_irpf2,s_irpf7,s_irpf9,s_irpf15,s_irpf18,s_irpf19,s_irpf19a,s_irpf195a,s_irpf20,s_irpf20a,s_irpf21,s_irpf21a,s_irpf24,s_irpfnrnue24,s_irpfnrue19","verifactu_map"
-"verifactu_map_line_base_not_included","BaseNotIncludedInTotal","Bases no incluidas en ImporteTotal","s_iva0_art22,s_iva0_art23,s_iva0_g_e,s_iva0_g_i,s_iva0_nsd,s_iva0_ns","verifactu_map"
+"verifactu_map_line_base_not_included","BaseNotIncludedInTotal","Bases no incluidas en ImporteTotal","s_iva0_art22,s_iva0_art23,s_iva0_nsd,s_iva0_ns","verifactu_map"

--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -12,6 +12,15 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 VERIFACTU_VALID_INVOICE_STATES = ["posted"]
+VERIFACTU_OPERATION_MAPPING = {
+    "sujeto": "S1",
+    "sujeto_agricultura": "S1",
+    "sujeto_isp": "S2",
+    "no_sujeto": "N1",
+    "no_sujeto_loc": "N2",
+    "no_deducible": "S1",
+    # Not included here: exento, retencion, recargo, dua & ignore
+}
 
 
 class AccountMove(models.Model):
@@ -336,34 +345,25 @@ class AccountMove(models.Model):
         """
         tax = tax_line["tax"]
         tax_base_amount = tax_line["base"]
+        tax_dict = {"BaseImponibleOimporteNoSujeto": tax_base_amount}
+        operation_type = VERIFACTU_OPERATION_MAPPING.get(tax.l10n_es_type)
+        if tax.l10n_es_type == "exento":
+            tax_dict["OperacionExenta"] = tax.l10n_es_exempt_reason
+            return tax_dict
+        tax_dict["CalificacionOperacion"] = operation_type
+        if operation_type in ("N1", "N2"):
+            return tax_dict
         if tax.amount_type == "group":
-            tax_type = abs(tax.children_tax_ids.filtered("amount")[:1].amount)
+            tax_percentage = abs(tax.children_tax_ids.filtered("amount")[:1].amount)
         else:
-            tax_type = abs(tax.amount)
-        tax_dict = {
-            "TipoImpositivo": str(tax_type),
-            "BaseImponibleOimporteNoSujeto": tax_base_amount,
-        }
-        key = "CuotaRepercutida"
-        tax_dict[key] = tax_line["amount"]
+            tax_percentage = abs(tax.amount)
+        tax_dict["TipoImpositivo"] = str(tax_percentage)
+        tax_dict["CuotaRepercutida"] = tax_line["amount"]
         # Recargo de equivalencia
         req_tax = self._get_verifactu_tax_req(tax)
         if req_tax:
             tax_dict["TipoRecargoEquivalencia"] = req_tax.amount
             tax_dict["CuotaRecargoEquivalencia"] = tax_lines[req_tax]["amount"]
-        return tax_dict
-
-    def _get_verifactu_tax_dict_ns(self, tax_line):
-        """Get the VERI*FACTU tax dictionary for the passed tax line.
-
-        :param self: Single invoice record.
-        :param tax_line: Tax line that is being analyzed.
-        :return: A dictionary with the corresponding VERI*FACTU tax values.
-        """
-        tax_base_amount = tax_line["base"]
-        tax_dict = {
-            "BaseImponibleOimporteNoSujeto": tax_base_amount,
-        }
         return tax_dict
 
     def _get_verifactu_tax_req(self, tax):
@@ -405,26 +405,17 @@ class AccountMove(models.Model):
         breakdown_taxes = taxes_S1 + taxes_S2 + taxes_N1 + taxes_N2
         not_in_amount_total = 0.0
         not_in_taxes = 0.0
-        for tax_line in tax_lines.values():
-            tax = tax_line["tax"]
+        for tax, tax_line in tax_lines.items():
             if tax in taxes_not_in_total:
                 not_in_amount_total += tax_line["amount"]
             elif tax in base_not_in_total:
                 not_in_amount_total += tax_line["base"]
             if tax in breakdown_taxes:
-                operation_type = self._get_verifactu_operation_type(
-                    tax_line, taxes_S1, taxes_S2, taxes_N1, taxes_N2
-                )
                 tax_dict = {
                     "Impuesto": self.verifactu_tax_key,
                     "ClaveRegimen": self.verifactu_registration_key_code,
-                    "CalificacionOperacion": operation_type,
                 }
-                if operation_type not in ("N1", "N2"):
-                    new_tax_dict = self._get_verifactu_tax_dict(tax_line, tax_lines)
-                    tax_dict.update(new_tax_dict)
-                else:
-                    tax_dict.update(self._get_verifactu_tax_dict_ns(tax_line))
+                tax_dict.update(self._get_verifactu_tax_dict(tax_line, tax_lines))
                 taxes_dict["DetalleDesglose"].append(tax_dict)
             elif tax in excluded_taxes:
                 not_in_taxes += tax_line["amount"]
@@ -432,31 +423,7 @@ class AccountMove(models.Model):
                 raise UserError(_("%s tax is not mapped to VERI*FACTU.", tax.name))
         amount_tax = self.amount_tax_signed - not_in_taxes
         amount_total = self.amount_total_signed - not_in_amount_total
-        return (
-            taxes_dict,
-            amount_tax,
-            amount_total,
-        )
-
-    def _get_verifactu_operation_type(
-        self, tax_line, taxes_S1, taxes_S2, taxes_N1, taxes_N2
-    ):
-        """
-        S1	Operación Sujeta y No exenta - Sin inversión del sujeto pasivo.
-        S2	Operación Sujeta y No exenta - Con Inversión del sujeto pasivo
-        N1	Operación No Sujeta artículo 7, 14, otros.
-        N2	Operación No Sujeta por Reglas de localización.
-        """
-        tax = tax_line["tax"]
-        if tax in taxes_S1:
-            return "S1"
-        elif tax in taxes_S2:
-            return "S2"
-        elif tax in taxes_N1:
-            return "N1"
-        elif tax in taxes_N2:
-            return "N2"
-        return "S1"
+        return (taxes_dict, amount_tax, amount_total)
 
     def _get_verifactu_receiver_dict(self):
         self.ensure_one()

--- a/l10n_es_verifactu_oca/tests/common.py
+++ b/l10n_es_verifactu_oca/tests/common.py
@@ -21,9 +21,14 @@ class TestVerifactuCommon(TestL10nEsAeatModBase, TestL10nEsAeatCertificateBase):
         cls.fp_registration_key_01 = cls.env.ref(
             "l10n_es_verifactu_oca.verifactu_registration_keys_01"
         )
+        cls.fp_registration_key_02 = cls.env.ref(
+            "l10n_es_verifactu_oca.verifactu_registration_keys_02"
+        )
         cls.fp_nacional.verifactu_registration_key = cls.fp_registration_key_01
         cls.fp_recargo = cls.env.ref(f"account.{cls.company.id}_fp_recargo")
         cls.fp_recargo.verifactu_registration_key = cls.fp_registration_key_01
+        cls.fp_extra = cls.env.ref(f"account.{cls.company.id}_fp_extra")
+        cls.fp_extra.verifactu_registration_key = cls.fp_registration_key_02
         cls.partner = cls.env["res.partner"].create(
             {
                 "name": "Test partner",

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_g_e_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_g_e_dict.json
@@ -1,0 +1,49 @@
+{
+  "RegistroAlta": {
+    "IDVersion": 1.0,
+    "IDFactura": {
+      "IDEmisorFactura": "G87846952",
+      "NumSerieFactura": "TEST_EXEMPT_002",
+      "FechaExpedicionFactura": "01-01-2026"
+    },
+    "NombreRazonEmisor": "Spanish test company",
+    "TipoFactura": "F1",
+    "DescripcionOperacion": "/",
+    "Destinatarios": {
+      "IDDestinatario": {
+        "NombreRazon": "Test partner",
+        "NIF": "89890001K"
+      }
+    },
+    "Desglose": {
+      "DetalleDesglose": [
+        {
+          "Impuesto": "01",
+          "ClaveRegimen": "01",
+          "BaseImponibleOimporteNoSujeto": 200.0,
+          "OperacionExenta": "E2"
+        }
+      ]
+    },
+    "CuotaTotal": 0.0,
+    "ImporteTotal": 200.0,
+    "Encadenamiento": {
+      "PrimerRegistro": "S"
+    },
+    "SistemaInformatico": {
+      "NombreRazon": "Odoo Developer",
+      "NIF": "A12345674",
+      "NombreSistemaInformatico": "odoo",
+      "IdSistemaInformatico": "11",
+      "Version": "1.0",
+      "NumeroInstalacion": 1,
+      "TipoUsoPosibleSoloVerifactu": "S",
+      "TipoUsoPosibleMultiOT": "S",
+      "IndicadorMultiplesOT": "N",
+      "IDOtro": {
+        "IDType": "",
+        "ID": ""
+      }
+    }
+  }
+}

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_g_i_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_g_i_dict.json
@@ -1,0 +1,49 @@
+{
+  "RegistroAlta": {
+    "IDVersion": 1.0,
+    "IDFactura": {
+      "IDEmisorFactura": "G87846952",
+      "NumSerieFactura": "TEST_EXEMPT_001",
+      "FechaExpedicionFactura": "01-01-2026"
+    },
+    "NombreRazonEmisor": "Spanish test company",
+    "TipoFactura": "F1",
+    "DescripcionOperacion": "/",
+    "Destinatarios": {
+      "IDDestinatario": {
+        "NombreRazon": "Test partner",
+        "NIF": "89890001K"
+      }
+    },
+    "Desglose": {
+      "DetalleDesglose": [
+        {
+          "Impuesto": "01",
+          "ClaveRegimen": "02",
+          "BaseImponibleOimporteNoSujeto": 200.0,
+          "OperacionExenta": "E5"
+        }
+      ]
+    },
+    "CuotaTotal": 0.0,
+    "ImporteTotal": 200.0,
+    "Encadenamiento": {
+      "PrimerRegistro": "S"
+    },
+    "SistemaInformatico": {
+      "NombreRazon": "Odoo Developer",
+      "NIF": "A12345674",
+      "NombreSistemaInformatico": "odoo",
+      "IdSistemaInformatico": "11",
+      "Version": "1.0",
+      "NumeroInstalacion": 1,
+      "TipoUsoPosibleSoloVerifactu": "S",
+      "TipoUsoPosibleMultiOT": "S",
+      "IndicadorMultiplesOT": "N",
+      "IDOtro": {
+        "IDType": "",
+        "ID": ""
+      }
+    }
+  }
+}

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva_ns_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva_ns_dict.json
@@ -1,0 +1,49 @@
+{
+  "RegistroAlta": {
+    "IDVersion": 1.0,
+    "IDFactura": {
+      "IDEmisorFactura": "G87846952",
+      "NumSerieFactura": "TEST_EXPORT",
+      "FechaExpedicionFactura": "01-01-2026"
+    },
+    "NombreRazonEmisor": "Spanish test company",
+    "TipoFactura": "F1",
+    "DescripcionOperacion": "/",
+    "Destinatarios": {
+      "IDDestinatario": {
+        "NombreRazon": "Test partner",
+        "NIF": "89890001K"
+      }
+    },
+    "Desglose": {
+      "DetalleDesglose": [
+        {
+          "Impuesto": "01",
+          "ClaveRegimen": "02",
+          "CalificacionOperacion": "N2",
+          "BaseImponibleOimporteNoSujeto": 200.0
+        }
+      ]
+    },
+    "CuotaTotal": 0.0,
+    "ImporteTotal": 200.0,
+    "Encadenamiento": {
+      "PrimerRegistro": "S"
+    },
+    "SistemaInformatico": {
+      "NombreRazon": "Odoo Developer",
+      "NIF": "A12345674",
+      "NombreSistemaInformatico": "odoo",
+      "IdSistemaInformatico": "11",
+      "Version": "1.0",
+      "NumeroInstalacion": 1,
+      "TipoUsoPosibleSoloVerifactu": "S",
+      "TipoUsoPosibleMultiOT": "S",
+      "IndicadorMultiplesOT": "N",
+      "IDOtro": {
+        "IDType": "",
+        "ID": ""
+      }
+    }
+  }
+}

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -165,6 +165,63 @@ class TestL10nEsAeatVerifactu(TestVerifactuCommon):
         self.company.verifactu_start_date = False
         self.assertTrue(invoice2.verifactu_enabled)
 
+    def test_verifactu_export_invoice_data(self):
+        mapping = [
+            (
+                "TEST_EXPORT",
+                "out_invoice",
+                [(200, ["s_iva_ns"])],
+                {
+                    "fiscal_position_id": self.fp_extra.id,
+                    "verifactu_registration_key": self.fp_registration_key_02.id,
+                    "verifactu_registration_date": "2026-01-01 19:20:30",
+                },
+            )
+        ]
+        for name, inv_type, lines, extra_vals in mapping:
+            self._create_and_test_invoice_verifactu_dict(
+                name, inv_type, lines, extra_vals
+            )
+
+    def test_verifactu_with_exemption_cause_e5_invoice_data(self):
+        # test exemption cause E5
+        mapping = [
+            (
+                "TEST_EXEMPT_001",
+                "out_invoice",
+                [(200, ["s_iva0_g_i"])],
+                {
+                    "fiscal_position_id": self.fp_extra.id,
+                    "verifactu_registration_key": self.fp_registration_key_02.id,
+                    "verifactu_registration_date": "2026-01-01 19:20:30",
+                },
+            )
+        ]
+        for name, inv_type, lines, extra_vals in mapping:
+            self._create_and_test_invoice_verifactu_dict(
+                name, inv_type, lines, extra_vals
+            )
+
+    def test_verifactu_with_exemption_cause_e2_invoice_data(self):
+        # test exemption cause E2
+        mapping_2 = [
+            (
+                "TEST_EXEMPT_002",
+                "out_invoice",
+                [(200, ["s_iva0_g_e"])],
+                {
+                    "fiscal_position_id": self.fp_nacional.id,
+                    "verifactu_registration_key": self.fp_registration_key_01.id,
+                    "verifactu_registration_date": "2026-01-01 19:20:30",
+                },
+            )
+        ]
+        for name, inv_type, lines, extra_vals in mapping_2:
+            self._create_and_test_invoice_verifactu_dict(
+                name, inv_type, lines, extra_vals
+            )
+        return
+
 
 class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):
     def _get_required_qr_params(self):


### PR DESCRIPTION
Adaptation of #4499 now using the exempt causes already included in this Odoo version.

There's a mix between the mapping included in this module and the one that Odoo provides, but let's keep it for now. Odoo definition is static, while the mapping provided here can be planned for future changes, but no changes have occurred meanwhile, as it's very stable since SII, so we may want to remove that complex part, and restore it only if needed in the future.

@Tecnativa 