### PR TITLE
[19.0][FIX] l10n_es_aeat_mod347: Fix partner_vat_unique compatibility

### DIFF
--- a/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
+++ b/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py
@@ -72,7 +72,13 @@ class TestL10nEsAeatMod347(TestL10nEsAeatModBase):
             }
         )
         cls.supplier_2 = cls.supplier.with_context(no_vat_validation=True).copy(
-            {"name": "Test supplier 2"}
+            {
+                "name": "Test supplier 2",
+                # partner_vat_unique compatibility: It is necessary to define the vat
+                # field because if partner_vat_unique is installed, the vat field
+                # will have copy=False
+                "vat": cls.supplier.vat,
+            }
         )
         # Invoice lower than the limit
         cls.taxes_sale = {


### PR DESCRIPTION
Fix `partner_vat_unique` compatibility

It is necessary to define the vat field because if partner_vat_unique is installed, the vat field will have copy=False

When adding the test at https://github.com/OCA/l10n-spain/commit/55896666b6dc9fdddb8923f46e4314a08df57ff4, an error may occur in the tests if `partner_vat_unique` is installed

```
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/l10n_es_aeat_mod347/tests/test_l10n_es_aeat_mod347.py", line 239, in test_mod347_unit_report
    self.assertEqual(errors.get(self.model347.id), 1)
AssertionError: 2 != 1
```

Please @pedrobaeza can you review it?

@Tecnativa