### PR TITLE
[18.0][IMP] l10n_es_aeat: improve display name of tax xmlid mapping entries

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_map_tax_line.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_map_tax_line.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2018 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class L10nEsAeatMapTaxLine(models.Model):
@@ -94,6 +94,20 @@ class L10nEsAeatMapTaxLineTax(models.Model):
     _description = "AEAT tax mapping line - Tax"
 
     name = fields.Char()
+
+    @api.depends("name")
+    @api.depends_context("allowed_company_ids")
+    def _compute_display_name(self):
+        company = self.env.company
+        self.display_name = False
+        for rec in self.filtered("name"):
+            tax_id = company._get_tax_id_from_xmlid(rec.name)
+            if tax_id:
+                tax = self.env["account.tax"].browse(tax_id)
+                rec.display_name = f"{tax.name} [{rec.name}]"
+            else:
+                clean = rec.name.replace("account_tax_template_", "")
+                rec.display_name = clean
 
 
 class L10nEsAeatMapTaxLineAccount(models.Model):


### PR DESCRIPTION
Since account.tax.template was removed in Odoo 17, tax xmlids are stored as plain strings in l10n.es.aeat.map.tax.line.tax. This made the UI show raw xmlids like "account_tax_template_s_iva21b" in many2many_tags widgets, which is hard to read for end users.

Override _compute_display_name to resolve the xmlid to the actual tax name for the current company. If the xmlid cannot be resolved (e.g. tax not installed), fall back to the xmlid without the "account_tax_template_" prefix for a cleaner representation.