### PR TITLE
[16.0][IMP] l10n_es_verifactu_oca: identificar el documento rectificado sin factura original enlazada

### DIFF
--- a/l10n_es_igic_verifactu_oca/tests/json/verifactu_out_refund_igic_r_3_igic_r_3_igic_r_7_dict.json
+++ b/l10n_es_igic_verifactu_oca/tests/json/verifactu_out_refund_igic_r_3_igic_r_3_igic_r_7_dict.json
@@ -46,7 +46,15 @@
         "NumSerieFactura": "TEST001"
       }
     },
-    "FacturasRectificadas": [],
+    "FacturasRectificadas": [
+      {
+        "IDFacturaRectificada": {
+          "IDEmisorFactura": "G87846952",
+          "NumSerieFactura": "ORIGIN001",
+          "FechaExpedicionFactura": "31-12-2025"
+        }
+      }
+    ],
     "SistemaInformatico": {
       "NombreRazon": "Odoo Developer",
       "NIF": "A12345674",

--- a/l10n_es_igic_verifactu_oca/tests/test_10n_es_igic_verifactu.py
+++ b/l10n_es_igic_verifactu_oca/tests/test_10n_es_igic_verifactu.py
@@ -60,6 +60,10 @@ class TestL10nEsAeatVerifactuIgic(TestVerifactuIgicCommon):
                     "fiscal_position_id": self.fp_nacional.id,
                     "verifactu_registration_key": self.fp_registration_key_01.id,
                     "verifactu_registration_date": "2026-01-01 19:20:30",
+                    # There is no linked original invoice, so the rectified
+                    # document is identified through these fields.
+                    "verifactu_original_document_number": "ORIGIN001",
+                    "verifactu_original_document_date": "2025-12-31",
                 },
             ),
         ]

--- a/l10n_es_verifactu_oca/i18n/es.po
+++ b/l10n_es_verifactu_oca/i18n/es.po
@@ -49,6 +49,17 @@ msgstr "- No tiene todos los impuestos mapeados."
 #. odoo-python
 #: code:addons/l10n_es_verifactu_oca/models/account_move.py:0
 #, python-format
+msgid ""
+"- Link the original invoice or fill in the VERI*FACTU original document "
+"number and date."
+msgstr ""
+"- Enlazar la factura original o rellenar el número y la fecha del "
+"documento original VERI*FACTU."
+
+#. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/account_move.py:0
+#, python-format
 msgid "- There are some inconsistent taxes on lines."
 msgstr "- Hay algunos impuestos inconsistentes en las líneas."
 
@@ -778,6 +789,20 @@ msgid "Is cancellation"
 msgstr "Es una cancelación"
 
 #. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_bank_statement_line__verifactu_original_document_date
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_move__verifactu_original_document_date
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_payment__verifactu_original_document_date
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_verifactu_mixin__verifactu_original_document_date
+msgid ""
+"Issue date of the rectified document, to be filled in when it is not "
+"registered in the system. It is only taken into account if there is no "
+"linked original document."
+msgstr ""
+"Fecha de expedición del documento rectificado, a rellenar cuando no está "
+"registrado en el sistema. Solo se tiene en cuenta si no hay un documento "
+"original enlazado."
+
+#. module: l10n_es_verifactu_oca
 #: model:ir.model,name:l10n_es_verifactu_oca.model_account_journal
 msgid "Journal"
 msgstr "Diario"
@@ -987,6 +1012,16 @@ msgstr ""
 "envía a VERI*FACTU"
 
 #. module: l10n_es_verifactu_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_form
+msgid "Original document date"
+msgstr "Fecha de documento original"
+
+#. module: l10n_es_verifactu_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_form
+msgid "Original document number"
+msgstr "Número de documento original"
+
+#. module: l10n_es_verifactu_oca
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_map_line__verifactu_map_id
 msgid "Parent mapping"
 msgstr "Mapeo padre"
@@ -1180,6 +1215,20 @@ msgstr "Contenido enviado"
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_form
 msgid "Sent header"
 msgstr "Cabecera enviada"
+
+#. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_bank_statement_line__verifactu_original_document_number
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_move__verifactu_original_document_number
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_payment__verifactu_original_document_number
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_verifactu_mixin__verifactu_original_document_number
+msgid ""
+"Serial number of the rectified document, to be filled in when it is not "
+"registered in the system. It is only taken into account if there is no "
+"linked original document."
+msgstr ""
+"Número de serie del documento rectificado, a rellenar cuando no está "
+"registrado en el sistema. Solo se tiene en cuenta si no hay un documento "
+"original enlazado."
 
 #. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.view_company_verifactu_form
