### PR TITLE
[16.0][FIX] l10n_es_verifactu_oca: minor fixes (tax agency check, registration key backfill, is_cancellation depends)

### DIFF
--- a/l10n_es_verifactu_oca/hooks.py
+++ b/l10n_es_verifactu_oca/hooks.py
@@ -38,6 +38,7 @@ def post_init_hook(cr, registry):
     key = env.ref("l10n_es_verifactu_oca.verifactu_registration_keys_01")
     cr.execute(
         "UPDATE account_move SET verifactu_registration_key = %s "
-        "WHERE move_type = 'out_refund' AND verifactu_registration_key IS NULL",
+        "WHERE move_type IN ('out_invoice', 'out_refund') "
+        "AND verifactu_registration_key IS NULL",
         (key.id,),
     )

--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry_response_line.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry_response_line.py
@@ -1,7 +1,7 @@
 # Copyright 2025 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 from ..models.verifactu_invoice_entry import VERIFACTU_SEND_STATES
 
@@ -42,6 +42,7 @@ class VerifactuInvoiceEntryResponseLine(models.Model):
     def document(self):
         return self.env[self.model].browse(self.document_id).exists()
 
+    @api.depends("entry_id.entry_type")
     def _compute_is_cancellation(self):
         for rec in self:
             rec.is_cancellation = rec.entry_id.entry_type == "cancel"

--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -397,9 +397,11 @@ class VerifactuMixin(models.AbstractModel):
             )
         if not self.company_id.tax_agency_id:
             suffixes.append(_("- Your company does not have a tax agency configured."))
-        if (
-            self.company_id.tax_agency_id.get_external_id
-            in self._get_verifactu_accepted_tax_agencies()
+        elif (
+            self.company_id.tax_agency_id.get_external_id().get(
+                self.company_id.tax_agency_id.id
+            )
+            not in self._get_verifactu_accepted_tax_agencies()
         ):
             suffixes.append(_("- Your company's tax agency is not supported."))
         if not self.company_id.verifactu_developer_id:
@@ -409,7 +411,7 @@ class VerifactuMixin(models.AbstractModel):
         if not self.company_id.country_code or self.company_id.country_code != "ES":
             suffixes.append(_("Your company is not registered in Spain."))
         if suffixes:
-            raise UserError((prefix + "\n".join(suffixes)) % self[self._rec_name])
+            raise UserError(prefix % self[self._rec_name] + "\n" + "\n".join(suffixes))
 
     @api.model
     def _get_verifactu_map(self, date):

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -565,3 +565,17 @@ class TestVerifactuSendResponse(TestVerifactuCommon):
             activity,
             "A warning activity should be created for 'AceptadoConErrores' response",
         )
+
+    def test_check_verifactu_configuration_tax_agency(self):
+        # The default company uses the Spanish tax agency, which is accepted,
+        # so a fully configured invoice passes the configuration check.
+        self.invoice._check_verifactu_configuration()
+        # A tax agency that is not in the accepted list must be rejected.
+        # Regression: this branch used to reference the unbound method
+        # ``get_external_id`` and use ``in`` instead of ``not in``, so it never
+        # triggered regardless of the configured agency.
+        self.company.tax_agency_id = self.env.ref(
+            "l10n_es_aeat.aeat_tax_agency_bizkaia"
+        )
+        with self.assertRaises(UserError):
+            self.invoice._check_verifactu_configuration()


### PR DESCRIPTION
Este PR agrupa tres correcciones pequeñas e independientes para `l10n_es_verifactu_oca`.

### Validación de la agencia tributaria y mensaje de error de configuración

`_check_verifactu_configuration` comparaba el método `get_external_id` (que nunca es una cadena) y usaba `in` en lugar de `not in`, por lo que la rama de "agencia tributaria no soportada" no se activaba nunca, fuera cual fuera la agencia configurada. Ahora compara el external id de la agencia con `not in` y usa `elif` para que la comprobación no salte también cuando no hay ninguna
agencia configurada.

También se corrige el mensaje lanzado: el `%s` se aplica ahora solo al prefijo (así un `%` en un sufijo traducido ya no rompe el formato) y se añade el salto de línea que faltaba entre el prefijo y la primera línea.

### Relleno de la clave de registro para facturas de venta

El `post_init_hook` solo asignaba una clave de registro por defecto (`01`) a los asientos `out_refund` existentes, mientras que la clave de impuesto se rellena tanto para `out_invoice` como para `out_refund`. Como `verifactu_registration_key` es un campo calculado almacenado que depende únicamente de `fiscal_position_id`, las facturas de venta en borrador ya existentes no se recalculan al validarse, por lo que llegan a la comprobación de configuración con la clave de registro vacía y quedan bloqueadas al enviarse a VERI*FACTU. El hook ahora rellena también `out_invoice`, en coherencia con la inicialización de la clave de impuesto.

### Dependencia que faltaba en `is_cancellation`

`_compute_is_cancellation` leía `entry_id.entry_type` sin declararlo como dependencia, por lo que el campo calculado no se invalidaba cuando el tipo de asiento cambiaba dentro de una transacción. Ahora se declara la dependencia.
