### PR TITLE
[19.0][FIX] l10n_es_aeat_mod349: Change ACL group to l10n_es_aeat.group_account_aeat

### DIFF
--- a/l10n_es_aeat_mod349/security/ir.model.access.csv
+++ b/l10n_es_aeat_mod349/security/ir.model.access.csv
@@ -1,14 +1,14 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_l10n_es_aeat_mod349_report_user","AEAT 349 Model: Report - Account User","model_l10n_es_aeat_mod349_report","account.group_account_user",1,0,0,0
-"access_l10n_es_aeat_mod349_report_manager","AEAT 349 Model: Report - Account Manager","model_l10n_es_aeat_mod349_report","account.group_account_manager",1,1,1,1
+"access_l10n_es_aeat_mod349_report_manager","AEAT 349 Model: Report - Account Manager","model_l10n_es_aeat_mod349_report","l10n_es_aeat.group_account_aeat",1,1,1,1
 "access_l10n_es_aeat_mod349_partner_record_user","AEAT 349 Model: Partner record - Account User","model_l10n_es_aeat_mod349_partner_record","account.group_account_user",1,0,0,0
-"access_l10n_es_aeat_mod349_partner_record_manager","AEAT 349 Model: Partner record - Account Manager","model_l10n_es_aeat_mod349_partner_record","account.group_account_manager",1,1,1,1
+"access_l10n_es_aeat_mod349_partner_record_manager","AEAT 349 Model: Partner record - Account Manager","model_l10n_es_aeat_mod349_partner_record","l10n_es_aeat.group_account_aeat",1,1,1,1
 "access_l10n_es_aeat_mod349_partner_record_detail_user","AEAT 349 Model: Partner record detail - Account User","model_l10n_es_aeat_mod349_partner_record_detail","account.group_account_user",1,0,0,0
-"access_l10n_es_aeat_mod349_partner_record_detail_manager","AEAT 349 Model: Partner record detail - Account Manager","model_l10n_es_aeat_mod349_partner_record_detail","account.group_account_manager",1,1,1,1
+"access_l10n_es_aeat_mod349_partner_record_detail_manager","AEAT 349 Model: Partner record detail - Account Manager","model_l10n_es_aeat_mod349_partner_record_detail","l10n_es_aeat.group_account_aeat",1,1,1,1
 "access_l10n_es_aeat_mod349_partner_refund_user","AEAT 349 Model: Partner refund - Account User","model_l10n_es_aeat_mod349_partner_refund","account.group_account_user",1,0,0,0
-"access_l10n_es_aeat_mod349_partner_refund_manager","AEAT 349 Model: Partner refund - Account Manager","model_l10n_es_aeat_mod349_partner_refund","account.group_account_manager",1,1,1,1
+"access_l10n_es_aeat_mod349_partner_refund_manager","AEAT 349 Model: Partner refund - Account Manager","model_l10n_es_aeat_mod349_partner_refund","l10n_es_aeat.group_account_aeat",1,1,1,1
 "access_l10n_es_aeat_mod349_partner_refund_detail_user","AEAT 349 Model: Partner refund detail - Account User","model_l10n_es_aeat_mod349_partner_refund_detail","account.group_account_user",1,0,0,0
-"access_l10n_es_aeat_mod349_partner_refund_detail_manager","AEAT 349 Model: Partner refund detail - Account Manager","model_l10n_es_aeat_mod349_partner_refund_detail","account.group_account_manager",1,1,1,1
+"access_l10n_es_aeat_mod349_partner_refund_detail_manager","AEAT 349 Model: Partner refund detail - Account Manager","model_l10n_es_aeat_mod349_partner_refund_detail","l10n_es_aeat.group_account_aeat",1,1,1,1
 "access_l10n_es_aeat_mod349_aeat_349_map_line_billing","AEAT 349 Model: Operation key Map - Billing User","model_aeat_349_map_line","account.group_account_invoice",1,0,0,0
 "access_l10n_es_aeat_mod349_aeat_349_map_line_user","AEAT 349 Model: Operation key Map - Account User","model_aeat_349_map_line","account.group_account_user",1,0,0,0
-"access_l10n_es_aeat_mod349_aeat_349_map_line_manager","AEAT 349 Model: Operation key Map - Account Manager","model_aeat_349_map_line","account.group_account_manager",1,1,1,1
+"access_l10n_es_aeat_mod349_aeat_349_map_line_manager","AEAT 349 Model: Operation key Map - Account Manager","model_aeat_349_map_line","l10n_es_aeat.group_account_aeat",1,1,1,1


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/l10n-spain/pull/5111

Change ACL group to l10n_es_aeat.group_account_aeat

Similar to what happens with other models (347, for example), access permissions for model 349 must be set to l10n_es_aeat.group_account_aeat.

Please @pedrobaeza can you review it?

@Tecnativa TT63708