### PR TITLE
[16.0][FIX] l10n_es_verifactu_oca: validar los registros contra el esquema oficial antes de enviarlos

### DIFF
--- a/l10n_es_verifactu_oca/README.rst
+++ b/l10n_es_verifactu_oca/README.rst
@@ -74,6 +74,29 @@ Usage
 
 Cuando se valida una factura, automáticamente genera el registro de envío para verifactu. Cada minuto se enviarán todos aquellos registros pendientes de enviar mediante un cron.
 
+Antes de validar, la factura se comprueba contra el esquema oficial de la Agencia Tributaria, que
+viene incluido en el módulo (no hace falta conexión). Si el registro no cumple ese esquema, la
+factura no se valida y el mensaje indica qué dato falla. Se comprueba en ese momento porque es el
+último en el que la factura todavía se puede corregir: una vez validada es un documento fiscal
+cerrado.
+
+La misma comprobación se repite al enviar, para los registros que ya estaban validados. El que no
+cumple el esquema se queda fuera del envío y los demás se comunican con normalidad. El documento
+que se queda fuera lo indica en su propio formulario, en el campo de error de envío, y se crea un
+aviso para el grupo responsable de VERI*FACTU. Mientras no se corrija el dato, ese registro se
+reintenta en cada pase del cron.
+
+Para que ese aviso lo vea alguien, el grupo *VERI\*FACTU responsable* tiene que tener usuarios: la
+actividad se asigna al primero del grupo y, si el grupo está vacío, al usuario con el que se
+ejecuta el cron, que no suele mirarlas. Conviene añadir al grupo a quien vaya a atender los
+rechazos antes de empezar a facturar.
+
+En la compañía, la casilla *Omitir la comprobación del esquema al validar* deja de impedir la
+validación de la factura. Está pensada para poder seguir facturando mientras se investiga un
+rechazo indebido, no como ajuste permanente: el registro que no cumple el esquema se sigue
+quedando fuera del envío, así que apagarla no consigue que llegue a la Agencia. El cambio queda
+registrado en el historial de la compañía.
+
 Known issues / Roadmap
 ======================
 

