### PR TITLE
[IMP] l10n_es_vat_book: calcular los clientes de caja una sola vez

### DIFF
--- a/l10n_es_vat_book/README.rst
+++ b/l10n_es_vat_book/README.rst
@@ -141,6 +141,7 @@ Contributors
 - Victor Garcia <victor.garcia@kayuulab.com>
 - Luis Lafaurie <ldlafaurie@gmail.com>
 - Eduardo de miguel <edu@moduon.team>
+- David Jaen <djaen@ontinet.com>
 
 Maintainers
 -----------

--- a/l10n_es_vat_book/models/l10n_es_vat_book.py
+++ b/l10n_es_vat_book/models/l10n_es_vat_book.py
@@ -334,6 +334,9 @@ class L10nEsVatBook(models.Model):
         )
 
     def get_pos_partner_ids(self):
+        cached = self.env.context.get("vat_book_pos_partner_ids")
+        if cached is not None:
+            return cached
         return (
             self.env["res.partner"]
             .with_context(active_test=False)
@@ -398,10 +401,13 @@ class L10nEsVatBook(models.Model):
                 moves_dic[line_key] = self._prepare_book_line_vals(move_line, line_type)
             self.upsert_book_line_tax(move_line, moves_dic[line_key], taxes)
         lines_values = []
+        sp_taxes_dic = self.get_special_taxes_dic()
+        self = self.with_context(
+            vat_book_pos_partner_ids=frozenset(self.get_pos_partner_ids())
+        )
         for line_vals in moves_dic.values():
             tax_lines = line_vals.pop("tax_lines")
             # Match special taxes groups
-            sp_taxes_dic = self.get_special_taxes_dic()
             sp_taxes = {}
             # First loop for extracting special taxes
             for tax_line in tax_lines.values():

--- a/l10n_es_vat_book/readme/CONTRIBUTORS.md
+++ b/l10n_es_vat_book/readme/CONTRIBUTORS.md
@@ -11,3 +11,4 @@
 - Victor Garcia \<<victor.garcia@kayuulab.com>\>
 - Luis Lafaurie \<<ldlafaurie@gmail.com>\>
 - Eduardo de miguel \<<edu@moduon.team>\>
+- David Jaen \<<djaen@ontinet.com>\>

--- a/l10n_es_vat_book/static/description/index.html
+++ b/l10n_es_vat_book/static/description/index.html
@@ -487,6 +487,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Victor Garcia &lt;<a class="reference external" href="mailto:victor.garcia&#64;kayuulab.com">victor.garcia&#64;kayuulab.com</a>&gt;</li>
 <li>Luis Lafaurie &lt;<a class="reference external" href="mailto:ldlafaurie&#64;gmail.com">ldlafaurie&#64;gmail.com</a>&gt;</li>
 <li>Eduardo de miguel &lt;<a class="reference external" href="mailto:edu&#64;moduon.team">edu&#64;moduon.team</a>&gt;</li>
+<li>David Jaen &lt;<a class="reference external" href="mailto:djaen&#64;ontinet.com">djaen&#64;ontinet.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
+++ b/l10n_es_vat_book/tests/test_l10n_es_aeat_vat_book.py
@@ -145,3 +145,37 @@ class TestL10nEsAeatVatBook(TestL10nEsAeatVatBookBase):
         self.assertEqual(len(vat_book.issued_line_ids), 0)
         self.assertEqual(len(vat_book.rectification_issued_line_ids), 0)
         self.assertEqual(len(vat_book.issued_tax_summary_ids), 0)
+
+    def test_anonymous_cash_customer_refreshed_on_recalculation(self):
+        self.customer.write({"country_id": self.env.ref("base.es").id, "vat": False})
+        self._invoice_sale_create("2017-01-13")
+        self.company.vat = "ES12345678Z"
+        vat_book = self.env["l10n.es.vat.book"].create(
+            {
+                "name": "Test VAT Book anonymous customer",
+                "company_id": self.company.id,
+                "company_vat": "1234567890",
+                "contact_name": "Test owner",
+                "statement_type": "N",
+                "support_type": "T",
+                "contact_phone": "911234455",
+                "year": 2017,
+                "period_type": "1T",
+                "date_start": "2017-01-01",
+                "date_end": "2017-03-31",
+            }
+        )
+        vat_book.button_calculate()
+        line = vat_book.issued_line_ids.filtered(
+            lambda x: x.partner_id == self.customer
+        )
+        self.assertTrue(line, "The customer invoice is not in the VAT book")
+        self.assertTrue(
+            line.exception_text, "A customer without VAT must raise an exception"
+        )
+        self.customer.aeat_anonymous_cash_customer = True
+        vat_book.button_recalculate()
+        line = vat_book.issued_line_ids.filtered(
+            lambda x: x.partner_id == self.customer
+        )
+        self.assertFalse(line.exception_text)


### PR DESCRIPTION
El cálculo del libro de IVA se vuelve inservible en empresas con muchos asientos y muchos contactos.

La causa está en get_pos_partner_ids(). Busca sobre toda la tabla res.partner y se llama una vez por cada línea del libro cuyo contacto no tenga NIF.

Antes estaba cacheado, pero el decorador @ormcache se quitó en #4536, y con razón: el valor se guardaba entre cálculos, así que marcabas un contacto como venta anónima de caja, recalculabas y el aviso seguía apareciendo.

Ahora se calcula una sola vez al principio de create_vat_book_lines() y se propaga por el contexto. Es igual de rápido que la caché, pero el valor se descarta al terminar el cálculo, de modo que el problema de #4536 no reaparece. Se añade un test que lo comprueba: falla si se vuelve a poner el decorador.

Se pasa por el contexto y no como argumento para no tocar la firma de _check_exceptions(), que otros módulos redefinen, como l10n_es_vat_book_pos. Por el mismo motivo se saca get_special_taxes_dic() fuera del bucle.

Medido sobre un trimestre real de 37.000 asientos: de 722,6 a 58,8 segundos. Se ha comprobado que el resultado no cambia, comparando las 37.000 líneas del libro, las 42.980 líneas de impuesto y los dos resúmenes campo a campo: volcados idénticos.