### PR TITLE
[16.0][FIX] l10n_es_vat_book: Compatibility with Python <=3.8

### DIFF
--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -275,7 +275,7 @@ class L10nEsVatBook(models.Model):
             tax = move_line.tax_line_id
             move_line._process_aeat_tax_fee_info(res, tax, sign)
             key = self.get_book_line_tax_key(move_line, tax)
-            value = tax_lines.setdefault(key, default_dict | {"tax_id": tax.id})
+            value = tax_lines.setdefault(key, {**default_dict, "tax_id": tax.id})
             value["tax_amount"] += res[tax]["amount"]
             value["deductible_amount"] += res[tax]["deductible_amount"]
             value["move_line_ids"].append((4, move_line.id))
@@ -287,7 +287,7 @@ class L10nEsVatBook(models.Model):
             if tax not in implied_taxes:
                 continue
             key = self.get_book_line_tax_key(move_line, tax)
-            value = tax_lines.setdefault(key, default_dict | {"tax_id": tax.id})
+            value = tax_lines.setdefault(key, {**default_dict, "tax_id": tax.id})
             value["base_amount"] += res[tax]["base"]
             value["base_move_line_ids"].append((4, move_line.id))
             # For later matching special taxes


### PR DESCRIPTION
## Description

This change replaces the dictionary union operator used in `l10n_es_vat_book`:

```python
default_dict | {"tax_id": tax.id}
```

with the equivalent dictionary-unpacking syntax:

```python
{**default_dict, "tax_id": tax.id}
```

## Reason for the change

The dictionary union operator (`|`) was introduced in Python 3.9. Therefore, the
current implementation fails on Python 3.7 and Python 3.8 with:

```text
TypeError: unsupported operand type(s) for |: 'dict' and 'dict'
```

The Odoo 16 source code explicitly declares the following supported Python version
range:

```python
MIN_PY_VERSION = (3, 7)
MAX_PY_VERSION = (3, 12)
```

The same version range is also declared in the OCA OCB 16.0 codebase.

Using syntax introduced in Python 3.9 therefore unnecessarily prevents this module
from running on Python versions that are explicitly supported by both Odoo 16 and
OCB 16.0.

## Behaviour

This is a compatibility-only change. It does not modify the functional behaviour of
the module.

Both expressions create a new dictionary containing the values from `default_dict`
and the specified `tax_id`:

```python
default_dict | {"tax_id": tax.id}
```

```python
{**default_dict, "tax_id": tax.id}
```

They also have the same key precedence: if `default_dict` already contains `tax_id`,
the value from `tax.id` takes precedence.

Neither expression mutates `default_dict`, and the behaviour of
`tax_lines.setdefault()` remains unchanged.

## Benefits

This change:

* restores compatibility with Python 3.7 and Python 3.8;
* preserves the current behaviour on Python 3.9 through Python 3.12;
* does not alter the generated VAT book data;
* does not introduce dependencies or additional runtime complexity;
* aligns `l10n_es_vat_book` with the Python version range declared by Odoo 16 and
  OCB 16.0.

## References

* Odoo 16 Python version declaration:
  https://github.com/odoo/odoo/blob/16.0/odoo/__init__.py
* OCB 16.0 Python version declaration:
  https://github.com/OCA/OCB/blob/16.0/odoo/__init__.py
