### PR TITLE
[19.0][FIX] l10n_es_aeat: Remove CryptographyDeprecationWarning warning log

### DIFF
--- a/l10n_es_aeat/wizard/aeat_certificate_password.py
+++ b/l10n_es_aeat/wizard/aeat_certificate_password.py
@@ -111,8 +111,20 @@ class L10nEsAeatCertificatePassword(models.TransientModel):
         with pfx_to_crt(p12, directory) as public_key:
             vals["public_key"] = public_key
         certificate = p12[1]
-        vals["date_start"] = certificate.not_valid_before
-        vals["date_end"] = certificate.not_valid_after
+        # Use the timezone-aware certificate validity properties when available
+        # (introduced in cryptography 42.0.0) to avoid the corresponding
+        # CryptographyDeprecationWarning emitted by the legacy naive datetime
+        # properties.
+        vals["date_start"] = (
+            certificate.not_valid_before_utc
+            if hasattr(certificate, "not_valid_before_utc")
+            else certificate.not_valid_before
+        )
+        vals["date_end"] = (
+            certificate.not_valid_after_utc
+            if hasattr(certificate, "not_valid_after_utc")
+            else certificate.not_valid_after
+        )
         if not record.name:
             name = certificate.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
             if name:


### PR DESCRIPTION
Remove CryptographyDeprecationWarning warning log

`WARNING prod py.warnings: /opt/odoo/auto/addons/l10n_es_aeat/wizard/aeat_certificate_password.py:114: CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_before_utc.`

`WARNING prod py.warnings: /opt/odoo/auto/addons/l10n_es_aeat/wizard/aeat_certificate_password.py:115: CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_after_utc.`

Please @pedrobaeza can you review it?

@Tecnativa