### PR TITLE
[17.0][IMP] l10n_es_aeat_sii_match: try match invoice with SII info in '3000 | Factura duplicada' case

### DIFF
--- a/l10n_es_aeat_sii_match/models/account_move.py
+++ b/l10n_es_aeat_sii_match/models/account_move.py
@@ -273,3 +273,12 @@ class AccountMove(models.Model):
                 new_cr.commit()
                 new_cr.close()
                 raise
+
+    def _send_document_to_sii(self):
+        res = super()._send_document_to_sii()
+        # Try match invoice data with SII info in this case
+        # TODO: Use other data like as a standard code instead of this string
+        self.filtered(
+            lambda am: am.aeat_send_error == "3000 | Factura duplicada"
+        )._contrast_invoice_to_aeat()
+        return res


### PR DESCRIPTION
Justo después de que un envío al SII falle con el error "3000 | Factura duplicada", se intenta automáticamente contrastar la factura con la AEAT, en lugar de dejarla bloqueada hasta que alguien lance manualmente "Contrastar con AEAT".

Backport del commit 4d3888b (18.0, #5132).

Depende de:
- [x] https://github.com/OCA/l10n-spain/pull/5134

@Tecnativa TT63975

@victoralmau @david-banon-tecnativa @carlos-lopez-tecnativa