--- a/l10n_es_verifactu_oca/data/SuministroInformacion.xsd
+++ b/l10n_es_verifactu_oca/data/SuministroInformacion.xsd
@@ -1,0 +1,1390 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:sf="https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/tike/cont/ws/SuministroInformacion.xsd" targetNamespace="https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/tike/cont/ws/SuministroInformacion.xsd" elementFormDefault="qualified">
+	<import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="http://www.w3.org/TR/xmldsig-core/xmldsig-core-schema.xsd"/>
+	<complexType name="CabeceraType">
+		<annotation>
+			<documentation xml:lang="es"> Datos de cabecera </documentation>
+		</annotation>
+		<sequence>
+			<element name="ObligadoEmision" type="sf:PersonaFisicaJuridicaESType">
+				<annotation>
+					<documentation xml:lang="es"> Obligado a expedir la factura. </documentation>
+				</annotation>
+			</element>
+			<element name="Representante" type="sf:PersonaFisicaJuridicaESType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="es"> Representante del obligado tributario. A rellenar solo en caso de que los registros de facturación remitdos hayan sido generados por un representante/asesor del obligado tributario. </documentation>
+				</annotation>
+			</element>
+			<element name="RemisionVoluntaria" minOccurs="0">
+				<complexType>
+					<sequence>
+						<element name="FechaFinVeriFactu" type="sf:fecha" minOccurs="0"/>
+						<element name="Incidencia" type="sf:IncidenciaType" minOccurs="0"/>
+					</sequence>
+				</complexType>
+			</element>
+			<element name="RemisionRequerimiento" minOccurs="0">
+				<complexType>
+					<sequence>
+						<element name="RefRequerimiento" type="sf:TextMax18Type"/>
+						<element name="FinRequerimiento" type="sf:FinRequerimientoType" minOccurs="0"/>
+					</sequence>
+				</complexType>
+			</element>
+		</sequence>
+	</complexType>
+	<element name="RegistroAlta" type="sf:RegistroFacturacionAltaType"/>
+	<element name="RegistroAnulacion" type="sf:RegistroFacturacionAnulacionType"/>
+	<!-- Datos de presentacion en la respuesta
+-->
+	<complexType name="DatosPresentacionType">
+		<sequence>
+			<element name="NIFPresentador" type="sf:NIFType"/>
+			<element name="TimestampPresentacion" type="dateTime"/>
+		</sequence>
+	</complexType>
+	<complexType name="DatosPresentacion2Type">
+		<sequence>
+			<element name="NIFPresentador" type="sf:NIFType"/>
+			<element name="TimestampPresentacion" type="dateTime"/>
+			<element name="IdPeticion" type="sf:TextMax20Type"/>
+		</sequence>
+	</complexType>
+	<complexType name="PeriodoImputacionType">
+		<sequence>
+			<element name="Ejercicio" type="sf:YearType"/>
+			<element name="Periodo" type="sf:TipoPeriodoType"/>
+		</sequence>
+	</complexType>
+	<complexType name="IDFacturaExpedidaBCType">
+		<annotation>
+			<documentation xml:lang="es"> Datos de identificación de factura expedida para operaciones de consulta</documentation>
+		</annotation>
+		<sequence>
+			<element name="IDEmisorFactura" type="sf:NIFType"/>
+			<element name="NumSerieFactura" type="sf:TextoIDFacturaType">
+				<annotation>
+					<documentation xml:lang="es"> Nº Serie+Nº Factura de la Factura del Emisor.</documentation>
+				</annotation>
+			</element>
+			<element name="FechaExpedicionFactura" type="sf:fecha">
+				<annotation>
+					<documentation xml:lang="es"> Fecha de emisión de la factura</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="IDFacturaExpedidaBajaType">
+		<annotation>
+			<documentation xml:lang="es"> Datos de identificación de factura que se anula para operaciones de baja</documentation>
+		</annotation>
+		<sequence>
+			<element name="IDEmisorFacturaAnulada" type="sf:NIFType">
+				<annotation>
+					<documentation xml:lang="es"> NIF del obligado</documentation>
+				</annotation>
+			</element>
+			<element name="NumSerieFacturaAnulada" type="sf:TextoIDFacturaType">
+				<annotation>
+					<documentation xml:lang="es"> Nº Serie+Nº Factura de la Factura que se anula.</documentation>
+				</annotation>
+			</element>
+			<element name="FechaExpedicionFacturaAnulada" type="sf:fecha">
+				<annotation>
+					<documentation xml:lang="es"> Fecha de emisión de la factura que se anula</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="RegistroFacturacionAltaType">
+		<annotation>
+			<documentation xml:lang="es">Datos correspondientes al registro de facturacion de alta </documentation>
+		</annotation>
+		<sequence>
+			<element name="IDVersion" type="sf:VersionType"/>
+			<element name="IDFactura" type="sf:IDFacturaExpedidaType"/>
+			<element name="RefExterna" type="sf:TextMax60Type" minOccurs="0"/>
+			<element name="NombreRazonEmisor" type="sf:TextMax120Type"/>
+			<element name="Subsanacion" type="sf:SubsanacionType" minOccurs="0"/>
+			<element name="RechazoPrevio" type="sf:RechazoPrevioType" minOccurs="0"/>
+			<element name="TipoFactura" type="sf:ClaveTipoFacturaType">
+				<annotation>
+					<documentation xml:lang="es"> Clave del tipo de factura </documentation>
+				</annotation>
+			</element>
+			<element name="TipoRectificativa" type="sf:ClaveTipoRectificativaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="es"> Identifica si el tipo de factura rectificativa es por sustitución o por diferencia </documentation>
+				</annotation>
+			</element>
+			<element name="FacturasRectificadas" minOccurs="0">
+				<complexType>
+					<annotation>
+						<documentation xml:lang="es">El ID de las facturas rectificadas, únicamente se rellena en el caso de rectificación de facturas</documentation>
+					</annotation>
+					<sequence>
+						<element name="IDFacturaRectificada" type="sf:IDFacturaARType" maxOccurs="1000"/>
+					</sequence>
+				</complexType>
+			</element>
+			<element name="FacturasSustituidas" minOccurs="0">
+				<complexType>
+					<annotation>
+						<documentation xml:lang="es">El ID de las facturas sustituidas, únicamente se rellena en el caso de facturas sustituidas</documentation>
+					</annotation>
+					<sequence>
+						<element name="IDFacturaSustituida" type="sf:IDFacturaARType" maxOccurs="1000"/>
+					</sequence>
+				</complexType>
+			</element>
+			<element name="ImporteRectificacion" type="sf:DesgloseRectificacionType" minOccurs="0"/>
+			<element name="FechaOperacion" type="sf:fecha" minOccurs="0"/>
+			<element name="DescripcionOperacion" type="sf:TextMax500Type"/>
+			<element name="FacturaSimplificadaArt7273" type="sf:SimplificadaCualificadaType" minOccurs="0"/>
+			<element name="FacturaSinIdentifDestinatarioArt61d" type="sf:CompletaSinDestinatarioType" minOccurs="0"/>
+			<element name="Macrodato" type="sf:MacrodatoType" minOccurs="0"/>
+			<element name="EmitidaPorTerceroODestinatario" type="sf:TercerosODestinatarioType" minOccurs="0"/>
+			<element name="Tercero" type="sf:PersonaFisicaJuridicaType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="es"> Tercero que expida la factura y/o genera el registro de alta. </documentation>
+				</annotation>
+			</element>
+			<element name="Destinatarios" minOccurs="0">
+				<complexType>
+					<annotation>
+						<documentation xml:lang="es">Contraparte de la operación. Cliente</documentation>
+					</annotation>
+					<sequence>
+						<element name="IDDestinatario" type="sf:PersonaFisicaJuridicaType" maxOccurs="1000"/>
+					</sequence>
+				</complexType>
+			</element>
+			<element name="Cupon" type="sf:CuponType" minOccurs="0"/>
+			<element name="Desglose" type="sf:DesgloseType"/>
+			<element name="CuotaTotal" type="sf:ImporteSgn12.2Type"/>
+			<element name="ImporteTotal" type="sf:ImporteSgn12.2Type"/>
+			<element name="Encadenamiento">
+				<complexType>
+					<choice>
+						<element name="PrimerRegistro" type="sf:PrimerRegistroCadenaType"/>
+						<element name="RegistroAnterior" type="sf:EncadenamientoFacturaAnteriorType"/>
+					</choice>
+				</complexType>
+			</element>
+			<element name="SistemaInformatico" type="sf:SistemaInformaticoType"/>
+			<element name="FechaHoraHusoGenRegistro" type="dateTime"/>
+			<element name="NumRegistroAcuerdoFacturacion" type="sf:TextMax15Type" minOccurs="0"/>
+			<element name="IdAcuerdoSistemaInformatico" type="sf:TextMax16Type" minOccurs="0"/>
+			<element name="TipoHuella" type="sf:TipoHuellaType"/>
+			<element name="Huella" type="sf:TextMax64Type"/>
+			<element ref="ds:Signature" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="RegistroFacturacionAnulacionType">
+		<annotation>
+			<documentation xml:lang="es">Datos correspondientes al registro de facturacion de anulacion </documentation>
+		</annotation>
+		<sequence>
+			<element name="IDVersion" type="sf:VersionType"/>
+			<element name="IDFactura" type="sf:IDFacturaExpedidaBajaType"/>
+			<element name="RefExterna" type="sf:TextMax60Type" minOccurs="0"/>
+			<element name="SinRegistroPrevio" type="sf:SinRegistroPrevioType" minOccurs="0"/>
+			<element name="RechazoPrevio" type="sf:RechazoPrevioAnulacionType" minOccurs="0"/>
+			<element name="GeneradoPor" type="sf:GeneradoPorType" minOccurs="0"/>
+			<element name="Generador" type="sf:PersonaFisicaJuridicaType" minOccurs="0"/>
+			<element name="Encadenamiento">
+				<complexType>
+					<choice>
+						<element name="PrimerRegistro" type="sf:PrimerRegistroCadenaType"/>
+						<element name="RegistroAnterior" type="sf:EncadenamientoFacturaAnteriorType"/>
+					</choice>
+				</complexType>
+			</element>
+			<element name="SistemaInformatico" type="sf:SistemaInformaticoType"/>
+			<element name="FechaHoraHusoGenRegistro" type="dateTime"/>
+			<element name="TipoHuella" type="sf:TipoHuellaType"/>
+			<element name="Huella" type="sf:TextMax64Type"/>
+			<element ref="ds:Signature" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="EncadenamientoFacturaAnteriorType">
+		<annotation>
+			<documentation xml:lang="es">Datos de encadenamiento </documentation>
+		</annotation>
+		<sequence>
+			<element name="IDEmisorFactura" type="sf:NIFType">
+				<annotation>
+					<documentation xml:lang="es"> NIF del obligado a expedir la factura a que se refiere el registro de facturación anterior</documentation>
+				</annotation>
+			</element>
+			<element name="NumSerieFactura" type="sf:TextMax60Type"/>
+			<element name="FechaExpedicionFactura" type="sf:fecha"/>
+			<element name="Huella" type="sf:TextMax64Type"/>
+		</sequence>
+	</complexType>
+	<complexType name="SistemaInformaticoType">
+		<sequence>
+			<sequence>
+				<element name="NombreRazon" type="sf:TextMax120Type"/>
+				<choice>
+					<element name="NIF" type="sf:NIFType"/>
+					<element name="IDOtro" type="sf:IDOtroType"/>
+				</choice>
+			</sequence>
+			<element name="NombreSistemaInformatico" type="sf:TextMax30Type"/>
+			<element name="IdSistemaInformatico" type="sf:TextMax2Type"/>
+			<element name="Version" type="sf:TextMax50Type"/>
+			<element name="NumeroInstalacion" type="sf:TextMax100Type"/>
+			<element name="TipoUsoPosibleSoloVerifactu" type="sf:SiNoType"/>
+			<element name="TipoUsoPosibleMultiOT" type="sf:SiNoType"/>
+			<element name="IndicadorMultiplesOT" type="sf:SiNoType"/>
+		</sequence>
+	</complexType>
+	<complexType name="SistemaInformaticoConsultaType">
+		<sequence>
+			<sequence>
+				<element name="NombreRazon" type="sf:TextMax120Type"/>
+				<choice>
+					<element name="NIF" type="sf:NIFType"/>
+					<element name="IDOtro" type="sf:IDOtroType"/>
+				</choice>
+			</sequence>
+			<element name="NombreSistemaInformatico" type="sf:TextMax30Type" minOccurs="0"/>
+			<element name="IdSistemaInformatico" type="sf:TextMax2Type"/>
+			<element name="Version" type="sf:TextMax50Type" minOccurs="0"/>
+			<element name="NumeroInstalacion" type="sf:TextMax100Type"/>
+			<element name="TipoUsoPosibleSoloVerifactu" type="sf:SiNoType" minOccurs="0"/>
+			<element name="TipoUsoPosibleMultiOT" type="sf:SiNoType" minOccurs="0"/>
+			<element name="IndicadorMultiplesOT" type="sf:SiNoType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="IDFacturaExpedidaType">
+		<annotation>
+			<documentation xml:lang="es"> Datos de identificación de factura </documentation>
+		</annotation>
+		<sequence>
+			<element name="IDEmisorFactura" type="sf:NIFType">
+				<annotation>
+					<documentation xml:lang="es"> NIF del obligado</documentation>
+				</annotation>
+			</element>
+			<element name="NumSerieFactura" type="sf:TextoIDFacturaType">
+				<annotation>
+					<documentation xml:lang="es"> Nº Serie+Nº Factura de la Factura del Emisor</documentation>
+				</annotation>
+			</element>
+			<element name="FechaExpedicionFactura" type="sf:fecha">
+				<annotation>
+					<documentation xml:lang="es"> Fecha de emisión de la factura</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<!--tipo definido para la identificacion de facturas sustituidas o rectificadas-->
+	<complexType name="IDFacturaARType">
+		<annotation>
+			<documentation xml:lang="es"> Datos de identificación de factura sustituida o rectificada. El NIF se cogerá del NIF indicado en el bloque IDFactura</documentation>
+		</annotation>
+		<sequence>
+			<element name="IDEmisorFactura" type="sf:NIFType">
+				<annotation>
+					<documentation xml:lang="es"> NIF del obligado</documentation>
+				</annotation>
+			</element>
+			<element name="NumSerieFactura" type="sf:TextoIDFacturaType">
+				<annotation>
+					<documentation xml:lang="es">Nº Serie+Nº Factura de la factura</documentation>
+				</annotation>
+			</element>
+			<element name="FechaExpedicionFactura" type="sf:fecha">
+				<annotation>
+					<documentation xml:lang="es"> Fecha de emisión de la factura sustituida o rectificada</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="DetalleType">
+		<sequence>
+			<element name="Impuesto" type="sf:ImpuestoType" minOccurs="0"/>
+			<element name="ClaveRegimen" type="sf:IdOperacionesTrascendenciaTributariaType" minOccurs="0"/>
+			<choice>
+				<element name="CalificacionOperacion" type="sf:CalificacionOperacionType"/>
+				<element name="OperacionExenta" type="sf:OperacionExentaType"/>
+			</choice>
+			<element name="TipoImpositivo" type="sf:Tipo2.2Type" minOccurs="0"/>
+			<element name="BaseImponibleOimporteNoSujeto" type="sf:ImporteSgn12.2Type"/>
+			<element name="BaseImponibleACoste" type="sf:ImporteSgn12.2Type" minOccurs="0"/>
+			<element name="CuotaRepercutida" type="sf:ImporteSgn12.2Type" minOccurs="0"/>
+			<element name="TipoRecargoEquivalencia" type="sf:Tipo2.2Type" minOccurs="0"/>
+			<element name="CuotaRecargoEquivalencia" type="sf:ImporteSgn12.2Type" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="DesgloseRectificacionType">
+		<annotation>
+			<documentation xml:lang="es">Desglose de Base y Cuota sustituida en las Facturas Rectificativas sustitutivas</documentation>
+		</annotation>
+		<sequence>
+			<element name="BaseRectificada" type="sf:ImporteSgn12.2Type"/>
+			<element name="CuotaRectificada" type="sf:ImporteSgn12.2Type"/>
+			<element name="CuotaRecargoRectificado" type="sf:ImporteSgn12.2Type" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<!-- Datos de persona Física o jurídica : Denominación, representación, identificación (NIF) -->
+	<complexType name="PersonaFisicaJuridicaESType">
+		<annotation>
+			<documentation xml:lang="es">Datos de una persona física o jurídica Española con un NIF asociado</documentation>
+		</annotation>
+		<sequence>
+			<element name="NombreRazon" type="sf:TextMax120Type"/>
+			<element name="NIF" type="sf:NIFType"/>
+		</sequence>
+	</complexType>
+	<!-- Datos de persona Física o jurídica : Denominación, representación, identificación (NIF/Otro) -->
+	<complexType name="PersonaFisicaJuridicaType">
+		<annotation>
+			<documentation xml:lang="es">Datos de una persona física o jurídica Española o Extranjera</documentation>
+		</annotation>
+		<sequence>
+			<element name="NombreRazon" type="sf:TextMax120Type"/>
+			<choice>
+				<element name="NIF" type="sf:NIFType"/>
+				<element name="IDOtro" type="sf:IDOtroType"/>
+			</choice>
+		</sequence>
+	</complexType>
+	<!-- Datos de persona Física o jurídica : Denominación, representación, identificación (NIF/Otro) -->
+	<complexType name="IDOtroType">
+		<annotation>
+			<documentation xml:lang="es">Identificador de persona Física o jurídica distinto del NIF
+        								 (Código pais, Tipo de Identificador, y hasta 15 caractéres)
+        								 No se permite CodigoPais=ES e IDType=01-NIFContraparte
+        								 para ese caso, debe utilizarse NIF en lugar de IDOtro.
+        	</documentation>
+		</annotation>
+		<sequence>
+			<element name="CodigoPais" type="sf:CountryType2" minOccurs="0"/>
+			<element name="IDType" type="sf:PersonaFisicaJuridicaIDTypeType"/>
+			<element name="ID" type="sf:TextMax20Type"/>
+		</sequence>
+	</complexType>
+	<complexType name="RangoFechaExpedicionType">
+		<annotation>
+			<documentation xml:lang="es">Rango de fechas de expedicion</documentation>
+		</annotation>
+		<sequence>
+			<element name="Desde" type="sf:fecha" minOccurs="0"/>
+			<element name="Hasta" type="sf:fecha" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<complexType name="FechaExpedicionConsultaType">
+		<choice>
+			<element name="FechaExpedicionFactura" type="sf:fecha" minOccurs="0"/>
+			<element name="RangoFechaExpedicion" type="sf:RangoFechaExpedicionType" minOccurs="0"/>
+		</choice>
+	</complexType>
+	<complexType name="RegistroDuplicadoType">
+		<sequence>
+			<element name="IdPeticionRegistroDuplicado" type="sf:TextMax20Type">
+				<annotation>
+					<documentation xml:lang="es">
+						IdPeticion asociado a la factura registrada previamente en el sistema. Solo se suministra si la factura enviada es rechazada por estar duplicada
+					</documentation>
+				</annotation>
+			</element>
+			<element name="EstadoRegistroDuplicado" type="sf:EstadoRegistroSFType">
+				<annotation>
+					<documentation xml:lang="es">
+						Estado del registro duplicado almacenado en el sistema. Los estados posibles son: Correcta, AceptadaConErrores y Anulada. Solo se suministra si la factura enviada es rechazada por estar duplicada
+											</documentation>
+				</annotation>
+			</element>
+			<element name="CodigoErrorRegistro" type="sf:ErrorDetalleType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="es">
+						Código del error de registro duplicado almacenado en el sistema, en su caso.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="DescripcionErrorRegistro" type="sf:TextMax500Type" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="es">
+						Descripción detallada del error de registro duplicado almacenado en el sistema, en su caso.
+					</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<simpleType name="VersionType">
+		<restriction base="string">
+			<enumeration value="1.0"/>
+		</restriction>
+	</simpleType>
+	<!-- ==== Tipos básicos (Listas de claves y patrones) ============================================= -->
+	<!-- Año en formato YYYY -->
+	<simpleType name="YearType">
+		<annotation>
+			<documentation xml:lang="es"> Año en formato YYYY </documentation>
+		</annotation>
+		<restriction base="string">
+			<length value="4"/>
+			<pattern value="\d{4,4}"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="TipoPeriodoType">
+		<annotation>
+			<documentation xml:lang="es"> Período de la factura  </documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="01">
+				<annotation>
+					<documentation xml:lang="es"> Enero </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="02">
+				<annotation>
+					<documentation xml:lang="es"> Febrero </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="03">
+				<annotation>
+					<documentation xml:lang="es"> Marzo </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="04">
+				<annotation>
+					<documentation xml:lang="es"> Abril </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="05">
+				<annotation>
+					<documentation xml:lang="es"> Mayo </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="06">
+				<annotation>
+					<documentation xml:lang="es"> Junio </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="07">
+				<annotation>
+					<documentation xml:lang="es"> Julio </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="08">
+				<annotation>
+					<documentation xml:lang="es"> Agosto </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="09">
+				<annotation>
+					<documentation xml:lang="es"> Septiembre </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="10">
+				<annotation>
+					<documentation xml:lang="es"> Octubre </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="11">
+				<annotation>
+					<documentation xml:lang="es"> Noviembre </documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="12">
+				<annotation>
+					<documentation xml:lang="es"> Diciembre </documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<!-- Identificador único de facturas -->
+	<simpleType name="TextoIDenvioType">
+		<restriction base="string">
+			<maxLength value="20"/>
+		</restriction>
+	</simpleType>
+	<!-- Identificador único de facturas -->
+	<simpleType name="TextoIDFacturaType">
+		<restriction base="string">
+			<minLength value="1"/>
+			<maxLength value="60"/>
+		</restriction>
+	</simpleType>
+	<!-- Tipo de 10 dígitos -->
+	<simpleType name="Tipo10Type">
+		<restriction base="string">
+			<pattern value="\d{0,10}"/>
+		</restriction>
+	</simpleType>
+	<!-- Importe de 15 dígitos (12+2) "." como separador decimal -->
+	<simpleType name="ImporteSgn12.2Type">
+		<restriction base="string">
+			<pattern value="(\+|-)?\d{1,12}(\.\d{0,2})?"/>
+		</restriction>
+	</simpleType>
+	<!-- Importe de 17 dígitos (14+2) "." como separador decimal -->
+	<simpleType name="ImporteSgn14.2Type">
+		<restriction base="string">
+			<pattern value="(\+|-)?\d{1,14}(\.\d{0,2})?"/>
+		</restriction>
+	</simpleType>
+	<!-- Tipo de 6 dígitos (3+2) "." como separador decimal -->
+	<simpleType name="Tipo2.2Type">
+		<restriction base="string">
+			<pattern value="\d{1,3}(\.\d{0,2})?"/>
+		</restriction>
+	</simpleType>
+	<!-- Tipo de 3 dígitos -->
+	<simpleType name="Tipo3Type">
+		<restriction base="string">
+			<pattern value="\d{0,3}"/>
+		</restriction>
+	</simpleType>
+	<!-- Tipo de 6 dígitos -->
+	<simpleType name="Tipo6Type">
+		<restriction base="string">
+			<pattern value="\d{0,4}"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 1500 caracteres -->
+	<simpleType name="TextMax1500Type">
+		<restriction base="string">
+			<maxLength value="1500"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 500 caracteres -->
+	<simpleType name="TextMax500Type">
+		<restriction base="string">
+			<maxLength value="500"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 250 caracteres -->
+	<simpleType name="TextMax250Type">
+		<restriction base="string">
+			<maxLength value="250"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 150 caracteres -->
+	<simpleType name="TextMax150Type">
+		<restriction base="string">
+			<maxLength value="150"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 120 caracteres -->
+	<simpleType name="TextMax120Type">
+		<restriction base="string">
+			<maxLength value="120"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 100 caracteres -->
+	<simpleType name="TextMax100Type">
+		<restriction base="string">
+			<maxLength value="100"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 70 caracteres -->
+	<simpleType name="TextMax70Type">
+		<restriction base="string">
+			<maxLength value="70"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 65 caracteres -->
+	<simpleType name="TextMax65Type">
+		<restriction base="string">
+			<maxLength value="65"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 60 caracteres -->
+	<simpleType name="TextMax60Type">
+		<restriction base="string">
+			<maxLength value="60"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 64 caracteres -->
+	<simpleType name="TextMax64Type">
+		<restriction base="string">
+			<maxLength value="64"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 40 caracteres -->
+	<simpleType name="TextMax40Type">
+		<restriction base="string">
+			<maxLength value="40"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 34 caracteres -->
+	<simpleType name="TextMax34Type">
+		<restriction base="string">
+			<maxLength value="34"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 20 caracteres -->
+	<simpleType name="TextMax20Type">
+		<restriction base="string">
+			<maxLength value="20"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 18 caracteres -->
+	<simpleType name="TextMax18Type">
+		<restriction base="string">
+			<maxLength value="18"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 15 caracteres -->
+	<simpleType name="TextMax15Type">
+		<restriction base="string">
+			<maxLength value="15"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 16 caracteres -->
+	<simpleType name="TextMax16Type">
+		<restriction base="string">
+			<maxLength value="16"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 25 caracteres -->
+	<simpleType name="TextMax25Type">
+		<restriction base="string">
+			<maxLength value="25"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 30 caracteres -->
+	<simpleType name="TextMax30Type">
+		<restriction base="string">
+			<maxLength value="30"/>
+		</restriction>
+	</simpleType>
+	<!-- Referencia Catastral -->
+	<simpleType name="ReferenciaCatastralType">
+		<restriction base="string">
+			<maxLength value="25"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 2 caracteres -->
+	<simpleType name="TextMax2Type">
+		<restriction base="string">
+			<maxLength value="2"/>
+		</restriction>
+	</simpleType>
+	<!-- Cadena de 50 caracteres -->
+	<simpleType name="TextMax50Type">
+		<restriction base="string">
+			<maxLength value="50"/>
+		</restriction>
+	</simpleType>
+	<!-- NIF -->
+	<simpleType name="NIFType">
+		<annotation>
+			<documentation xml:lang="es">NIF</documentation>
+		</annotation>
+		<restriction base="string">
+			<length value="9"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="fecha">
+		<restriction base="string">
+			<length value="10"/>
+			<pattern value="\d{2,2}-\d{2,2}-\d{4,4}"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="Timestamp">
+		<restriction base="string">
+			<length value="19"/>
+			<pattern value="\d{2,2}-\d{2,2}-\d{4,4} \d{2,2}:\d{2,2}:\d{2,2}"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="OperacionExentaType">
+		<restriction base="string">
+			<enumeration value="E1"/>
+			<enumeration value="E2"/>
+			<enumeration value="E3"/>
+			<enumeration value="E4"/>
+			<enumeration value="E5"/>
+			<enumeration value="E6"/>
+			<enumeration value="E7"/>
+			<enumeration value="E8"/>
+		</restriction>
+	</simpleType>
+	<!-- Códigos de Tipo de factura -->
+	<simpleType name="ClaveTipoFacturaType">
+		<restriction base="string">
+			<enumeration value="F1">
+				<annotation>
+					<documentation xml:lang="es">FACTURA (ART. 6, 7.2 Y 7.3 DEL RD 1619/2012)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="F2">
+				<annotation>
+					<documentation xml:lang="es">FACTURA SIMPLIFICADA Y FACTURAS SIN IDENTIFICACIÓN DEL DESTINATARIO ART. 6.1.D) RD 1619/2012</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="R1">
+				<annotation>
+					<documentation xml:lang="es">FACTURA RECTIFICATIVA	(Art 80.1 y 80.2 y error fundado en derecho)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="R2">
+				<annotation>
+					<documentation xml:lang="es">FACTURA RECTIFICATIVA (Art. 80.3)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="R3">
+				<annotation>
+					<documentation xml:lang="es">FACTURA RECTIFICATIVA	(Art. 80.4)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="R4">
+				<annotation>
+					<documentation xml:lang="es">FACTURA RECTIFICATIVA	(Resto)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="R5">
+				<annotation>
+					<documentation xml:lang="es">FACTURA RECTIFICATIVA	EN FACTURAS SIMPLIFICADAS</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="F3">
+				<annotation>
+					<documentation xml:lang="es">FACTURA EMITIDA EN SUSTITUCIÓN DE FACTURAS SIMPLIFICADAS FACTURADAS Y DECLARADAS</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="RechazoPrevioType">
+		<restriction base="string">
+			<enumeration value="N">
+				<annotation>
+					<documentation xml:lang="es">No ha habido rechazo previo por la AEAT.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="S">
+				<annotation>
+					<documentation xml:lang="es">Ha habido rechazo previo por la AEAT.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="X">
+				<annotation>
+					<documentation xml:lang="es">Independientemente de si ha habido o no algún rechazo previo por la AEAT, el registro de facturación no existe en la AEAT (registro existente en ese SIF o en algún SIF del obligado tributario y que no se remitió a la AEAT, por ejemplo, al acogerse a Veri*factu desde no Veri*factu). No deberían existir operaciones de alta (N,X), por lo que no se admiten. </documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="RechazoPrevioAnulacionType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="SinRegistroPrevioType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="PrimerRegistroCadenaType">
+		<restriction base="string">
+			<enumeration value="S"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="SubsanacionType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ClaveTipoRectificativaType">
+		<restriction base="string">
+			<enumeration value="S">
+				<annotation>
+					<documentation xml:lang="es">SUSTITUTIVA</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="I">
+				<annotation>
+					<documentation xml:lang="es">INCREMENTAL</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<!-- Tercero o Destinatario -->
+	<simpleType name="TercerosODestinatarioType">
+		<restriction base="string">
+			<enumeration value="D">
+				<annotation>
+					<documentation xml:lang="es">Destinatario</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="T">
+				<annotation>
+					<documentation xml:lang="es">Tercero</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<!-- Factura simplificada Articulo 7,2 Y 7,3 RD 1619/2012, -->
+	<simpleType name="SimplificadaCualificadaType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<!-- Factura sin identificación destinatario artículo 6,1,d) RD 1619/2012 -->
+	<simpleType name="CompletaSinDestinatarioType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<!-- Permitira identificar aquellas facturas con importe de la factura superior a un umbral -->
+	<simpleType name="MacrodatoType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<!-- Identificador que especifica si la generación del registro de facturación se ha realizado durante algún tipo de incidencia -->
+	<simpleType name="IncidenciaType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<!-- Indicador que especifica que se ha finalizado la remisión de registros de facturación tras un requerimiento -->
+	<simpleType name="FinRequerimientoType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<!--Indicador que especifica si se quiere obtener en la respuesta el bloque SistemaInformatico en la información del registro se facturacion. Si el Valor es S aumenta el tiempo de respuesta en la cosulta. Si se consulta por Destinatario el valor del campo MostrarSistemaInformatico debe valer 'N' o no estar cumplimentado -->
+	<simpleType name="MostrarSistemaInformaticoType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<!--Indicador de la cosulta que especifica si se quiere recibir en la respuesta el campo NombreRazonEmisor en la información registro se facturacion. Si el Valor es S aumenta el tiempo de respuesta en la cosulta por detinatario -->
+	<simpleType name="MostrarNombreRazonEmisorType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="GeneradoPorType">
+		<restriction base="string">
+			<enumeration value="E">
+				<annotation>
+					<documentation xml:lang="es">Expedidor (obligado a Expedir la factura anulada).</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="D">
+				<annotation>
+					<documentation xml:lang="es">Destinatario</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="T">
+				<annotation>
+					<documentation xml:lang="es">Tercero</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<!-- Tipo de identificador fiscal de persona Física o jurídica -->
+	<simpleType name="PersonaFisicaJuridicaIDTypeType">
+		<restriction base="string">
+			<enumeration value="02">
+				<annotation>
+					<documentation xml:lang="es">NIF-IVA</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="03">
+				<annotation>
+					<documentation xml:lang="es">Pasaporte</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="04">
+				<annotation>
+					<documentation xml:lang="es">IDEnPaisResidencia</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="05">
+				<annotation>
+					<documentation xml:lang="es">Certificado Residencia</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="06">
+				<annotation>
+					<documentation xml:lang="es">Otro documento Probatorio</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="07">
+				<annotation>
+					<documentation xml:lang="es">No Censado</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<!-- Tipo Hash -->
+	<simpleType name="TipoHuellaType">
+		<restriction base="string">
+			<enumeration value="01">
+				<annotation>
+					<documentation xml:lang="es">SHA-256</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<!-- CLAVE QUE IDENTIFICARÁ EL TIPO DE RÉGIMEN DEL IVA/IGIC
+     -->
+	<simpleType name="IdOperacionesTrascendenciaTributariaType">
+		<restriction base="string">
+			<enumeration value="01"/>
+			<enumeration value="02"/>
+			<enumeration value="03"/>
+			<enumeration value="04"/>
+			<enumeration value="05"/>
+			<enumeration value="06"/>
+			<enumeration value="07"/>
+			<enumeration value="08"/>
+			<enumeration value="09"/>
+			<enumeration value="10"/>
+			<enumeration value="11"/>
+			<enumeration value="14"/>
+			<enumeration value="15"/>
+			<enumeration value="17"/>
+			<enumeration value="18"/>
+			<enumeration value="19"/>
+			<enumeration value="20"/>
+			<enumeration value="21"/>
+		</restriction>
+	</simpleType>
+	<!-- ISO 3166-1 alpha-2 codes -->
+	<simpleType name="CountryType2">
+		<restriction base="string">
+			<enumeration value="AF"/>
+			<enumeration value="AL"/>
+			<enumeration value="DE"/>
+			<enumeration value="AD"/>
+			<enumeration value="AO"/>
+			<enumeration value="AI"/>
+			<enumeration value="AQ"/>
+			<enumeration value="AG"/>
+			<enumeration value="SA"/>
+			<enumeration value="DZ"/>
+			<enumeration value="AR"/>
+			<enumeration value="AM"/>
+			<enumeration value="AW"/>
+			<enumeration value="AU"/>
+			<enumeration value="AT"/>
+			<enumeration value="AZ"/>
+			<enumeration value="BS"/>
+			<enumeration value="BH"/>
+			<enumeration value="BD"/>
+			<enumeration value="BB"/>
+			<enumeration value="BE"/>
+			<enumeration value="BZ"/>
+			<enumeration value="BJ"/>
+			<enumeration value="BM"/>
+			<enumeration value="BY"/>
+			<enumeration value="BO"/>
+			<enumeration value="BA"/>
+			<enumeration value="BW"/>
+			<enumeration value="BV"/>
+			<enumeration value="BR"/>
+			<enumeration value="BN"/>
+			<enumeration value="BG"/>
+			<enumeration value="BF"/>
+			<enumeration value="BI"/>
+			<enumeration value="BT"/>
+			<enumeration value="CV"/>
+			<enumeration value="KY"/>
+			<enumeration value="KH"/>
+			<enumeration value="CM"/>
+			<enumeration value="CA"/>
+			<enumeration value="CF"/>
+			<enumeration value="CC"/>
+			<enumeration value="CO"/>
+			<enumeration value="KM"/>
+			<enumeration value="CG"/>
+			<enumeration value="CD"/>
+			<enumeration value="CK"/>
+			<enumeration value="KP"/>
+			<enumeration value="KR"/>
+			<enumeration value="CI"/>
+			<enumeration value="CR"/>
+			<enumeration value="HR"/>
+			<enumeration value="CU"/>
+			<enumeration value="TD"/>
+			<enumeration value="CZ"/>
+			<enumeration value="CL"/>
+			<enumeration value="CN"/>
+			<enumeration value="CY"/>
+			<enumeration value="CW"/>
+			<enumeration value="DK"/>
+			<enumeration value="DM"/>
+			<enumeration value="DO"/>
+			<enumeration value="EC"/>
+			<enumeration value="EG"/>
+			<enumeration value="AE"/>
+			<enumeration value="ER"/>
+			<enumeration value="SK"/>
+			<enumeration value="SI"/>
+			<enumeration value="ES"/>
+			<enumeration value="US"/>
+			<enumeration value="EE"/>
+			<enumeration value="ET"/>
+			<enumeration value="FO"/>
+			<enumeration value="PH"/>
+			<enumeration value="FI"/>
+			<enumeration value="FJ"/>
+			<enumeration value="FR"/>
+			<enumeration value="GA"/>
+			<enumeration value="GM"/>
+			<enumeration value="GE"/>
+			<enumeration value="GS"/>
+			<enumeration value="GH"/>
+			<enumeration value="GI"/>
+			<enumeration value="GD"/>
+			<enumeration value="GR"/>
+			<enumeration value="GL"/>
+			<enumeration value="GU"/>
+			<enumeration value="GT"/>
+			<enumeration value="GG"/>
+			<enumeration value="GN"/>
+			<enumeration value="GQ"/>
+			<enumeration value="GW"/>
+			<enumeration value="GY"/>
+			<enumeration value="HT"/>
+			<enumeration value="HM"/>
+			<enumeration value="HN"/>
+			<enumeration value="HK"/>
+			<enumeration value="HU"/>
+			<enumeration value="IN"/>
+			<enumeration value="ID"/>
+			<enumeration value="IR"/>
+			<enumeration value="IQ"/>
+			<enumeration value="IE"/>
+			<enumeration value="IM"/>
+			<enumeration value="IS"/>
+			<enumeration value="IL"/>
+			<enumeration value="IT"/>
+			<enumeration value="JM"/>
+			<enumeration value="JP"/>
+			<enumeration value="JE"/>
+			<enumeration value="JO"/>
+			<enumeration value="KZ"/>
+			<enumeration value="KE"/>
+			<enumeration value="KG"/>
+			<enumeration value="KI"/>
+			<enumeration value="KW"/>
+			<enumeration value="LA"/>
+			<enumeration value="LS"/>
+			<enumeration value="LV"/>
+			<enumeration value="LB"/>
+			<enumeration value="LR"/>
+			<enumeration value="LY"/>
+			<enumeration value="LI"/>
+			<enumeration value="LT"/>
+			<enumeration value="LU"/>
+			<enumeration value="XG"/>
+			<enumeration value="MO"/>
+			<enumeration value="MK"/>
+			<enumeration value="MG"/>
+			<enumeration value="MY"/>
+			<enumeration value="MW"/>
+			<enumeration value="MV"/>
+			<enumeration value="ML"/>
+			<enumeration value="MT"/>
+			<enumeration value="FK"/>
+			<enumeration value="MP"/>
+			<enumeration value="MA"/>
+			<enumeration value="MH"/>
+			<enumeration value="MU"/>
+			<enumeration value="MR"/>
+			<enumeration value="YT"/>
+			<enumeration value="UM"/>
+			<enumeration value="MX"/>
+			<enumeration value="FM"/>
+			<enumeration value="MD"/>
+			<enumeration value="MC"/>
+			<enumeration value="MN"/>
+			<enumeration value="ME"/>
+			<enumeration value="MS"/>
+			<enumeration value="MZ"/>
+			<enumeration value="MM"/>
+			<enumeration value="NA"/>
+			<enumeration value="NR"/>
+			<enumeration value="CX"/>
+			<enumeration value="NP"/>
+			<enumeration value="NI"/>
+			<enumeration value="NE"/>
+			<enumeration value="NG"/>
+			<enumeration value="NU"/>
+			<enumeration value="NF"/>
+			<enumeration value="NO"/>
+			<enumeration value="NC"/>
+			<enumeration value="NZ"/>
+			<enumeration value="IO"/>
+			<enumeration value="OM"/>
+			<enumeration value="NL"/>
+			<enumeration value="BQ"/>
+			<enumeration value="PK"/>
+			<enumeration value="PW"/>
+			<enumeration value="PA"/>
+			<enumeration value="PG"/>
+			<enumeration value="PY"/>
+			<enumeration value="PE"/>
+			<enumeration value="PN"/>
+			<enumeration value="PF"/>
+			<enumeration value="PL"/>
+			<enumeration value="PT"/>
+			<enumeration value="PR"/>
+			<enumeration value="QA"/>
+			<enumeration value="GB"/>
+			<enumeration value="RW"/>
+			<enumeration value="RO"/>
+			<enumeration value="RU"/>
+			<enumeration value="RE"/>
+			<enumeration value="SB"/>
+			<enumeration value="SV"/>
+			<enumeration value="WS"/>
+			<enumeration value="AS"/>
+			<enumeration value="KN"/>
+			<enumeration value="SM"/>
+			<enumeration value="SX"/>
+			<enumeration value="PM"/>
+			<enumeration value="VC"/>
+			<enumeration value="SH"/>
+			<enumeration value="LC"/>
+			<enumeration value="ST"/>
+			<enumeration value="SN"/>
+			<enumeration value="RS"/>
+			<enumeration value="SC"/>
+			<enumeration value="SL"/>
+			<enumeration value="SG"/>
+			<enumeration value="SY"/>
+			<enumeration value="SO"/>
+			<enumeration value="LK"/>
+			<enumeration value="SZ"/>
+			<enumeration value="ZA"/>
+			<enumeration value="SD"/>
+			<enumeration value="SS"/>
+			<enumeration value="SE"/>
+			<enumeration value="CH"/>
+			<enumeration value="SR"/>
+			<enumeration value="TH"/>
+			<enumeration value="TW"/>
+			<enumeration value="TZ"/>
+			<enumeration value="TJ"/>
+			<enumeration value="PS"/>
+			<enumeration value="TF"/>
+			<enumeration value="TL"/>
+			<enumeration value="TG"/>
+			<enumeration value="TK"/>
+			<enumeration value="TO"/>
+			<enumeration value="TT"/>
+			<enumeration value="TN"/>
+			<enumeration value="TC"/>
+			<enumeration value="TM"/>
+			<enumeration value="TR"/>
+			<enumeration value="TV"/>
+			<enumeration value="UA"/>
+			<enumeration value="UG"/>
+			<enumeration value="UY"/>
+			<enumeration value="UZ"/>
+			<enumeration value="VU"/>
+			<enumeration value="VA"/>
+			<enumeration value="VE"/>
+			<enumeration value="VN"/>
+			<enumeration value="VG"/>
+			<enumeration value="VI"/>
+			<enumeration value="WF"/>
+			<enumeration value="YE"/>
+			<enumeration value="DJ"/>
+			<enumeration value="ZM"/>
+			<enumeration value="ZW"/>
+			<enumeration value="QU"/>
+			<enumeration value="XB"/>
+			<enumeration value="XU"/>
+			<enumeration value="XN"/>
+		</restriction>
+	</simpleType>
+	<!-- Estado del registro duplicado almacenado en el sistema -->
+	<simpleType name="EstadoRegistroSFType">
+		<restriction base="string">
+			<enumeration value="Correcta">
+				<annotation>
+					<documentation xml:lang="es">El registro se ha almacenado sin errores</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="AceptadaConErrores">
+				<annotation>
+					<documentation xml:lang="es">El registro que se ha almacenado tiene algunos errores. Ver detalle del error</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Anulada">
+				<annotation>
+					<documentation xml:lang="es">El registro almacenado ha sido anulado</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<simpleType name="ErrorDetalleType">
+		<restriction base="integer"/>
+	</simpleType>
+	<simpleType name="CalificacionOperacionType">
+		<restriction base="string">
+			<enumeration value="S1">
+				<annotation>
+					<documentation xml:lang="es"> OPERACIÓN SUJETA Y NO EXENTA - SIN INVERSIÓN DEL SUJETO PASIVO.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="S2">
+				<annotation>
+					<documentation xml:lang="es">OPERACIÓN SUJETA Y NO EXENTA - CON INVERSIÓN DEL SUJETO PASIVO</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="N1">
+				<annotation>
+					<documentation xml:lang="es">OPERACIÓN NO SUJETA ARTÍCULO 7, 14, OTROS.</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="N2">
+				<annotation>
+					<documentation xml:lang="es">OPERACIÓN NO SUJETA POR REGLAS DE LOCALIZACIÓN</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<!-- Lineas de detalle del desglose -->
+	<complexType name="DesgloseType">
+		<sequence>
+			<element name="DetalleDesglose" type="sf:DetalleType" maxOccurs="12"/>
+		</sequence>
+	</complexType>
+	<simpleType name="SiNoType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<complexType name="ContraparteConsultaType">
+		<annotation>
+			<documentation xml:lang="es">Datos de una persona física o jurídica Española o Extranjera</documentation>
+		</annotation>
+		<sequence>
+			<element name="NombreRazon" type="sf:TextMax120Type"/>
+			<choice>
+				<element name="NIF" type="sf:NIFType"/>
+				<element name="IDOtro" type="sf:IDOtroType"/>
+			</choice>
+		</sequence>
+	</complexType>
+	<complexType name="CabeceraConsultaSf">
+		<annotation>
+			<documentation xml:lang="es"> Cabecera de la Cobnsulta </documentation>
+		</annotation>
+		<sequence>
+			<element name="IDVersion" type="sf:VersionType"/>
+			<choice>
+				<element name="ObligadoEmision" type="sf:ObligadoEmisionConsultaType" minOccurs="0">
+					<annotation>
+						<documentation xml:lang="es"> Obligado a la emision de los registros de facturacion </documentation>
+					</annotation>
+				</element>
+				<element name="Destinatario" type="sf:PersonaFisicaJuridicaESType" minOccurs="0">
+					<annotation>
+						<documentation xml:lang="es"> Destinatario (a veces también denominado contraparte, es decir, el cliente) de la operación </documentation>
+					</annotation>
+				</element>
+			</choice>
+			<element name="IndicadorRepresentante" type="sf:IndicadorRepresentanteType" minOccurs="0">
+				<annotation>
+					<documentation xml:lang="es"> Flag opcional que tendrá valor S si quien realiza la cosulta es el representante/asesor del obligado tributario. Permite, a quien realiza la cosulta, obtener los registros de facturación en los que figura como representante. Este flag solo se puede cumplimentar cuando esté informado el obligado tributario en la consulta </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<!-- Obligado a la emision consulta -->
+	<complexType name="ObligadoEmisionConsultaType">
+		<annotation>
+			<documentation xml:lang="es">Datos de una persona física o jurídica Española con un NIF asociado</documentation>
+		</annotation>
+		<sequence>
+			<element name="NombreRazon" type="sf:TextMax120Type"/>
+			<element name="NIF" type="sf:NIFType"/>
+		</sequence>
+	</complexType>
+	<!-- Obligado a la gerneracion de la anulacion -->
+	<complexType name="ObligadoGeneracionType">
+		<sequence>
+			<element name="NombreRazon" type="sf:TextMax120Type"/>
+			<element name="NIF" type="sf:NIFType"/>
+		</sequence>
+	</complexType>
+	<simpleType name="Numerico4Type">
+		<restriction base="string">
+			<pattern value="\d{1,4}"/>
+		</restriction>
+	</simpleType>
+	<!-- Minoración de la base imponible por la concesión de cupones, bonificaciones o descuentos cuando solo se expide el original de la factura -->
+	<simpleType name="CuponType">
+		<restriction base="string">
+			<enumeration value="S"/>
+			<enumeration value="N"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="IndicadorRepresentanteType">
+		<restriction base="string">
+			<enumeration value="S"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="ImpuestoType">
+		<restriction base="string">
+			<enumeration value="01">
+				<annotation>
+					<documentation xml:lang="es"> Impuesto sobre el Valor Añadido (IVA)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="02">
+				<annotation>
+					<documentation xml:lang="es">Impuesto sobre la Producción, los Servicios y la Importación (IPSI) de Ceuta y Melilla</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="03">
+				<annotation>
+					<documentation xml:lang="es">Impuesto General Indirecto Canario (IGIC)</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="05">
+				<annotation>
+					<documentation xml:lang="es">Otros</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+	<!--Información de la operación realizada que se devuelve como respuesta al envío de un registro de facturación -->
+	<complexType name="OperacionType">
+		<sequence>
+			<element name="TipoOperacion" type="sf:TipoOperacionType"/>
+			<element name="Subsanacion" type="sf:SubsanacionType" minOccurs="0"/>
+			<element name="RechazoPrevio" type="sf:RechazoPrevioType" minOccurs="0"/>
+			<element name="SinRegistroPrevio" type="sf:SinRegistroPrevioType" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<simpleType name="TipoOperacionType">
+		<restriction base="string">
+			<enumeration value="Alta">
+				<annotation>
+					<documentation xml:lang="es">La operación realizada ha sido un alta</documentation>
+				</annotation>
+			</enumeration>
+			<enumeration value="Anulacion">
+				<annotation>
+					<documentation xml:lang="es">La operación realizada ha sido una anulación</documentation>
+				</annotation>
+			</enumeration>
+		</restriction>
+	</simpleType>
+</schema>

