### PR TITLE
[16.0][FIX] l10n_es_verifactu_oca: requerir VERI*FACTU en diarios de venta

### DIFF
--- a/l10n_es_verifactu_oca/i18n/es.po
+++ b/l10n_es_verifactu_oca/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-28 10:22+0000\n"
-"PO-Revision-Date: 2025-11-28 10:22+0000\n"
+"POT-Creation-Date: 2026-08-12 03:00+0000\n"
+"PO-Revision-Date: 2026-08-12 05:05+0200\n"
 "Last-Translator: Mario Montes <admin@syci.es>\n"
 "Language-Team: \n"
 "Language: \n"
@@ -97,6 +97,17 @@ msgstr "<span>Otros detalles</span>"
 #: model:ir.model.constraint,message:l10n_es_verifactu_oca.constraint_verifactu_chaining_verifactu_chaining_name_uniq
 msgid "A chaining with the same name already exists!"
 msgstr "¡Ya existe un encadenamiento con el mismo nombre!"
+
+#. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/account_journal.py:0
+#, python-format
+msgid ""
+"A sales journal must have VERI*FACTU enabled when its company has VERI*FACTU "
+"enabled."
+msgstr ""
+"Un diario de venta debe tener VERI*FACTU activado cuando la compañía tiene "
+"VERI*FACTU activado."
 
 #. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.view_verifactu_invoice_entry_form
@@ -1130,6 +1141,17 @@ msgstr "Nombre del SIF"
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_mixin__aeat_send_failed
 msgid "SII send failed"
 msgstr "Envío SII fallido"
+
+#. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/account_move.py:0
+#, python-format
+msgid ""
+"Sales invoices cannot be validated in a journal without VERI*FACTU when the "
+"company has VERI*FACTU activated."
+msgstr ""
+"Las facturas de venta no pueden ser validadas en un diario sin VERI*FACTU "
+"cuando la compañía tiene VERI*FACTU activado."
 
 #. module: l10n_es_verifactu_oca
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_invoice_entry__send_attempt

--- a/l10n_es_verifactu_oca/i18n/l10n_es_verifactu_oca.pot
+++ b/l10n_es_verifactu_oca/i18n/l10n_es_verifactu_oca.pot
@@ -92,6 +92,15 @@ msgid "A chaining with the same name already exists!"
 msgstr ""
 
 #. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/account_journal.py:0
+#, python-format
+msgid ""
+"A sales journal must have VERI*FACTU enabled when its company has VERI*FACTU"
+" enabled."
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_oca.view_verifactu_invoice_entry_form
 msgid "AEAT DATA"
 msgstr ""
@@ -642,7 +651,6 @@ msgstr ""
 
 #. module: l10n_es_verifactu_oca
 #: model:ir.model.fields.selection,name:l10n_es_verifactu_oca.selection__account_move__aeat_state__incorrect
-#: model:ir.model.fields.selection,name:l10n_es_verifactu_oca.selection__pos_order__aeat_state__incorrect
 #: model:ir.model.fields.selection,name:l10n_es_verifactu_oca.selection__verifactu_mixin__aeat_state__incorrect
 msgid "Incorrect"
 msgstr ""
@@ -1096,6 +1104,15 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_account_move__aeat_send_failed
 #: model:ir.model.fields,field_description:l10n_es_verifactu_oca.field_verifactu_mixin__aeat_send_failed
 msgid "SII send failed"
+msgstr ""
+
+#. module: l10n_es_verifactu_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_oca/models/account_move.py:0
+#, python-format
+msgid ""
+"Sales invoices cannot be validated in a journal without VERI*FACTU when the "
+"company has VERI*FACTU activated."
 msgstr ""
 
 #. module: l10n_es_verifactu_oca

--- a/l10n_es_verifactu_oca/models/account_journal.py
+++ b/l10n_es_verifactu_oca/models/account_journal.py
@@ -22,6 +22,26 @@ class AccountJournal(models.Model):
     )
     verifactu_enabled = fields.Boolean(string="VERI*FACTU enabled", default=True)
 
+    def _is_verifactu_exempt(self):
+        """Hook for journals managed by a different invoicing system."""
+        return False
+
+    @api.constrains("company_id", "type", "verifactu_enabled")
+    def _check_verifactu_sale_journal(self):
+        invalid = self.filtered(
+            lambda journal: journal.company_id.verifactu_enabled
+            and journal.type == "sale"
+            and not journal.verifactu_enabled
+            and not journal._is_verifactu_exempt()
+        )
+        if invalid:
+            raise ValidationError(
+                _(
+                    "A sales journal must have VERI*FACTU enabled when its company "
+                    "has VERI*FACTU enabled."
+                )
+            )
+
     @api.depends(
         "company_id", "company_id.verifactu_enabled", "verifactu_enabled", "type"
     )  # company_id* triggers aren't launched anyway - see res.company~write method

--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -543,7 +543,7 @@ class AccountMove(models.Model):
             lambda move: (
                 move.company_id.verifactu_enabled
                 and move.journal_id.type == "sale"
-                and move.move_type in ("out_invoice", "out_refund")
+                and move.is_sale_document()
                 and not move.journal_id.verifactu_enabled
                 and not move.journal_id._is_verifactu_exempt()
             )

--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -539,6 +539,22 @@ class AccountMove(models.Model):
         )
 
     def _post(self, soft=True):