@@ -1555,6 +1604,22 @@ msgstr "VERI*FACTU mixin"
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_search
 msgid "VERI*FACTU not sent"
 msgstr "VERI*FACTU no enviado"
+
+#. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_bank_statement_line__verifactu_original_document_date
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_move__verifactu_original_document_date
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_payment__verifactu_original_document_date
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_mixin__verifactu_original_document_date
+msgid "VERI*FACTU original document date"
+msgstr "Fecha de documento original VERI*FACTU"
+
+#. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_bank_statement_line__verifactu_original_document_number
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_move__verifactu_original_document_number
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_payment__verifactu_original_document_number
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_mixin__verifactu_original_document_number
+msgid "VERI*FACTU original document number"
+msgstr "Número de documento original VERI*FACTU"
 
 #. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_search

--- a/l10n_es_verifactu_oca/i18n/l10n_es_verifactu_oca.pot
+++ b/l10n_es_verifactu_oca/i18n/l10n_es_verifactu_oca.pot
@@ -45,6 +45,15 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_es_verifactu_oca/models/account_move.py:0
 #, python-format
+msgid ""
+"- Link the original invoice or fill in the VERI*FACTU original document "
+"number and date."
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/account_move.py:0
+#, python-format
 msgid "- There are some inconsistent taxes on lines."
 msgstr ""
 
@@ -749,6 +758,17 @@ msgid "Is cancellation"
 msgstr ""
 
 #. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_bank_statement_line__verifactu_original_document_date
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_move__verifactu_original_document_date
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_payment__verifactu_original_document_date
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_verifactu_mixin__verifactu_original_document_date
+msgid ""
+"Issue date of the rectified document, to be filled in when it is not "
+"registered in the system. It is only taken into account if there is no "
+"linked original document."
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
 #: model:ir.model,name:l10n_es_verifactu_oca.model_account_journal
 msgid "Journal"
 msgstr ""
@@ -956,6 +976,16 @@ msgid ""
 msgstr ""
 
 #. module: l10n_es_verifactu_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_form
+msgid "Original document date"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_form
+msgid "Original document number"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_map_line__verifactu_map_id
 msgid "Parent mapping"
 msgstr ""
@@ -1146,6 +1176,17 @@ msgstr ""
 #. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_form
 msgid "Sent header"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_bank_statement_line__verifactu_original_document_number
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_move__verifactu_original_document_number
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_account_payment__verifactu_original_document_number
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_verifactu_mixin__verifactu_original_document_number
+msgid ""
+"Serial number of the rectified document, to be filled in when it is not "
+"registered in the system. It is only taken into account if there is no "
+"linked original document."
 msgstr ""
 
 #. module: l10n_es_verifactu_oca
@@ -1515,6 +1556,22 @@ msgstr ""
 #. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_search
 msgid "VERI*FACTU not sent"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_bank_statement_line__verifactu_original_document_date
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_move__verifactu_original_document_date
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_payment__verifactu_original_document_date
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_mixin__verifactu_original_document_date
+msgid "VERI*FACTU original document date"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_bank_statement_line__verifactu_original_document_number
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_move__verifactu_original_document_number
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_payment__verifactu_original_document_number
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_mixin__verifactu_original_document_number
+msgid "VERI*FACTU original document number"
 msgstr ""
 
 #. module: l10n_es_verifactu_oca

--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -244,6 +244,22 @@ class AccountMove(models.Model):
                         }
                     }
                     inv_dict["FacturasRectificadas"].append(origin_data)
+                elif (
+                    self.verifactu_original_document_number
+                    and self.verifactu_original_document_date
+                ):
+                    # The rectified document is not registered in the system, so
+                    # its identification is taken from the manually filled fields.
+                    origin_data = {
+                        "IDFacturaRectificada": {
+                            "IDEmisorFactura": company_vat,
+                            "NumSerieFactura": self.verifactu_original_document_number,
+                            "FechaExpedicionFactura": self._get_verifactu_date(
+                                self.verifactu_original_document_date
+                            ),
+                        }
+                    }
+                    inv_dict["FacturasRectificadas"].append(origin_data)
                 # inv_dict["ImporteRectificacion"] = {
                 #     "BaseRectificada": abs(origin.amount_untaxed_signed),
                 #     "CuotaRectificada": abs(
@@ -561,7 +577,31 @@ class AccountMove(models.Model):
             suffixes.append(_("- There are some inconsistent taxes on lines."))
         if not self._check_all_taxes_mapped():
             suffixes.append(_("- It does not have all taxes mapped."))
+        if not self._check_rectified_document():
+            suffixes.append(
+                _(
+                    "- Link the original invoice or fill in the VERI*FACTU "
+                    "original document number and date."
+                )
+            )
         return super()._check_verifactu_configuration(suffixes=suffixes)