--- a/l10n_es_verifactu_oca/data/SuministroLR.xsd
+++ b/l10n_es_verifactu_oca/data/SuministroLR.xsd
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- editado con XMLSpy v2019 sp1 (x64) (http://www.altova.com) por Puesto de Trabajo (Agencia Estatal de Administracion Tributaria ((AEAT))) -->
+<!-- edited with XMLSpy v2009 sp1 (http://www.altova.com) by PC Corporativo (AGENCIA TRIBUTARIA) -->
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:sfLR="https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/tike/cont/ws/SuministroLR.xsd" xmlns:sf="https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/tike/cont/ws/SuministroInformacion.xsd" targetNamespace="https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/tike/cont/ws/SuministroLR.xsd" elementFormDefault="qualified">
+	<import namespace="https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/tike/cont/ws/SuministroInformacion.xsd" schemaLocation="SuministroInformacion.xsd"/>
+	<element name="RegFactuSistemaFacturacion">
+		<complexType>
+			<sequence>
+				<element name="Cabecera" type="sf:CabeceraType"/>
+				<element name="RegistroFactura" type="sfLR:RegistroFacturaType" maxOccurs="1000"/>
+			</sequence>
+		</complexType>
+	</element>
+	<complexType name="RegistroFacturaType">
+		<annotation>
+			<documentation xml:lang="es">Datos correspondientes a los registros de facturacion</documentation>
+		</annotation>
+		<sequence>
+			<choice>
+				<element ref="sf:RegistroAlta"/>
+				<element ref="sf:RegistroAnulacion"/>
+			</choice>
+		</sequence>
+	</complexType>
+</schema>

--- a/l10n_es_verifactu_oca/data/xmldsig-core-schema.xsd
+++ b/l10n_es_verifactu_oca/data/xmldsig-core-schema.xsd
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE schema PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd" [
+   <!ATTLIST schema
+     xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
+   <!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
+   <!ENTITY % p ''>
+   <!ENTITY % s ''>
+  ]>
+<!-- Schema for XML Signatures
+    http://www.w3.org/2000/09/xmldsig#
+    $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $
+
+    Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+    of Technology, Institut National de Recherche en Informatique et en
+    Automatique, Keio University). All Rights Reserved.
+    http://www.w3.org/Consortium/Legal/
+
+    This document is governed by the W3C Software License [1] as described
+    in the FAQ [2].
+
+    [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.w3.org/2000/09/xmldsig#" version="0.1" elementFormDefault="qualified">
+
+<!-- Basic Types Defined for Signatures -->
+
+<simpleType name="CryptoBinary">
+  <restriction base="base64Binary">
+  </restriction>
+</simpleType>
+
+<!-- Start Signature -->
+
+<element name="Signature" type="ds:SignatureType"/>
+<complexType name="SignatureType">
+  <sequence>
+    <element ref="ds:SignedInfo"/>
+    <element ref="ds:SignatureValue"/>
+    <element ref="ds:KeyInfo" minOccurs="0"/>
+    <element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="SignatureValue" type="ds:SignatureValueType"/>
+  <complexType name="SignatureValueType">
+    <simpleContent>
+      <extension base="base64Binary">
+        <attribute name="Id" type="ID" use="optional"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+
+<!-- Start SignedInfo -->
+
+<element name="SignedInfo" type="ds:SignedInfoType"/>
+<complexType name="SignedInfoType">
+  <sequence>
+    <element ref="ds:CanonicalizationMethod"/>
+    <element ref="ds:SignatureMethod"/>
+    <element ref="ds:Reference" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType"/>
+  <complexType name="CanonicalizationMethodType" mixed="true">
+    <sequence>
+      <any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+  </complexType>
+
+  <element name="SignatureMethod" type="ds:SignatureMethodType"/>
+  <complexType name="SignatureMethodType" mixed="true">
+    <sequence>
+      <element name="HMACOutputLength" minOccurs="0" type="ds:HMACOutputLengthType"/>
+      <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) external namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+  </complexType>
+
+<!-- Start Reference -->
+
+<element name="Reference" type="ds:ReferenceType"/>
+<complexType name="ReferenceType">
+  <sequence>
+    <element ref="ds:Transforms" minOccurs="0"/>
+    <element ref="ds:DigestMethod"/>
+    <element ref="ds:DigestValue"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+  <attribute name="URI" type="anyURI" use="optional"/>
+  <attribute name="Type" type="anyURI" use="optional"/>
+</complexType>
+
+  <element name="Transforms" type="ds:TransformsType"/>
+  <complexType name="TransformsType">
+    <sequence>
+      <element ref="ds:Transform" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <element name="Transform" type="ds:TransformType"/>
+  <complexType name="TransformType" mixed="true">
+    <choice minOccurs="0" maxOccurs="unbounded">
+      <any namespace="##other" processContents="lax"/>
+      <!-- (1,1) elements from (0,unbounded) namespaces -->
+      <element name="XPath" type="string"/>
+    </choice>
+    <attribute name="Algorithm" type="anyURI" use="required"/>
+  </complexType>
+
+<!-- End Reference -->
+
+<element name="DigestMethod" type="ds:DigestMethodType"/>
+<complexType name="DigestMethodType" mixed="true">
+  <sequence>
+    <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Algorithm" type="anyURI" use="required"/>
+</complexType>
+
+<element name="DigestValue" type="ds:DigestValueType"/>
+<simpleType name="DigestValueType">
+  <restriction base="base64Binary"/>
+</simpleType>
+
+<!-- End SignedInfo -->
+
+<!-- Start KeyInfo -->
+
+<element name="KeyInfo" type="ds:KeyInfoType"/>
+<complexType name="KeyInfoType" mixed="true">
+  <choice maxOccurs="unbounded">
+    <element ref="ds:KeyName"/>
+    <element ref="ds:KeyValue"/>
+    <element ref="ds:RetrievalMethod"/>
+    <element ref="ds:X509Data"/>
+    <element ref="ds:PGPData"/>
+    <element ref="ds:SPKIData"/>
+    <element ref="ds:MgmtData"/>
+    <any processContents="lax" namespace="##other"/>
+    <!-- (1,1) elements from (0,unbounded) namespaces -->
+  </choice>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="KeyName" type="string"/>
+  <element name="MgmtData" type="string"/>
+
+  <element name="KeyValue" type="ds:KeyValueType"/>
+  <complexType name="KeyValueType" mixed="true">
+   <choice>
+     <element ref="ds:DSAKeyValue"/>
+     <element ref="ds:RSAKeyValue"/>
+     <any namespace="##other" processContents="lax"/>
+   </choice>
+  </complexType>
+
+  <element name="RetrievalMethod" type="ds:RetrievalMethodType"/>
+  <complexType name="RetrievalMethodType">
+    <sequence>
+      <element ref="ds:Transforms" minOccurs="0"/>
+    </sequence>
+    <attribute name="URI" type="anyURI"/>
+    <attribute name="Type" type="anyURI" use="optional"/>
+  </complexType>
+
+<!-- Start X509Data -->
+
+<element name="X509Data" type="ds:X509DataType"/>
+<complexType name="X509DataType">
+  <sequence maxOccurs="unbounded">
+    <choice>
+      <element name="X509IssuerSerial" type="ds:X509IssuerSerialType"/>
+      <element name="X509SKI" type="base64Binary"/>
+      <element name="X509SubjectName" type="string"/>
+      <element name="X509Certificate" type="base64Binary"/>
+      <element name="X509CRL" type="base64Binary"/>
+      <any namespace="##other" processContents="lax"/>
+    </choice>
+  </sequence>
+</complexType>
+
+<complexType name="X509IssuerSerialType">
+  <sequence>
+    <element name="X509IssuerName" type="string"/>
+    <element name="X509SerialNumber">
+      <simpleType>
+        <restriction base="string">
+            <pattern value="[0-9]+"></pattern>
+        </restriction>
+      </simpleType>
+    </element>
+  </sequence>
+</complexType>
+
+<!-- End X509Data -->
+
+<!-- Begin PGPData -->
+
+<element name="PGPData" type="ds:PGPDataType"/>
+<complexType name="PGPDataType">
+  <choice>
+    <sequence>
+      <element name="PGPKeyID" type="base64Binary"/>
+      <element name="PGPKeyPacket" type="base64Binary" minOccurs="0"/>
+      <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <sequence>
+      <element name="PGPKeyPacket" type="base64Binary"/>
+      <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </choice>
+</complexType>
+
+<!-- End PGPData -->
+
+<!-- Begin SPKIData -->
+
+<element name="SPKIData" type="ds:SPKIDataType"/>
+<complexType name="SPKIDataType">
+  <sequence maxOccurs="unbounded">
+    <element name="SPKISexp" type="base64Binary"/>
+    <any namespace="##other" processContents="lax" minOccurs="0"/>
+  </sequence>
+</complexType>
+
+<!-- End SPKIData -->
+
+<!-- End KeyInfo -->
+
+<!-- Start Object (Manifest, SignatureProperty) -->
+
+<element name="Object" type="ds:ObjectType"/>
+<complexType name="ObjectType" mixed="true">
+  <sequence minOccurs="0" maxOccurs="unbounded">
+    <any namespace="##any" processContents="lax"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+  <attribute name="MimeType" type="string" use="optional"/> <!-- add a grep facet -->
+  <attribute name="Encoding" type="anyURI" use="optional"/>
+</complexType>
+
+<element name="Manifest" type="ds:ManifestType"/>
+<complexType name="ManifestType">
+  <sequence>
+    <element ref="ds:Reference" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+<element name="SignatureProperties" type="ds:SignaturePropertiesType"/>
+<complexType name="SignaturePropertiesType">
+  <sequence>
+    <element ref="ds:SignatureProperty" maxOccurs="unbounded"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+   <element name="SignatureProperty" type="ds:SignaturePropertyType"/>
+   <complexType name="SignaturePropertyType" mixed="true">
+     <choice maxOccurs="unbounded">
+       <any namespace="##other" processContents="lax"/>
+       <!-- (1,1) elements from (1,unbounded) namespaces -->
+     </choice>
+     <attribute name="Target" type="anyURI" use="required"/>
+     <attribute name="Id" type="ID" use="optional"/>
+   </complexType>
+
+<!-- End Object (Manifest, SignatureProperty) -->
+
+<!-- Start Algorithm Parameters -->
+
+<simpleType name="HMACOutputLengthType">
+  <restriction base="integer"/>
+</simpleType>
+
+<!-- Start KeyValue Element-types -->
+
+<element name="DSAKeyValue" type="ds:DSAKeyValueType"/>
+<complexType name="DSAKeyValueType">
+  <sequence>
+    <sequence minOccurs="0">
+      <element name="P" type="ds:CryptoBinary"/>
+      <element name="Q" type="ds:CryptoBinary"/>
+    </sequence>
+    <element name="G" type="ds:CryptoBinary" minOccurs="0"/>
+    <element name="Y" type="ds:CryptoBinary"/>
+    <element name="J" type="ds:CryptoBinary" minOccurs="0"/>
+    <sequence minOccurs="0">
+      <element name="Seed" type="ds:CryptoBinary"/>
+      <element name="PgenCounter" type="ds:CryptoBinary"/>
+    </sequence>
+  </sequence>
+</complexType>
+
+<element name="RSAKeyValue" type="ds:RSAKeyValueType"/>
+<complexType name="RSAKeyValueType">
+  <sequence>
+    <element name="Modulus" type="ds:CryptoBinary"/>
+    <element name="Exponent" type="ds:CryptoBinary"/>
+  </sequence>
+</complexType>
+
+<!-- End KeyValue Element-types -->
+
+<!-- End Signature -->
+
+</schema>

