### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_match: fix aeat_state xpath ambiguity

### DIFF
--- a/l10n_es_aeat_sii_match/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_match/views/account_move_views.xml
@@ -15,7 +15,10 @@
                     groups="l10n_es_aeat.group_account_aeat"
                 />
             </field>
-            <field name="aeat_state" position="after">
+            <xpath
+                expr="//page[@name='page_sii_result_general']//field[@name='aeat_state']"
+                position="after"
+            >
                 <field
                     name="sii_match_state"
                     groups="l10n_es_aeat.group_account_aeat"
@@ -24,7 +27,7 @@
                     name="sii_contrast_state"
                     groups="l10n_es_aeat.group_account_aeat"
                 />
-            </field>
+            </xpath>
             <page name="page_sii_result_general" position="inside">
                 <group
                     invisible="not sii_match_difference_ids"


### PR DESCRIPTION
Base view defines aeat_state twice; target the one inside page_sii_result_general explicitly.

--------------


Como se define dos veces estaba usando la primera referencia y no la segunda:

https://github.com/OCA/l10n-spain/blob/18.0/l10n_es_aeat_sii_oca/views/account_move_views.xml#L23

https://github.com/OCA/l10n-spain/blob/18.0/l10n_es_aeat_sii_oca/views/account_move_views.xml#L132