+        invalid_moves = self.filtered(
+            lambda move: (
+                move.company_id.verifactu_enabled
+                and move.journal_id.type == "sale"
+                and move.move_type in ("out_invoice", "out_refund")
+                and not move.journal_id.verifactu_enabled
+                and not move.journal_id._is_verifactu_exempt()
+            )
+        )
+        if invalid_moves:
+            raise UserError(
+                _(
+                    "Sales invoices cannot be validated in a journal without "
+                    "VERI*FACTU when the company has VERI*FACTU activated."
+                )
+            )
         res = super()._post(soft=soft)
         for record in self.sorted(lambda inv: inv.name or ""):
             if record.verifactu_enabled and record.aeat_state == "not_sent":

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -3,6 +3,7 @@
 # Copyright 2025 ForgeFlow S.L.
 # Copyright 2025 Process Control - Jorge Luis López
 # Copyright 2025 Tecnativa - Pedro M. Baeza
+# Copyright 2026 Odoo Community Association (OCA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 import json
 from datetime import datetime
@@ -13,7 +14,7 @@ from urllib.parse import parse_qs, urlparse
 from freezegun import freeze_time
 
 from odoo import Command
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.modules.module import get_resource_path
 
 from .common import TestVerifactuCommon
@@ -223,6 +224,20 @@ class TestL10nEsAeatVerifactu(TestVerifactuCommon):
                 name, inv_type, lines, extra_vals
             )
         return
+
+    def test_sale_journal_requires_verifactu(self):
+        with self.assertRaises(ValidationError):
+            self.env["account.journal"].create(
+                {
+                    "name": "Strict VERI*FACTU journal",
+                    "code": "SVF",
+                    "type": "sale",
+                    "company_id": self.company.id,
+                    "verifactu_enabled": False,
+                }
+            )
+        with self.assertRaises(ValidationError):
+            self.invoice.journal_id.write({"verifactu_enabled": False})
 
 
 class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):

--- a/l10n_es_verifactu_oca/tests/test_verifactu_invoice.py
+++ b/l10n_es_verifactu_oca/tests/test_verifactu_invoice.py
@@ -1,9 +1,11 @@
 # Copyright 2024 Aures TIC - Almudena de La Puente <almudena@aurestic.es>
+# Copyright 2026 Odoo Community Association (OCA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from datetime import date, timedelta
 
 from odoo import Command
+from odoo.exceptions import UserError
 
 from .common import TestVerifactuCommon
 
@@ -357,6 +359,17 @@ class TestVerifactuInvoice(TestVerifactuCommon):
             .create({})
         )
         wizard.validate_move()
+
+    def test_legacy_journal_cannot_post_customer_invoice(self):
+        journal = self.invoice.journal_id
+        self.env.cr.execute(
+            "UPDATE account_journal SET verifactu_enabled = FALSE WHERE id = %s",
+            [journal.id],
+        )
+        journal.invalidate_recordset(["verifactu_enabled"])
+        with self.assertRaises(UserError):
+            self.invoice.action_post()
+        self.assertEqual(self.invoice.state, "draft")
 
     def test_invoice_entry_creation(self):
         """Test the VERI*FACTU invoice entry creation."""

--- a/l10n_es_verifactu_oca/views/account_journal_view.xml
+++ b/l10n_es_verifactu_oca/views/account_journal_view.xml
@@ -20,7 +20,7 @@
                 <field name="company_verifactu_enabled" invisible="1" />
                 <field
                     name="verifactu_enabled"
-                    attrs="{'invisible': ['|', ('company_verifactu_enabled', '=', False), ('type', '!=', 'sale')]}"
+                    attrs="{'invisible': ['|', ('company_verifactu_enabled', '=', False), ('type', '!=', 'sale')], 'readonly': [('company_verifactu_enabled', '=', True), ('verifactu_enabled', '=', True)]}"
                 />
             </xpath>
         </field>

--- a/l10n_es_verifactu_pos_oca/tests/test_l10n_es_verifactu_pos.py
+++ b/l10n_es_verifactu_pos_oca/tests/test_l10n_es_verifactu_pos.py
@@ -576,21 +576,6 @@ class TestL10nEsVerifactuPOS(TestVerifactuCommon):
             "Default registration key should have code '01'",
         )
 
-    def test_pos_verifactu_journal_disabled(self):
-        """Test POS order when journal is disabled for verifactu"""
-        # Disable verifactu for the POS journal
-        self.pos_config.journal_id.verifactu_enabled = False
-
-        orders_data = [self._create_ui_order_data()]
-        order_ids = self.env["pos.order"].create_from_ui(orders_data)
-        order = self.env["pos.order"].browse(order_ids[0]["id"])
-
-        # Should not be enabled even if company is enabled
-        self.assertFalse(
-            order.verifactu_enabled,
-            "Order should not be verifactu enabled when journal is disabled",
-        )
-
     def test_pos_verifactu_one2many_fields(self):
         """Test that One2many fields work correctly with verifactu entries"""
         orders_data = [self._create_ui_order_data()]


### PR DESCRIPTION
Según lo debatido en #4631 , Verifactu debe ser obligatorio para los diarios de venta de una compañia con verifactu habilitado, para evitar incumplimientos regulatorios.

Este fix imposibilita crear diarios no-verifactu y postear facturas no-verifactu.

Incluye un hook (_is_verifactu_exempt) para permitir en el futuro que otros modulos puedan generar diarios de venta especiales según lo debatido en #4631