### PR TITLE
[19.0][FIX] l10n_es_aeat_mod347: fix report partner

### DIFF
--- a/l10n_es_aeat_mod347/views/report_347_partner.xml
+++ b/l10n_es_aeat_mod347/views/report_347_partner.xml
@@ -26,23 +26,23 @@
                 <t t-if="o.amount">
                     <h2>Invoices</h2>
                     <div class="row mt32 mb32">
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col mb-2">
                             <strong>Amount:</strong>
                             <p class="m-0" t-field="o.amount" />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col mb-2">
                             <strong>Amount 1Q:</strong>
                             <p class="m-0" t-field="o.first_quarter" />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col mb-2">
                             <strong>Amount 2Q:</strong>
                             <p class="m-0" t-field="o.second_quarter" />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col mb-2">
                             <strong>Amount 3Q:</strong>
                             <p class="m-0" t-field="o.third_quarter" />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col mb-2">
                             <strong>Amount 4Q:</strong>
                             <p class="m-0" t-field="o.fourth_quarter" />
                         </div>
@@ -124,35 +124,35 @@
                 <t t-if="o.real_estate_transmissions_amount">
                     <h2>Real State Transmissions</h2>
                     <div class="row mt32 mb32">
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col mb-2">
                             <strong>Amount:</strong>
                             <p
                                 class="m-0"
                                 t-field="o.real_estate_transmissions_amount"
                             />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col mb-2">
                             <strong>Amount 1Q:</strong>
                             <p
                                 class="m-0"
                                 t-field="o.first_quarter_real_estate_transmission"
                             />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col mb-2">
                             <strong>Amount 2Q:</strong>
                             <p
                                 class="m-0"
                                 t-field="o.second_quarter_real_estate_transmission"
                             />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col mb-2">
                             <strong>Amount 3Q:</strong>
                             <p
                                 class="m-0"
                                 t-field="o.third_quarter_real_estate_transmission"
                             />
                         </div>
-                        <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="col mb-2">
                             <strong>Amount 4Q:</strong>
                             <p
                                 class="m-0"


### PR DESCRIPTION
Problem with report l10n_es_aeat_mod347.report_347_partner

<img width="2487" height="1127" alt="image" src="https://github.com/user-attachments/assets/fa5621d7-a6c4-4415-91a9-7c292b3202c9" />

The last columna we can't see the value.