### PR TITLE
[17.0][FIX] l10n_es_aeat_sii_match: fix crash and keep contrasting the rest of the batch on AEAT error

### DIFF
--- a/l10n_es_aeat_sii_match/models/account_move.py
+++ b/l10n_es_aeat_sii_match/models/account_move.py
@@ -5,12 +5,14 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import json
+import logging
 
 from deepdiff import DeepDiff
 from zeep.helpers import serialize_object
 
-from odoo import _, api, exceptions, fields, models
-from odoo.modules.registry import Registry
+from odoo import _, exceptions, fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountMove(models.Model):
@@ -259,9 +261,9 @@ class AccountMove(models.Model):
                 )
                 invoice.write(inv_vals)
             except Exception as fault:
-                new_cr = Registry(self.env.cr.dbname).cursor()
-                env = api.Environment(new_cr, self.env.uid, self.env.context)
-                invoice = env["account.move"].browse(self.id)
+                _logger.exception(
+                    "Error contrasting invoice %s with AEAT", invoice.name
+                )
                 inv_vals.update(
                     {
                         "sii_match_return": repr(fault),
@@ -270,9 +272,6 @@ class AccountMove(models.Model):
                     }
                 )
                 invoice.write(inv_vals)
-                new_cr.commit()
-                new_cr.close()
-                raise
 
     def _send_document_to_sii(self):
         res = super()._send_document_to_sii()

--- a/l10n_es_aeat_sii_match/tests/test_l10n_es_aeat_sii_match.py
+++ b/l10n_es_aeat_sii_match/tests/test_l10n_es_aeat_sii_match.py
@@ -105,3 +105,27 @@ class TestL10nEsAeatSiiMatch(TestL10nEsAeatSiiBase):
         )
         with self.assertRaises(UserError):
             invoice.contrast_aeat()
+
+    def test_contrast_aeat_batch_continues_after_error(self):
+        """Contrasting several invoices at once must not crash nor stop the
+        batch just because one invoice raises (e.g. an AEAT communication
+        error): it must record the error on that invoice and keep
+        contrasting the rest.
+        """
+        self._activate_certificate()
+        invoice = self.invoice
+        invoice.write({"aeat_state": "sent", "sii_csv": "FAKECSV000"})
+        invoice2 = self._create_invoice("out_invoice")
+        invoice2.name = "INV002"
+        invoice2.action_post()
+        invoice2.write({"aeat_state": "sent", "sii_csv": "FAKECSV111"})
+        fake_serv = MagicMock()
+        fake_serv.ConsultaLRFacturasEmitidas.side_effect = [
+            Exception("AEAT communication error"),
+            {"RegistroRespuestaConsultaLRFacturasEmitidas": []},
+        ]
+        with patch.object(type(invoice), "_connect_aeat", return_value=fake_serv):
+            (invoice + invoice2).contrast_aeat()
+        self.assertFalse(invoice.sii_contrast_state)
+        self.assertIn("AEAT communication error", invoice.sii_match_return)
+        self.assertEqual(invoice2.sii_contrast_state, "no_exist")


### PR DESCRIPTION
La acción "Contrastar con AEAT", pensada para lanzarse sobre varias facturas a la vez, fallaba con "ValueError: Expected singleton" en cuanto se seleccionaba más de una factura y alguna de ellas fallaba al contrastar (p. ej. un fault SOAP de la AEAT).

El bloque except de _contrast_invoice_to_aeat abría un cursor auxiliar para persistir el error antes de relanzar la excepción, pero buscaba la factura a escribir con env["account.move"].browse(self.id): self es el recordset completo pasado a contrast_aeat(), no la factura actual del bucle, así que self.id provocaba ese error en cualquier lote con más de una factura.

Dado que el cursor auxiliar y el raise final solo existían para que esta escritura informativa sobreviviera al rollback que el propio raise provocaba, y una acción de lote no debería abortar el resto de facturas solo porque una haya fallado, ahora simplemente se registra el error en el log, se escribe en la factura actual usando la transacción normal, y el bucle continúa con el resto del lote.

@Tecnativa TT63975

@Abranes @carlos-lopez-tecnativa @HaraldPanten 