--- a/l10n_es_verifactu_oca/i18n/es.po
+++ b/l10n_es_verifactu_oca/i18n/es.po
@@ -766,6 +766,13 @@ msgstr ""
 "                con VERI*FACTU habilitado."
 
 #. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py:0
+#, python-format
+msgid "Invoices not matching the VERI*FACTU schema"
+msgstr "Facturas que no cumplen el esquema de VERI*FACTU"
+
+#. module: l10n_es_verifactu_oca
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_chaining__message_is_follower
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_developer__message_is_follower
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_invoice_entry_response__message_is_follower
@@ -1183,6 +1190,11 @@ msgstr "Cabecera enviada"
 
 #. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.view_company_verifactu_form
+msgid "Skip the schema check when posting?"
+msgstr "¿Omitir la comprobación del esquema al validar?"
+
+#. module: l10n_es_verifactu_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.view_company_verifactu_form
 msgid "Start date"
 msgstr "Fecha de inicio"
 
@@ -1198,6 +1210,18 @@ msgstr ""
 "Atrasado: La fecha de vencimiento ya ha sido sobrepasada\n"
 "Hoy: La fecha de actividad es hoy\n"
 "Planificado: Actividades futuras."
+
+#. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_res_company__verifactu_skip_schema_check
+msgid ""
+"Stop refusing to post invoices whose VERI*FACTU record does not match the official schema. It is an escape hatch to keep invoicing while a wrong rejection is looked into, not a permanent setting.\n"
+"It does not make those records reach the Agency: a record that does not match the schema is still left out when the batch is sent."
+msgstr ""
+"Deja de impedir que se validen facturas cuyo registro VERI*FACTU no cumple "
+"el esquema oficial. Es una válvula de escape para poder seguir facturando "
+"mientras se investiga un rechazo indebido, no un ajuste permanente.\n"
+"No hace que esos registros lleguen a la Agencia: un registro que no cumple "
+"el esquema se sigue quedando fuera del envío del lote."
 
 #. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.verifactu_tax_agency_form_view
