### PR TITLE
[16.0][FIX] l10n_es_verifactu_oca: report non-subject taxes as N2

### DIFF
--- a/l10n_es_verifactu_oca/data/verifactu_map_data.xml
+++ b/l10n_es_verifactu_oca/data/verifactu_map_data.xml
@@ -47,13 +47,7 @@
     </record>
     <record id="verifactu_map_line_N1" model="verifactu.map.line">
         <field name="code">N1</field>
-        <field
-            name="taxes"
-            eval="[(6, 0, [
-                ref('l10n_es.account_tax_template_s_iva_ns_b'),
-                ref('l10n_es.account_tax_template_s_iva_ns'),
-        ])]"
-        />
+        <field name="taxes" eval="[(6, 0, [])]" />
         <field name="verifactu_map_id" ref="verifactu_map" />
         <field name="name">Operación No Sujeta artículo 7, 14, otros.</field>
     </record>
@@ -65,6 +59,8 @@
             eval="[(6, 0, [
                 ref('l10n_es.account_tax_template_s_iva_e'),
                 ref('l10n_es.account_tax_template_s_iva0_sp_i'),
+                ref('l10n_es.account_tax_template_s_iva_ns_b'),
+                ref('l10n_es.account_tax_template_s_iva_ns'),
             ])]"
         />
         <field name="verifactu_map_id" ref="verifactu_map" />

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva_ns_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva_ns_dict.json
@@ -20,7 +20,7 @@
         {
           "Impuesto": "01",
           "ClaveRegimen": "02",
-          "CalificacionOperacion": "N1",
+          "CalificacionOperacion": "N2",
           "BaseImponibleOimporteNoSujeto": 200.0
         }
       ]


### PR DESCRIPTION
Partimos de https://github.com/OCA/l10n-spain/pull/4499#discussion_r3460429589

Los impuestos "No sujeto Repercutido (Servicios)" (s_iva_ns) and "No sujeto Repercutido (Bienes)" (s_iva_ns_b) se mapearon como N1 (Operación No Sujeta artículo 7, 14, otros) en laa v 16.0, mientras que en 17.0 y 18.0 están como N2 (Operación No Sujeta por Reglas de localización). Ambos impuestos están mapeados a la casilla 120, por lo que N2 es la clasificación correcta y que diverge en v16.

Las bases de datos existentes se corrigen con un script de migración que desvincula únicamente esos dos impuestos de N1.