### PR TITLE
[19.0][FIX] l10n_es_aeat_sii_oca: Show only posted invoices in "SII not sent" filter

### DIFF
--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -194,7 +194,7 @@
                 <filter
                     name="sii_not_sent"
                     string="SII not sent"
-                    domain="[('aeat_state', '=', 'not_sent'), ('sii_enabled', '=', True), ('date', '>=', '2017-01-01')]"
+                    domain="[('aeat_state', '=', 'not_sent'), ('sii_enabled', '=', True), ('state', '=', 'posted'), ('date', '>=', '2017-01-01')]"
                     help="Never sent to SII"
                 />
                 <filter


### PR DESCRIPTION
En el dashboard de diarios aparecen las facturas no enviadas publicadas, pero cuando haces click sobre él te muestra también las que están en borrador y canceladas

<img width="948" height="339" alt="image" src="https://github.com/user-attachments/assets/24b6629e-3d96-449b-9c22-4c649fc52161" />
<img width="1863" height="574" alt="image" src="https://github.com/user-attachments/assets/0f502250-e8f7-4920-8ee5-4a14049e58f3" />

Después del fix ya sólo se muestran las facturas públicadas con el filtro de no enviadas

MT-15395 @moduon