@@ -1249,6 +1273,20 @@ msgstr "¿Es entorno de pruebas?"
 #: model:ir.model.fields,help:l10n_es_verifactu_oca.field_res_company__verifactu_description
 msgid "The description for VERI*FACTU invoices if not set"
 msgstr "La descripción para las facturas VERI*FACTU no está establecida"
+
+#. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/account_move.py:0
+#, python-format
+msgid ""
+"The following invoices cannot be posted because their VERI*FACTU record does not match the official schema:\n"
+"\n"
+"%(details)s"
+msgstr ""
+"Las siguientes facturas no se pueden validar porque su registro VERI*FACTU "
+"no cumple el esquema oficial:\n"
+"\n"
+"%(details)s"
 
 #. module: l10n_es_verifactu_oca
 #. odoo-python
@@ -1660,6 +1698,11 @@ msgstr "VERI*FACTU enviando"
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_search
 msgid "VERI*FACTU sent"
 msgstr "VERI*FACTU enviado"
+
+#. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_res_company__verifactu_skip_schema_check
+msgid "VERI*FACTU skip the schema check when posting"
+msgstr "VERI*FACTU omitir la comprobación del esquema al validar"
 
 #. module: l10n_es_verifactu_oca
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_res_company__verifactu_start_date

--- a/l10n_es_verifactu_oca/i18n/l10n_es_verifactu_oca.pot
+++ b/l10n_es_verifactu_oca/i18n/l10n_es_verifactu_oca.pot
@@ -737,6 +737,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py:0
+#, python-format
+msgid "Invoices not matching the VERI*FACTU schema"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_chaining__message_is_follower
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_developer__message_is_follower
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_invoice_entry_response__message_is_follower
@@ -1150,6 +1157,11 @@ msgstr ""
 
 #. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.view_company_verifactu_form
+msgid "Skip the schema check when posting?"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.view_company_verifactu_form
 msgid "Start date"
 msgstr ""
 
@@ -1163,6 +1175,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,help:l10n_es_verifactu_oca.field_res_company__verifactu_skip_schema_check
+msgid ""
+"Stop refusing to post invoices whose VERI*FACTU record does not match the official schema. It is an escape hatch to keep invoicing while a wrong rejection is looked into, not a permanent setting.\n"
+"It does not make those records reach the Agency: a record that does not match the schema is still left out when the batch is sent."
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.verifactu_tax_agency_form_view
 msgid "Suministro Facturas Emitidas"
 msgstr ""
@@ -1170,6 +1189,13 @@ msgstr ""
 #. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.verifactu_registration_keys_view_search
 msgid "Tax Type"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py:0
+#, python-format
+msgid "Tax is not mapped to VERI*FACTU."
 msgstr ""
 
 #. module: l10n_es_verifactu_oca
@@ -1211,6 +1237,16 @@ msgstr ""
 #. module: l10n_es_verifactu_oca
 #: model:ir.model.fields,help:l10n_es_verifactu_oca.field_res_company__verifactu_description
 msgid "The description for VERI*FACTU invoices if not set"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/account_move.py:0
+#, python-format
+msgid ""
+"The following invoices cannot be posted because their VERI*FACTU record does not match the official schema:\n"
+"\n"
+"%(details)s"
 msgstr ""
 
 #. module: l10n_es_verifactu_oca
@@ -1620,6 +1656,11 @@ msgstr ""
 #. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.invoice_verifactu_search
 msgid "VERI*FACTU sent"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_res_company__verifactu_skip_schema_check
+msgid "VERI*FACTU skip the schema check when posting"
 msgstr ""
 
 #. module: l10n_es_verifactu_oca

--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -3,13 +3,17 @@
 # Copyright 2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import logging
 from collections import OrderedDict
 from datetime import datetime
+from textwrap import indent
 
 import pytz
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
 
 VERIFACTU_VALID_INVOICE_STATES = ["posted"]
 
@@ -110,7 +114,12 @@ class AccountMove(models.Model):
         return invoice_type
 
     def _get_verifactu_description(self):
