### PR TITLE
[18.0][FIX] l10n_es_aeat + l10n_es_atc_sii_oca: fix aeat_identification collision in _parse_aeat_vat_info

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -90,7 +90,6 @@ class ResPartner(models.Model):
             )
         return europe.country_ids.mapped("code") + ["XI"]
 
-    @ormcache("self.vat, self.country_id")
     def _parse_aeat_vat_info(self):
         """Return tuple with split info (country_code, identifier_type and
         vat_number) from vat and country partner

--- a/l10n_es_aeat/tests/test_l10n_es_aeat.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat.py
@@ -102,6 +102,38 @@ class TestL10nEsAeat(BaseCommon):
         self.assertEqual(identifier_type, "04")
         self.assertEqual(vat_number, "CU12345678Z")
 
+    def test_parse_vat_info_no_collision_between_partners(self):
+        """Two partners without VAT and the same country must not share their
+        AEAT identification. This guards against a caching regression where the
+        result was keyed only on (vat, country_id), so partners without VAT in
+        the same country returned another partner's aeat_identification.
+        """
+        portugal = self.env.ref("base.pt")
+        partner_a = self.env["res.partner"].create(
+            {
+                "name": "PT partner A",
+                "country_id": portugal.id,
+                "aeat_identification": "PT_IDENTIFICATION_A",
+                "aeat_identification_type": "06",
+            }
+        )
+        partner_b = self.env["res.partner"].create(
+            {
+                "name": "PT partner B",
+                "country_id": portugal.id,
+                "aeat_identification": "PT_IDENTIFICATION_B",
+                "aeat_identification_type": "06",
+            }
+        )
+        self.assertEqual(
+            partner_a._parse_aeat_vat_info(),
+            ("PT", "06", "PT_IDENTIFICATION_A"),
+        )
+        self.assertEqual(
+            partner_b._parse_aeat_vat_info(),
+            ("PT", "06", "PT_IDENTIFICATION_B"),
+        )
+
     def test_unique_date_range(self):
         self.env["l10n.es.aeat.map.tax"].create(
             {"date_from": "2020-01-01", "date_to": "2020-12-31", "model": 303}

--- a/l10n_es_atc_sii_oca/models/res_partner.py
+++ b/l10n_es_atc_sii_oca/models/res_partner.py
@@ -3,13 +3,11 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import models
-from odoo.tools import ormcache_context
 
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    @ormcache_context("self.vat, self.country_id", keys=("is_canary_tax_agency",))
     def _parse_aeat_vat_info(self):
         # NOTE:
         # The Canary Islands Tax Agency (ATC) SII-IGIC implementation does NOT support


### PR DESCRIPTION
Forward-port de #5151

El método `_parse_aeat_vat_info` de `res.partner` estaba cacheado con `@ormcache("self.vat, self.country_id")`, de modo que la clave de caché solo tenía en cuenta el VAT y el país del contacto. El problema es que lo que devuelve el    
  método depende también de `aeat_identification` y `aeat_identification_type`, que no están en esa clave. Cuando dos contactos tienen el mismo VAT y el mismo país, comparten entrada de caché y el segundo acaba recibiendo el resultado   
  del primero.                                                                                                                                                                                                                               
                                                                                                                                                                                                                                             
  Esto pasa con dos contactos extranjeros sin VAT del mismo país (por ejemplo dos portugueses), cada uno con su propio `aeat_identification`: como ambos tienen el VAT vacío y el mismo país, la clave es idéntica, y el que se calcula en   
  segundo lugar devuelve el identificador del primero. En un caso real esto provocó que una factura se enviara al SII con el `aeat_identification` de otro contacto distinto que se había procesado antes.                                   
                                                                                                                                                                                                                                             
  Aparte de la colisión, aquí `ormcache` no es la herramienta adecuada: es una caché global de proceso que no se invalida al escribir en el contacto, así que cambiar el VAT o la identificación dejaría datos obsoletos hasta limpiar las   
  cachés. Por eso, en vez de intentar meter todos esos campos en la clave, se quita directamente la caché del método. No compensa mantenerla: el método no es pesado (troceado de cadenas y una búsqueda), y su única parte pesada,             
  `_get_aeat_europe_codes()`, ya tiene su propia caché sobre datos que casi nunca cambian, así que quitar la de `_parse_aeat_vat_info` no afecta al rendimiento.                                                                             
                                                                                                                                                                                                                                             
  El mismo fallo estaba en `l10n_es_atc_sii_oca`, cuyo override repetía la misma caché (`ormcache_context` sobre VAT y país), así que se corrige igual.                                                                                      
                                                                                                                                                                                                                                             
  Se añade además un test que crea dos contactos sin VAT del mismo país con identificación distinta y comprueba que cada uno devuelve la suya; con la caché anterior fallaba.

@Tecnativa TT63975