### PR TITLE
[18.0][IMP] l10n_es_facturae: Add LegalLiterals

### DIFF
--- a/l10n_es_facturae/models/account_tax.py
+++ b/l10n_es_facturae/models/account_tax.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
+from odoo.tools import html2plaintext
 
 
 class AccountTax(models.Model):
@@ -53,3 +54,8 @@ class AccountTax(models.Model):
             ("19", "REIPSI: Régimen especial de IPSI para agencias de viajes"),
         ],
     )
+
+    def get_invoice_legal_notes(self):
+        return [
+            html2plaintext(note) for note in self.mapped("invoice_legal_notes") if note
+        ]

--- a/l10n_es_facturae/tests/common.py
+++ b/l10n_es_facturae/tests/common.py
@@ -32,6 +32,7 @@ class CommonTest(TestL10nEsAeatCertificateBase, TestL10nEsAeatModBase):
                 "amount": 21,
                 "type_tax_use": "sale",
                 "facturae_code": "01",
+                "invoice_legal_notes": "Legal note for tax",
             }
         )
 
@@ -765,3 +766,16 @@ class CommonTest(TestL10nEsAeatCertificateBase, TestL10nEsAeatModBase):
             }
         )
         self.assertTrue(new_partner)
+
+    def test_facturae_legal_literals(self):
+        self.move.action_post()
+        self._activate_certificate(self.certificate_password)
+        self.move.name = "2999/99999"
+        generated_facturae = self._create_facturae_file(self.move)
+        self.assertEqual(
+            generated_facturae.xpath(
+                "/fe:Facturae/Invoices/Invoice/LegalLiterals/LegalReference",
+                namespaces={"fe": self.fe},
+            )[0].text,
+            "Legal note for tax",
+        )

--- a/l10n_es_facturae/views/report_facturae.xml
+++ b/l10n_es_facturae/views/report_facturae.xml
@@ -749,7 +749,13 @@
                             <DebitReconciliationReference />
                         </Installment>
                     </PaymentDetails>
-                    <LegalLiterals />
+                    <LegalLiterals>
+                        <LegalReference
+                            t-foreach="move.line_ids.tax_ids.get_invoice_legal_notes()"
+                            t-as="legal_reference"
+                            t-esc="legal_reference"
+                        />
+                    </LegalLiterals>
                     <t
                         t-set="attachments"
                         t-value="move._get_facturae_move_attachments()"


### PR DESCRIPTION
Este PR añade los Literales Legales al xml de facturae, con esto cubrimos el envío de facturas exentas de manera que podamos indicar el motivo por el cuál está exenta, Art.10, Art.22, etc. usando la nota legal en el impuesto.

@Tecnativa TT63606
@pedrobaeza 