-        return self.verifactu_description or self.company_id.verifactu_description
+        description = (
+            self.verifactu_description or self.company_id.verifactu_description
+        )
+        # Truncated, like the issuer and receiver names: a description over the
+        # limit is set on the company and would otherwise block every invoice.
+        return description and description[:500]
 
     def _get_document_date(self):
         """
@@ -345,7 +354,10 @@ class AccountMove(models.Model):
         else:
             tax_type = abs(tax.amount)
         tax_dict = {
-            "TipoImpositivo": str(tax_type),
+            # The schema takes two decimals at most, and `amount` holds four:
+            # rounding here keeps a rate like 7.527 from blocking every invoice
+            # that carries that tax.
+            "TipoImpositivo": str(round(tax_type, 2)),
             "BaseImponibleOimporteNoSujeto": tax_base_amount,
         }
         key = "CuotaRepercutida"
@@ -507,7 +519,12 @@ class AccountMove(models.Model):
             identifier = "NO_DISPONIBLE"
             identifier_type = "06"
         if identifier_type == "":
-            return {"IDDestinatario": {"NombreRazon": receiver.name, "NIF": identifier}}
+            return {
+                "IDDestinatario": {
+                    "NombreRazon": receiver.name and receiver.name[:120],
+                    "NIF": identifier,
+                }
+            }
         if (
             receiver._map_aeat_country_code(country_code)
             in receiver._get_aeat_europe_codes()
@@ -515,7 +532,7 @@ class AccountMove(models.Model):
             identifier = country_code + identifier
         return {
             "IDDestinatario": {
-                "NombreRazon": receiver.name,
+                "NombreRazon": receiver.name and receiver.name[:120],
                 "IDOtro": {
                     "CodigoPais": receiver.country_id.code,
                     "IDType": identifier_type,
@@ -540,12 +557,58 @@ class AccountMove(models.Model):
 
     def _post(self, soft=True):
         res = super()._post(soft=soft)
+        schema_errors = {}
         for record in self.sorted(lambda inv: inv.name or ""):
             if record.verifactu_enabled and record.aeat_state == "not_sent":
                 record._check_verifactu_configuration()
                 record.verifactu_registration_date = datetime.now()
                 record._generate_verifactu_chaining()
+                if not record.company_id.verifactu_skip_schema_check:
+                    error = record._get_verifactu_schema_error()
+                    if error:
+                        schema_errors[record.name] = error
+        if schema_errors:
+            # Every offender at once: the whole posting is rolled back anyway,
+            # so reporting only the first would make a mass posting be repeated
+            # once per invoice.
+            raise UserError(
+                _(
+                    "The following invoices cannot be posted because their "
+                    "VERI*FACTU record could not be built or does not match "
+                    "the official schema:\n\n%(details)s",
+                    details="\n\n".join(
+                        "%s:\n%s" % (name, indent(error, "    "))
+                        for name, error in schema_errors.items()
+                    ),
+                )
+            )
         return res
+
+    def _get_verifactu_schema_error(self):
+        """Reason this record would not reach the Agency as it is, if any.
+
+        Checked after `_generate_verifactu_chaining` and not inside
+        `_check_verifactu_configuration`: that one runs earlier, when the
+        payload still has no registration date, hash or chaining block.
+        Posting is the last moment at which the invoice can be corrected.
+        """
+        self.ensure_one()
+        try:
+            return self._validate_verifactu_registro(self._get_verifactu_invoice_dict())
+        except UserError as fault:
+            # A record that cannot even be built will not reach the Agency
+            # either, so it is reported like a schema violation instead of
+            # raised: raising here would abort the whole posting at the first
+            # offender, which is what reporting every one of them avoids.
+            # The message is already translated and actionable.
+            return str(fault)
+        except Exception:
+            # Fail open: a failure of the check itself must not stop invoicing.
+            _logger.exception(
+                "VERI*FACTU: the schema of invoice %s could not be checked",
+                self.name,
+            )
+            return None
 
     def _check_verifactu_configuration(self, suffixes=None):
         if not suffixes:

--- a/l10n_es_verifactu_oca/models/res_company.py
+++ b/l10n_es_verifactu_oca/models/res_company.py
@@ -12,6 +12,15 @@ class ResCompany(models.Model):
     verifactu_test = fields.Boolean(
         string="VERI*FACTU test environment?", tracking=True
     )
+    verifactu_skip_schema_check = fields.Boolean(
+        string="VERI*FACTU skip the schema check when posting",
+        help="Stop refusing to post invoices whose VERI*FACTU record does not "
+        "match the official schema. It is an escape hatch to keep invoicing "
+        "while a wrong rejection is looked into, not a permanent setting.\n"
+        "It does not make those records reach the Agency: a record that does "
+        "not match the schema is still left out when the batch is sent.",
+        tracking=True,
+    )
     verifactu_description = fields.Text(
         string="VERI*FACTU description",
         default="/",

--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import datetime
 import json
+import logging
 
 from requests import Session
 from zeep import Client, Settings
@@ -13,6 +14,8 @@ from zeep.transports import Transport
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import split_every
+
+_logger = logging.getLogger(__name__)
 
 VERIFACTU_SEND_STATES = [
     ("not_sent", "Not sent"),
@@ -148,10 +151,18 @@ class VerifactuInvoiceEntry(models.Model):
                     lambda r: r.document.verifactu_registration_date < threshold_time
                 )
                 current_records = records_to_send - outdated_records
-                outdated_records.with_context(
-                    verifactu_incident=True
-                )._send_documents_to_verifactu()
-                current_records._send_documents_to_verifactu()
+                # One warning per pass, not one per call: a record that was
+                # never sent belongs neither to the incident group nor to the
+                # current one.
+                failures = {}
+                failures.update(
+                    outdated_records.with_context(
+                        verifactu_incident=True
+                    )._send_documents_to_verifactu()
+                )
+                failures.update(current_records._send_documents_to_verifactu())
+                if failures:
+                    records_to_send._register_verifactu_send_failures(failures)
         return True
 
     def _get_verifactu_aeat_header(self):
@@ -288,22 +299,161 @@ class VerifactuInvoiceEntry(models.Model):
             response_line.document.write(doc_vals)
         return doc_vals
 
-    def _send_documents_to_verifactu(self):
-        if not self:
-            return False
-        rec = self[0]
-        header = rec._get_verifactu_aeat_header()
+    def _format_verifactu_fault(self, fault):
+        """Readable text for a failure while building a record."""
+        message = str(fault)
+        path = getattr(fault, "path", None)
+        if path:
+            message += " | Path: %s" % ".".join(str(part) for part in path)
+        return message
+
+    def _build_verifactu_registro_list(self):
+        """Build the payload record by record, leaving the invalid ones out.
+
+        Reporting a later record first does not break the chain: chaining is
+        required over the sequence in which records are created (RD 1007/2023,
+        art. 8.2.b), not over the order in which they are reported.
+        """
         registro_factura_list = []
-        create_exception = False
-        for rec in self:
-            rec.send_attempt += 1
-            if rec.document:
-                inv_dict = rec.document._get_verifactu_invoice_dict(
-                    cancel=rec.entry_type == "cancel"
+        valid_entries = self.browse()
+        failures = {}
+        for entry in self:
+            entry.send_attempt += 1
+            if not entry.document:
+                continue
+            try:
+                inv_dict = entry.document._get_verifactu_invoice_dict(
+                    cancel=entry.entry_type == "cancel"
                 )
-                registro_factura_list.append(inv_dict)
+            except Exception as fault:
+                failures[entry.id] = self._format_verifactu_fault(fault)
+                continue
+            try:
+                error = entry.document._validate_verifactu_registro(inv_dict)
+            except Exception:
+                # Fail open, as when posting: a failure of the check itself
+                # must not stop the whole batch from being sent.
+                _logger.exception(
+                    "VERI*FACTU: the schema of %s could not be checked",
+                    entry.document_name or entry.id,
+                )
+                error = None
+            if error:
+                failures[entry.id] = error
+                continue
+            registro_factura_list.append(inv_dict)
+            valid_entries |= entry
+        return registro_factura_list, valid_entries, failures
+
+    def _register_verifactu_send_failure(self, message, response=False):
+        """Attribute a failure to this entry's document only.
+
+        The whole message is kept: `aeat_send_error` is a Text field, and
+        truncating a schema error drops the name of the offending element,
+        which is its only actionable part.
+        """
+        self.ensure_one()
+        line = (
+            self.env["verifactu.invoice.entry.response.line"]
+            .sudo()
+            .create(
+                {
+                    "entry_id": self.id,
+                    "model": self.model,
+                    "document_id": self.document_id,
+                    "entry_response_id": response and response.id,
+                    "response": message,
+                    "send_state": "not_sent",
+                    "error_code": "SCHEMA_ERROR",
+                }
+            )
+        )
+        self.last_response_line_id = line
+        document = self.document
+        if document:
+            document.last_verifactu_response_line_id = line
+            document.write({"aeat_send_failed": True, "aeat_send_error": message})
+        return line
+
+    def _is_verifactu_failure_already_registered(self, message):
+        """Whether this very exclusion is already on the entry."""
+        self.ensure_one()
+        line = self.last_response_line_id
+        return (
+            bool(line)
+            and line.error_code == "SCHEMA_ERROR"
+            and (line.response == message)
+        )
+
+    def _register_verifactu_send_failures(self, failures):
+        """Register every exclusion, and warn whoever has to act on it.
+
+        An excluded record stays `not_sent` on purpose, so that it goes out as
+        soon as the data is corrected, which means every pass of the cron
+        finds it again. Each of those passes leaves its own response: without
+        one there is no way to tell the record is still being retried, and a
+        queue that looks abandoned is worse than a noisy one.
+
+        The warning is raised only when the exclusion is new, though. It is an
+        activity, so it stays open until somebody attends it -- repeating it
+        every minute would bury the one that matters instead of insisting. A
+        different error, or the same record failing after having been sent,
+        warns again.
+        """
+        # Read before the lines of this pass are written, or they would make
+        # every exclusion look like one already warned about.
+        is_new = any(
+            not self.browse(entry_id)._is_verifactu_failure_already_registered(message)
+            for entry_id, message in failures.items()
+        )
+        response = (
+            self.env["verifactu.invoice.entry.response"]
+            .sudo()
+            .create(
+                {
+                    "name": _("Invoices not matching the VERI*FACTU schema"),
+                    "response": "\n\n".join(failures.values()),
+                    "date_response": fields.Datetime.now(),
+                }
+            )
+        )
+        for entry in self.browse(list(failures)):
+            if is_new:
+                _logger.warning(
+                    "VERI*FACTU: %s left out of the batch, not registered: %s",
+                    entry.document_name or entry.id,
+                    failures[entry.id],
+                )
+            entry._register_verifactu_send_failure(
+                failures[entry.id], response=response
+            )
+        if is_new:
+            response.create_send_response_activity()
+        return response
+
+    def _send_documents_to_verifactu(self):
+        """Send what can be sent and return what was left out, by entry id.
+
+        The exclusions are returned instead of registered here because the
+        cron splits every batch in two calls -- the records it reports as an
+        incident and the rest -- and a record that was never sent belongs to
+        neither: reporting per call would raise two identical warnings for one
+        pass.
+        """
+        if not self:
+            return {}
+        header = self[0]._get_verifactu_aeat_header()
+        (
+            registro_factura_list,
+            valid_entries,
+            failures,
+        ) = self._build_verifactu_registro_list()
+        if not valid_entries:
+            # Nothing left to ask the Agency about.
+            return failures
+        create_exception = False
         try:
-            serv = rec._connect_verifactu()
+            serv = valid_entries[0]._connect_verifactu()
             res = serv.RegFactuSistemaFacturacion(header, registro_factura_list)
         except Exception as AEATError:
             res = {AEATError}
@@ -327,7 +477,7 @@ class VerifactuInvoiceEntry(models.Model):
             if not response.date_response:
                 response.date_response = fields.Datetime.now()
             response.create_activity_on_exception()
-        create_response_activity = self._create_response_lines(
+        create_response_activity = valid_entries._create_response_lines(
             response=response, header=header, verifactu_response=res
         )
         updated_response_name = _("VERI*FACTU sending")
@@ -338,7 +488,7 @@ class VerifactuInvoiceEntry(models.Model):
         response.name = updated_response_name
         if create_response_activity:
             response.create_send_response_activity()
-        return True
+        return failures
 
     def _create_response_lines(
         self, response=False, header=False, verifactu_response=False

--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -6,14 +6,17 @@
 import base64
 import io
 import json
+import re
 from hashlib import sha256
 from urllib.parse import urlencode
 
 import psycopg2
 import qrcode
+from lxml import etree
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.modules.module import get_resource_path
 from odoo.tools.float_utils import float_compare
 
 from odoo.addons.l10n_es_aeat.models.aeat_mixin import round_by_keys
@@ -21,6 +24,35 @@ from odoo.addons.l10n_es_aeat.models.aeat_mixin import round_by_keys
 VERIFACTU_VERSION = 1.0
 VERIFACTU_DATE_FORMAT = "%d-%m-%Y"
 VERIFACTU_MACRODATA_LIMIT = 100000000.0
+
+VERIFACTU_SCHEMA_NS = (
+    "https://www2.agenciatributaria.gob.es/static_files/common/internet/dep"
+    "/aplicaciones/es/aeat/tike/cont/ws/SuministroInformacion.xsd"
+)
+VERIFACTU_SCHEMA_FILE = "SuministroInformacion.xsd"
+VERIFACTU_DSIG_FILE = "xmldsig-core-schema.xsd"
+# Elements that wrap their items instead of repeating once per item, unlike
+# `DetalleDesglose`.
+VERIFACTU_LIST_WRAPPERS = frozenset(
+    {"Destinatarios", "FacturasRectificadas", "FacturasSustituidas"}
+)
+
+
+class VerifactuSchemaResolver(etree.Resolver):
+    """Resolve the xmldsig import to the copy in `data/`, so nothing is fetched.
+
+    Validation runs while an invoice is being posted and must not touch the
+    network.
+    """
+
+    def resolve(self, system_url, public_id, context):
+        if system_url and system_url.endswith(VERIFACTU_DSIG_FILE):
+            return self.resolve_filename(
+                get_resource_path("l10n_es_verifactu_oca", "data", VERIFACTU_DSIG_FILE),
+                context,
+            )
+        return None
+
 
 VERIFACTU_EXTRA_AEAT_STATES = [
     ("incorrect", "Incorrect"),
@@ -257,6 +289,118 @@ class VerifactuMixin(models.AbstractModel):
         )
         return inv_dict
 
+    @api.model
+    def _get_verifactu_schema_tree(self):
+        """The official schema, read from `data/`.
+
+        Not kept between calls, as `odoo.tools.xml_utils._check_with_xsd` and
+        `l10n_es_facturae` do not keep it either: an `lxml` validator holds the
+        error log it fills while validating, so sharing one between threads
+        can lose the element name that makes the error actionable.
+        """
+        parser = etree.XMLParser(no_network=True)
+        parser.resolvers.add(VerifactuSchemaResolver())
+        return etree.parse(
+            get_resource_path("l10n_es_verifactu_oca", "data", VERIFACTU_SCHEMA_FILE),
+            parser,
+        )
+
+    @api.model
+    def _get_verifactu_schema_order(self, tree, root_tag):
+        """Order the schema expects for the children of `root_tag`.
+
+        Not the order of the dict: the builders append keys where they read
+        best (`Subsanacion` last, the schema wants it fifth) and `zeep` maps
+        names onto the positions of the type. Reordering here is what keeps a
+        valid record from being reported as invalid.
+        """
+        xs = "{http://www.w3.org/2001/XMLSchema}"
+        root = tree.getroot()
+        type_name = ""
+        for element in root.findall("%selement" % xs):
+            if element.get("name") == root_tag:
+                type_name = (element.get("type") or "").split(":")[-1]
+                break
+        order = []
+        for complex_type in root.iter("%scomplexType" % xs):
+            if complex_type.get("name") != type_name:
+                continue
+            for child in complex_type.iter("%selement" % xs):
+                name = child.get("name")
+                # Direct children only: nested elements have their own
+                # sequence.
+                if name and child.getparent().getparent() is complex_type:
+                    order.append(name)
+            break
+        return order
+
+    @api.model
+    def _verifactu_render_element(self, parent, tag, value):
+        if value is None or value is False:
+            return
+        qualified_tag = "{%s}%s" % (VERIFACTU_SCHEMA_NS, tag)
+        if isinstance(value, list):
+            if tag in VERIFACTU_LIST_WRAPPERS:
+                # An empty list is rendered as an empty element, which is what
+                # `zeep` puts on the wire and what the schema then rejects.
+                # Skipping it here would validate a document that is not the
+                # one being sent.
+                wrapper = etree.SubElement(parent, qualified_tag)
+                for item in value:
+                    for key, sub_value in item.items():
+                        self._verifactu_render_element(wrapper, key, sub_value)
+                return
+            for item in value:
+                self._verifactu_render_element(parent, tag, item)
+            return
+        element = etree.SubElement(parent, qualified_tag)
+        if isinstance(value, dict):
+            for key, sub_value in value.items():
+                self._verifactu_render_element(element, key, sub_value)
+        else:
+            element.text = str(value)
+
+    @api.model
+    def _format_verifactu_schema_error(self, invalid):
+        """Every reason the record is invalid, with the namespaces stripped.
+
+        The whole log, not just the first failure as
+        `odoo.tools.xml_utils._check_with_xsd` does, so a record with two
+        problems does not need two attempts to be fixed.
+        """
+        errors = [entry.message for entry in invalid.error_log] or [str(invalid)]
+        return re.sub(r"\{[^}]+\}", "", "\n".join(errors))
+
+    def _validate_verifactu_registro(self, inv_dict):
+        """Return an error message if the record breaks the official schema.
+
+        Cannot be delegated to `zeep`: it only checks cardinality, not facets
+        such as maxLength, length, pattern or enumeration, so a facet violation
+        would leave the machine and be rejected by the Agency instead.
+        """
+        self.ensure_one()
+        if not inv_dict:
+            return None
+        root_tag = next(iter(inv_dict))
+        document = etree.Element("{%s}%s" % (VERIFACTU_SCHEMA_NS, root_tag))
+        values = inv_dict[root_tag] or {}
+        # Read once and used for both: the expected order comes from the same
+        # tree the validator is built from.
+        tree = self._get_verifactu_schema_tree()
+        schema_order = self._get_verifactu_schema_order(tree, root_tag)
+        # Unknown keys last, so they are reported as unexpected instead of
+        # shifting the position of the valid ones.
+        ordered_keys = [key for key in schema_order if key in values] + [
+            key for key in values if key not in schema_order
+        ]
+        for key in ordered_keys:
+            self._verifactu_render_element(document, key, values[key])
+        try:
+            etree.XMLSchema(tree).assertValid(document)
+        except etree.DocumentInvalid as invalid:
+            return self._format_verifactu_schema_error(invalid)
+        return None
+
     def _get_verifactu_developer_dict(self):
         """Datos del desarrollador del sistema informático."""
         if not self.company_id.verifactu_developer_id:
@@ -280,10 +424,9 @@ class VerifactuMixin(models.AbstractModel):
             "TipoUsoPosibleSoloVerifactu": "S",
             "TipoUsoPosibleMultiOT": "S",
             "IndicadorMultiplesOT": "S" if verifactu_companies > 1 else "N",
-            "IDOtro": {
-                "IDType": "",
-                "ID": "",
-            },
+            # No `IDOtro`: it is a choice with `NIF` in SistemaInformaticoType,
+            # so carrying both is invalid. `zeep` already dropped it, so the
+            # sent envelope is unchanged.
         }
 
     def _get_verifactu_chaining_invoice_dict(self):

--- a/l10n_es_verifactu_oca/readme/USAGE.rst
+++ b/l10n_es_verifactu_oca/readme/USAGE.rst
@@ -1,1 +1,24 @@
 Cuando se valida una factura, automáticamente genera el registro de envío para verifactu. Cada minuto se enviarán todos aquellos registros pendientes de enviar mediante un cron.
+
+Antes de validar, la factura se comprueba contra el esquema oficial de la Agencia Tributaria, que
+viene incluido en el módulo (no hace falta conexión). Si el registro no cumple ese esquema, la
+factura no se valida y el mensaje indica qué dato falla. Se comprueba en ese momento porque es el
+último en el que la factura todavía se puede corregir: una vez validada es un documento fiscal
+cerrado.
+
+La misma comprobación se repite al enviar, para los registros que ya estaban validados. El que no
+cumple el esquema se queda fuera del envío y los demás se comunican con normalidad. El documento
+que se queda fuera lo indica en su propio formulario, en el campo de error de envío, y se crea un
+aviso para el grupo responsable de VERI*FACTU. Mientras no se corrija el dato, ese registro se
+reintenta en cada pase del cron.
+
+Para que ese aviso lo vea alguien, el grupo *VERI\*FACTU responsable* tiene que tener usuarios: la
+actividad se asigna al primero del grupo y, si el grupo está vacío, al usuario con el que se
+ejecuta el cron, que no suele mirarlas. Conviene añadir al grupo a quien vaya a atender los
+rechazos antes de empezar a facturar.
+
+En la compañía, la casilla *Omitir la comprobación del esquema al validar* deja de impedir la
+validación de la factura. Está pensada para poder seguir facturando mientras se investiga un
+rechazo indebido, no como ajuste permanente: el registro que no cumple el esquema se sigue
+quedando fuera del envío, así que apagarla no consigue que llegue a la Agencia. El cambio queda
+registrado en el historial de la compañía.

--- a/l10n_es_verifactu_oca/static/description/index.html
+++ b/l10n_es_verifactu_oca/static/description/index.html
@@ -425,6 +425,25 @@ Subir el certificado p12 y extraer las claves públicas y privadas con el botón
 <div class="section" id="usage">
 <h2><a class="toc-backref" href="#toc-entry-3">Usage</a></h2>
 <p>Cuando se valida una factura, automáticamente genera el registro de envío para verifactu. Cada minuto se enviarán todos aquellos registros pendientes de enviar mediante un cron.</p>
+<p>Antes de validar, la factura se comprueba contra el esquema oficial de la Agencia Tributaria, que
+viene incluido en el módulo (no hace falta conexión). Si el registro no cumple ese esquema, la
+factura no se valida y el mensaje indica qué dato falla. Se comprueba en ese momento porque es el
+último en el que la factura todavía se puede corregir: una vez validada es un documento fiscal
+cerrado.</p>
+<p>La misma comprobación se repite al enviar, para los registros que ya estaban validados. El que no
+cumple el esquema se queda fuera del envío y los demás se comunican con normalidad. El documento
+que se queda fuera lo indica en su propio formulario, en el campo de error de envío, y se crea un
+aviso para el grupo responsable de VERI*FACTU. Mientras no se corrija el dato, ese registro se
+reintenta en cada pase del cron.</p>
+<p>Para que ese aviso lo vea alguien, el grupo <em>VERI*FACTU responsable</em> tiene que tener usuarios: la
+actividad se asigna al primero del grupo y, si el grupo está vacío, al usuario con el que se
+ejecuta el cron, que no suele mirarlas. Conviene añadir al grupo a quien vaya a atender los
+rechazos antes de empezar a facturar.</p>
+<p>En la compañía, la casilla <em>Omitir la comprobación del esquema al validar</em> deja de impedir la
+validación de la factura. Está pensada para poder seguir facturando mientras se investiga un
+rechazo indebido, no como ajuste permanente: el registro que no cumple el esquema se sigue
+quedando fuera del envío, así que apagarla no consigue que llegue a la Agencia. El cambio queda
+registrado en el historial de la compañía.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h2><a class="toc-backref" href="#toc-entry-4">Known issues / Roadmap</a></h2>

--- a/l10n_es_verifactu_oca/tests/common.py
+++ b/l10n_es_verifactu_oca/tests/common.py
@@ -1,5 +1,7 @@
 # Copyright 2024 FactorLibre - Luis J. Salvatierra
 # Copyright 2025 Tecnativa - Pedro M. Baeza
+from unittest.mock import MagicMock
+
 from odoo import Command, fields
 
 from odoo.addons.l10n_es_aeat.tests.test_l10n_es_aeat_certificate import (
@@ -279,3 +281,37 @@ class TestVerifactuCommon(TestL10nEsAeatModBase, TestL10nEsAeatCertificateBase):
         """
         invoice._generate_verifactu_chaining()
         return invoice.last_verifactu_invoice_entry_id
+
+    def _mock_batch_response(self, documents, state="Correcto"):
+        """Build an AEAT response with one line per document of a batch.
+
+        The single-document helper rewrites `NumSerieFactura` with one invoice
+        name, so it cannot be used for a batch: a response line only matches an
+        entry when its number equals the document's, and unmatched lines are
+        skipped silently.
+        """
+        return {
+            "CSV": "A-Y23JP3582934",
+            "EstadoEnvio": state,
+            "RespuestaLinea": [
+                {
+                    "IDFactura": {
+                        "IDEmisorFactura": "89890001K",
+                        "NumSerieFactura": document._get_document_serial_number(),
+                        "FechaExpedicionFactura": "01-01-2026",
+                    },
+                    "Operacion": {"TipoOperacion": "Alta"},
+                    "EstadoRegistro": state,
+                }
+                for document in documents
+            ],
+        }
+
+    def _mock_batch_service(self, mock_connect, documents, state="Correcto"):
+        """Patch the connection so a batch send answers for `documents` only."""
+        mock_service = MagicMock()
+        mock_service.RegFactuSistemaFacturacion.return_value = (
+            self._mock_batch_response(documents, state=state)
+        )
+        mock_connect.return_value = mock_service
+        return mock_service

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_e_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_e_dict.json
@@ -39,11 +39,7 @@
       "NumeroInstalacion": 1,
       "TipoUsoPosibleSoloVerifactu": "S",
       "TipoUsoPosibleMultiOT": "S",
-      "IndicadorMultiplesOT": "N",
-      "IDOtro": {
-        "IDType": "",
-        "ID": ""
-      }
+      "IndicadorMultiplesOT": "N"
     }
   }
 }

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_ic_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva0_ic_dict.json
@@ -39,11 +39,7 @@
       "NumeroInstalacion": 1,
       "TipoUsoPosibleSoloVerifactu": "S",
       "TipoUsoPosibleMultiOT": "S",
-      "IndicadorMultiplesOT": "N",
-      "IDOtro": {
-        "IDType": "",
-        "ID": ""
-      }
+      "IndicadorMultiplesOT": "N"
     }
   }
 }

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva10b_s_iva21s_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva10b_s_iva21s_dict.json
@@ -49,11 +49,7 @@
       "NumeroInstalacion": 1,
       "TipoUsoPosibleSoloVerifactu": "S",
       "TipoUsoPosibleMultiOT": "S",
