### PR TITLE
[18.0][IMP]l10n_es_aeat: add common partner AEAT identification validation

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -126,3 +126,15 @@ class ResPartner(models.Model):
             self.aeat_identification_type or identifier_type,
             self.aeat_identification if self.aeat_identification_type else vat_number,
         )
+
+    def _has_valid_aeat_identification(self, allow_alternative_identification=True):
+        """Check whether a partner has a valid identification for AEAT reports."""
+        self.ensure_one()
+        return bool(
+            self.vat
+            or (
+                allow_alternative_identification
+                and self.aeat_identification_type
+                and self.aeat_identification
+            )
+        )

--- a/l10n_es_aeat/tests/test_l10n_es_aeat.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat.py
@@ -124,3 +124,51 @@ class TestL10nEsAeat(BaseCommon):
         iso_code = "ES"
         mapping_return = res_partner_obj._map_aeat_country_iso_code(spain_country)
         self.assertEqual(iso_code, mapping_return)
+
+    def test_has_valid_aeat_identification(self):
+        partner_with_vat = self.env["res.partner"].create(
+            {
+                "name": "Partner with VAT",
+                "vat": "ES12345678Z",
+            }
+        )
+        self.assertTrue(partner_with_vat._has_valid_aeat_identification())
+        partner_with_aeat_identification = self.env["res.partner"].create(
+            {
+                "name": "Partner with AEAT identification",
+                "aeat_identification_type": "06",
+                "aeat_identification": "ABC123456",
+            }
+        )
+        self.assertTrue(
+            partner_with_aeat_identification._has_valid_aeat_identification()
+        )
+        self.assertFalse(
+            partner_with_aeat_identification._has_valid_aeat_identification(
+                allow_alternative_identification=False
+            )
+        )
+        partner_without_identification = self.env["res.partner"].create(
+            {
+                "name": "Partner without identification",
+            }
+        )
+        self.assertFalse(
+            partner_without_identification._has_valid_aeat_identification()
+        )
+        partner_only_aeat_type = self.env["res.partner"].create(
+            {
+                "name": "Partner only AEAT type",
+                "aeat_identification_type": "06",
+            }
+        )
+        self.assertFalse(partner_only_aeat_type._has_valid_aeat_identification())
+        partner_only_aeat_identification = self.env["res.partner"].create(
+            {
+                "name": "Partner only AEAT identification",
+                "aeat_identification": "ABC123456",
+            }
+        )
+        self.assertFalse(
+            partner_only_aeat_identification._has_valid_aeat_identification()
+        )

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -377,14 +377,8 @@ class L10nEsVatBook(models.Model):
             line_vals["exception_text"] = self.env._("Without Partner")
         elif not line_vals["vat_number"]:  # Doesn't have VAT
             partner = rp_model.browse(line_vals["partner_id"])
-            country_code, identifier_type, vat_number = partner._parse_aeat_vat_info()
-            req_vat_identif_types = [
-                s_opt[0]
-                for s_opt in rp_model._fields["aeat_identification_type"].selection
-            ] + [""]  # "" is the identification type for Spain
-            # Partner type requires VAT
             if (
-                identifier_type in req_vat_identif_types
+                not partner._has_valid_aeat_identification()
                 and line_vals["partner_id"] not in self.get_pos_partner_ids()
             ):
                 line_vals["exception_text"] = self.env._("Without VAT")

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -33,6 +33,14 @@ class TestL10nEsAeatVatBookBase(TestL10nEsAeatModBase):
 
 class TestL10nEsAeatVatBook(TestL10nEsAeatVatBookBase):
     def test_model_vat_book(self):
+        # Customer with alternative AEAT identification
+        self.customer.write(
+            {
+                "vat": False,
+                "aeat_identification_type": "06",
+                "aeat_identification": "ABC123456",
+            }
+        )
         # Purchase invoices
         self._invoice_purchase_create("2017-01-01")
         # Sale invoices
@@ -60,6 +68,11 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatVatBookBase):
         )
         _logger.debug("Calculate VAT Book 1T 2017")
         vat_book.button_calculate()
+        # Check that the customer is not marked as "Without VAT"
+        for line in vat_book.issued_line_ids:
+            self.assertNotEqual(line.exception_text, self.env._("Without VAT"))
+        for line in vat_book.rectification_issued_line_ids:
+            self.assertNotEqual(line.exception_text, self.env._("Without VAT"))
         # Check issued invoices
         for line in vat_book.issued_line_ids:
             self.assertEqual(fields.Date.to_string(line.invoice_date), "2017-01-13")


### PR DESCRIPTION
@HaraldPanten @Jaimermaccione @ValentinVinagre 

Refs:
- https://github.com/OCA/l10n-spain/issues/4964

This PR adds a reusable AEAT partner identification validation in `l10n_es_aeat`. It also reuses the common validation from `l10n_es_vat_book`.

Partners identified through `aeat_identification_type` and `aeat_identification` are now accepted without requiring a `vat`.

**Note:** this PR temporarily includes a commit adapting l10n_es_vat_book so the new functionality can be tested. The changes will be split into separate pull requests before merging.

- [T-9509]