### PR TITLE
[19.0][FIX] l10n_es_aeat_sii_oca: DUA exempt tax in sii_enabled search

### DIFF
--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -743,6 +743,18 @@ class AccountMove(models.Model):
         conditions = [domain, condition_1, condition_2]
         if condition_3:
             conditions.append(condition_3)
+        if not search_ko:
+            dua_conditions = []
+            for company in self.env.companies.filtered("sii_enabled"):
+                dua_exempt_tax = company._get_tax_id_from_xmlid(
+                    "account_tax_template_p_dua_exempt"
+                )
+                if dua_exempt_tax:
+                    dua_conditions.append(dua_exempt_tax)
+            if dua_conditions:
+                conditions.append(
+                    [("invoice_line_ids.tax_ids", "not in", dua_conditions)]
+                )
         return Domain.AND(
             [[("move_type", "in", invoice_types)], exp_condition(conditions)]
         )

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -753,7 +753,20 @@ class AccountMove(models.Model):
                     dua_conditions.append(dua_exempt_tax)
             if dua_conditions:
                 conditions.append(
-                    [("invoice_line_ids.tax_ids", "not in", dua_conditions)]
+                    [
+                        (
+                            "invoice_line_ids",
+                            "not any",
+                            [
+                                (
+                                    "display_type",
+                                    "not in",
+                                    ["line_section", "line_note"],
+                                ),
+                                ("tax_ids", "in", dua_conditions),
+                            ],
+                        )
+                    ]
                 )
         return Domain.AND(
             [[("move_type", "in", invoice_types)], exp_condition(conditions)]


### PR DESCRIPTION
Añade la condición del impuesto *Dua exento* en el método search `_search_sii_enabled` como también está en el método compute `_compute_sii_enabled`.

Antes en facturas con el impuesto *Dua exento* había incompatibilidades como que el campo `sii_enabled` estuviera a False y al buscar por ese campo devolviera True

¿@pedrobaeza @chienandalu podéis revisar por favor? Gracias

MT-15131 @moduon