-      "IndicadorMultiplesOT": "N",
-      "IDOtro": {
-        "IDType": "",
-        "ID": ""
-      }
+      "IndicadorMultiplesOT": "N"
     }
   }
 }

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva21s_s_req52_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva21s_s_req52_dict.json
@@ -48,11 +48,7 @@
       "NumeroInstalacion": 1,
       "TipoUsoPosibleSoloVerifactu": "S",
       "TipoUsoPosibleMultiOT": "S",
-      "IndicadorMultiplesOT": "N",
-      "IDOtro": {
-        "IDType": "",
-        "ID": ""
-      }
+      "IndicadorMultiplesOT": "N"
     }
   }
 }

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva_ns_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_invoice_s_iva_ns_dict.json
@@ -39,11 +39,7 @@
       "NumeroInstalacion": 1,
       "TipoUsoPosibleSoloVerifactu": "S",
       "TipoUsoPosibleMultiOT": "S",
-      "IndicadorMultiplesOT": "N",
-      "IDOtro": {
-        "IDType": "",
-        "ID": ""
-      }
+      "IndicadorMultiplesOT": "N"
     }
   }
 }

--- a/l10n_es_verifactu_oca/tests/json/verifactu_out_refund_s_iva10b_s_iva10b_s_iva21s_dict.json
+++ b/l10n_es_verifactu_oca/tests/json/verifactu_out_refund_s_iva10b_s_iva10b_s_iva21s_dict.json
@@ -56,11 +56,7 @@
       "NumeroInstalacion": 1,
       "TipoUsoPosibleSoloVerifactu": "S",
       "TipoUsoPosibleMultiOT": "S",
-      "IndicadorMultiplesOT": "N",
-      "IDOtro": {
-        "IDType": "",
-        "ID": ""
-      }
+      "IndicadorMultiplesOT": "N"
     }
   }
 }

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -5,14 +5,14 @@
 # Copyright 2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from hashlib import sha256
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
 from freezegun import freeze_time
 
-from odoo import Command
+from odoo import Command, _, fields
 from odoo.exceptions import UserError
 from odoo.modules.module import get_resource_path
 
@@ -460,6 +460,523 @@ class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):
         self.assertFalse(self.invoice.verifactu_macrodata)
         self.invoice.invoice_line_ids.price_unit = 130000000
         self.assertTrue(self.invoice.verifactu_macrodata)
+
+
+class TestVerifactuSchemaValidation(TestVerifactuCommon):
+    """Records that do not match the official schema must not break the batch."""
+
+    def setUp(self):
+        super().setUp()
+        self._activate_certificate(self.certificate_password)
+        self.entry_model = self.env["verifactu.invoice.entry"]
+
+    def _create_pending_invoice(self, **kwargs):
+        """Invoice that will enter the sending queue once posted.
+
+        `_create_test_invoice` marks invoices as already sent, so they never
+        reach the cron; this resets that.
+        """
+        invoice = self._create_test_invoice(**kwargs)
+        invoice.aeat_state = "not_sent"
+        return invoice
+
+    def _post_batch(self):
+        """Post three invoices sharing the company chaining."""
+        batch = (
+            self.invoice
+            + self._create_pending_invoice(amount=200)
+            + self._create_pending_invoice(amount=300)
+        )
+        batch.action_post()
+        return batch
+
+    def _patch_dict(self, documents, transform):
+        """Patch the payload builder, applying `transform` only to `documents`."""
+        move_class = type(self.env["account.move"])
+        original = move_class._get_verifactu_invoice_dict
+
+        def _fake(record, cancel=False):
+            if record.id in documents.ids:
+                return transform(record, original)
+            return original(record, cancel=cancel)
+
+        return patch.object(move_class, "_get_verifactu_invoice_dict", _fake)
+
+    def _empty_breakdown(self, record, original):
+        inv_dict = original(record)
+        inv_dict["RegistroAlta"]["Desglose"] = {"DetalleDesglose": []}
+        return inv_dict
+
+    def _raise_build_error(self, record, original):
+        raise UserError(_("Tax is not mapped to VERI*FACTU."))
+
+    def test_validate_registro_accepts_real_payload(self):
+        """The serializer must produce a schema-valid document for a good invoice."""
+        self.invoice.action_post()
+        inv_dict = self.invoice._get_verifactu_invoice_dict()
+        self.assertIsNone(
+            self.invoice._validate_verifactu_registro(inv_dict),
+            "A correct invoice must validate: a failure here means the serializer "
+            "emits elements in an order the schema does not allow.",
+        )
+
+    def test_validate_registro_rejects_empty_breakdown(self):
+        """The known offending case must be caught, naming its element."""
+        self.invoice.action_post()
+        inv_dict = self.invoice._get_verifactu_invoice_dict()
+        inv_dict["RegistroAlta"]["Desglose"] = {"DetalleDesglose": []}
+        error = self.invoice._validate_verifactu_registro(inv_dict)
+        self.assertIn("DetalleDesglose", error or "")
+        self.assertNotIn(
+            "{", error or "", "The namespace URI must be stripped from the message."
+        )
+
+    def test_post_blocks_invoice_not_matching_schema(self):
+        """V1 — prevention: an invalid record must not be posted at all."""
+        with self._patch_dict(self.invoice, self._empty_breakdown):
+            with self.assertRaises(UserError) as error:
+                self.invoice.action_post()
+        self.assertIn(
+            "DetalleDesglose",
+            str(error.exception),
+            "The error must name the schema element at fault so it can be fixed.",
+        )
+
+    def test_post_reports_every_invoice_not_matching_schema(self):
+        """A mass posting must name every offender, not only the first one."""
+        offenders = self.invoice + self._create_pending_invoice(amount=500)
+        with self._patch_dict(offenders, self._empty_breakdown):
+            with self.assertRaises(UserError) as error:
+                offenders.action_post()
+        message = str(error.exception)
+        self.assertEqual(
+            message.count("DetalleDesglose"),
+            2,
+            "Both offending invoices must be reported by a single posting, so "
+            "that a mass posting is not repeated once per offending invoice.",
+        )
+        for invoice in offenders:
+            self.assertIn(
+                invoice.name,
+                message,
+                "Each offender must be named: the error is only actionable if "
+                "it says which invoice to fix.",
+            )
+
+    def test_post_reports_build_failure_next_to_schema_error(self):
+        """A record that cannot be built belongs in the same report.
+
+        It will not reach the Agency either, so raising it on the spot would
+        abort the posting at its first offender and force a mass posting to be
+        repeated once per bad invoice — what reporting every one of them
+        avoids.
+        """
+        unbuildable = self._create_pending_invoice(amount=500)
+        offenders = self.invoice + unbuildable
+        with self._patch_dict(self.invoice, self._empty_breakdown), self._patch_dict(
+            unbuildable, self._raise_build_error
+        ):
+            with self.assertRaises(UserError) as error:
+                offenders.action_post()
+        message = str(error.exception)
+        for invoice in offenders:
+            self.assertIn(
+                invoice.name,
+                message,
+                "Both offenders must be named, whatever stopped each of them: "
+                "a build failure raised on its own would name neither.",
+            )
+        self.assertEqual(
+            message.count("DetalleDesglose"),
+            1,
+            "Only one of them broke the schema; the other never got built.",
+        )
+
+    def test_check_failing_does_not_stop_the_post(self):
+        """A failure of the check itself must not stop the invoice being posted.
+
+        Mirror of `test_check_failing_does_not_stop_the_batch` on the posting
+        side: turning that fail-open into a raise would stop all invoicing, and
+        nothing else in the suite would notice.
+        """
+        move_class = type(self.env["account.move"])
+
+        def _boom(record, inv_dict):
+            raise RuntimeError("the schema could not be read")
+
+        with patch.object(move_class, "_validate_verifactu_registro", _boom):
+            self.invoice.action_post()
+        self.assertEqual(
+            self.invoice.state,
+            "posted",
+            "What the check protects against is a record the Agency would "
+            "reject, not the check being unable to run.",
+        )
+
+    def test_long_description_is_truncated(self):
+        """A description over the limit must be normalised, not block the post.
+
+        It is set on the company, so blocking would stop every invoice at once
+        and the user could not fix it from the invoice.
+        """
+        self.invoice.verifactu_description = "L" * 600
+        self.invoice.action_post()
+        inv_dict = self.invoice._get_verifactu_invoice_dict()
+        self.assertEqual(
+            len(inv_dict["RegistroAlta"]["DescripcionOperacion"]),
+            500,
+            "The description must be cut to the length the schema allows.",
+        )
+        self.assertIsNone(
+            self.invoice._validate_verifactu_registro(inv_dict),
+            "Once truncated, the record must validate.",
+        )
+
+    def test_tax_rate_with_extra_decimals_is_rounded(self):
+        """A rate the schema cannot express must be rounded, not block the post.
+
+        `account.tax.amount` holds four decimals and the schema takes two, so
+        a rate such as 7.527 would otherwise block every invoice using it.
+        """
+        tax = self.invoice.invoice_line_ids.tax_ids[:1]
+        self.assertTrue(tax, "The fixture invoice is expected to carry a tax.")
+        tax.amount = 7.527
+        self.invoice.action_post()
+        inv_dict = self.invoice._get_verifactu_invoice_dict()
+        rates = [
+            detail["TipoImpositivo"]
+            for detail in inv_dict["RegistroAlta"]["Desglose"]["DetalleDesglose"]
+        ]
+        self.assertIn(
+            "7.53",
+            rates,
+            "The rate must be rounded to the two decimals of the schema.",
+        )
+        self.assertIsNone(
+            self.invoice._validate_verifactu_registro(inv_dict),
+            "Once rounded, the record must validate.",
+        )
+
+    def test_rounded_rate_stays_within_the_reported_amount_tolerance(self):
+        """Rounding the rate must not put the record outside what is admitted.
+
+        The Agency validates `CuotaRepercutida = BaseImponibleOimporteNoSujeto
+        * TipoImpositivo / 100 +/- 10,00 euros` (Validaciones y errores 15.7),
+        and the amount travels as the invoice computed it, from the real rate.
+        Rounding the rate to what the schema can express therefore has to stay
+        inside that margin, which is what this fixes: on a base of 10.000 the
+        widest possible rounding moves the pair by 0,50 euros.
+        """
+        tax = self.invoice.invoice_line_ids.tax_ids[:1]
+        self.assertTrue(tax, "The fixture invoice is expected to carry a tax.")
+        # Before creating it, so that the invoice computes its amount from the
+        # rate under test: changing the rate afterwards leaves the amount of
+        # the previous one, which is not a case that can reach the Agency.
+        tax.amount = 7.527
+        invoice = self._create_pending_invoice(amount=10000)
+        invoice.action_post()
+        inv_dict = invoice._get_verifactu_invoice_dict()
+        checked = 0
+        for detail in inv_dict["RegistroAlta"]["Desglose"]["DetalleDesglose"]:
+            if "CuotaRepercutida" not in detail:
+                continue
+            base = float(detail["BaseImponibleOimporteNoSujeto"])
+            rate = float(detail["TipoImpositivo"])
+            reported = float(detail["CuotaRepercutida"])
+            checked += 1
+            self.assertLess(
+                abs(reported - base * rate / 100),
+                10.00,
+                "The amount reported and the rounded rate must stay within the "
+                "margin the Agency admits between them.",
+            )
+        self.assertTrue(checked, "The breakdown must carry an amount to check.")
+
+    def test_skip_schema_check_only_lifts_the_posting_gate(self):
+        """The escape hatch must not let an invalid record reach the Agency.
+
+        It exists to keep invoicing while a wrong rejection is looked into, so
+        it lifts the gate at posting and nothing else.
+        """
+        self.company.verifactu_skip_schema_check = True
+        with self._patch_dict(self.invoice, self._empty_breakdown):
+            self.invoice.action_post()
+            self.assertEqual(
+                self.invoice.state,
+                "posted",
+                "With the check skipped, the invoice must post.",
+            )
+            entry = self.invoice.last_verifactu_invoice_entry_id
+            self.assertTrue(entry, "Posting must still queue the record.")
+            _registros, valid, failures = entry._build_verifactu_registro_list()
+        self.assertFalse(
+            valid,
+            "The record must still be left out of the batch: skipping the "
+            "posting gate must not send what the Agency would reject.",
+        )
+        self.assertIn(
+            entry.id,
+            failures,
+            "The excluded record must still be attributed its own error.",
+        )
+
+    def test_check_failing_does_not_stop_the_batch(self):
+        """A failure of the check itself must not stop the batch being sent.
+
+        Same policy as when posting: what the check protects against is a
+        record the Agency would reject, not the check being unable to run.
+        """
+        batch = self._post_batch()
+        move_class = type(self.env["account.move"])
+
+        def _boom(record, inv_dict):
+            raise RuntimeError("the schema could not be read")
+
+        with patch.object(move_class, "_validate_verifactu_registro", _boom):
+            (
+                registros,
+                valid,
+                failures,
+            ) = batch.last_verifactu_invoice_entry_id._build_verifactu_registro_list()
+        self.assertFalse(
+            failures,
+            "A broken check must not be attributed to the records as if they "
+            "were the ones at fault.",
+        )
+        self.assertEqual(
+            len(registros),
+            len(batch),
+            "Every record must still be sent when the check cannot run.",
+        )
+
+    def test_schema_is_not_kept_between_calls(self):
+        """The validator must not be cached, so it is never shared.
+
+        `lxml` fills the error log of the validator while validating, so two
+        threads using the same one can lose the name of the offending element,
+        which is the only actionable part of the message.
+        """
+        self.assertIsNot(
+            self.invoice._get_verifactu_schema_tree(),
+            self.invoice._get_verifactu_schema_tree(),
+            "Caching the schema would share one validator between threads.",
+        )
+
+    def _count_schema_exclusions(self, document):
+        return self.env["verifactu.invoice.entry.response.line"].search_count(
+            [
+                ("entry_id", "=", document.last_verifactu_invoice_entry_id.id),
+                ("error_code", "=", "SCHEMA_ERROR"),
+            ]
+        )
+
+    def _exclusion_responses(self, document):
+        return (
+            self.env["verifactu.invoice.entry.response.line"]
+            .search(
+                [
+                    ("entry_id", "=", document.last_verifactu_invoice_entry_id.id),
+                    ("error_code", "=", "SCHEMA_ERROR"),
+                ]
+            )
+            .mapped("entry_response_id")
+        )
+
+    def _count_exclusion_activities(self, document):
+        """Activities on this document's exclusions only.
+
+        The database carries activities from elsewhere, so counting them all
+        would measure the fixtures instead of the behaviour.
+        """
+        return self.env["mail.activity"].search_count(
+            [
+                ("res_model", "=", "verifactu.invoice.entry.response"),
+                ("res_id", "in", self._exclusion_responses(document).ids),
+            ]
+        )
+
+    def test_every_pass_leaves_a_trace_but_warns_once(self):
+        """Retries must be visible, and the warning must not be repeated.
+
+        The record stays queued on purpose so that it goes out once corrected,
+        which means the cron finds it every minute. Each pass leaves its own
+        response so the retries can be seen, but the activity is raised once:
+        it stays open until somebody attends it, and repeating it every minute
+        would bury it.
+        """
+        batch = self._post_batch()
+        culprit = batch[1]
+        valid = batch - culprit
+        with self._patch_dict(culprit, self._empty_breakdown), patch(
+            "odoo.addons.l10n_es_verifactu_oca.models."
+            "verifactu_invoice_entry.VerifactuInvoiceEntry._connect_verifactu"
+        ) as mock_connect:
+            self._mock_batch_service(mock_connect, valid)
+            self.entry_model._cron_send_documents_to_verifactu()
+            self.entry_model._cron_send_documents_to_verifactu()
+            self.entry_model._cron_send_documents_to_verifactu()
+        self.assertEqual(
+            self._count_schema_exclusions(culprit),
+            3,
+            "Every pass must leave its trace, or the queue looks abandoned.",
+        )
+        self.assertEqual(
+            self._count_exclusion_activities(culprit),
+            1,
+            "The warning must be raised once: it stays open until attended.",
+        )
+
+    def test_one_warning_per_pass_not_per_send_call(self):
+        """A pass splits the batch in two calls but warns once.
+
+        The cron reports the records registered long ago as an incident and
+        the rest normally. A record that was never sent belongs to neither, so
+        reporting per call would raise two warnings for a single pass.
+        """
+        batch = self._post_batch()
+        # One offender in each of the two groups the cron makes.
+        batch[0].last_verifactu_invoice_entry_id.document.write(
+            {
+                "verifactu_registration_date": fields.Datetime.now()
+                - timedelta(seconds=300)
+            }
+        )
+        offenders = batch[0] + batch[1]
+        with self._patch_dict(offenders, self._empty_breakdown), patch(
+            "odoo.addons.l10n_es_verifactu_oca.models."
+            "verifactu_invoice_entry.VerifactuInvoiceEntry._connect_verifactu"
+        ) as mock_connect:
+            self._mock_batch_service(mock_connect, batch - offenders)
+            self.entry_model._cron_send_documents_to_verifactu()
+        lines = self.env["verifactu.invoice.entry.response.line"].search(
+            [
+                (
+                    "entry_id",
+                    "in",
+                    offenders.mapped("last_verifactu_invoice_entry_id").ids,
+                ),
+                ("error_code", "=", "SCHEMA_ERROR"),
+            ]
+        )
+        self.assertEqual(len(lines), 2, "Each offender must get its own line.")
+        self.assertEqual(
+            len(lines.mapped("entry_response_id")),
+            1,
+            "Both lines must hang from a single response: reporting per send "
+            "call would raise two warnings for one pass.",
+        )
+
+    def test_send_batch_excludes_schema_invalid_entry(self):
+        """V1 — one invalid record must not stop the other two."""
+        batch = self._post_batch()
+        culprit = batch[1]
+        valid = batch - culprit
+        with self._patch_dict(culprit, self._empty_breakdown), patch(
+            "odoo.addons.l10n_es_verifactu_oca.models."
+            "verifactu_invoice_entry.VerifactuInvoiceEntry._connect_verifactu"
+        ) as mock_connect:
+            service = self._mock_batch_service(mock_connect, valid)
+            self.entry_model._cron_send_documents_to_verifactu()
+        self.assertEqual(
+            service.RegFactuSistemaFacturacion.call_count,
+            1,
+            "The batch must be sent once, without per-record retries.",
+        )
+        self.assertEqual(
+            len(service.RegFactuSistemaFacturacion.call_args[0][1]),
+            2,
+            "Only the two valid records should have been sent.",
+        )
+        for invoice in valid:
+            self.assertEqual(invoice.aeat_state, "sent")
+        self.assertEqual(
+            culprit.aeat_state, "not_sent", "The culprit stays queued for a later pass."
+        )
+
+    def test_send_batch_error_only_on_culprit(self):
+        """V2 — the error belongs to the offending invoice only."""
+        batch = self._post_batch()
+        culprit = batch[1]
+        valid = batch - culprit
+        with self._patch_dict(culprit, self._empty_breakdown), patch(
+            "odoo.addons.l10n_es_verifactu_oca.models."
+            "verifactu_invoice_entry.VerifactuInvoiceEntry._connect_verifactu"
+        ) as mock_connect:
+            self._mock_batch_service(mock_connect, valid)
+            self.entry_model._cron_send_documents_to_verifactu()
+        self.assertTrue(culprit.aeat_send_failed)
+        self.assertIn(
+            "DetalleDesglose",
+            culprit.aeat_send_error or "",
+            "The stored error must keep the offending element, not a truncation.",
+        )
+        for invoice in valid:
+            self.assertFalse(invoice.aeat_send_failed)
+            self.assertFalse(invoice.aeat_send_error)
+        lines = self.env["verifactu.invoice.entry.response.line"].search(
+            [("error_code", "=", "SCHEMA_ERROR")]
+        )
+        self.assertEqual(len(lines), 1, "Exactly one response line for the culprit.")
+        self.assertEqual(lines.document_id, culprit.id)
+
+    def test_send_batch_build_failure_isolated(self):
+        """V1 — a payload that cannot even be built must not abort the pass."""
+        batch = self._post_batch()
+        culprit = batch[1]
+        valid = batch - culprit
+        with self._patch_dict(culprit, self._raise_build_error), patch(
+            "odoo.addons.l10n_es_verifactu_oca.models."
+            "verifactu_invoice_entry.VerifactuInvoiceEntry._connect_verifactu"
+        ) as mock_connect:
+            self._mock_batch_service(mock_connect, valid)
+            self.entry_model._cron_send_documents_to_verifactu()
+        for invoice in valid:
+            self.assertEqual(invoice.aeat_state, "sent")
+        self.assertTrue(culprit.aeat_send_failed)
+        self.assertIn("not mapped", culprit.aeat_send_error or "")
+
+    def test_send_batch_schema_failure_raises_activity(self):
+        """The exclusion must not be silent: somebody has to be told."""
+        responsible_group = self.env.ref(
+            "l10n_es_verifactu_oca.group_verifactu_responsible"
+        )
+        responsible_group.sudo().users = [Command.link(self.env.user.id)]
+        batch = self._post_batch()
+        culprit = batch[1]
+        valid = batch - culprit
+        with self._patch_dict(culprit, self._empty_breakdown), patch(
+            "odoo.addons.l10n_es_verifactu_oca.models."
+            "verifactu_invoice_entry.VerifactuInvoiceEntry._connect_verifactu"
+        ) as mock_connect:
+            self._mock_batch_service(mock_connect, valid)
+            self.entry_model._cron_send_documents_to_verifactu()
+        activity = self.env["mail.activity"].search(
+            [("res_model", "=", "verifactu.invoice.entry.response")]
+        )
+        self.assertTrue(
+            activity, "An activity must warn the responsible group of the exclusion."
+        )
+        self.assertIn(
+            self.env.user,
+            activity.mapped("user_id"),
+            "The activity must land on a member of the responsible group.",
+        )
+
+    def test_receiver_name_is_truncated(self):
+        """A long customer name must be normalised, not block the invoice."""
+        self.partner.name = "X" * 130
+        self.invoice.action_post()
+        inv_dict = self.invoice._get_verifactu_invoice_dict()
+        receiver = inv_dict["RegistroAlta"]["Destinatarios"]["IDDestinatario"]
+        self.assertEqual(
+            len(receiver["NombreRazon"]),
+            120,
+            "The receiver name must be truncated like the issuer's.",
+        )
+        self.assertFalse(
+            self.invoice._validate_verifactu_registro(inv_dict),
+            "The truncated payload must match the schema.",
+        )
 
 
 class TestVerifactuSendResponse(TestVerifactuCommon):

