### PR TITLE
[17.0][IMP] l10n_es_atc_mod417: Allow payment type 4 (Domiciliación bancaria)

### DIFF
--- a/l10n_es_atc_mod417/__manifest__.py
+++ b/l10n_es_atc_mod417/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": "ATC Modelo 417",
-    "version": "17.0.1.2.3",
+    "version": "17.0.1.2.4",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "category": "Accounting",
     "website": "https://github.com/OCA/l10n-spain",

--- a/l10n_es_atc_mod417/migrations/17.0.1.2.4/pre-migration.py
+++ b/l10n_es_atc_mod417/migrations/17.0.1.2.4/pre-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2026 Tecnativa - Carlos Lopez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    cr.execute(
+        """
+        UPDATE l10n_es_atc_mod417_report SET partner_bank_id = bank_account_id
+        WHERE bank_account_id IS NOT NULL AND partner_bank_id IS NULL;"""
+    )

--- a/l10n_es_atc_mod417/models/mod417.py
+++ b/l10n_es_atc_mod417/models/mod417.py
@@ -130,10 +130,6 @@ class L10nEsAtcmod417Report(models.Model):
         string="Result type",
         compute="_compute_result_type",
     )
-    bank_account_id = fields.Many2one(
-        comodel_name="res.partner.bank",
-        string="Bank account",
-    )
     counterpart_account_id = fields.Many2one(
         comodel_name="account.account",
         string="Counterpart account",
@@ -194,16 +190,8 @@ class L10nEsAtcmod417Report(models.Model):
 
     def button_confirm(self):
         """Check records"""
-        msg = ""
         for mod417 in self:
-            if mod417.result_type == "I" and not mod417.bank_account_id:
-                msg = _("Select an account for making the charge")
-            if mod417.result_type == "D" and not mod417.bank_account_id:
-                msg = _("Select an account for receiving the money")
-        if msg:
-            # Don't raise error, because data is not used
-            # raise exceptions.Warning(msg)
-            pass
+            mod417._atc_validate_fields()
         return super().button_confirm()
 
     @api.model
@@ -238,7 +226,11 @@ class L10nEsAtcmod417Report(models.Model):
         messages = super()._atc_get_messages()
         if not self.payment_type and self.resultado_autoliquidacion > 0:
             messages.append(_("- Select a payment type"))
-        if self.output_type == "T" and self.payment_type and self.payment_type != "5":
+        if (
+            self.output_type == "T"
+            and self.payment_type
+            and self.payment_type not in ["4", "5"]
+        ):
             messages.append(
                 _(
                     "- The selected payment type "
@@ -246,4 +238,9 @@ class L10nEsAtcmod417Report(models.Model):
                     "Please select a different payment type."
                 )
             )
+        if self._is_partner_bank_required() and not self.partner_bank_id:
+            messages.append(_("- Select a bank account"))
         return messages
+
+    def _is_partner_bank_required(self):
+        return self.payment_type == "4" and self.result_type in ["I", "D"]

--- a/l10n_es_atc_mod417/reports/mod417_report.xml
+++ b/l10n_es_atc_mod417/reports/mod417_report.xml
@@ -129,6 +129,7 @@
                 t-att-TIP="'S' if doc.result_type == 'N' else doc.result_type"
                 t-att-IMP="doc._format_amount(abs(doc.resultado_autoliquidacion))"
                 t-att-FPA="doc.payment_type"
+                t-att-IBAN="doc.partner_bank_id.sanitized_acc_number if doc._is_partner_bank_required() else None"
             />
             <!-- TODO: support for SAF, ACT_EST, OPE, ACT_PRO, ACT_DED? -->
         </DEC>

--- a/l10n_es_atc_mod417/tests/test_l10n_es_atc_mod417.py
+++ b/l10n_es_atc_mod417/tests/test_l10n_es_atc_mod417.py
@@ -445,6 +445,12 @@ class TestL10nEsAeatmod417(TestL10nEsAtcmod417Base):
         cls._invoice_sale_create("2017-01-12")
         sale = cls._invoice_sale_create("2017-01-13")
         cls._invoice_refund(sale, "2017-01-14")
+        cls.bank_account = cls.env["res.partner.bank"].create(
+            {
+                "acc_number": "ES9121000418450200051332",
+                "partner_id": cls.model417.company_id.partner_id.id,
+            }
+        )
 
     @classmethod
     def _request_handler(cls, s, r, /, **kw):
@@ -615,6 +621,7 @@ class TestL10nEsAeatmod417(TestL10nEsAtcmod417Base):
         self.assertEqual(res_node[0].attrib["TIP"], "I")
         self.assertEqual(res_node[0].attrib["IMP"], "78385")
         self.assertEqual(res_node[0].attrib["FPA"], "5")
+        self.assertFalse(res_node[0].attrib.get("IBAN"))
 
     @freeze_time("2026-01-01")
     def test_model_417_declaration_pdf(self):
@@ -664,6 +671,22 @@ class TestL10nEsAeatmod417(TestL10nEsAtcmod417Base):
             UserError, r".*payment type is not compatible with the output type.*"
         ):
             self.model417.action_generar_mod417()
+        self.model417.payment_type = "4"  # Domiciliación bancaria
+        with self.assertRaisesRegex(UserError, r".*Select a bank account.*"):
+            self.model417.action_generar_mod417()
+        self.model417.partner_bank_id = self.bank_account
+        report_name = "l10n_es_atc_mod417.mod417_report_xml"
+        xml_data = self.env["ir.actions.report"]._render_qweb_xml(
+            report_name, self.model417.ids
+        )[0]
+        # Parse the XML data and check the values
+        doc = etree.XML(xml_data)
+        dec_node = doc.xpath("//DEC")
+        self.assertEqual(len(dec_node), 1)
+        dec_node = dec_node[0]
+        res_node = dec_node.xpath("//RES")
+        self.assertEqual(len(res_node), 1)
+        self.assertEqual(res_node[0].attrib["IBAN"], "ES9121000418450200051332")
         self.model417.payment_type = "5"  # Pago telemático
         # In oca-ci, we have an issue: https://github.com/OCA/oca-ci/issues/94
         # Read the ROADMAP for more information.

--- a/l10n_es_atc_mod417/views/mod417_view.xml
+++ b/l10n_es_atc_mod417/views/mod417_view.xml
@@ -38,6 +38,9 @@
             <field name="export_config_id" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
+            <xpath expr="//field[@name='partner_bank_id']" position="attributes">
+                <attribute name="readonly">state == 'done'</attribute>
+            </xpath>
             <field name="statement_type" position="after">
                 <field
                     name="output_type"
@@ -90,13 +93,6 @@
                     />
                     <field name="result_type" />
                     <field name="company_partner_id" invisible="1" />
-                    <field
-                        name="bank_account_id"
-                        domain="[('partner_id', '=', company_partner_id)]"
-                        invisible="result_type not in ('D', 'B', 'I')"
-                        required="result_type == 'D'"
-                        readonly="state == 'done'"
-                    />
                 </group>
                 <field
                     name="tax_line_ids"


### PR DESCRIPTION
When the payment type is 4, a bank account is required, and the IBAN is included in the generated XML.

Remove the use of bank_account_id and use partner_bank_id instead.

TT63445
@Tecnativa @pedrobaeza @carlosdauden @christian-ramos-tecnativa could you please review this?