### PR TITLE
[FIX] l10n_es_vat_book: handle group taxes (e.g. DUA)

### DIFF
--- a/l10n_es_vat_book/README.rst
+++ b/l10n_es_vat_book/README.rst
@@ -141,6 +141,7 @@ Contributors
 - Victor Garcia <victor.garcia@kayuulab.com>
 - Luis Lafaurie <ldlafaurie@gmail.com>
 - Eduardo de miguel <edu@moduon.team>
+- David Jaen <djaen@ontinet.com>
 
 Maintainers
 -----------

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -272,26 +272,31 @@ class L10nEsVatBook(models.Model):
             sign = 1
         if move_line.tax_line_id:
             res = {}
-            tax = move_line.tax_line_id
-            move_line._process_aeat_tax_fee_info(res, tax, sign)
-            key = self.get_book_line_tax_key(move_line, tax)
-            value = tax_lines.setdefault(key, default_dict | {"tax_id": tax.id})
-            value["tax_amount"] += res[tax]["amount"]
-            value["deductible_amount"] += res[tax]["deductible_amount"]
-            value["move_line_ids"].append((4, move_line.id))
+            move_line._process_aeat_tax_fee_info(res, move_line.tax_line_id, sign)
+            for child_tax, info in res.items():
+                key = self.get_book_line_tax_key(move_line, child_tax)
+                value = tax_lines.setdefault(
+                    key, default_dict | {"tax_id": child_tax.id}
+                )
+                value["tax_amount"] += info["amount"]
+                value["deductible_amount"] += info["deductible_amount"]
+                value["move_line_ids"].append((4, move_line.id))
         for i, tax in enumerate(move_line.tax_ids):
             res = {}
             move_line._process_aeat_tax_base_info(res, tax, sign)
             if i == 0:
-                vat_book_line["base_amount"] += res[tax]["base"]
-            if tax not in implied_taxes:
-                continue
-            key = self.get_book_line_tax_key(move_line, tax)
-            value = tax_lines.setdefault(key, default_dict | {"tax_id": tax.id})
-            value["base_amount"] += res[tax]["base"]
-            value["base_move_line_ids"].append((4, move_line.id))
-            # For later matching special taxes
-            value["other_tax_ids"] = (move_line.tax_ids - tax).ids
+                vat_book_line["base_amount"] += next(iter(res.values()))["base"]
+            for child_tax, info in res.items():
+                if child_tax not in implied_taxes:
+                    continue
+                key = self.get_book_line_tax_key(move_line, child_tax)
+                value = tax_lines.setdefault(
+                    key, default_dict | {"tax_id": child_tax.id}
+                )
+                value["base_amount"] += info["base"]
+                value["base_move_line_ids"].append((4, move_line.id))
+                # For later matching special taxes
+                value["other_tax_ids"] = (move_line.tax_ids - tax).ids
 
     def _clear_old_data(self):
         """

--- a/l10n_es_vat_book/readme/CONTRIBUTORS.md
+++ b/l10n_es_vat_book/readme/CONTRIBUTORS.md
@@ -11,3 +11,4 @@
 - Victor Garcia \<<victor.garcia@kayuulab.com>\>
 - Luis Lafaurie \<<ldlafaurie@gmail.com>\>
 - Eduardo de miguel \<<edu@moduon.team>\>
+- David Jaen \<<djaen@ontinet.com>\>

--- a/l10n_es_vat_book/static/description/index.html
+++ b/l10n_es_vat_book/static/description/index.html
@@ -487,6 +487,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Victor Garcia &lt;<a class="reference external" href="mailto:victor.garcia&#64;kayuulab.com">victor.garcia&#64;kayuulab.com</a>&gt;</li>
 <li>Luis Lafaurie &lt;<a class="reference external" href="mailto:ldlafaurie&#64;gmail.com">ldlafaurie&#64;gmail.com</a>&gt;</li>
 <li>Eduardo de miguel &lt;<a class="reference external" href="mailto:edu&#64;moduon.team">edu&#64;moduon.team</a>&gt;</li>
+<li>David Jaen &lt;<a class="reference external" href="mailto:djaen&#64;ontinet.com">djaen&#64;ontinet.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -28,6 +28,7 @@ class TestL10nEsAeatVatBookBase(TestL10nEsAeatModBase):
         "P_REQ014": (280, 3.92),
         "P_REQ52": (290, 15.08),
         "P_IRPF19": (1024, 194.56),
+        "P_IVA21_IBC_GROUP": (1000, 210),
     }
 
 
@@ -79,38 +80,42 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatVatBookBase):
             self.assertEqual(line.base_amount, 0.0)
             self.assertEqual(line.tax_amount, 0.0)
         # Check tax summary for received invoices
-        self.assertEqual(len(vat_book.received_tax_summary_ids), 7)
+        self.assertEqual(len(vat_book.received_tax_summary_ids), 8)
         rec_summaries = sorted(
             vat_book.received_tax_summary_ids,
             key=lambda line: line.tax_amount,
             reverse=True,
         )
-        # P_IVA21_SC - 21% IVA soportado (servicios corrientes)
+        # P_IVA21_IBC_GROUP - IVA 21% Importaciones DUA bienes corrientes
         line = rec_summaries[0]
+        self.assertAlmostEqual(line.base_amount, 1000)
+        self.assertAlmostEqual(line.tax_amount, 210)
+        # P_IVA21_SC - 21% IVA soportado (servicios corrientes)
+        line = rec_summaries[1]
         self.assertAlmostEqual(line.base_amount, 230)
         self.assertAlmostEqual(line.tax_amount, 48.3)
         # P_IVA21_IC_BC - IVA 21% Adquisición Intracomunitaria. Bienes corrientes
-        line = rec_summaries[1]
+        line = rec_summaries[2]
         self.assertAlmostEqual(line.base_amount, 200)
         self.assertAlmostEqual(line.tax_amount, 42)
         # P_IVA0_ND - 21% IVA Soportado no deducible
-        line = rec_summaries[2]
+        line = rec_summaries[3]
         self.assertAlmostEqual(line.base_amount, 100)
         self.assertAlmostEqual(line.tax_amount, 21)
         # P_REQ52 - 5.2% Recargo de equivalencia sobre operaciones sujetas a IVA
-        line = rec_summaries[3]
+        line = rec_summaries[4]
         self.assertAlmostEqual(line.base_amount, 290)
         self.assertAlmostEqual(line.tax_amount, 15.08)
         # P_REQ014 - 1.4% Recargo de equivalencia sobre operaciones sujetas a IVA
-        line = rec_summaries[4]
+        line = rec_summaries[5]
         self.assertAlmostEqual(line.base_amount, 280)
         self.assertAlmostEqual(line.tax_amount, 3.92)
         # P_REQ05 - 0.5% Recargo de equivalencia sobre operaciones sujetas a IVA
-        line = rec_summaries[5]
+        line = rec_summaries[6]
         self.assertAlmostEqual(line.base_amount, 270)
         self.assertAlmostEqual(line.tax_amount, 1.35)
         # P_IRPF19 - 19% Impuesto sobre la resta fisica
-        line = rec_summaries[6]
+        line = rec_summaries[7]
         self.assertAlmostEqual(line.base_amount, 1024)
         self.assertAlmostEqual(line.tax_amount, -194.56)
         # Let's dig into this tax detail for checking the deductible amount


### PR DESCRIPTION
Group taxes are expanded into their children, so the parent is never a key of the dict returned by the AEAT helpers. 
Iterate over the returned taxes instead of indexing by the parent.


Backport of #5034 (18.0) by @EmilioPascual. Closes #4652