--- a/l10n_es_verifactu_oca/views/res_company_view.xml
+++ b/l10n_es_verifactu_oca/views/res_company_view.xml
@@ -16,6 +16,10 @@
                         <group name="verifactu_config">
                             <field name="verifactu_test" string="Test environment?" />
                             <field name="verifactu_start_date" string="Start date" />
+                            <field
+                                name="verifactu_skip_schema_check"
+                                string="Skip the schema check when posting?"
+                            />
                         </group>
                     </group>
                     <group attrs="{'invisible': [('verifactu_enabled', '=', False)]}">


### PR DESCRIPTION
## El problema

El envío de registros de facturación a VERI\*FACTU es hoy todo-o-nada. El cron agrupa los registros pendientes por cadena y los manda en **una sola llamada**. Si uno solo de ellos produce un mensaje que no cumple el esquema oficial, la llamada entera falla y **ninguno** de los registros del grupo se comunica: todos quedan pendientes, el siguiente pase repite el mismo
fallo, y no queda rastro de la causa en ninguna factura.

El caso que lo destapó es una factura de una única línea con un impuesto no sujeto: su `DetalleDesglose` queda vacío y el esquema exige `minOccurs="1"`.

## Por qué validar antes de enviar, y no reintentar después de fallar

La vía natural sería envolver la construcción de cada registro en un `try` y reintentar uno a uno. No basta, por dos motivos que aparecieron al verificarla:

1. **Ese caso no falla al construir, falla al validar.** El desglose vacío se  construye sin lanzar ninguna excepción, porque el impuesto sí está mapeado — a  `TaxNotIncludedInTotal` / `BaseNotIncludedInTotal`, códigos legítimos del mapa que están
   excluidos del desglose por diseño. Aislar la construcción no cubre este caso.

2. **`zeep` solo comprueba cardinalidad, no facetas** —longitudes, patrones, enumerados—.
   Verificado con `zeep` 4.3.1 construyendo el mensaje con `create_message` y la misma configuración del módulo:

   | Caso | `zeep` | XSD local |
   |---|---|---|
   | Desglose vacío (`minOccurs`) | cazado | cazado |
   | `NombreRazon` de 130 (máx. 120) | pasa | cazado |
   | `NIF` de 8 (`length=9`) | pasa | cazado |
   | `TipoImpositivo` con 3 decimales | pasa | cazado |
   | `TipoImpositivo` negativo | pasa | cazado |
   | Número de factura de 70 (máx. 60) | pasa | cazado |
   | `DescripcionOperacion` de 600 (máx. 500) | pasa | cazado |
   | `CalificacionOperacion` fuera del enum | pasa | cazado |
   | Fecha en ISO en vez de `dd-mm-yyyy` | pasa | cazado |

   Discriminar por clase de excepción habría cubierto solo las violaciones estructurales; las de faceta se envían tal cual y las rechaza la Agencia.

Validar contra el esquema cubre la clase completa, y además permite avisar **al contabilizar**, cuando quien factura todavía puede corregir.

## Qué hace este PR

**Embarca los XSD oficiales** en `data/`, sin modificar. El import del esquema de firma hacia w3.org se redirige a la copia local con un `etree.Resolver` propio y `no_network=True`, así que la validación es 100 % offline — condición necesaria, porque corre mientras se contabiliza. Es el mismo patrón que ya usa `l10n_es_facturae` en este repositorio. Los ficheros están verificados por SHA-256 contra el host de producción de la Agencia.

**Valida en dos momentos:**

- **Al contabilizar** (`_get_verifactu_schema_error`, que `_post` llama después de  `_generate_verifactu_chaining`): si el registro no valida, no se contabiliza y el mensaje dice qué elemento incumple. Contabilizar es el último momento en que la factura se puede corregir.

<img width="1745" height="390" alt="verfiactu 2" src="https://github.com/user-attachments/assets/b21e668c-9997-43db-9209-93e040103ea1" />


- **Al construir el lote** (`verifactu_invoice_entry`): para el histórico ya contabilizado y para  el TPV, donde rechazar una venta no es una opción. El registro inválido se **excluye** de la llamada y el error se atribuye a **su** documento `aeat_send_error`, `error_code`), de forma que el resto de la cadena sí se comunica y quien da soporte ve cuál falló.

**Avisa** al grupo responsable de que ha quedado un registro sin comunicar: la obligación de remitirlo sigue viva hasta que se corrija.

El registro excluido se queda en `not_sent` **a propósito**, para que salga en cuanto se corrija el dato, así que el cron lo encuentra en cada pase. Eso separa dos cosas que conviene no confundir:

- **La traza se deja en cada pase**: una respuesta por pase, con una línea por documento  excluido. Sin ella no hay forma de saber que se sigue reintentando, y una cola que parece  abandonada es peor que una ruidosa.
- **El aviso se levanta una sola vez.** Es una actividad, así que queda abierta hasta que alguien la atienda; repetirla cada minuto no insistiría más, solo enterraría la que importa.
  Un error distinto, o el mismo registro fallando después de haberse enviado, vuelve a avisar.

Y una respuesta **por pase**, no por llamada: el cron parte cada lote en dos —los registros con más de 240 s se comunican marcados como incidencia— y un registro que nunca se envió no pertenece a ninguno de los dos grupos, así que registrar por llamada dejaba dos respuestas idénticas en el mismo segundo para un solo pase.

> Para recibir el aviso hay que pertenecer al grupo **VERI\*FACTU Responsible**. Si está vacío,
> el módulo asigna la actividad al usuario que ejecuta el cron y en la práctica no la ve nadie
> (comportamiento previo de `create_send_response_activity`, que además solo asigna al primer
> usuario del grupo).

Al contabilizar en bloque, **se recorren todas las facturas y se informa de todas las que incumplen en un solo error**, en lugar de abortar en la primera. La contabilización se deshace entera igual —eso ya ocurría con `_check_verifactu_configuration`—, así que parar en la primera solo obligaría a repetir la operación una vez por cada factura defectuosa:

```
Las siguientes facturas no se pueden validar porque su registro VERI*FACTU no cumple el esquema oficial:

FAC/2026/0003:
    Element 'FacturasRectificadas': Missing child element(s). Expected is
    ( IDFacturaRectificada ).

FAC/2026/0007:
    Element 'NombreRazon': [facet 'maxLength'] The value has a length of
    '134'; this exceeds the allowed maximum of '120'.
```

## Normaliza lo que puede, bloquea solo lo que no

El criterio es que únicamente llegue a bloquear lo que necesita una decisión humana. Lo que el código puede arreglar sin ambigüedad, lo arregla:

| Campo | Límite del esquema | Qué se hace |
|---|---|---|
| `NombreRazon` del destinatario | 120 | Se trunca, simétrico con el emisor, que ya se truncaba |
| `DescripcionOperacion` | 500 | Se trunca. Cuando la factura no la lleva se toma de la compañía, así que pasarse bloquearía **todas** las facturas a la vez y no habría forma de arreglarlo desde la factura |
| `TipoImpositivo` | 2 decimales | Se redondea. `account.tax.amount` guarda cuatro, así que un tipo como 7,527 bloquearía todas las facturas que lleven ese impuesto |

Los importes ya venían redondeados por `round_by_keys`, y el número de factura y el nombre del emisor ya se truncaban.

Con eso, lo que queda bloqueando al contabilizar son datos concretos de una factura, visibles y corregibles: desglose vacío, rectificativa sin identificar el documento rectificado (lo resuelve #5118), NIF que no tiene los 9 caracteres exactos, o un código de calificación/exención que no está en el enumerado del esquema.

También **se retira el `IDOtro`** del bloque de desarrollador: iba fijo con `IDType` e `ID` en blanco y no había nada que lo poblara, así que siempre se enviaba vacío. Además `NIF` e `IDOtro` son un `choice`, de modo que llevar los dos es inválido. Verificado que el XML que se envía es byte a byte idéntico con y sin él, porque `zeep` ya cogía `NIF` y descartaba el resto.

## Válvula de escape

La validación es lo que se interpone entre un rechazo indebido y poder facturar, así que la compañía tiene una casilla —**Omitir la comprobación del esquema al validar**, con `tracking` como el resto de su configuración VERI\*FACTU— para levantarla mientras se investiga.

Dos decisiones sobre su forma, por si se discuten en la revisión:

- **Solo levanta el bloqueo al contabilizar.** La exclusión al construir el lote no se puede desactivar: no bloquea a nadie, y quitarla solo conseguiría que el lote volviera a caerse entero. Encenderla nunca hace que un registro inválido llegue a la Agencia.
- **Va en la compañía, no en un parámetro del sistema.** Toda la configuración de VERI\*FACTU es por compañía, y un parámetro global la apagaría en todas a la vez en un multi-compañía. Además  no dejaría rastro, mientras que los cuatro campos de configuración existentes llevan `tracking`.

El campo es negativo (*omitir*) a propósito: así el valor por omisión en base de datos deja la validación activa y las instalaciones existentes no la pierden en silencio al actualizar, sin necesidad de una migración.

<img width="906" height="329" alt="verfiactu 3" src="https://github.com/user-attachments/assets/0dd4a1cf-3139-43bd-8b02-81228babe5d0" />

