### PR TITLE
[19.0][FIX] l10n_es_aeat: Filter previous reports by company

### DIFF
--- a/l10n_es_aeat/models/l10n_es_aeat_report.py
+++ b/l10n_es_aeat/models/l10n_es_aeat_report.py
@@ -384,6 +384,7 @@ class L10nEsAeatReport(models.AbstractModel):
         return self.search(
             Domain.AND(
                 [
+                    Domain("company_id", "=", self.company_id.id),
                     Domain("year", "=", self.year),
                     Domain("date_start", "<", date),
                 ]

--- a/l10n_es_aeat_mod303/models/mod303.py
+++ b/l10n_es_aeat_mod303/models/mod303.py
@@ -509,7 +509,10 @@ class L10nEsAeatMod303Report(models.Model):
         res = super().calculate()
         for mod303 in self:
             prev_reports = self.search(
-                [("date_start", "<", mod303.date_start)]
+                [
+                    ("company_id", "=", mod303.company_id.id),
+                    ("date_start", "<", mod303.date_start),
+                ]
             ).filtered(lambda m: m.state not in ["draft", "cancelled"])
             if prev_reports:
                 prev_report = min(


### PR DESCRIPTION
## Contexto

En entornos multi-empresa, las declaraciones AEAT buscaban las declaraciones previas **sin filtrar por compañía**:

- `l10n_es_aeat.report._get_previous_fiscalyear_reports()` (usado por el Modelo 130 en `_calc_prev_trimesters_data` y por el Modelo 303 en `_compute_exception_msg`).
- `l10n_es_aeat_mod303.report.calculate()`, que calcula `potential_cuota_compensar` / `cuota_compensar` a partir del 303 anterior más cercano.

## Comportamiento actual

Con dos empresas, el 303 de la empresa A puede tomar como "declaración anterior" un 303 de la empresa B, arrastrando su cuota compensable a la autoliquidación enviada a la AEAT, además de generar mensajes de excepción incorrectos.

## Comportamiento esperado

Cada declaración solo debe considerar declaraciones previas de su misma `company_id`.

## Cambios

- `l10n_es_aeat`: añade `Domain("company_id", ...)` en `_get_previous_fiscalyear_reports()`.
- `l10n_es_aeat_mod303`: filtra por `company_id` en el `search()` de `calculate()`.
- Test `test_model_303_previous_reports_other_company` que crea una segunda compañía con un 303 previo compensable y verifica que no contamina `potential_cuota_compensar`, `cuota_compensar` ni `exception_msg` del 303 de la compañía principal.

## Impacto

Fix mínimo de aislamiento multi-empresa, sin cambios de comportamiento en escenarios de una sola compañía.
