### PR TITLE
[18.0][IMP] l10n_es_aeat_sii_match: Try match invoice with SII info in '3000 | Factura duplicada' case

### DIFF
--- a/l10n_es_aeat_sii_match/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_match/models/sii_mixin.py
@@ -287,3 +287,12 @@ class SiiMixin(models.AbstractModel):
                 new_cr.commit()
                 new_cr.close()
                 raise
+
+    def _send_document_to_sii(self):
+        res = super()._send_document_to_sii()
+        # Try match invoice data with SII info in this case
+        # TODO: Use other data like as a standard code instead of this string
+        self.filtered(
+            lambda am: am.aeat_send_error == "3000 | Factura duplicada"
+        )._contrast_invoice_to_aeat()
+        return res


### PR DESCRIPTION

Debido a errores inesperados en el envío de facturas al SII podemos encontrarnos con facturas que han sido comunicadas al SII pero que en Odoo no se ha actualizado el estado.
Entonces en el siguiente envío se vuelve a intentar enviar y el SII nos devuelve error de factura duplicada.
Con esta mejora las facturas que se encuentren en esta situación se intentará hacer el match para que queden con la info correcta en Odoo.

@Tecnativa TT63975

ping @carlosdauden @victoralmau @carlos-lopez-tecnativa @acysos 