+
+    def _check_rectified_document(self):
+        """A rectification by differences must identify the rectified document,
+        either through the linked original invoice or through the manually
+        filled fields. Otherwise AEAT rejects the whole batch for not matching
+        the schema, as `IDFacturaRectificada` is mandatory.
+        """
+        self.ensure_one()
+        if self.move_type != "out_refund" or self.verifactu_refund_type != "I":
+            return True
+        return bool(
+            self.reversed_entry_id
+            or (
+                self.verifactu_original_document_number
+                and self.verifactu_original_document_date
+            )
+        )
 
     def _check_inconsistent_taxes(self):
         document_date = self._get_document_date()

--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -54,6 +54,20 @@ class VerifactuMixin(models.AbstractModel):
         store=True,
         readonly=False,
     )
+    verifactu_original_document_number = fields.Char(
+        string="VERI*FACTU original document number",
+        copy=False,
+        help="Serial number of the rectified document, to be filled in when it "
+        "is not registered in the system. It is only taken into account if "
+        "there is no linked original document.",
+    )
+    verifactu_original_document_date = fields.Date(
+        string="VERI*FACTU original document date",
+        copy=False,
+        help="Issue date of the rectified document, to be filled in when it is "
+        "not registered in the system. It is only taken into account if there "
+        "is no linked original document.",
+    )
     verifactu_description = fields.Text(string="VERI*FACTU description", copy=False)
     verifactu_macrodata = fields.Boolean(
         string="VERI*FACTU macrodata?",

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_refund_s_iva10b_s_iva10b_s_iva21s_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_refund_s_iva10b_s_iva10b_s_iva21s_dict.json
@@ -46,7 +46,15 @@
         "NumSerieFactura": "TEST001"
       }
     },
-    "FacturasRectificadas": [],
+    "FacturasRectificadas": [
+      {
+        "IDFacturaRectificada": {
+          "IDEmisorFactura": "G87846952",
+          "NumSerieFactura": "ORIGIN001",
+          "FechaExpedicionFactura": "31-12-2025"
+        }
+      }
+    ],
     "SistemaInformatico": {
       "NombreRazon": "Odoo Developer",
       "NIF": "A12345674",

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -138,6 +138,10 @@ class TestL10nEsAeatVerifactu(TestVerifactuCommon):
                     "fiscal_position_id": self.fp_nacional.id,
                     "verifactu_registration_key": self.fp_registration_key_01.id,
                     "verifactu_registration_date": "2026-01-01 19:20:30",
+                    # There is no linked original invoice, so the rectified
+                    # document is identified through these fields.
+                    "verifactu_original_document_number": "ORIGIN001",
+                    "verifactu_original_document_date": "2025-12-31",
                 },
             ),
             (
@@ -223,6 +227,85 @@ class TestL10nEsAeatVerifactu(TestVerifactuCommon):
                 name, inv_type, lines, extra_vals
             )
         return
+
+
+class TestVerifactuRectifiedDocument(TestVerifactuCommon):
+    """Identification of the rectified document on rectifications.
+
+    Kept in its own class on purpose: ``TestL10nEsAeatVerifactu`` is
+    subclassed by other modules, whose set-up applies different fiscal
+    positions and taxes, and these cases need a controlled environment.
+    """
+
+    def test_check_rectified_document(self):
+        """A rectification by differences must identify the rectified document,
+        either through the linked original invoice or through the manual fields.
+        """
+        # A regular invoice is not a rectification, so it is always valid
+        self.assertTrue(self.invoice._check_rectified_document())
+        refund = self._create_test_invoice(move_type="out_refund")
+        self.assertEqual(refund.verifactu_refund_type, "I")
+        # Neither the link nor the manual fields
+        self.assertFalse(refund._check_rectified_document())
+        # Only the number is not enough, the date is also mandatory
+        refund.verifactu_original_document_number = "ORIGIN001"
+        self.assertFalse(refund._check_rectified_document())
+        refund.verifactu_original_document_date = "2025-12-31"
+        self.assertTrue(refund._check_rectified_document())
+        # The linked original invoice is enough by itself
+        linked_refund = self._create_test_invoice(move_type="out_refund")
+        linked_refund.reversed_entry_id = self.invoice
+        self.assertTrue(linked_refund._check_rectified_document())
+
+    def _create_postable_refund(self, **extra_vals):
+        """Build a refund with the same shape as ``self.invoice``.
+
+        The generic ``_create_test_invoice`` helper is not usable here because
+        it creates the document with ``aeat_state="sent"``, and the
+        configuration check only runs on documents still pending to be sent.
+        """
+        vals = {
+            "company_id": self.company.id,
+            "partner_id": self.partner.id,
+            "invoice_date": "2026-01-01",
+            "move_type": "out_refund",
+            "invoice_line_ids": [
+                Command.create(
+                    {
+                        "product_id": self.product.id,
+                        "account_id": self.account_expense.id,
+                        "name": "Test line",
+                        "price_unit": 100,
+                        "quantity": 1,
+                    },
+                )
+            ],
+        }
+        vals.update(extra_vals)
+        return self.env["account.move"].create(vals)
+
+    def test_rectified_document_required_on_post(self):
+        """A rectification by differences cannot be posted without identifying
+        the rectified document.
+
+        Both refunds are built the same way and only differ on that
+        identification, so the failure can only come from the new check and not
+        from any other configuration requirement.
+        """
+        self._activate_certificate(self.certificate_password)
+        identified = self._create_postable_refund(
+            verifactu_original_document_number="ORIGIN001",
+            verifactu_original_document_date="2025-12-31",
+        )
+        # Guard the precondition: without these the check is skipped and the
+        # test would pass vacuously.
+        self.assertTrue(identified.verifactu_enabled)
+        self.assertEqual(identified.aeat_state, "not_sent")
+        identified.action_post()
+        self.assertEqual(identified.state, "posted")
+        not_identified = self._create_postable_refund()
+        with self.assertRaises(UserError):
+            not_identified.action_post()
 
 
 class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):

