### PR TITLE
[18.0][FIX] l10n_es_verifactu_oca: un registro defectuoso ya no bloquea el lote entero

### DIFF
--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import datetime
 import json
+import logging
 
 from requests import Session
 from zeep import Client, Settings
@@ -13,6 +14,8 @@ from zeep.transports import Transport
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import split_every
+
+_logger = logging.getLogger(__name__)
 
 VERIFACTU_SEND_STATES = [
     ("not_sent", "Not sent"),
@@ -102,6 +105,13 @@ class VerifactuInvoiceEntry(models.Model):
         string="Last Response Line",
         readonly=True,
     )
+    payload_error = fields.Text(
+        readonly=True,
+        copy=False,
+        help="Error raised while building the data of this entry for the AEAT. "
+        "While it is set the entry could not even be sent, so it is still "
+        "pending: it is retried on every run until the cause is fixed.",
+    )
 
     @api.depends("response_line_ids", "response_line_ids.send_state")
     def _compute_send_state(self):
@@ -145,8 +155,7 @@ class VerifactuInvoiceEntry(models.Model):
                 threshold_time = send_date - datetime.timedelta(seconds=240)
                 # Look for documents where we have to send as an incident
                 outdated_records = records_to_send.filtered(
-                    lambda r, t=threshold_time: r.document.verifactu_registration_date
-                    < t
+                    lambda r, t=threshold_time: r._is_verifactu_incident(t)
                 )
                 current_records = records_to_send - outdated_records
                 outdated_records.with_context(
@@ -154,6 +163,17 @@ class VerifactuInvoiceEntry(models.Model):
                 )._send_documents_to_verifactu()
                 current_records._send_documents_to_verifactu()
         return True
