### PR TITLE
[18.0][FIX] l10n_es_facturae: force spanish selection values

### DIFF
--- a/l10n_es_facturae/models/account_move.py
+++ b/l10n_es_facturae/models/account_move.py
@@ -137,16 +137,16 @@ class AccountMove(models.Model):
 
     def get_refund_reason_string(self):
         return dict(
-            self.fields_get(allfields=["facturae_refund_reason"])[
-                "facturae_refund_reason"
-            ]["selection"]
+            self.with_context(lang=None).fields_get(
+                allfields=["facturae_refund_reason"]
+            )["facturae_refund_reason"]["selection"]
         )[self.facturae_refund_reason]
 
     def get_correction_method_string(self):
         return dict(
-            self.fields_get(allfields=["correction_method"])["correction_method"][
-                "selection"
-            ]
+            self.with_context(lang=None).fields_get(allfields=["correction_method"])[
+                "correction_method"
+            ]["selection"]
         )[self.correction_method]
 
     def _get_valid_move_statuses(self):


### PR DESCRIPTION
Por defecto, Odoo analiza los campos de Selección estáticos y extrae sus etiquetas para su traducción. Sin embargo, estas opciones específicas de Facturae representan terminología normativa española estricta que no debe modificarse, independientemente del idioma del usuario.

Al trasladar las listas a métodos auxiliares dinámicos y omitir deliberadamente los adaptadores de traducción (_), se evita que Odoo las exporte a catálogos .po, manteniendo su visualización en español en todo momento.

Esto solo lo he ocurrido actualmente con la traducción en catalán, ya que es la única que tiene valores asignados a estos campos.

Con este cambio no es necesario eliminar los valores del PO al coger los valores de manera fija.

```
odoo.addons.l10n_es_facturae.reports.report_facturae: Element 'ReasonDescription': [facet 'enumeration'] The value 'Detall operació' is not an element of the set {'Número de la factura', 'Serie de la factura', 'Fecha expedición', 'Nombre y apellidos/Razón Social-Emisor', 'Nombre y apellidos/Razón Social-Receptor', 'Identificación fiscal Emisor/obligado', 'Identificación fiscal Receptor', 'Domicilio Emisor/Obligado', 'Domicilio Receptor', 'Detalle Operación', 'Porcentaje impositivo a aplicar', 'Cuota tributaria a aplicar', 'Fecha/Periodo a aplicar', 'Clase de factura', 'Literales legales', 'Base imponible', 'Cálculo de cuotas repercutidas', 'Cálculo de cuotas retenidas', 'Base imponible modificada por devolución de envases / embalajes', 'Base imponible modificada por descuentos y bonificaciones', 'Base imponible modificada por resolución firme, judicial o administrativa', 'Base imponible modificada cuotas repercutidas no satisfechas. Auto de declaración de concurso'}., line 136 
``` 

## Pasos para reproducir.
- Asignar un contacto con idioma en catalán y configurar con factura electrónica Facturae
- Realizar una factura.
- Crear una factura rectificativa.
- La traducción modifica el XML del facturae saltando el error.