### PR TITLE
[18.0][IMP] l10n_es_pos_oca: No offline force simplified number increase

### DIFF
--- a/l10n_es_pos_oca/models/pos_config.py
+++ b/l10n_es_pos_oca/models/pos_config.py
@@ -144,3 +144,9 @@ class PosConfig(models.Model):
     def _get_l10n_es_sequence_name(self):
         """HACK: This is done for getting the proper translation."""
         return _("Simplified Invoice %s")
+
+    def next_l10n_es_sequence_number(self):
+        seq = self.l10n_es_simplified_invoice_sequence_id
+        number_actual = seq._get_current_sequence().number_next_actual
+        seq.next_by_id()
+        return number_actual

--- a/l10n_es_pos_oca/models/pos_order.py
+++ b/l10n_es_pos_oca/models/pos_order.py
@@ -51,7 +51,6 @@ class PosOrder(models.Model):
         simplified_invoice_number = pos_order.get("l10n_es_unique_id", False)
         if not simplified_invoice_number:
             return super()._process_order(pos_order, existing_order)
-
         pos_order_obj = self.env["pos.order"]
         pos = self.env["pos.session"].browse(pos_order.get("session_id")).config_id
 
@@ -64,5 +63,6 @@ class PosOrder(models.Model):
                     "is_l10n_es_simplified_invoice": True,
                 }
             )
-            self._update_sequence_number(pos)
+            if not pos.prevent_offline_validation:
+                self._update_sequence_number(pos)
         return super()._process_order(pos_order, existing_order)

--- a/l10n_es_pos_oca/static/src/app/store/pos_store.esm.js
+++ b/l10n_es_pos_oca/static/src/app/store/pos_store.esm.js
@@ -85,14 +85,28 @@ patch(PosStore.prototype, {
     async getSimpleInvNextNumber() {
         // First, get the next number from the DB to be sure we have the latest
         try {
-            const config = await this.data.searchRead(
-                "pos.config",
-                [["id", "=", this.config.id]],
-                ["l10n_es_simplified_invoice_number"]
-            );
+            if (this.config.prevent_offline_validation) {
+                // Execute pos.l10n_es_simplified_invoice_sequence_id.next_by_id() directly
+                // as on this mode there should be no pending orders
+                var l10n_es_simplified_invoice_number = await this.data.call(
+                    "pos.config",
+                    "next_l10n_es_sequence_number",
+                    [this.config.id],
+                    {}
+                );
+            } else {
+                const config = await this.data.searchRead(
+                    "pos.config",
+                    [["id", "=", this.config.id]],
+                    ["l10n_es_simplified_invoice_number"]
+                );
+
+                var l10n_es_simplified_invoice_number =
+                    config[0]?.l10n_es_simplified_invoice_number || 1;
+            }
 
             this.config.l10n_es_simplified_invoice_number =
-                config[0]?.l10n_es_simplified_invoice_number || 1;
+                l10n_es_simplified_invoice_number || 1;
         } catch (error) {
             // Throw error if it's a connection lost error and we want to prevent offline validation
             if (
@@ -123,8 +137,6 @@ patch(PosStore.prototype, {
                 this.config.l10n_es_simplified_invoice_number =
                     simplifiedInvNumFromOrderPending;
             }
-
-            return Promise.reject(new ConnectionLostError());
         }
 
         return this.config.l10n_es_simplified_invoice_number;


### PR DESCRIPTION
Hemos detectado que si tenemos un mismo tpv con múltiples sesiones, en ocasiones el número de factura simplificada puede llegarse a duplicar. Esto es debido a que realizamos 2 llamadas al config, para preguntar por el número actual y otra para incrementarlo. 
Esto no supone ningún tipo de problema para 1 solo TPV que permita validar offline.

El cambio propuesto plantea que cuando tengamos marcado el check "Prevenir validación offline" en lugar de solo consultar el número también incremente el valor del mismo. Asegurándonos de esta manera que no se puedan duplicar números de factura simplificada al procesar múltiples pedidos a la vez.

@Tecnativa TT63323
@pedrobaeza 