--- a/l10n_es_verifactu_oca/views/account_move_view.xml
+++ b/l10n_es_verifactu_oca/views/account_move_view.xml
@@ -40,6 +40,7 @@
                             name="group_verifactu_configuration"
                         >
                             <field name="aeat_state" invisible="1" />
+                            <field name="reversed_entry_id" invisible="1" />
                             <field
                                 name="verifactu_refund_type"
                                 string="Refund type"
@@ -49,6 +50,16 @@
                                 name="verifactu_refund_specific_type"
                                 string="Refund specific type"
                                 attrs="{'invisible': ['|', ('verifactu_enabled', '=', False), ('move_type', '!=', 'out_refund')]}"
+                            />
+                            <field
+                                name="verifactu_original_document_number"
+                                string="Original document number"
+                                attrs="{'required': [('verifactu_enabled', '=', True), ('move_type', '=', 'out_refund'), ('verifactu_refund_type', '=', 'I'), ('reversed_entry_id', '=', False)], 'invisible': ['|', '|', '|', ('verifactu_enabled', '=', False), ('move_type', '!=', 'out_refund'), ('verifactu_refund_type', '!=', 'I'), ('reversed_entry_id', '!=', False)]}"
+                            />
+                            <field
+                                name="verifactu_original_document_date"
+                                string="Original document date"
+                                attrs="{'required': [('verifactu_enabled', '=', True), ('move_type', '=', 'out_refund'), ('verifactu_refund_type', '=', 'I'), ('reversed_entry_id', '=', False)], 'invisible': ['|', '|', '|', ('verifactu_enabled', '=', False), ('move_type', '!=', 'out_refund'), ('verifactu_refund_type', '!=', 'I'), ('reversed_entry_id', '!=', False)]}"
                             />
                             <field
                                 name="verifactu_tax_key"


### PR DESCRIPTION
Relacionado con https://github.com/OCA/l10n-spain/issues/4642

En verifactu se exige informar IDFacturaRectificada, pero hasta ahora solo se rellenaba cuando el abono tenía factura original enlazada (reversed_entry_id).

Un abono sin ese enlace genera una rectificativa que no cumple el esquema y AEAT la rechaza.

Para los casos en que no se dispone de la factura original en el sistema:
  - Se han creado 2 campos nuevos en verifactu.mixin para identificar el documento rectificado cuando no está registrado en el sistema: número de serie y fecha de expedición. El NIF del emisor no necesita campo, porque el  emisor de la factura rectificada es la propia compañía, igual que ya se asume en la rama que usa el enlace. Se declaran en el mixin para que posteriormente se pueda hacer el arreglo también para el módulo l10n_es_verifactu_pos_oca.
  - En el RegistroAlta, esos campos se informan sólo si no hay factura original enlazada. El reversed_entry_id siempre prevalece.
  - En la vista, los campos aparecen y son obligatorios únicamente cuando se trata de una rectificativa de venta sin factura original enlazada. En cualquier otro caso están ocultos.
  - Antes de validar la rectificativa, se comprueba si está establecido el reversed_entry_id o los datos manuales del documento original, si no están rellenados, avisa al usuario y no permite validarla.