+
+    def _is_verifactu_incident(self, threshold_time):
+        """Whether this entry has to be sent flagging it as an incident.
+
+        A missing document or registration date is not an incident: such an entry
+        goes through the regular flow, which reports the problem on the entry
+        itself instead of breaking the whole batch here.
+        """
+        self.ensure_one()
+        registration_date = self.document.verifactu_registration_date
+        return bool(registration_date) and registration_date < threshold_time
 
     def _get_verifactu_aeat_header(self):
         """Builds VERI*FACTU send header
@@ -290,26 +310,70 @@ class VerifactuInvoiceEntry(models.Model):
             response_line.document.write(doc_vals)
         return doc_vals
 
+    def _get_verifactu_document_dict(self):
+        """Build the data of this entry for the AEAT.
+
+        Raising here means this entry cannot be sent. The caller isolates it, so
+        raising is also how the real cause gets reported on the entry.
+        """
+        self.ensure_one()
+        document = self.document
+        if not document:
+            raise UserError(
+                self.env._(
+                    "The document %(document)s of this entry does not exist anymore.",
+                    document=self.document_name or self.document_id,
+                )
+            )
+        return document._get_verifactu_invoice_dict(cancel=self.entry_type == "cancel")
+
+    def _register_verifactu_payload_error(self, error):
+        """Report on the entry and its document why it could not be sent."""
+        self.ensure_one()
+        _logger.exception(
+            "VERI*FACTU: the data of the entry %(entry)s (%(document)s) could not "
+            "be built, so it has not been sent",
+            {"entry": self.id, "document": self.document_name},
+        )
+        message = f"{type(error).__name__}: {error}"
+        self.payload_error = message
+        document = self.document
+        if document:
+            document.write({"aeat_send_failed": True, "aeat_send_error": message})
+        return message
+
     def _send_documents_to_verifactu(self):
         if not self:
             return False
-        rec = self[0]
-        header = rec._get_verifactu_aeat_header()
+        header = self[0]._get_verifactu_aeat_header()
         registro_factura_list = []
+        entries_to_send = self.browse()
+        payload_errors = False
         create_exception = False
         for rec in self:
             rec.send_attempt += 1
-            if rec.document:
-                inv_dict = rec.document._get_verifactu_invoice_dict(
-                    cancel=rec.entry_type == "cancel"
-                )
-                registro_factura_list.append(inv_dict)
-        try:
-            serv = rec._connect_verifactu()
-            res = serv.RegFactuSistemaFacturacion(header, registro_factura_list)
-        except Exception:
-            res = {}
-            create_exception = True
+            try:
+                # The savepoint is needed because a failed build may leave the
+                # transaction in an aborted state, which would take down every
+                # remaining record of the batch with it.
+                with self.env.cr.savepoint():
+                    inv_dict = rec._get_verifactu_document_dict()
+            except Exception as error:  # noqa: BLE001 - isolate the faulty entry
+                rec._register_verifactu_payload_error(error)
+                payload_errors = True
+                continue
+            if rec.payload_error:
+                rec.payload_error = False
+            registro_factura_list.append(inv_dict)
+            entries_to_send |= rec
+        res = {}
+        if registro_factura_list:
+            try:
+                serv = self[0]._connect_verifactu()
+                res = serv.RegFactuSistemaFacturacion(header, registro_factura_list)
+            except Exception:
+                _logger.exception("VERI*FACTU: the documents could not be sent")
+                create_exception = True
         response_name = ""
         response = (
             self.env["verifactu.invoice.entry.response"]
@@ -329,17 +393,21 @@ class VerifactuInvoiceEntry(models.Model):
             if not response.date_response:
                 response.date_response = fields.Datetime.now()
             response.create_activity_on_exception()
-        create_response_activity = self._create_response_lines(
+        create_response_activity = entries_to_send._create_response_lines(
             response=response, header=header, verifactu_response=res
         )
-        updated_response_name = _("VERI*FACTU sending")
+        updated_response_name = self.env._("VERI*FACTU sending")
         if create_exception:
-            updated_response_name = _("Connection error with VERI*FACTU")
+            updated_response_name = self.env._("Connection error with VERI*FACTU")
         elif create_response_activity:
-            updated_response_name = _("Incorrect invoices sent to VERI*FACTU")
+            updated_response_name = self.env._("Incorrect invoices sent to VERI*FACTU")
+        elif payload_errors:
+            updated_response_name = self.env._("Documents not sent to VERI*FACTU")
         response.name = updated_response_name
         if create_response_activity:
             response.create_send_response_activity()
+        if payload_errors:
+            response.create_payload_error_activity()
         return True
 
     def _create_response_lines(

--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry_response.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry_response.py
@@ -99,6 +99,52 @@ class VerifactuInvoiceEntryResponse(models.Model):
             )
         return self.env["mail.activity"].create(activity_vals)
 
+    def create_payload_error_activity(self):
+        """Warn that some documents could not even be built to be sent.
+
+        Only one activity is kept open at a time: those entries stay pending and
+        are retried on every run, so recreating it on each one would flood the
+        responsible user. The cause of each entry is reported on the entry
+        itself, and on its document, so the activity only has to point there.
+        """
+        activity_type = self.env.ref("mail.mail_activity_data_warning")
+        model_id = self.env["ir.model"]._get_id("verifactu.invoice.entry.response")
+        summary = self.env._("Check documents that could not be sent to VERI*FACTU")
+        existing = self.env["mail.activity"].search_count(
+            [
+                ("activity_type_id", "=", activity_type.id),
+                ("res_model", "=", "verifactu.invoice.entry.response"),
+                ("summary", "=", summary),
+            ],
+            limit=1,
+        )
+        if existing:
+            return False
+        responsible_group = self.env.ref(
+            "l10n_es_verifactu_oca.group_verifactu_responsible"
+        )
+        users = responsible_group.users
+        activity_vals = []
+        for record in self:
+            user = users[:1] or self.env.user
+            activity_vals.append(
+                {
+                    "activity_type_id": activity_type.id,
+                    "user_id": user.id,
+                    "res_id": record.id,
+                    "res_model": "verifactu.invoice.entry.response",
+                    "res_model_id": model_id,
+                    "summary": summary,
+                    "note": self.env._(
+                        "One or more documents could not be built to be sent to "
+                        "VERI*FACTU, so they are still pending. They are retried "
+                        "on every run, but the cause has to be fixed first: check "
+                        "the VERI*FACTU entries having a payload error."
+                    ),
+                }
+            )
+        return self.env["mail.activity"].create(activity_vals)
+
     def complete_open_activity_on_exception(self):
         exception_activity_type = self.env.ref(
             "l10n_es_verifactu_oca.mail_activity_data_exception"

--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -6,6 +6,7 @@
 import base64
 import io
 import json
+import logging
 from hashlib import sha256
 from urllib.parse import urlencode
 
@@ -17,6 +18,8 @@ from odoo.exceptions import UserError
 from odoo.tools.float_utils import float_compare
 
 from odoo.addons.l10n_es_aeat.models.aeat_mixin import round_by_keys
+
+_logger = logging.getLogger(__name__)
 
 VERIFACTU_VERSION = 1.0
 VERIFACTU_DATE_FORMAT = "%d-%m-%Y"
@@ -347,14 +350,23 @@ class VerifactuMixin(models.AbstractModel):
                 self.verifactu_hash = hash_string.hexdigest().upper()
                 # Generate JSON data for AEAT
                 aeat_json_data = ""
+                payload_error = False
                 try:
                     inv_dict = self._get_verifactu_invoice_dict(cancel=cancel)
                     aeat_json_data = json.dumps(inv_dict, indent=4)
-                except Exception:
-                    # If JSON generation fails, store empty string
-                    aeat_json_data = ""
+                except Exception as error:  # noqa: BLE001
+                    # The document is registered and chained anyway: the entry
+                    # exists, so it keeps its link, and the sending is retried
+                    # until this is fixed. Report the cause instead of hiding it.
+                    _logger.exception(
+                        "VERI*FACTU: the data of the document %s could not be "
+                        "built when registering it",
+                        self.name,
+                    )
+                    payload_error = f"{type(error).__name__}: {error}"
                 invoice_entry.document_hash = hash_string.hexdigest().upper()
                 invoice_entry.aeat_json_data = aeat_json_data
+                invoice_entry.payload_error = payload_error
                 self.env.cr.execute(
                     f"UPDATE {chaining._table} "
                     "SET last_verifactu_invoice_entry_id = %s WHERE id = %s",

--- a/l10n_es_verifactu_oca/readme/CONTRIBUTORS.md
+++ b/l10n_es_verifactu_oca/readme/CONTRIBUTORS.md
@@ -16,5 +16,7 @@
   - Pedro M. Baeza
 - Factor Libre S.L.:
   - Luis J. Salvatierra
+- MDSX:
+  - Manuel Diez Silva \<<manu@mdsx.es>\>
 - Batista10:
   - Ivan Vilata i Balaguer

--- a/l10n_es_verifactu_oca/tests/__init__.py
+++ b/l10n_es_verifactu_oca/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_10n_es_verifactu
+from . import test_verifactu_batch_isolation
 from . import test_verifactu_invoice

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -14,6 +14,7 @@ from freezegun import freeze_time
 
 from odoo import Command
 from odoo.exceptions import UserError
+from odoo.tools import mute_logger
 from odoo.tools.misc import file_path
 
 from .common import TestVerifactuCommon
@@ -458,6 +459,7 @@ class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):
 
 
 class TestVerifactuSendResponse(TestVerifactuCommon):
+    @mute_logger("odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry")
     def test_create_activity_on_exception(self):
         """
         Creates an activity whenever the connection with VERI*FACTU

