### PR TITLE
[16.0][FIX] l10n_es_verifactu_oca: handle lock contention in the send cron

### DIFF
--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
@@ -3,7 +3,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import datetime
 import json
+import logging
 
+import psycopg2
 from requests import Session
 from zeep import Client, Settings
 from zeep.cache import SqliteCache
@@ -13,6 +15,8 @@ from zeep.transports import Transport
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import split_every
+
+_logger = logging.getLogger(__name__)
 
 VERIFACTU_SEND_STATES = [
     ("not_sent", "Not sent"),
@@ -128,17 +132,35 @@ class VerifactuInvoiceEntry(models.Model):
     def _cron_send_documents_to_verifactu(self):
         batch_limit = self.env["verifactu.mixin"]._get_verifactu_batch()
         for chaining in self.env["verifactu.chaining"].search([]):
-            self.env.cr.execute(
-                """
-                SELECT id FROM verifactu_invoice_entry AS vsq
-                WHERE vsq.send_state = 'not_sent'
-                AND vsq.verifactu_chaining_id = %s
-                ORDER BY id
-                FOR UPDATE NOWAIT
-                """,
-                [chaining.id],
-            )
-            entries_to_send_ids = [entry[0] for entry in self.env.cr.fetchall()]
+            try:
+                with self.env.cr.savepoint():
+                    self.env.cr.execute(
+                        """
+                        SELECT id FROM verifactu_invoice_entry AS vsq
+                        WHERE vsq.send_state = 'not_sent'
+                        AND vsq.verifactu_chaining_id = %s
+                        ORDER BY id
+                        FOR UPDATE NOWAIT
+                        """,
+                        [chaining.id],
+                    )
+                    entries_to_send_ids = [entry[0] for entry in self.env.cr.fetchall()]
+            except psycopg2.OperationalError as err:
+                # 55P03: entries locked by another process (FOR UPDATE NOWAIT).
+                # 40001: serialization failure (a concurrent transaction
+                # committed a change to these entries under REPEATABLE READ).
+                # 40P01: deadlock. In every case another process is holding or
+                # has concurrently modified the entries, so skip this chaining
+                # and retry it on the next cron run instead of aborting.
+                if err.pgcode in ("55P03", "40001", "40P01"):
+                    _logger.info(
+                        "Skipping VERI*FACTU chaining %s due to concurrent "
+                        "access (SQLSTATE %s); will retry on the next cron run.",
+                        chaining.id,
+                        err.pgcode,
+                    )
+                    continue
+                raise
             for entries_batch_ids in split_every(batch_limit, entries_to_send_ids):
                 records_to_send = self.browse(entries_batch_ids)
                 send_date = fields.Datetime.now()

--- a/l10n_es_verifactu_oca/tests/__init__.py
+++ b/l10n_es_verifactu_oca/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_10n_es_verifactu
 from . import test_verifactu_invoice
+from . import test_verifactu_cron_lock

--- a/l10n_es_verifactu_oca/tests/test_verifactu_cron_lock.py
+++ b/l10n_es_verifactu_oca/tests/test_verifactu_cron_lock.py
@@ -1,0 +1,123 @@
+# Copyright 2026 FactorLibre
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import odoo
+from odoo.tests import common
+from odoo.tests.common import BaseCase
+from odoo.tools.misc import mute_logger
+
+from odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry import (
+    VerifactuInvoiceEntry,
+)
+
+ADMIN_USER_ID = common.ADMIN_USER_ID
+
+
+@contextmanager
+def environment():
+    """Environment with a new committed cursor (needed to reproduce the lock
+    contention across two real connections, as core does in test_ir_sequence)."""
+    registry = odoo.registry(common.get_db_name())
+    with registry.cursor() as cr:
+        yield odoo.api.Environment(cr, ADMIN_USER_ID, {})
+
+
+class TestVerifactuCronLock(BaseCase):
+    """The send cron must skip a chaining whose pending entries are locked by
+    another process (SELECT ... FOR UPDATE NOWAIT -> SQLSTATE 55P03) instead of
+    aborting the whole run."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        with environment() as env:
+            chaining = env["verifactu.chaining"].create(
+                {
+                    "name": "TEST LOCK CHAINING",
+                    "sif_id": "TESTLOCK",
+                    "installation_number": 1,
+                }
+            )
+            entry = env["verifactu.invoice.entry"].create(
+                {
+                    "verifactu_chaining_id": chaining.id,
+                    "model": "account.move",
+                    "document_id": 1,
+                    "company_id": env.company.id,
+                    "document_hash": "TESTLOCK",
+                }
+            )
+            cls.chaining_id = chaining.id
+            cls.entry_id = entry.id
+
+    @classmethod
+    def tearDownClass(cls):
+        with environment() as env:
+            env["verifactu.invoice.entry"].browse(cls.entry_id).unlink()
+            env["verifactu.chaining"].browse(cls.chaining_id).unlink()
+        super().tearDownClass()
+
+    @mute_logger("odoo.sql_db")
+    def test_cron_skips_locked_chaining(self):
+        # Patch the send so no real submission happens for any other chaining.
+        with patch.object(
+            VerifactuInvoiceEntry, "_send_documents_to_verifactu", return_value=None
+        ):
+            with environment() as env0:
+                # env0 holds a row lock on the pending entry.
+                env0.cr.execute(
+                    "SELECT id FROM verifactu_invoice_entry "
+                    "WHERE id = %s FOR UPDATE",
+                    (self.entry_id,),
+                )
+                with environment() as env1:
+                    # The cron cannot obtain the lock (55P03). It must skip that
+                    # chaining and return normally instead of raising.
+                    result = env1[
+                        "verifactu.invoice.entry"
+                    ]._cron_send_documents_to_verifactu()
+                    self.assertTrue(result)
+        # The locked entry was skipped, so it stays pending for the next run.
+        with environment() as env:
+            self.assertEqual(
+                env["verifactu.invoice.entry"].browse(self.entry_id).send_state,
+                "not_sent",
+            )
+
+    @mute_logger("odoo.sql_db")
+    def test_cron_skips_serialization_failure(self):
+        # A concurrent COMMITTED update on the pending entry makes the cron's
+        # SELECT ... FOR UPDATE fail with a serialization error (SQLSTATE 40001)
+        # under REPEATABLE READ. The cron must skip that chaining, not abort.
+        with patch.object(
+            VerifactuInvoiceEntry, "_send_documents_to_verifactu", return_value=None
+        ):
+            with environment() as env1:
+                # Fix env1's snapshot before the concurrent commit happens.
+                env1.cr.execute(
+                    "SELECT id FROM verifactu_invoice_entry WHERE id = %s",
+                    (self.entry_id,),
+                )
+                env1.cr.fetchall()
+                # Another connection updates and COMMITS the same entry.
+                with environment() as env0:
+                    env0.cr.execute(
+                        "UPDATE verifactu_invoice_entry "
+                        "SET send_attempt = send_attempt + 1 WHERE id = %s",
+                        (self.entry_id,),
+                    )
+                    env0.cr.commit()
+                # env1's FOR UPDATE now raises 40001; the cron must skip and
+                # return normally instead of raising.
+                result = env1[
+                    "verifactu.invoice.entry"
+                ]._cron_send_documents_to_verifactu()
+                self.assertTrue(result)
+        # The conflicted entry was skipped, so it stays pending for the next run.
+        with environment() as env:
+            self.assertEqual(
+                env["verifactu.invoice.entry"].browse(self.entry_id).send_state,
+                "not_sent",
+            )


### PR DESCRIPTION
Corrige el manejo de contención de acceso en el cron de envío a VERI*FACTU.

`_cron_send_documents_to_verifactu` bloquea las entradas pendientes de cada  encadenamiento con `SELECT ... FOR UPDATE NOWAIT`, pero no capturaba el error  resultante, así que un acceso concurrente abortaba todo el cron. Ocurre en dos  situaciones:
  
  - **Lock no disponible (`55P03`)**: otra ejecución solapada mantiene el lock (por ejemplo, un "Ejecutar manualmente" mientras el cron programado está  corriendo) y el `NOWAIT` lanza el error de inmediato.
  - **Fallo de serialización (`40001`) / interbloqueo (`40P01`)**: bajo el aislamiento REPEATABLE READ de Odoo, si otra transacción ha commiteado un  cambio sobre esas entradas después del snapshot del cron, el `FOR UPDATE`
    lanza un error de serialización (o de deadlock).
  
Ahora el bloqueo va dentro de un `savepoint` y, ante cualquiera de esos errores,  se salta ese encadenamiento y se continúa con el resto; las entradas saltadas  siguen pendientes y se recogen en la siguiente ejecución. Sigue el mismo patrón  que ya usa `_generate_verifactu_chaining`.

Incluye tests para `55P03` (lock retenido por otra conexión) y `40001` (update  concurrente commiteado con snapshot previo).
