### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_oca: enviar cancelaciones al SII inmediatamente

### DIFF
--- a/l10n_es_aeat_sii_oca/README.rst
+++ b/l10n_es_aeat_sii_oca/README.rst
@@ -153,6 +153,7 @@ Contributors
 
   - Pedro M. Baeza
   - João Marques
+  - Sergio Teruel
 
 - Lois Rilo Antelo <lois.rilo@forgeflow.com>
 - Eduardo de Miguel (edu@moduon.team)

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -87,6 +87,7 @@ class AccountMove(models.Model):
         copy=False,
     )
     sii_dua_invoice = fields.Boolean(compute="_compute_dua_invoice")
+    sii_send_date_visible = fields.Boolean(compute="_compute_sii_send_date_visible")
 
     @api.depends("move_type")
     def _compute_sii_refund_type(self):
@@ -119,6 +120,18 @@ class AccountMove(models.Model):
             taxes = invoice.company_id._get_taxes_from_xmlids(xmlids)
             invoice.sii_dua_invoice = invoice.line_ids.filtered(
                 lambda x, taxes=taxes: bool(taxes & x.tax_ids)
+            )
+
+    @api.depends("state", "aeat_state", "sii_needs_cancel")
+    def _compute_sii_send_date_visible(self):
+        for invoice in self:
+            invoice.sii_send_date_visible = (
+                invoice.state == "posted"
+                and invoice.aeat_state not in ["sent", "cancelled"]
+            ) or (
+                invoice.state == "cancel"
+                and invoice.sii_needs_cancel
+                and invoice.aeat_state in ["sent", "sent_w_errors", "sent_modified"]
             )
 
     def _aeat_get_partner(self):

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -249,17 +249,21 @@ class SiiMixin(models.AbstractModel):
 
     def _sii_filter_to_send(self):
         """Helper method to filter documents to send to SII."""
-        return self.filtered(
-            lambda document: (
-                document.sii_enabled
-                and document.state in self._get_valid_document_states()
-                and (
-                    (document.aeat_state != "sent" and not document.sii_needs_cancel)
-                    or (
-                        document.aeat_state != "cancelled" and document.sii_needs_cancel
-                    )
-                )
-            )
+        return self.filtered(lambda document: document._is_sii_document_to_send())
+
+    def _is_sii_document_to_send(self):
+        self.ensure_one()
+        if not self.sii_enabled:
+            return False
+        if self.sii_needs_cancel:
+            return self.state == "cancel" and self.aeat_state in [
+                "sent",
+                "sent_w_errors",
+                "sent_modified",
+            ]
+        return (
+            self.state in self._get_valid_document_states()
+            and self.aeat_state not in ["sent", "cancelled"]
         )
 
     def send_sii_now(self):

--- a/l10n_es_aeat_sii_oca/readme/CONTRIBUTORS.md
+++ b/l10n_es_aeat_sii_oca/readme/CONTRIBUTORS.md
@@ -17,6 +17,7 @@
 - [Tecnativa](https://www.tecnativa.com):
   - Pedro M. Baeza
   - João Marques
+  - Sergio Teruel
 - Lois Rilo Antelo \<<lois.rilo@forgeflow.com>\>
 - Eduardo de Miguel (<edu@moduon.team>)
 - Jose Zambudio \<<jose@aurestic.es>\>

--- a/l10n_es_aeat_sii_oca/static/description/index.html
+++ b/l10n_es_aeat_sii_oca/static/description/index.html
@@ -502,6 +502,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Pedro M. Baeza</li>
 <li>João Marques</li>
+<li>Sergio Teruel</li>
 </ul>
 </li>
 <li>Lois Rilo Antelo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -7,8 +7,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import json
+from datetime import timedelta
 
-from odoo import exceptions
+from odoo import exceptions, fields
 from odoo.tools.misc import file_path
 
 from odoo.addons.l10n_es_aeat.tests.test_l10n_es_aeat_certificate import (
@@ -594,6 +595,27 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         self.assertTrue(invoice.sii_send_date)
         self.assertTrue(invoice_sii_failed.sii_send_date)
         self.assertTrue(invoice_sii_modified.sii_send_date)
+
+    def test_send_sii_now_cancelled_invoice(self):
+        invoice = self._create_invoice("out_invoice")
+        invoice.action_post()
+        invoice.write({"aeat_state": "sent"})
+        invoice.button_cancel()
+        future_send_date = fields.Datetime.now() + timedelta(days=2)
+        invoice.write(
+            {
+                "sii_needs_cancel": True,
+                "sii_send_date": future_send_date,
+            }
+        )
+        wizard = (
+            self.env["wizard.send.sii"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create({})
+        )
+        self.assertEqual(wizard.moves_to_send, 1)
+        invoice.send_sii_now()
+        self.assertLess(invoice.sii_send_date, future_send_date)
 
     def test_start_date(self):
         self.company.sii_start_date = "2018-01-01"

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -89,15 +89,16 @@
                             groups="account.group_account_invoice"
                             invisible="1"
                         />
+                        <field name="sii_send_date_visible" invisible="1" />
                         <label
                             for="sii_send_date"
                             string="Send date"
-                            invisible="aeat_state in ['sent','cancelled'] or state != 'posted'"
+                            invisible="not sii_send_date_visible"
                         />
                         <div
                             name="sii_send_date"
                             string="Send date"
-                            invisible="aeat_state in ['sent','cancelled'] or state != 'posted'"
+                            invisible="not sii_send_date_visible"
                         >
                             <field name="sii_send_date" class="oe_inline text-break" />
                             <button

--- a/l10n_es_aeat_sii_oca/wizards/account_move_send_sii.py
+++ b/l10n_es_aeat_sii_oca/wizards/account_move_send_sii.py
@@ -26,11 +26,7 @@ class SendSIIWizard(models.TransientModel):
         modified = account_moves.filtered(
             lambda a: a.aeat_state in ["sent_modified", "cancelled_modified"]
         )
-        moves_to_send = account_moves.filtered(
-            lambda a: a.sii_enabled
-            and a.state in a._get_valid_document_states()
-            and a.aeat_state not in ["sent", "cancelled"]
-        )
+        moves_to_send = account_moves._sii_filter_to_send()
         res.update(
             {
                 "moves_to_send": len(moves_to_send),


### PR DESCRIPTION
1. Corregir el flujo de envío inmediato para que las facturas canceladas con anulación pendiente puedan programarse al momento.
2. Mostrar también la fecha de envío SII en facturas canceladas cuando queda pendiente comunicar su anulación.

cc @Tecnativa TT63592

ping @carlosdauden @carlos-lopez-tecnativa @omar7r @acysos 