### PR TITLE
[17.0][IMP] l10n_es_aeat: Use Zeep cache

### DIFF
--- a/l10n_es_aeat/models/aeat_mixin.py
+++ b/l10n_es_aeat/models/aeat_mixin.py
@@ -15,6 +15,7 @@ _logger = logging.getLogger(__name__)
 
 try:
     from zeep import Client
+    from zeep.cache import SqliteCache
     from zeep.plugins import HistoryPlugin
     from zeep.transports import Transport
 except (OSError, ImportError) as err:
@@ -140,7 +141,9 @@ class AeatMixin(models.AbstractModel):
         params = self._connect_params_aeat(mapping_key)
         session = Session()
         session.cert = (public_crt, private_key)
-        transport = Transport(session=session)
+        # The cache avoids hammering AEAT and W3 servers with WSDL and schema requests
+        cache = SqliteCache(timeout=7200)  # in seconds
+        transport = Transport(session=session, cache=cache)
         history = HistoryPlugin()
         client = Client(wsdl=params["wsdl"], transport=transport, plugins=[history])
         return self._bind_service(client, params["port_name"], params["address"])

--- a/l10n_es_aeat/models/aeat_soap.py
+++ b/l10n_es_aeat/models/aeat_soap.py
@@ -10,6 +10,7 @@ _logger = logging.getLogger(__name__)
 
 try:
     from zeep import Client
+    from zeep.cache import SqliteCache
     from zeep.plugins import HistoryPlugin
     from zeep.transports import Transport
 except (OSError, ImportError) as err:
@@ -29,11 +30,11 @@ class L10nEsAeatSoap(models.TransientModel):
             public_crt, private_key = self.env[
                 "l10n.es.aeat.certificate"
             ].get_certificates()
-
         session = Session()
         session.cert = (public_crt, private_key)
-        transport = Transport(session=session)
-
+        # The cache avoids hammering AEAT and W3 servers with WSDL and schema requests
+        cache = SqliteCache(timeout=7200)  # in seconds
+        transport = Transport(session=session, cache=cache)
         history = HistoryPlugin()
         client = Client(wsdl=wsdl, transport=transport, plugins=[history])
         return client


### PR DESCRIPTION
Backport of #5126

The same as #4951, we can use a cache for avoiding hammering AEAT and W3 servers for the WSDL and schema requests.

@Tecnativa 