### PR TITLE
[14.0][IMP] l10n_es_payment_order_confirming_aef: Check line communication if no ref is set in move and change limit from 15 to 20

### DIFF
--- a/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
+++ b/l10n_es_payment_order_confirming_aef/models/confirming_aef.py
@@ -45,13 +45,14 @@ class ConfirmingAEF(object):
                     % line.partner_id.name
                 )
             # Num Factura
-            if len(line.move_line_id.move_id.ref or "") > 15:
+            if len(line.move_line_id.move_id.ref or line.communication or "") > 20:
                 validation_errors.append(
                     _(
                         "- La referencia de factura %s de proveedor no puede ocupar "
-                        "más de 15 caracteres."
+                        "más de 20 caracteres."
                     )
                     % line.move_line_id.move_id.ref
+                    or line.communication
                 )
             # Ciudad
             if not line.partner_id.city:


### PR DESCRIPTION
Según el Formato Estándar de Confirming, en los registros numero 6, el segundo campo (Numero factura) tiene una longitud de 20 caracteres.

A la hora de comprobar si los datos son correctos se comprueba que la longitud del campo referencia de la factura no sea mayor que 15. Propongo cambiar este limite a 20 y añadir el campo comunicación de la linea de pago que es el que se usa en caso de que la referencia de la factura no este establecida.