### PR TITLE
[19.0][FIX] l10n_es_aeat_sii_oca: Ocultar facturas no enviadas y no publicadas en el dashboard del diario

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_journal.py
+++ b/l10n_es_aeat_sii_oca/models/account_journal.py
@@ -23,7 +23,7 @@ class AccountJournal(models.Model):
             Domain("journal_id", "in", journals.ids)
             & Domain("sii_enabled", "=", True)
             & (
-                Domain("aeat_state", "=", "not_sent")
+                (Domain("aeat_state", "=", "not_sent") & Domain("state", "=", "posted"))
                 | Domain("aeat_send_failed", "=", True)
             )
         )

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -613,13 +613,16 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.company.sii_start_date = "2018-01-01"
         invoice1 = self._create_invoice("out_invoice")
         invoice1.invoice_date = "2019-01-01"
+        invoice1._post()
         invoice2 = self._create_invoice("out_invoice")
         invoice2.invoice_date = "2017-01-01"
+        invoice2._post()
         invoice3 = self._create_invoice("out_invoice")
         invoice3.invoice_date = "2019-06-01"
         invoice3.aeat_send_failed = True
+        invoice3._post()
         dashboard_data = {invoice1.journal_id.id: {}}
         invoice1.journal_id._fill_sale_purchase_dashboard_data(dashboard_data)
         data = dashboard_data.get(invoice1.journal_id.id, {})
-        self.assertEqual(data.get("number_not_sent"), 4)
+        self.assertEqual(data.get("number_not_sent"), 3)
         self.assertEqual(data.get("number_aeat_failed"), 1)


### PR DESCRIPTION
## Descripción

En el dashboard SII del diario se mostraban las facturas que todavía no se habían enviado al SII aunque no estuvieran publicadas. Esto generaba ruido en la contabilidad: el responsable veía una lista muy larga en la que la mayoría de documentos no requerían ninguna acción por su parte.

Con este cambio el dashboard muestra únicamente las facturas que realmente necesitan seguimiento del SII:

- Facturas publicadas que **aún no se han enviado** al SII.

Se ocultan del dashboard las facturas en borrador o canceladas que nunca se han enviado al SII.

## Motivación

En una empresa con un volumen alto de facturas, el dashboard SII se volvía inutilizable porque listaba cientos de facturas que ya estaban correctamente tramitadas. El usuario tenía que filtrar manualmente para encontrar las facturas que requerían acción, lo que aumentaba el riesgo de olvidar facturas pendientes y de dedicar tiempo a revisar facturas ya cerradas.

@chienandalu @ArantxaSudon  @Gelojr @pedrobaeza pódeis revisarlo por favor. Gracias.

MT-15131 @moduon