### PR TITLE
[19.0][FIX]delivery_mrw: convert picking notes to plain text

### DIFF
--- a/delivery_mrw/models/delivery_carrier.py
+++ b/delivery_mrw/models/delivery_carrier.py
@@ -8,6 +8,7 @@ from lxml import etree
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools import html2plaintext
 
 from .mrw_request import MRWRequest
 
@@ -310,7 +311,7 @@ class DeliveryCarrier(models.Model):
                 "Nombre": receiving_partner.name,
                 "Telefono": receiving_partner.phone or "",
                 "ALaAtencionDe": "",
-                "Observaciones": picking.note or "",
+                "Observaciones": html2plaintext(picking.note) or "",
             },
             # nodo opcional
             "DatosServicio": {


### PR DESCRIPTION
# [FIX] delivery_mrw: convert picking notes to plain text

## Issue

When a delivery note is entered in the **Notes** tab of a stock picking, Odoo stores it as HTML.

The `delivery_mrw` module sends this value directly to MRW as `DatosEntrega/Observaciones`. MRW does not render HTML and prints the tags literally on the shipping label.

For example, this note:

```html
<div data-oe-version="2.0">Abierto de 06:00h a 14:00h</div>
```

was printed as:

```text
<DIV DATA-OE-VERSION="2.0">ABIERTO DE 06:00H A 14:00H</DIV>
```
<img width="524" height="454" alt="image" src="https://github.com/user-attachments/assets/05d38d09-8297-4117-80a8-9be8b5020202" />

## Solution

Convert `picking.note` to plain text before assigning it to the MRW `Observaciones` field.

This preserves the note content while removing HTML markup, so MRW receives:

```text
Abierto de 06:00h a 14:00h
```

## Impact

- Fixes incorrect HTML tags displayed on MRW labels.
- Does not alter the note stored in Odoo.
- Only affects the value sent to MRW when creating the shipment.