--- a/l10n_es_verifactu_oca/tests/test_verifactu_batch_isolation.py
+++ b/l10n_es_verifactu_oca/tests/test_verifactu_batch_isolation.py
@@ -1,0 +1,294 @@
+# Copyright 2026 MDSX - Manuel Diez Silva
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from unittest.mock import MagicMock, patch
+
+from odoo import Command
+from odoo.tools import mute_logger
+
+from .common import TestVerifactuCommon
+
+CONNECT_METHOD = (
+    "odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry."
+    "VerifactuInvoiceEntry._connect_verifactu"
+)
+
+
+class TestVerifactuBatchIsolation(TestVerifactuCommon):
+    """A document that cannot be built must not block the rest of the batch."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tax_21 = cls.env.ref(
+            f"account.{cls.company.id}_account_tax_template_s_iva21b"
+        )
+        cls.tax_10 = cls.env.ref(
+            f"account.{cls.company.id}_account_tax_template_s_iva10b"
+        )
+        cls.map_line_s1 = cls.env.ref("l10n_es_verifactu_oca.verifactu_map_line_S1")
+        cls.map_tax_10 = cls.env.ref("l10n_es_verifactu_oca.s_iva10b")
+
+    def _create_posted_invoice(self, tax, amount=100):
+        invoice = self.env["account.move"].create(
+            {
+                "company_id": self.company.id,
+                "partner_id": self.partner.id,
+                "invoice_date": "2026-01-01",
+                "move_type": "out_invoice",
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "account_id": self.account_expense.id,
+                            "name": "Test line",
+                            "price_unit": amount,
+                            "quantity": 1,
+                            "tax_ids": [Command.set(tax.ids)],
+                        },
+                    )
+                ],
+            }
+        )
+        invoice.action_post()
+        return invoice
+
+    def _unmap_tax_10(self):
+        """Leave the 10% VAT out of the VERI*FACTU map.
+
+        Reproduces the reported case: a tax that was mapped when the invoice was
+        posted stops being mapped afterwards, so the data of that invoice can no
+        longer be built when the queue is sent.
+        """
+        self.map_line_s1.tax_xmlid_ids = [Command.unlink(self.map_tax_10.id)]
+
+    def _map_tax_10(self):
+        self.map_line_s1.tax_xmlid_ids = [Command.link(self.map_tax_10.id)]
+
+    def _chain_snapshot(self):
+        """The links and hashes that make up the chain, to check they survive."""
+        entries = self.env["verifactu.invoice.entry"].search(
+            [("company_id", "=", self.company.id)]
+        )
+        return {
+            entry.id: (entry.previous_invoice_entry_id.id, entry.document_hash)
+            for entry in entries
+        }
+
+    def _mock_connection(self, mock_connect):
+        """Accept whatever documents are actually sent, and record them."""
+        sent_batches = []
+
+        def _send(header, registro_factura_list):
+            sent_batches.append(
+                [
+                    registro["RegistroAlta"]["IDFactura"]["NumSerieFactura"]
+                    for registro in registro_factura_list
+                ]
+            )
+            return {
+                "CSV": "TEST-CSV",
+                "EstadoEnvio": "Correcto",
+                "RespuestaLinea": [
+                    {
+                        "IDFactura": {
+                            "NumSerieFactura": registro["RegistroAlta"]["IDFactura"][
+                                "NumSerieFactura"
+                            ]
+                        },
+                        "EstadoRegistro": "Correcto",
+                    }
+                    for registro in registro_factura_list
+                ],
+            }
+
+        mock_service = MagicMock()
+        mock_service.RegFactuSistemaFacturacion.side_effect = _send
+        mock_connect.return_value = mock_service
+        return sent_batches
+
+    def _run_cron(self):
+        # Every real run of the cron gets its own transaction. Flush so that its
+        # raw SQL sees the state left behind by the previous one.
+        self.env.flush_all()
+        self.env["verifactu.invoice.entry"]._cron_send_documents_to_verifactu()
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry")
+    def test_faulty_document_does_not_block_the_batch(self):
+        """The rest of the batch is sent, and the faulty one says why it is not."""
+        self._activate_certificate(self.certificate_password)
+        good_1 = self._create_posted_invoice(self.tax_21)
+        faulty = self._create_posted_invoice(self.tax_10)
+        good_2 = self._create_posted_invoice(self.tax_21)
+        chain_before = self._chain_snapshot()
+        self._unmap_tax_10()
+        with patch(CONNECT_METHOD) as mock_connect:
+            sent_batches = self._mock_connection(mock_connect)
+            self._run_cron()
+        self.assertEqual(
+            sent_batches,
+            [[good_1.name, good_2.name]],
+            "Only the documents that could be built are sent, in chain order",
+        )
+        self.assertEqual(good_1.aeat_state, "sent")
+        self.assertEqual(good_2.aeat_state, "sent")
+        self.assertEqual(
+            faulty.aeat_state,
+            "not_sent",
+            "The faulty document is still pending, it has not been sent",
+        )
+        entry = faulty.last_verifactu_invoice_entry_id
+        self.assertEqual(
+            entry.send_state,
+            "not_sent",
+            "The entry keeps its slot in the chain and is retried later",
+        )
+        self.assertIn(
+            "not mapped to VERI*FACTU",
+            entry.payload_error,
+            "The entry states the real cause, not a connection error",
+        )
+        self.assertTrue(faulty.aeat_send_failed)
+        self.assertEqual(
+            faulty.aeat_send_error,
+            entry.payload_error,
+            "The cause is also visible on the document itself",
+        )
+        for invoice in (good_1, good_2):
+            self.assertFalse(invoice.last_verifactu_invoice_entry_id.payload_error)
+        self.assertEqual(
+            self._chain_snapshot(),
+            chain_before,
+            "No link or hash of the chain may change because of a failed send",
+        )
+        self.assertEqual(
+            [1, 1, 1],
+            [
+                invoice.last_verifactu_invoice_entry_id.send_attempt
+                for invoice in (good_1, faulty, good_2)
+            ],
+            "The attempt is counted for every entry, including the faulty one",
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry")
+    def test_faulty_document_is_not_reported_as_connection_error(self):
+        """The response of the batch must not be labelled as a connection error."""
+        self._activate_certificate(self.certificate_password)
+        self._create_posted_invoice(self.tax_21)
+        self._create_posted_invoice(self.tax_10)
+        self._unmap_tax_10()
+        with patch(CONNECT_METHOD) as mock_connect:
+            self._mock_connection(mock_connect)
+            self._run_cron()
+        response = self.env["verifactu.invoice.entry.response"].search([], limit=1)
+        self.assertEqual(response.name, "Documents not sent to VERI*FACTU")
+        exception_activity = self.env["mail.activity"].search(
+            [
+                (
+                    "activity_type_id",
+                    "=",
+                    self.env.ref(
+                        "l10n_es_verifactu_oca.mail_activity_data_exception"
+                    ).id,
+                ),
+                ("res_model", "=", "verifactu.invoice.entry.response"),
+            ]
+        )
+        self.assertFalse(
+            exception_activity,
+            "A faulty document is not a connection problem with the AEAT",
+        )
+        warning_activity = self.env["mail.activity"].search(
+            [
+                ("res_model", "=", "verifactu.invoice.entry.response"),
+                (
+                    "summary",
+                    "=",
+                    "Check documents that could not be sent to VERI*FACTU",
+                ),
+            ]
+        )
+        self.assertEqual(
+            len(warning_activity), 1, "The responsible user is warned about it"
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry")
+    def test_whole_batch_faulty_is_not_sent_to_the_aeat(self):
+        """With nothing that can be built there is nothing to send."""
+        self._activate_certificate(self.certificate_password)
+        faulty = self._create_posted_invoice(self.tax_10)
+        self._unmap_tax_10()
+        with patch(CONNECT_METHOD) as mock_connect:
+            self._mock_connection(mock_connect)
+            self._run_cron()
+            mock_connect.assert_not_called()
+        self.assertEqual(faulty.aeat_state, "not_sent")
+        self.assertIn(
+            "not mapped to VERI*FACTU",
+            faulty.last_verifactu_invoice_entry_id.payload_error,
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry")
+    def test_missing_document_does_not_break_the_batch(self):
+        """An entry whose document is gone is reported, it does not stop the rest."""
+        self._activate_certificate(self.certificate_password)
+        good = self._create_posted_invoice(self.tax_21)
+        orphan = self._create_posted_invoice(self.tax_21)
+        orphan_entry = orphan.last_verifactu_invoice_entry_id
+        orphan_entry.document_id = 0
+        with patch(CONNECT_METHOD) as mock_connect:
+            sent_batches = self._mock_connection(mock_connect)
+            self._run_cron()
+        self.assertEqual(sent_batches, [[good.name]])
+        self.assertEqual(good.aeat_state, "sent")
+        self.assertEqual(orphan_entry.send_state, "not_sent")
+        self.assertIn("does not exist anymore", orphan_entry.payload_error)
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry")
+    def test_pending_document_is_sent_once_the_cause_is_fixed(self):
+        """The entry keeps its slot, so it is sent as soon as it can be built."""
+        self._activate_certificate(self.certificate_password)
+        good = self._create_posted_invoice(self.tax_21)
+        faulty = self._create_posted_invoice(self.tax_10)
+        chain_before = self._chain_snapshot()
+        self._unmap_tax_10()
+        with patch(CONNECT_METHOD) as mock_connect:
+            sent_batches = self._mock_connection(mock_connect)
+            self._run_cron()
+            self.assertEqual(sent_batches, [[good.name]])
+            self._map_tax_10()
+            self._run_cron()
+        self.assertEqual(
+            sent_batches,
+            [[good.name], [faulty.name]],
+            "The document left behind is sent on the next run, on its own",
+        )
+        entry = faulty.last_verifactu_invoice_entry_id
+        self.assertEqual(faulty.aeat_state, "sent")
+        self.assertFalse(entry.payload_error, "The reported cause is cleared")
+        self.assertEqual(entry.send_attempt, 2)
+        self.assertEqual(
+            self._chain_snapshot(),
+            chain_before,
+            "The chain is the same one built when the documents were posted",
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry")
+    def test_connection_error_is_still_a_connection_error(self):
+        """Documents that can be built but not sent are not payload errors."""
+        self._activate_certificate(self.certificate_password)
+        invoices = [
+            self._create_posted_invoice(self.tax_21),
+            self._create_posted_invoice(self.tax_21),
+        ]
+        with patch(CONNECT_METHOD) as mock_connect:
+            mock_connect.side_effect = ConnectionError("AEAT is down")
+            self._run_cron()
+        response = self.env["verifactu.invoice.entry.response"].search([], limit=1)
+        self.assertEqual(response.name, "Connection error with VERI*FACTU")
+        for invoice in invoices:
+            self.assertEqual(invoice.aeat_state, "not_sent")
+            self.assertFalse(
+                invoice.last_verifactu_invoice_entry_id.payload_error,
+                "Their data was built correctly, the problem was the connection",
+            )

--- a/l10n_es_verifactu_oca/views/verifactu_invoice_entry_view.xml
+++ b/l10n_es_verifactu_oca/views/verifactu_invoice_entry_view.xml
@@ -22,6 +22,7 @@
                     decoration-warning="send_state in ('sent_w_errors', 'incorrect', 'cancel_incorrect', 'cancel_w_errors')"
                     decoration-muted="send_state == 'cancel'"
                 />
+                <field name="payload_error" optional="show" decoration-danger="1" />
             </list>
         </field>
     </record>
@@ -49,6 +50,11 @@
                             <field name="entry_type" />
                             <field name="send_state" />
                         </group>
+                    </group>
+                    <group invisible="not payload_error">
+                        <div class="alert alert-warning" role="alert" colspan="2">
+                            <field name="payload_error" nolabel="1" />
+                        </div>
                     </group>
                     <notebook>
                         <page string="AEAT DATA">
@@ -88,6 +94,17 @@
                 <field name="document_id" />
                 <field name="company_id" />
                 <field name="document_hash" />
+                <filter
+                    string="Not sent"
+                    name="filter_not_sent"
+                    domain="[('send_state', '=', 'not_sent')]"
+                />
+                <filter
+                    string="Payload error"
+                    name="filter_payload_error"
+                    domain="[('payload_error', '!=', False)]"
+                />
+                <separator />
                 <filter
                     string="Company"
                     name="group_by_company"


### PR DESCRIPTION
Un registro defectuoso deja hoy el lote entero sin enviar, etiquetado como «error de conexión», y el cron lo reintenta indefinidamente sin decir nunca cuál es la causa real. Lo anunciamos en aliatech/l10n-spain#1 (correcciones del TPV, sobre OCA/l10n-spain#4583) y aquí va, en PR aparte por ser otro módulo.

Un único commit, +449/-20, todo dentro de `l10n_es_verifactu_oca`.

## El fallo

En `_send_documents_to_verifactu()` la construcción del diccionario de **todos** los registros se hacía **fuera** del `try`, y el `except Exception` que la envolvía se interpretaba siempre como error de conexión:

```python
for rec in self:
    rec.send_attempt += 1
    if rec.document:
        inv_dict = rec.document._get_verifactu_invoice_dict(...)   # ← puede lanzar
        registro_factura_list.append(inv_dict)
try:
    serv = rec._connect_verifactu()
    res = serv.RegFactuSistemaFacturacion(header, registro_factura_list)
except Exception:
    res = {}
    create_exception = True
```

Basta con que un registro del lote no se pueda construir —un impuesto que deja de estar mapeado, un descuadre de recargo de equivalencia— para que **ninguno** se envíe. Todos se quedan en `not_sent`, la respuesta se etiqueta «error de conexión» y el cron repite el mismo lote cada minuto con el mismo resultado. Dado que VERI\*FACTU exige inmediatez, un atasco silencioso no es menor.

Reproducido con datos reales: dos registros en cola, uno inválido, ambos bloqueados; enviado el válido en solitario, pasa a `sent`.

## La corrección

Cada registro se construye ahora dentro de su propio *savepoint*. El *savepoint* no es decorativo: si la construcción falla contra la base de datos, la transacción queda abortada y **todos** los registros siguientes del lote fallarían también. Es el mismo patrón que ya usa `_generate_verifactu_chaining()` en este módulo.

El registro que no se puede construir se queda fuera del envío y la causa real se anota en su entrada (campo nuevo `payload_error`) y en su documento (`aeat_send_failed` y `aeat_send_error`, que la vista de factura ya muestra y por los que ya se puede filtrar y agrupar). El resto del lote sale con normalidad.

## Esto no toca el encadenado

La cadena se construye al **contabilizar** el documento, no al enviarlo, y el bloque `Encadenamiento` sale de `previous_invoice_entry_id` y `document_hash` almacenados, no de la posición del registro en el lote. Dejar un registro fuera del envío no puede mover, renumerar ni perder ningún eslabón: la fila sigue ahí, conserva sus enlaces y su huella, y permanece en `not_sent`, de modo que se reintenta y se envía en cuanto se corrige la causa —como incidencia si ya va con retraso, que es justo el mecanismo que el módulo ya aplica en `_cron_send_documents_to_verifactu()`.

Enviar con huecos es además el modo de funcionamiento normal: un registro `incorrect` sale del conjunto `not_sent` mientras los posteriores se siguen enviando.

Los tests no lo dan por supuesto: fotografían enlaces y huellas de toda la cadena antes y después y comparan.

## Tres fallos de la misma familia

Los tres dejaban también la cadena entera parada, y van en el mismo commit por ser el mismo defecto:

1. **No se intenta la conexión si no hay nada que enviar.** Antes, con el lote entero defectuoso, se llamaba a `RegFactuSistemaFacturacion` con una lista vacía y se reportaba como error de conexión.
2. **Entrada cuyo documento ya no existe.** Se descartaba en silencio (`if rec.document:`), quedando pendiente para siempre y sin nada que lo explicara. Y antes de llegar ahí, el cron reventaba con `TypeError` al comparar su fecha de registro inexistente contra el umbral de incidencia, tumbando la cadena completa. Ahora se reporta como cualquier otro registro defectuoso.
3. **`_generate_verifactu_chaining()` se tragaba el mismo error** al registrar el documento y guardaba `aeat_json_data` vacío, que es la razón de que el problema no aparezca hasta el envío. Ahora anota la causa en la entrada, en el momento en que se produce.

Se mantiene **una sola** actividad de aviso abierta mientras haya entradas sin construir, en lugar de una por ejecución.

## Cómo se ha verificado

Odoo 18 sobre Debian 13, PostgreSQL 18, contra el **entorno de pruebas de la AEAT**, con certificado real de un obligado tributario.

Suites en verde sobre base de datos limpia:

```
l10n_es_verifactu_oca:     43 tests, 0 failed, 0 error(s)
l10n_es_verifactu_pos_oca: 22 tests, 0 failed, 0 error(s)
```

Seis tests nuevos en `tests/test_verifactu_batch_isolation.py`: aislamiento del registro defectuoso, que no se etiquete como error de conexión, lote entero defectuoso sin conexión, documento inexistente, recuperación al corregir la causa, y un test de regresión que comprueba que un error de conexión **de verdad** se sigue clasificando como tal.

Envío real, con dos facturas en el mismo lote y un impuesto desmapeado después de contabilizarlas —el caso reportado:

- La válida: `EstadoRegistro: Correcto` y CSV devuelto por la AEAT.
- La defectuosa: `not_sent`, con `El impuesto 10% B no está mapeado para VERI*FACTU.` en la entrada y en la factura. Sin «error de conexión» por ningún lado.
- Enlaces y huellas de la cadena, idénticos antes y después.
- Al volver a mapear el impuesto, la siguiente ejecución del cron la envía sola, como incidencia por ir con retraso: `Correcto`, CSV devuelto, `payload_error` limpiado, y la cadena recorrida entera sin un solo enlace roto.

## Lo que **no** entra

Por transparencia, no como reproche:

- **`_get_verifactu_aeat_header()` sigue fuera del `try`.** Una empresa sin NIF configurado aborta el cron entero, no solo su lote. Es un error de configuración que afecta a todo el lote por igual, así que el aislamiento no aporta nada y arreglarlo pide otra rama de código. Merece su propio PR.
- **Se crea un registro de respuesta por ejecución** mientras haya registros pendientes de construir. Es el comportamiento que ya tiene la ruta de error de conexión; deduplicarlas es un cambio aparte.
- **`aeat_send_error` acaba con el literal `"None | None"`** en las facturas aceptadas: `hasattr(verifactu_response_line, "CodigoErrorRegistro")` es siempre cierto sobre los objetos de `zeep` (no sobre los `dict` de los tests), y se compone el mensaje con dos `None`. Es cosmético y anterior a este PR, pero lo dejamos apuntado porque se ve en cuanto se envía de verdad.

## Nota sobre `pre-commit`

No hemos podido ejecutar `pre-commit` en el entorno donde se ha preparado esto. El formato se ha ajustado a mano a las 88 columnas de `black`; si el CI encuentra algo, lo corregimos enseguida.

## Uso de IA

Este trabajo se ha desarrollado con asistencia de IA, declarada en el commit con `Assisted-by: Claude Opus 5` conforme a la [política de IA de la OCA](https://github.com/OCA/.github/blob/master/AI_POLICY.md).