### PR TITLE
[16.0][FIX] l10n_es_verifactu_pos_oca: no encadenar pedidos que no son ventas cerradas y recuperar los que quedan pendientes

### DIFF
--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -30,6 +30,15 @@ VERIFACTU_EXTRA_AEAT_STATES = [
 ]
 
 
+class VerifactuChainingLocked(UserError):
+    """The chaining row is held by another transaction.
+
+    Signalled apart from any other UserError because it is transient: a caller
+    retrying on its own must not treat it as a document that can never be
+    chained.
+    """
+
+
 class VerifactuMixin(models.AbstractModel):
     _name = "verifactu.mixin"
     _inherit = "aeat.mixin"
@@ -356,7 +365,7 @@ class VerifactuMixin(models.AbstractModel):
                 chaining.invalidate_recordset(["last_verifactu_invoice_entry_id"])
         except psycopg2.OperationalError as err:
             if err.pgcode == "55P03":  # could not obtain the lock
-                raise UserError(
+                raise VerifactuChainingLocked(
                     _(
                         "Could not obtain last document sent to VERI*FACTU for "
                         "chaining %s.",

--- a/l10n_es_verifactu_oca/tests/__init__.py
+++ b/l10n_es_verifactu_oca/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_10n_es_verifactu
+from . import test_verifactu_chaining_lock
 from . import test_verifactu_invoice

--- a/l10n_es_verifactu_oca/tests/test_verifactu_chaining_lock.py
+++ b/l10n_es_verifactu_oca/tests/test_verifactu_chaining_lock.py
@@ -1,0 +1,71 @@
+# Copyright 2026 FactorLibre - Almudena de La Puente
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from unittest.mock import patch
+
+import psycopg2
+from psycopg2 import errorcodes
+
+from odoo.exceptions import UserError
+
+from odoo.addons.l10n_es_verifactu_oca.models.verifactu_mixin import (
+    VerifactuChainingLocked,
+)
+
+from .common import TestVerifactuCommon
+
+
+class TestVerifactuChainingLock(TestVerifactuCommon):
+    """The chaining row is taken with FOR UPDATE NOWAIT, so a busy chain fails
+    instead of queueing. Every caller has to tell that failure apart from a
+    permanent one, and the exception type is the only reliable way: the message
+    goes through _(), and other UserError come out of the very same call.
+
+    The collision itself is not reproducible here -- the chaining row is created
+    inside the test transaction, so no other connection can see it, let alone
+    lock it. What is under test is the translation of the error PostgreSQL
+    raises into that type.
+    """
+
+    def _fail_the_lock(self, pgcode):
+        """Make only the chaining SELECT ... FOR UPDATE NOWAIT fail."""
+        original = type(self.env.cr).execute
+
+        class _LockError(psycopg2.OperationalError):
+            pass
+
+        _LockError.pgcode = pgcode
+
+        def _execute(cr, query, params=None, log_exceptions=None):
+            if "FOR UPDATE NOWAIT" in query:
+                raise _LockError("injected")
+            return original(cr, query, params)
+
+        return patch.object(type(self.env.cr), "execute", _execute)
+
+    def test_a_taken_chaining_row_raises_its_own_error(self):
+        self.invoice.action_post()
+        self.invoice.last_verifactu_invoice_entry_id = False
+        with self._fail_the_lock(errorcodes.LOCK_NOT_AVAILABLE):
+            with self.assertRaises(VerifactuChainingLocked) as caught:
+                self.invoice._generate_verifactu_chaining()
+        self.assertIsInstance(
+            caught.exception,
+            UserError,
+            "Existing callers catch UserError and must keep working",
+        )
+        # Asserted on the chaining name and not on the wording: the message
+        # goes through _() and comes out translated, which is precisely why
+        # callers cannot tell this failure apart by its text.
+        self.assertIn(self.verifactu_chaining.name, str(caught.exception))
+
+    def test_another_database_error_is_not_disguised_as_a_collision(self):
+        """Only 55P03 means contention. Anything else is a different problem
+        and must travel as itself, or a permanent failure would be retried for
+        ever as if it were transient.
+        """
+        self.invoice.action_post()
+        self.invoice.last_verifactu_invoice_entry_id = False
+        with self._fail_the_lock(errorcodes.UNDEFINED_COLUMN):
+            with self.assertRaises(psycopg2.OperationalError) as caught:
+                self.invoice._generate_verifactu_chaining()
+        self.assertNotIsInstance(caught.exception, VerifactuChainingLocked)

--- a/l10n_es_verifactu_pos_oca/README.rst
+++ b/l10n_es_verifactu_pos_oca/README.rst
@@ -39,6 +39,32 @@ Módulo para la presentación inmediata de la facturación desde TPV.
 .. contents::
    :local:
 
+Configuration
+=============
+
+El parámetro de sistema ``l10n_es_verifactu_pos_oca.max_chaining_attempts``
+(por defecto: 10) limita cuántas veces reintenta la acción planificada un
+mismo pedido. Los fallos que se resuelven solos, como una colisión del bloqueo
+de encadenamiento, no cuentan; un pedido que alcanza el límite deja de entrar
+en el barrido y necesita el botón manual.
+
+Usage
+=====
+
+Cuando falla el encadenamiento de un pedido de TPV ya cobrado, la venta no se
+interrumpe: el pedido queda marcado y se localiza con el filtro «VERI*FACTU
+failed» en Punto de venta > Pedidos, con el error a la vista en su pestaña
+VERI*FACTU.
+
+Los pedidos pendientes los encadena la acción planificada «Generar el
+encadenamiento VERI*FACTU pendiente de los pedidos de TPV», que se ejecuta
+cada diez minutos y toma primero los más antiguos, de modo que entran en la
+cadena en el orden en que se cobraron.
+
+El botón «Generar encadenamiento VERI*FACTU» de la ficha del pedido hace lo
+mismo para un pedido suelto. Es la vía de vuelta para un pedido que haya
+agotado los intentos, porque el botón no mira ese contador.
+
 Known issues / Roadmap
 ======================
 

--- a/l10n_es_verifactu_pos_oca/__manifest__.py
+++ b/l10n_es_verifactu_pos_oca/__manifest__.py
@@ -20,6 +20,8 @@
         ],
     },
     "data": [
+        "data/ir_config_parameter.xml",
+        "data/ir_cron.xml",
         "views/pos_order_view.xml",
     ],
 }

--- a/l10n_es_verifactu_pos_oca/data/ir_config_parameter.xml
+++ b/l10n_es_verifactu_pos_oca/data/ir_config_parameter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <record id="max_chaining_attempts" model="ir.config_parameter">
+        <field name="key">l10n_es_verifactu_pos_oca.max_chaining_attempts</field>
+        <field name="value">10</field>
+    </record>
+</odoo>

--- a/l10n_es_verifactu_pos_oca/data/ir_cron.xml
+++ b/l10n_es_verifactu_pos_oca/data/ir_cron.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+    <record
+        forcecreate="True"
+        id="pos_order_generate_pending_verifactu_chaining"
+        model="ir.cron"
+    >
+        <field name="name">Generate pending VERI*FACTU chaining for POS orders</field>
+        <field name="model_id" ref="model_pos_order" />
+        <field name="state">code</field>
+        <field
+            name="code"
+        >model._cron_generate_pending_verifactu_chaining(commit=True)</field>
+        <field name='interval_number'>10</field>
+        <field name='interval_type'>minutes</field>
+        <field name="numbercall">-1</field>
+    </record>
+</odoo>

--- a/l10n_es_verifactu_pos_oca/i18n/es.po
+++ b/l10n_es_verifactu_pos_oca/i18n/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-29 06:21+0000\n"
+"POT-Creation-Date: 2026-08-13 13:51+0000\n"
 "PO-Revision-Date: 2025-08-29 06:21+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -65,6 +65,11 @@ msgid "CSV"
 msgstr ""
 
 #. module: l10n_es_verifactu_pos_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_pos_oca.view_pos_order_verifactu_form
+msgid "Chaining attempts"
+msgstr "Intentos de encadenamiento"
+
+#. module: l10n_es_verifactu_pos_oca
 #: model:ir.model.fields,help:l10n_es_verifactu_pos_oca.field_pos_order__verifactu_macrodata
 msgid ""
 "Check to confirm that the document has an absolute amount greater o equal to "
@@ -94,6 +99,17 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_pos_oca.view_pos_order_verifactu_form
 msgid "General"
 msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_pos_oca.view_pos_order_verifactu_form
+msgid "Generate VERI*FACTU chaining"
+msgstr "Generar encadenamiento VERI*FACTU"
+
+#. module: l10n_es_verifactu_pos_oca
+#: model:ir.actions.server,name:l10n_es_verifactu_pos_oca.pos_order_generate_pending_verifactu_chaining_ir_actions_server
+#: model:ir.cron,cron_name:l10n_es_verifactu_pos_oca.pos_order_generate_pending_verifactu_chaining
+msgid "Generate pending VERI*FACTU chaining for POS orders"
+msgstr "Generar el encadenamiento VERI*FACTU pendiente de los pedidos de TPV"
 
 #. module: l10n_es_verifactu_pos_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_pos_oca.view_pos_order_verifactu_form
@@ -138,6 +154,15 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_pos_oca.poz_order_verifactu_search
 msgid "Never sent to VERI*FACTU"
 msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#: model:ir.model.fields,help:l10n_es_verifactu_pos_oca.field_pos_order__verifactu_chaining_attempts
+msgid ""
+"Number of times the chaining of this order has been attempted and failed. "
+"Used by the recovery cron to stop retrying an order that cannot be chained."
+msgstr ""
+"Número de veces que se ha intentado encadenar este pedido sin éxito. La "
+"recuperación automática deja de reintentarlo cuando se alcanza el límite."
 
 #. module: l10n_es_verifactu_pos_oca
 #: model:ir.model.fields,help:l10n_es_verifactu_pos_oca.field_pos_order__verifactu_cancel_reason
@@ -258,6 +283,20 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_es_verifactu_pos_oca/models/pos_order.py:0
 #, python-format
+msgid "The order has been added to the chain."
+msgstr "El pedido se ha añadido a la cadena."
+
+#. module: l10n_es_verifactu_pos_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_pos_oca/models/pos_order.py:0
+#, python-format
+msgid "The order is not eligible for chaining."
+msgstr "El pedido no cumple las condiciones para encadenarse."
+
+#. module: l10n_es_verifactu_pos_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_pos_oca/models/pos_order.py:0
+#, python-format
 msgid "There's a mismatch in taxes for RE. Check them."
 msgstr "Hay un desajuste en los impuestos para RE. Revíselos."
 
@@ -291,6 +330,25 @@ msgstr "VERI*FACTU"
 #: model:ir.model.fields,field_description:l10n_es_verifactu_pos_oca.field_pos_order__verifactu_cancel_reason
 msgid "VERI*FACTU cancel reason"
 msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#: model:ir.model.fields,field_description:l10n_es_verifactu_pos_oca.field_pos_order__verifactu_chaining_attempts
+msgid "VERI*FACTU chaining attempts"
+msgstr "Intentos de encadenamiento VERI*FACTU"
+
+#. module: l10n_es_verifactu_pos_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_pos_oca/models/pos_order.py:0
+#, python-format
+msgid "VERI*FACTU chaining generated"
+msgstr "Encadenamiento VERI*FACTU generado"
+
+#. module: l10n_es_verifactu_pos_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_pos_oca/models/pos_order.py:0
+#, python-format
+msgid "VERI*FACTU chaining not generated"
+msgstr "Encadenamiento VERI*FACTU no generado"
 
 #. module: l10n_es_verifactu_pos_oca
 #: model:ir.model.fields,field_description:l10n_es_verifactu_pos_oca.field_pos_order__verifactu_description

--- a/l10n_es_verifactu_pos_oca/i18n/l10n_es_verifactu_pos_oca.pot
+++ b/l10n_es_verifactu_pos_oca/i18n/l10n_es_verifactu_pos_oca.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-13 13:51+0000\n"
+"PO-Revision-Date: 2026-08-13 13:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -61,6 +63,11 @@ msgid "CSV"
 msgstr ""
 
 #. module: l10n_es_verifactu_pos_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_pos_oca.view_pos_order_verifactu_form
+msgid "Chaining attempts"
+msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
 #: model:ir.model.fields,help:l10n_es_verifactu_pos_oca.field_pos_order__verifactu_macrodata
 msgid ""
 "Check to confirm that the document has an absolute amount greater o equal to"
@@ -85,6 +92,17 @@ msgstr ""
 #. module: l10n_es_verifactu_pos_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_pos_oca.view_pos_order_verifactu_form
 msgid "General"
+msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_pos_oca.view_pos_order_verifactu_form
+msgid "Generate VERI*FACTU chaining"
+msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#: model:ir.actions.server,name:l10n_es_verifactu_pos_oca.pos_order_generate_pending_verifactu_chaining_ir_actions_server
+#: model:ir.cron,cron_name:l10n_es_verifactu_pos_oca.pos_order_generate_pending_verifactu_chaining
+msgid "Generate pending VERI*FACTU chaining for POS orders"
 msgstr ""
 
 #. module: l10n_es_verifactu_pos_oca
@@ -124,6 +142,13 @@ msgstr ""
 #. module: l10n_es_verifactu_pos_oca
 #: model_terms:ir.ui.view,arch_db:l10n_es_verifactu_pos_oca.poz_order_verifactu_search
 msgid "Never sent to VERI*FACTU"
+msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#: model:ir.model.fields,help:l10n_es_verifactu_pos_oca.field_pos_order__verifactu_chaining_attempts
+msgid ""
+"Number of times the chaining of this order has been attempted and failed. "
+"Used by the recovery cron to stop retrying an order that cannot be chained."
 msgstr ""
 
 #. module: l10n_es_verifactu_pos_oca
@@ -240,6 +265,20 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_es_verifactu_pos_oca/models/pos_order.py:0
 #, python-format
+msgid "The order has been added to the chain."
+msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_pos_oca/models/pos_order.py:0
+#, python-format
+msgid "The order is not eligible for chaining."
+msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_pos_oca/models/pos_order.py:0
+#, python-format
 msgid "There's a mismatch in taxes for RE. Check them."
 msgstr ""
 
@@ -269,6 +308,25 @@ msgstr ""
 #. module: l10n_es_verifactu_pos_oca
 #: model:ir.model.fields,field_description:l10n_es_verifactu_pos_oca.field_pos_order__verifactu_cancel_reason
 msgid "VERI*FACTU cancel reason"
+msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#: model:ir.model.fields,field_description:l10n_es_verifactu_pos_oca.field_pos_order__verifactu_chaining_attempts
+msgid "VERI*FACTU chaining attempts"
+msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_pos_oca/models/pos_order.py:0
+#, python-format
+msgid "VERI*FACTU chaining generated"
+msgstr ""
+
+#. module: l10n_es_verifactu_pos_oca
+#. odoo-python
+#: code:addons/l10n_es_verifactu_pos_oca/models/pos_order.py:0
+#, python-format
+msgid "VERI*FACTU chaining not generated"
 msgstr ""
 
 #. module: l10n_es_verifactu_pos_oca

--- a/l10n_es_verifactu_pos_oca/models/pos_order.py
+++ b/l10n_es_verifactu_pos_oca/models/pos_order.py
@@ -5,7 +5,6 @@ import pytz
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
 
@@ -105,20 +104,26 @@ class PosOrder(models.Model):
         return pos_order_id
 
     def _is_verifactu_order(self):
+        """Whether this order must be registered in VERI*FACTU.
+
+        The state check is part of the guard, not an afterthought: the chain is
+        append-only, so an order that is not a closed sale yet must never take
+        a link in it. Its hash string would be empty
+        (see _get_verifactu_hash_string) and the chain would carry the SHA-256
+        of an empty string for a sale that may never happen.
+        """
         self.ensure_one()
-        return self.exists() and not self.to_invoice and self.verifactu_enabled
+        return (
+            self.exists()
+            and not self.to_invoice
+            and self.verifactu_enabled
+            and self.state in VERIFACTU_VALID_POS_STATES
+        )
 
     def _is_refund_order(self):
         """Check if this POS order is a refund"""
         self.ensure_one()
         return self.amount_total < 0
-
-    def _should_send_to_verifactu(self, pos_order):
-        return (
-            pos_order._is_verifactu_order()
-            and not config["test_enable"]
-            and pos_order.state in VERIFACTU_VALID_POS_STATES
-        )
 
     def _get_verifactu_document_type(self):
         if self._is_refund_order():

--- a/l10n_es_verifactu_pos_oca/models/pos_order.py
+++ b/l10n_es_verifactu_pos_oca/models/pos_order.py
@@ -1,10 +1,16 @@
 import logging
 from collections import OrderedDict
 
+import psycopg2
 import pytz
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.service.model import PG_CONCURRENCY_ERRORS_TO_RETRY
+
+from odoo.addons.l10n_es_verifactu_oca.models.verifactu_mixin import (
+    VerifactuChainingLocked,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -14,6 +20,18 @@ VERIFACTU_VALID_POS_STATES = ["paid", "done"]
 class PosOrder(models.Model):
     _name = "pos.order"
     _inherit = ["pos.order", "verifactu.mixin"]
+
+    verifactu_chaining_attempts = fields.Integer(
+        string="VERI*FACTU chaining attempts",
+        copy=False,
+        readonly=True,
+        # Needed: without it the column is NULL, and `<` does not match NULL,
+        # so the sweep would not see the orders it exists to recover.
+        default=0,
+        help="Number of times the chaining of this order has been attempted "
+        "and failed. Used by the recovery cron to stop retrying an order that "
+        "cannot be chained.",
+    )
 
     @api.depends(
         "company_id",
@@ -91,17 +109,65 @@ class PosOrder(models.Model):
 
         try:
             pos_order._generate_verifactu_chaining()
-        except UserError as e:
-            # Don't re-raise the error to avoid blocking POS operations
-            _logger.error(
+        except Exception as e:  # noqa: BLE001 -- see below
+            if (
+                isinstance(e, psycopg2.OperationalError)
+                and e.pgcode in PG_CONCURRENCY_ERRORS_TO_RETRY
+            ):
+                # Odoo retries the whole request on these, which is a better
+                # answer than marking the order: the sync has written nothing
+                # yet that the retry would duplicate. A lock collision on the
+                # chaining row does not reach here -- verifactu_mixin turns it
+                # into VerifactuChainingLocked.
+                raise
+            # Not re-raised: the sale is already paid and the cashier cannot
+            # fix a chaining problem. Marked instead, so it is not lost.
+            # Every exception counts, not only UserError: a database error
+            # escaping here aborts the whole sync, so the sale never reaches
+            # the backend and its simplified invoice number is burnt anyway.
+            # Writing the mark is safe because the chaining SQL runs inside a
+            # savepoint, so the cursor is usable again once it fails.
+            _logger.exception(
                 "[ID: %d, REF: %s, INV: %s] Failed to create verifactu chaining: %s",
                 pos_order.id,
                 pos_order.pos_reference,
                 pos_order.l10n_es_unique_id,
                 str(e),
             )
+            pos_order._mark_verifactu_chaining_failure(
+                e, spend_attempt=not isinstance(e, VerifactuChainingLocked)
+            )
 
         return pos_order_id
+
+    def _mark_verifactu_chaining_failure(self, error, spend_attempt=True):
+        """Leave a visible trace of a chaining failure on the order.
+
+        Reuses the aeat.mixin error fields, which the form view and the
+        "VERI*FACTU failed" search filter already show.
+        """
+        self.ensure_one()
+        vals = {"aeat_send_failed": True, "aeat_send_error": str(error)}
+        if spend_attempt:
+            # Only a failure that will not fix itself spends budget: counting
+            # the transient ones abandons chainable sales after a busy spell.
+            vals["verifactu_chaining_attempts"] = self.verifactu_chaining_attempts + 1
+        self.write(vals)
+
+    def _generate_pos_order_invoice(self):
+        res = super()._generate_pos_order_invoice()
+        # Once invoiced the sale is registered through the invoice, so the
+        # pending failure is moot and nothing else would ever clear it. The
+        # invoice must be registered for real, though: it goes through another
+        # journal, which may well have VERI*FACTU disabled.
+        stale = self.filtered(
+            lambda order: order.aeat_send_failed
+            and not order.last_verifactu_invoice_entry_id
+            and order.account_move.last_verifactu_invoice_entry_id
+        )
+        if stale:
+            stale.write({"aeat_send_failed": False, "aeat_send_error": False})
+        return res
 
     def _is_verifactu_order(self):
         """Whether this order must be registered in VERI*FACTU.
@@ -498,6 +564,159 @@ class PosOrder(models.Model):
         elif tax in taxes_N2:
             return "N2"
         return "S1"
+
+    @api.model
+    def _cron_generate_pending_verifactu_chaining(self, limit=50, commit=False):
+        """Chain the paid orders that were left out of the chain.
+
+        Unlike backend invoices, a POS order cannot have its chaining failure
+        surfaced to the user: the sale is already paid when it happens, so
+        AccountMove._post() cannot be imitated (it lets the UserError abort the
+        posting, which keeps the state consistent). This sweep is the recovery
+        path that replaces it.
+
+        No retry counter or backoff of its own is needed: the cron interval IS
+        the backoff, and an order that loses the chaining lock simply shows up
+        again on the next pass. The attempts counter only exists to stop
+        retrying an order that can never be chained.
+        """
+        max_attempts = int(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("l10n_es_verifactu_pos_oca.max_chaining_attempts", 10)
+        )
+        # The domain replicates the computed field instead of searching by it:
+        # its search method is laxer, and the orders it would let through come
+        # back on every pass and, being the oldest, starve the rest.
+        companies = (
+            self.env["res.company"].sudo().search([("verifactu_enabled", "=", True)])
+        )
+        for company in companies:
+            domain = [
+                ("company_id", "=", company.id),
+                ("to_invoice", "=", False),
+                ("state", "in", VERIFACTU_VALID_POS_STATES),
+                ("last_verifactu_invoice_entry_id", "=", False),
+                ("verifactu_chaining_attempts", "<", max_attempts),
+                ("session_id.config_id.journal_id.verifactu_enabled", "=", True),
+                # Last leg of the computed field, easy to miss.
+                "|",
+                ("fiscal_position_id", "=", False),
+                ("fiscal_position_id.aeat_active", "=", True),
+            ]
+            if company.verifactu_start_date:
+                domain.append(
+                    (
+                        "date_order",
+                        ">=",
+                        fields.Date.to_string(company.verifactu_start_date),
+                    )
+                )
+            orders = self.search(
+                domain,
+                # Oldest first: the position in the chain is today's, but the
+                # pending orders enter it in the order they were charged.
+                order="date_order ASC",
+                limit=limit,
+            )
+            for order in orders:
+                try:
+                    with self.env.cr.savepoint():
+                        order._recover_verifactu_chaining()
+                except Exception as error:  # noqa: BLE001 -- see below
+                    # Isolated per order: unhandled, this would reach the
+                    # cron runner and roll back the whole pass. Only the id is
+                    # logged -- any other field goes back to a row that just
+                    # failed.
+                    _logger.exception(
+                        "[ID: %d] VERI*FACTU chaining recovery raised an "
+                        "unexpected error",
+                        order.id,
+                    )
+                    self._record_recovery_failure(order, error)
+                # The chaining lock is held until the transaction commits, so
+                # committing per order is what keeps the sweep from blocking
+                # the tills. Off by default: only the scheduled action opts in.
+                if commit:  # pragma: no cover
+                    self.env.cr.commit()  # pylint: disable=invalid-commit
+        return True
+
+    def _record_recovery_failure(self, order, error):
+        """Leave a trace of a failure the recovery could not handle itself.
+
+        Concurrency errors get none on purpose: they are transient, and the
+        write would land on the row that just failed and fail the same way.
+        """
+        if (
+            isinstance(error, psycopg2.OperationalError)
+            and error.pgcode in PG_CONCURRENCY_ERRORS_TO_RETRY
+        ):
+            return
+        try:
+            with self.env.cr.savepoint():
+                order._mark_verifactu_chaining_failure(error)
+        except Exception:  # noqa: BLE001
+            _logger.exception(
+                "[ID: %d] Could not record the VERI*FACTU chaining failure",
+                order.id,
+            )
+
+    def _recover_verifactu_chaining(self):
+        """Chain an order that has no entry yet. Idempotent by state."""
+        self.ensure_one()
+        # Idempotence lives here, not in an identity key: if the normal flow or
+        # a previous pass already chained this order, a second link would be a
+        # second registration of the same sale.
+        if self.last_verifactu_invoice_entry_id:
+            return False
+        # Re-validate: the order may have changed state between the failure and
+        # this retry.
+        if not self._is_verifactu_order():
+            return False
+        try:
+            # _check_verifactu_configuration() is deliberately not called:
+            # recovery reproduces the normal chaining path, which does not call
+            # it either. The override here demands a fiscal position, which a
+            # counter sale does not have.
+            self.verifactu_registration_date = fields.Datetime.now()
+            self._generate_verifactu_chaining()
+        except UserError as e:
+            _logger.error(
+                "[ID: %d, REF: %s] VERI*FACTU chaining recovery failed: %s",
+                self.id,
+                self.pos_reference,
+                str(e),
+            )
+            self._mark_verifactu_chaining_failure(
+                e, spend_attempt=not isinstance(e, VerifactuChainingLocked)
+            )
+            return False
+        self.write({"aeat_send_failed": False, "aeat_send_error": False})
+        return True
+
+    def action_recover_verifactu_chaining(self):
+        """Manual counterpart of the recovery cron, for a single order."""
+        self.ensure_one()
+        if self._recover_verifactu_chaining():
+            return {
+                "type": "ir.actions.client",
+                "tag": "display_notification",
+                "params": {
+                    "title": _("VERI*FACTU chaining generated"),
+                    "message": _("The order has been added to the chain."),
+                    "type": "success",
+                },
+            }
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": _("VERI*FACTU chaining not generated"),
+                "message": self.aeat_send_error
+                or _("The order is not eligible for chaining."),
+                "type": "warning",
+            },
+        }
 
     def resend_verifactu(self):
         """Resend POS orders to verifactu after errors"""

--- a/l10n_es_verifactu_pos_oca/readme/CONFIGURE.rst
+++ b/l10n_es_verifactu_pos_oca/readme/CONFIGURE.rst
@@ -1,0 +1,5 @@
+El parámetro de sistema ``l10n_es_verifactu_pos_oca.max_chaining_attempts``
+(por defecto: 10) limita cuántas veces reintenta la acción planificada un
+mismo pedido. Los fallos que se resuelven solos, como una colisión del bloqueo
+de encadenamiento, no cuentan; un pedido que alcanza el límite deja de entrar
+en el barrido y necesita el botón manual.

--- a/l10n_es_verifactu_pos_oca/readme/USAGE.rst
+++ b/l10n_es_verifactu_pos_oca/readme/USAGE.rst
@@ -1,0 +1,13 @@
+Cuando falla el encadenamiento de un pedido de TPV ya cobrado, la venta no se
+interrumpe: el pedido queda marcado y se localiza con el filtro «VERI*FACTU
+failed» en Punto de venta > Pedidos, con el error a la vista en su pestaña
+VERI*FACTU.
+
+Los pedidos pendientes los encadena la acción planificada «Generar el
+encadenamiento VERI*FACTU pendiente de los pedidos de TPV», que se ejecuta
+cada diez minutos y toma primero los más antiguos, de modo que entran en la
+cadena en el orden en que se cobraron.
+
+El botón «Generar encadenamiento VERI*FACTU» de la ficha del pedido hace lo
+mismo para un pedido suelto. Es la vía de vuelta para un pedido que haya
+agotado los intentos, porque el botón no mira ese contador.

--- a/l10n_es_verifactu_pos_oca/static/description/index.html
+++ b/l10n_es_verifactu_pos_oca/static/description/index.html
@@ -379,18 +379,42 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-1">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
+<p>El parámetro de sistema <tt class="docutils literal">l10n_es_verifactu_pos_oca.max_chaining_attempts</tt>
+(por defecto: 10) limita cuántas veces reintenta la acción planificada un
+mismo pedido. Los fallos que se resuelven solos, como una colisión del bloqueo
+de encadenamiento, no cuentan; un pedido que alcanza el límite deja de entrar
+en el barrido y necesita el botón manual.</p>
+</div>
+<div class="section" id="usage">
+<h2><a class="toc-backref" href="#toc-entry-2">Usage</a></h2>
+<p>Cuando falla el encadenamiento de un pedido de TPV ya cobrado, la venta no se
+interrumpe: el pedido queda marcado y se localiza con el filtro «VERI*FACTU
+failed» en Punto de venta &gt; Pedidos, con el error a la vista en su pestaña
+VERI*FACTU.</p>
+<p>Los pedidos pendientes los encadena la acción planificada «Generar el
+encadenamiento VERI*FACTU pendiente de los pedidos de TPV», que se ejecuta
+cada diez minutos y toma primero los más antiguos, de modo que entran en la
+cadena en el orden en que se cobraron.</p>
+<p>El botón «Generar encadenamiento VERI*FACTU» de la ficha del pedido hace lo
+mismo para un pedido suelto. Es la vía de vuelta para un pedido que haya
+agotado los intentos, porque el botón no mira ese contador.</p>
+</div>
 <div class="section" id="known-issues-roadmap">
-<h2><a class="toc-backref" href="#toc-entry-1">Known issues / Roadmap</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h2>
 <ul class="simple">
 <li>Implement cancelling simplified and complete invoices from the PoS</li>
 <li>Configure new chaining from PoS Config</li>
@@ -398,7 +422,7 @@ ul.auto-toc {
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-spain/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -406,22 +430,22 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-3">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-4">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-6">Authors</a></h3>
 <ul class="simple">
 <li>Factor Libre S.L.</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-5">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Contributors</a></h3>
 <ul class="simple">
 <li>Luis J. Salvatierra &lt;<a class="reference external" href="mailto:luis.salvatierra&#64;factorlibre.com">luis.salvatierra&#64;factorlibre.com</a>&gt;</li>
 <li>Almudena de La Puente &lt;<a class="reference external" href="mailto:almudena.delapuente&#64;factorlibre.com">almudena.delapuente&#64;factorlibre.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/l10n_es_verifactu_pos_oca/tests/test_l10n_es_verifactu_pos.py
+++ b/l10n_es_verifactu_pos_oca/tests/test_l10n_es_verifactu_pos.py
@@ -1,9 +1,17 @@
 import uuid
+from unittest.mock import patch
+
+import psycopg2
+from psycopg2 import errorcodes
 
 from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged
+from odoo.tools import mute_logger
 
+from odoo.addons.l10n_es_verifactu_oca.models.verifactu_mixin import (
+    VerifactuChainingLocked,
+)
 from odoo.addons.l10n_es_verifactu_oca.tests.common import TestVerifactuCommon
 
 
@@ -790,12 +798,15 @@ class TestL10nEsVerifactuPOS(TestVerifactuCommon):
             "SHA-256 of the empty string",
         )
 
+    @mute_logger("odoo.addons.point_of_sale.models.pos_order")
     def test_unpaid_order_is_not_chained(self):
         """An order the core could not mark as paid must stay out of the chain.
 
         The core calls action_pos_order_paid() inside a bare `except
         Exception`, so when the payment does not add up the order silently
-        stays in draft while the sync goes on and reports success.
+        stays in draft while the sync goes on and reports success. Its
+        _logger.error is muted here: it is the expected outcome of this
+        scenario, and an ERROR line in the log fails the build.
         """
         self.assertFalse(
             self.pos_config.cash_rounding,
@@ -833,4 +844,502 @@ class TestL10nEsVerifactuPOS(TestVerifactuCommon):
             len(entries),
             1,
             "The order must hold exactly one chain link, not one per sync",
+        )
+
+    def _fail_chaining(self):
+        """Patch the chaining so it raises what a lock collision would raise."""
+        return patch.object(
+            type(self.env["pos.order"]),
+            "_generate_verifactu_chaining",
+            side_effect=VerifactuChainingLocked(
+                "Could not obtain last document sent to VERI*FACTU for chaining X."
+            ),
+        )
+
+    def _fail_chaining_for_good(self):
+        """Patch the chaining so it raises a failure that will not fix itself."""
+        return patch.object(
+            type(self.env["pos.order"]),
+            "_generate_verifactu_chaining",
+            side_effect=UserError("VAT 21% tax is not mapped to VERI*FACTU."),
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_lock_collision_marks_order_pending(self):
+        """A chaining failure must leave a trace instead of only a log line.
+
+        Exercises the error handling, not PostgreSQL: the failure is injected as
+        the UserError that verifactu_mixin raises when the `FOR UPDATE NOWAIT`
+        on the chaining row hits 55P03. What is under test is that the sale is
+        not interrupted and the order stays findable.
+        """
+        orders_data = [self._create_ui_order_data()]
+        with self._fail_chaining():
+            order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+
+        self.assertEqual(order.state, "paid", "The sale must not be interrupted")
+        self.assertFalse(order.last_verifactu_invoice_entry_id)
+        self.assertTrue(
+            order.aeat_send_failed, "The failure must be visible on the order"
+        )
+        self.assertIn("Could not obtain last document", order.aeat_send_error)
+        self.assertEqual(
+            order.verifactu_chaining_attempts,
+            0,
+            "A lock collision is transient and must not spend budget",
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_database_error_does_not_interrupt_the_sale(self):
+        """A failure that is not a UserError must not abort the sync either.
+
+        A company with VERI*FACTU enabled and no chaining configured makes the
+        `FOR UPDATE NOWAIT` run as `WHERE id = false`, which raises a
+        ProgrammingError. Letting it escape aborts the whole sync: the sale
+        never reaches the backend and its simplified invoice number is burnt,
+        which is the opposite of what marking the order is for.
+        """
+        orders_data = [self._create_ui_order_data()]
+        failure = psycopg2.ProgrammingError(
+            "operator does not exist: integer = boolean"
+        )
+        with patch.object(
+            type(self.env["pos.order"]),
+            "_generate_verifactu_chaining",
+            side_effect=failure,
+        ):
+            order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+
+        self.assertEqual(order.state, "paid", "The sale must not be interrupted")
+        self.assertFalse(order.last_verifactu_invoice_entry_id)
+        self.assertTrue(
+            order.aeat_send_failed, "The failure must be visible on the order"
+        )
+        self.assertIn("operator does not exist", order.aeat_send_error)
+        self.assertEqual(
+            order.verifactu_chaining_attempts,
+            1,
+            "A failure that will not fix itself must spend budget",
+        )
+
+    def test_concurrency_error_is_left_to_the_framework(self):
+        """The exceptions Odoo retries on must keep travelling.
+
+        Marking the order would settle for a pending sale where a retry of the
+        request would have chained it. `_process_order` is called directly on
+        purpose: `create_from_ui` answers an escaping exception with a
+        rollback and a commit of its own (pos_session._handle_order_process_fail),
+        which would take this test's savepoint with it.
+        """
+
+        class _SerializationFailure(psycopg2.OperationalError):
+            pgcode = errorcodes.SERIALIZATION_FAILURE
+
+        order_data = self._create_ui_order_data()
+        with patch.object(
+            type(self.env["pos.order"]),
+            "_generate_verifactu_chaining",
+            side_effect=_SerializationFailure("could not serialize access"),
+        ), self.assertRaises(psycopg2.OperationalError):
+            self.env["pos.order"]._process_order(order_data, False, False)
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_cron_recovers_pending_order(self):
+        """The sweep must chain a paid order that has no entry."""
+        orders_data = [self._create_ui_order_data()]
+        with self._fail_chaining():
+            order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+        self.assertFalse(order.last_verifactu_invoice_entry_id)
+
+        self.env["pos.order"]._cron_generate_pending_verifactu_chaining()
+
+        self.assertTrue(
+            order.last_verifactu_invoice_entry_id,
+            "The cron must chain the pending order",
+        )
+        self.assertFalse(
+            order.aeat_send_failed, "A recovered order must not stay flagged as failed"
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_cron_recovery_is_idempotent(self):
+        """A second pass must not add a second link for the same order."""
+        orders_data = [self._create_ui_order_data()]
+        with self._fail_chaining():
+            order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+
+        self.env["pos.order"]._cron_generate_pending_verifactu_chaining()
+        first_entry = order.last_verifactu_invoice_entry_id
+        self.env["pos.order"]._cron_generate_pending_verifactu_chaining()
+
+        entries = self.env["verifactu.invoice.entry"].search(
+            [("model", "=", "pos.order"), ("document_id", "=", order.id)]
+        )
+        self.assertEqual(len(entries), 1, "The sweep must not duplicate the link")
+        self.assertEqual(order.last_verifactu_invoice_entry_id, first_entry)
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_cron_stops_after_max_attempts(self):
+        """An order at the attempts ceiling must not be retried forever."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "l10n_es_verifactu_pos_oca.max_chaining_attempts", "1"
+        )
+        orders_data = [self._create_ui_order_data()]
+        with self._fail_chaining_for_good():
+            order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+        self.assertEqual(
+            order.verifactu_chaining_attempts,
+            1,
+            "A failure that will not fix itself has to reach the ceiling",
+        )
+
+        self.env["pos.order"]._cron_generate_pending_verifactu_chaining()
+
+        self.assertFalse(
+            order.last_verifactu_invoice_entry_id,
+            "At the ceiling the order is left alone, still visible in the filter",
+        )
+        self.assertTrue(order.aeat_send_failed)
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_cron_isolates_an_unexpected_failure(self):
+        """One order blowing up must not take the pass -- nor the next ones.
+
+        Only the lock collision arrives as UserError; anything else would reach
+        the cron runner, which rolls back the whole job. The oldest order is
+        processed first, so without isolation it would poison every pass.
+        """
+        pos_order = type(self.env["pos.order"])
+        original = pos_order._generate_verifactu_chaining
+
+        def _no_chaining(order, *args, **kwargs):
+            return None
+
+        poison_data = self._create_ui_order_data()
+        poison_data["data"]["creation_date"] = "2020-01-01 10:00:00"
+        good_data = self._create_ui_order_data()
+        good_data["data"]["name"] = "Order 0002"
+        good_data["data"]["l10n_es_unique_id"] = "SIM/0002"
+        with patch.object(pos_order, "_generate_verifactu_chaining", _no_chaining):
+            poison_ids = self.env["pos.order"].create_from_ui([poison_data])
+            good_ids = self.env["pos.order"].create_from_ui([good_data])
+        poison = self.env["pos.order"].browse(poison_ids[0]["id"])
+        good = self.env["pos.order"].browse(good_ids[0]["id"])
+        poison.write({"date_order": "2020-01-01 10:00:00"})
+
+        def _explode_for_poison(order, *args, **kwargs):
+            if order.id == poison.id:
+                raise ValueError("something the mixin does not translate")
+            return original(order, *args, **kwargs)
+
+        with patch.object(
+            pos_order, "_generate_verifactu_chaining", _explode_for_poison
+        ):
+            self.env["pos.order"]._cron_generate_pending_verifactu_chaining()
+
+        self.assertFalse(
+            poison.last_verifactu_invoice_entry_id, "Sanity: the poison one failed"
+        )
+        self.assertTrue(
+            good.last_verifactu_invoice_entry_id,
+            "An unexpected failure must not stop the orders behind it",
+        )
+        self.assertEqual(
+            poison.verifactu_chaining_attempts,
+            1,
+            "The failure must spend budget, so the order eventually gives up",
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_invoicing_a_pending_order_clears_its_failure(self):
+        """A pending order that ends up invoiced must leave the failed filter.
+
+        Its sale is registered through the invoice, and nothing else could
+        clear the mark: the recovery button hides out of paid/done and
+        `resend_verifactu` needs a response line the order never got.
+        """
+        orders_data = [self._create_ui_order_data()]
+        with self._fail_chaining():
+            order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+        self.assertTrue(order.aeat_send_failed, "Sanity: it is in the filter")
+        self.assertFalse(order.last_verifactu_invoice_entry_id)
+
+        order.partner_id = self.partner
+        order.action_pos_order_invoice()
+
+        self.assertTrue(order.account_move, "Sanity: it ended up invoiced")
+        self.assertFalse(
+            order.aeat_send_failed,
+            "The sale is registered through the invoice, the mark must go",
+        )
+        self.assertFalse(order.aeat_send_error)
+
+    def _entries_of(self, order):
+        return self.env["verifactu.invoice.entry"].search(
+            [("model", "=", "pos.order"), ("document_id", "=", str(order.id))]
+        )
+
+    def test_recovery_on_a_chained_order_is_a_no_op(self):
+        """A second link would be a second registration of the same sale.
+
+        After the first pass the domain already hides the order, so only a
+        direct call -- the manual button over RPC -- reaches the in-method
+        guard, which is why no test exercised it.
+        """
+        orders_data = [self._create_ui_order_data()]
+        order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+        entry = order.last_verifactu_invoice_entry_id
+        self.assertTrue(entry, "Sanity: the normal path chained it")
+
+        self.assertFalse(
+            order._recover_verifactu_chaining(),
+            "Recovering an order that already has a link must do nothing",
+        )
+
+        self.assertEqual(order.last_verifactu_invoice_entry_id, entry)
+        self.assertEqual(len(self._entries_of(order)), 1, "Only one link per sale")
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_manual_recovery_button(self):
+        """The button is the way out for a single order, and it reports back."""
+        orders_data = [self._create_ui_order_data()]
+        with self._fail_chaining():
+            order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+        self.assertFalse(order.last_verifactu_invoice_entry_id)
+
+        action = order.action_recover_verifactu_chaining()
+
+        self.assertTrue(order.last_verifactu_invoice_entry_id)
+        self.assertEqual(action["params"]["type"], "success")
+
+        # A second click has nothing to do, and says so instead of chaining again
+        again = order.action_recover_verifactu_chaining()
+        self.assertEqual(again["params"]["type"], "warning")
+        self.assertEqual(len(self._entries_of(order)), 1)
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_recovered_order_hangs_from_the_current_chain_head(self):
+        """The recovered link goes after the sales made while it was pending.
+
+        The chain is append-only: the order takes today's position, not the one
+        it would have had when it was charged.
+        """
+        pending_data = self._create_ui_order_data()
+        with self._fail_chaining():
+            pending_ids = self.env["pos.order"].create_from_ui([pending_data])
+        pending = self.env["pos.order"].browse(pending_ids[0]["id"])
+
+        later_data = self._create_ui_order_data()
+        later_data["data"]["name"] = "Order 0002"
+        later_data["data"]["l10n_es_unique_id"] = "SIM/0002"
+        later_ids = self.env["pos.order"].create_from_ui([later_data])
+        later = self.env["pos.order"].browse(later_ids[0]["id"])
+        self.assertTrue(later.last_verifactu_invoice_entry_id, "Sanity: it chained")
+
+        self.env["pos.order"]._cron_generate_pending_verifactu_chaining()
+
+        recovered = pending.last_verifactu_invoice_entry_id
+        self.assertTrue(recovered)
+        self.assertEqual(
+            recovered.previous_invoice_entry_id,
+            later.last_verifactu_invoice_entry_id,
+            "The recovered link must hang from the head at recovery time",
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_cron_does_not_spend_budget_on_a_concurrency_error(self):
+        """A serialization failure is transient: it must not count as an attempt.
+
+        The framework itself retries these (PG_CONCURRENCY_ERRORS_TO_RETRY), so
+        spending budget on them abandons a chainable sale after a busy spell.
+        And nothing is written on the failing order: the savepoint restored the
+        cursor but not the snapshot, so the write would fail the same way.
+        """
+
+        class _SerializationFailure(psycopg2.OperationalError):
+            pgcode = errorcodes.SERIALIZATION_FAILURE
+
+        pos_order = type(self.env["pos.order"])
+        original = pos_order._generate_verifactu_chaining
+
+        clashing_data = self._create_ui_order_data()
+        clashing_data["data"]["creation_date"] = "2020-01-01 10:00:00"
+        good_data = self._create_ui_order_data()
+        good_data["data"]["name"] = "Order 0002"
+        good_data["data"]["l10n_es_unique_id"] = "SIM/0002"
+        with patch.object(
+            pos_order, "_generate_verifactu_chaining", lambda order, *a, **kw: None
+        ):
+            clashing_ids = self.env["pos.order"].create_from_ui([clashing_data])
+            good_ids = self.env["pos.order"].create_from_ui([good_data])
+        clashing = self.env["pos.order"].browse(clashing_ids[0]["id"])
+        good = self.env["pos.order"].browse(good_ids[0]["id"])
+        clashing.write({"date_order": "2020-01-01 10:00:00"})
+
+        def _clash_for_the_first(order, *args, **kwargs):
+            if order.id == clashing.id:
+                raise _SerializationFailure("could not serialize access")
+            return original(order, *args, **kwargs)
+
+        with patch.object(
+            pos_order, "_generate_verifactu_chaining", _clash_for_the_first
+        ):
+            self.env["pos.order"]._cron_generate_pending_verifactu_chaining()
+
+        self.assertEqual(
+            clashing.verifactu_chaining_attempts,
+            0,
+            "A concurrency error is transient and must not spend budget",
+        )
+        self.assertFalse(
+            clashing.aeat_send_failed,
+            "Nothing is written on the row that just failed",
+        )
+        self.assertTrue(
+            good.last_verifactu_invoice_entry_id,
+            "The orders behind it must still be recovered",
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_invoicing_without_registering_keeps_the_failure(self):
+        """If the invoice is not registered either, the mark must stay.
+
+        The invoice is issued in another journal than the one governing the
+        ticket, so it can perfectly well not be registered. Clearing the mark
+        then would leave a sale that printed its QR code, never reached the
+        AEAT, and shows no trace anywhere.
+        """
+        self.pos_config.invoice_journal_id.verifactu_enabled = False
+        orders_data = [self._create_ui_order_data()]
+        with self._fail_chaining():
+            order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+        self.assertTrue(order.aeat_send_failed, "Sanity: it is in the filter")
+
+        order.partner_id = self.partner
+        order.action_pos_order_invoice()
+
+        self.assertTrue(order.account_move, "Sanity: it ended up invoiced")
+        self.assertFalse(
+            order.account_move.last_verifactu_invoice_entry_id,
+            "Sanity: the invoice is not registered either",
+        )
+        self.assertTrue(
+            order.aeat_send_failed,
+            "With nothing registered, the sale must stay visible",
+        )
+
+    def test_cron_recovers_order_never_marked_as_failed(self):
+        """The sweep must reach a pending order that no failure ever marked.
+
+        The backlog the sweep exists for was charged before this code was
+        installed, so nothing ever touched its attempts counter. If the counter
+        has no default the column is NULL, `<` does not match NULL, and the
+        sweep is blind to exactly that population.
+        """
+        orders_data = [self._create_ui_order_data()]
+        with patch.object(
+            type(self.env["pos.order"]),
+            "_generate_verifactu_chaining",
+            return_value=None,
+        ):
+            order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+
+        self.assertFalse(order.last_verifactu_invoice_entry_id, "Sanity: pending")
+        self.assertFalse(order.aeat_send_failed, "Sanity: no failure was marked")
+
+        self.env["pos.order"]._cron_generate_pending_verifactu_chaining()
+
+        self.assertTrue(
+            order.last_verifactu_invoice_entry_id,
+            "The sweep must chain an order that was never marked as failed",
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_cron_skips_orders_with_excluded_fiscal_position(self):
+        """An order on a fiscal position out of AEAT must not starve the rest.
+
+        Same shape as the start date: the computed field rejects it, the
+        revalidation leaves its counter untouched, and being the oldest it
+        would hold the limit on every pass.
+        """
+        excluded_fp = self.fp_nacional.copy({"name": "Excluded from AEAT"})
+        excluded_fp.aeat_active = False
+
+        old_order_data = self._create_ui_order_data()
+        old_order_data["data"]["creation_date"] = "2020-01-01 10:00:00"
+        old_order_data["data"]["fiscal_position_id"] = excluded_fp.id
+        old_ids = self.env["pos.order"].create_from_ui([old_order_data])
+        old_order = self.env["pos.order"].browse(old_ids[0]["id"])
+        old_order.write({"date_order": "2020-01-01 10:00:00"})
+
+        pending_data = self._create_ui_order_data()
+        pending_data["data"]["name"] = "Order 0002"
+        pending_data["data"]["l10n_es_unique_id"] = "SIM/0002"
+        with self._fail_chaining():
+            pending_ids = self.env["pos.order"].create_from_ui([pending_data])
+        pending = self.env["pos.order"].browse(pending_ids[0]["id"])
+
+        self.assertFalse(
+            old_order.verifactu_enabled, "Sanity: the excluded one is not chainable"
+        )
+        self.assertTrue(pending.verifactu_enabled, "Sanity: the other one is")
+
+        # limit=1: if the excluded order were selected it would take the slot
+        self.env["pos.order"]._cron_generate_pending_verifactu_chaining(limit=1)
+
+        self.assertTrue(
+            pending.last_verifactu_invoice_entry_id,
+            "The excluded order must not hold the only slot of the pass",
+        )
+
+    @mute_logger("odoo.addons.l10n_es_verifactu_pos_oca.models.pos_order")
+    def test_cron_skips_orders_before_start_date(self):
+        """Orders below the start date must not starve the pending ones.
+
+        They are not chainable (the computed verifactu_enabled says so) and the
+        recovery leaves their attempts counter untouched, so if the sweep
+        selected them they would come back on every pass and, being the oldest,
+        fill the limit forever. The domain has to exclude them, not rely on the
+        per-order revalidation.
+        """
+        old_order_data = self._create_ui_order_data()
+        old_order_data["data"]["creation_date"] = "2020-01-01 10:00:00"
+        with self._fail_chaining():
+            old_ids = self.env["pos.order"].create_from_ui([old_order_data])
+        old_order = self.env["pos.order"].browse(old_ids[0]["id"])
+        old_order.write({"date_order": "2020-01-01 10:00:00"})
+
+        pending_data = self._create_ui_order_data()
+        pending_data["data"]["name"] = "Order 0002"
+        pending_data["data"]["l10n_es_unique_id"] = "SIM/0002"
+        with self._fail_chaining():
+            pending_ids = self.env["pos.order"].create_from_ui([pending_data])
+        pending = self.env["pos.order"].browse(pending_ids[0]["id"])
+
+        self.company.verifactu_start_date = "2021-01-01"
+        self.assertFalse(
+            old_order.verifactu_enabled, "Sanity: the old one is not chainable"
+        )
+        self.assertTrue(pending.verifactu_enabled, "Sanity: the recent one is")
+
+        # limit=1: if the old order were selected it would take the only slot
+        self.env["pos.order"]._cron_generate_pending_verifactu_chaining(limit=1)
+
+        self.assertTrue(
+            pending.last_verifactu_invoice_entry_id,
+            "The recent order must be recovered even with the old one pending",
+        )
+        self.assertFalse(
+            old_order.last_verifactu_invoice_entry_id,
+            "The order below the start date must stay out of the chain",
         )

--- a/l10n_es_verifactu_pos_oca/tests/test_l10n_es_verifactu_pos.py
+++ b/l10n_es_verifactu_pos_oca/tests/test_l10n_es_verifactu_pos.py
@@ -764,3 +764,73 @@ class TestL10nEsVerifactuPOS(TestVerifactuCommon):
         # Without partner, receiver dict is empty
         order.partner_id = False
         self.assertEqual(order._get_verifactu_receiver_dict(), {})
+
+    def test_draft_order_is_not_chained(self):
+        """An order synced as draft must stay out of the chain.
+
+        The chain is company-wide and shared with backend invoices, so a link
+        for an order that is not a fiscal document yet pollutes it for good:
+        the chain is append-only and the entry cannot be removed later.
+        """
+        orders_data = [self._create_ui_order_data()]
+        order_ids = self.env["pos.order"].create_from_ui(orders_data, draft=True)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+
+        self.assertEqual(
+            order.state, "draft", "Syncing with draft=True must leave the order draft"
+        )
+        self.assertFalse(
+            order.last_verifactu_invoice_entry_id,
+            "A draft order must not get a chaining entry",
+        )
+        self.assertFalse(
+            order.verifactu_hash,
+            "A draft order must not get a hash: _get_verifactu_hash_string() "
+            "returns an empty string for it, and hashing that would chain the "
+            "SHA-256 of the empty string",
+        )
+
+    def test_unpaid_order_is_not_chained(self):
+        """An order the core could not mark as paid must stay out of the chain.
+
+        The core calls action_pos_order_paid() inside a bare `except
+        Exception`, so when the payment does not add up the order silently
+        stays in draft while the sync goes on and reports success.
+        """
+        self.assertFalse(
+            self.pos_config.cash_rounding,
+            "The test needs cash_rounding off so that action_pos_order_paid raises",
+        )
+        order_data = self._create_ui_order_data(amount=100)
+        # Half paid: action_pos_order_paid() raises "not fully paid"
+        order_data["data"]["amount_paid"] = 60.5
+        order_data["data"]["statement_ids"][0][2]["amount"] = 60.5
+
+        order_ids = self.env["pos.order"].create_from_ui([order_data])
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+
+        self.assertEqual(
+            order.state, "draft", "An underpaid order stays draft even with draft=False"
+        )
+        self.assertFalse(
+            order.last_verifactu_invoice_entry_id,
+            "An unpaid order must not get a chaining entry",
+        )
+
+    def test_order_chained_once_after_draft_sync(self):
+        """Syncing draft and then paid must produce exactly one entry."""
+        order_data = self._create_ui_order_data()
+        self.env["pos.order"].create_from_ui([order_data], draft=True)
+        # Same pos_reference: the core finds the draft order and updates it
+        order_ids = self.env["pos.order"].create_from_ui([order_data])
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+
+        self.assertEqual(order.state, "paid")
+        entries = self.env["verifactu.invoice.entry"].search(
+            [("model", "=", "pos.order"), ("document_id", "=", order.id)]
+        )
+        self.assertEqual(
+            len(entries),
+            1,
+            "The order must hold exactly one chain link, not one per sync",
+        )

--- a/l10n_es_verifactu_pos_oca/views/pos_order_view.xml
+++ b/l10n_es_verifactu_pos_oca/views/pos_order_view.xml
@@ -14,8 +14,19 @@
                     attrs="{'invisible': ['|','|',('verifactu_enabled', '=', False), ('state', 'not in', ['paid', 'done']), ('aeat_state','not in', ('sent_w_errors', 'incorrect'))]}"
                 />
             </button>
+            <button name="resend_verifactu" position="after">
+                <button
+                    type="object"
+                    string="Generate VERI*FACTU chaining"
+                    name="action_recover_verifactu_chaining"
+                    groups="l10n_es_aeat.group_account_aeat"
+                    attrs="{'invisible': ['|','|','|',('verifactu_enabled', '=', False), ('state', 'not in', ['paid', 'done']), ('to_invoice', '=', True), ('last_verifactu_invoice_entry_id', '!=', False)]}"
+                />
+            </button>
              <notebook position="inside">
                 <field name="verifactu_enabled" invisible="1" />
+                <field name="last_verifactu_invoice_entry_id" invisible="1" />
+                <field name="to_invoice" invisible="1" />
                 <page
                     string="VERI*FACTU"
                     name="page_aeat"
@@ -56,6 +67,12 @@
                                 name="verifactu_registration_date"
                                 string="Registration date"
                                 readonly="1"
+                            />
+                            <field
+                                name="verifactu_chaining_attempts"
+                                string="Chaining attempts"
+                                readonly="1"
+                                attrs="{'invisible': [('verifactu_chaining_attempts', '=', 0)]}"
                             />
                         </group>
                     </group>


### PR DESCRIPTION
El encadenamiento del TPV tenía dos defectos que se dan la mano: se generaba sin comprobar el estado del pedido, y cuando fallaba no dejaba rastro. Van en dos commits.

**No encadenar pedidos que no son ventas cerradas.** Un pedido todavía en borrador podía tomar eslabón, y como la cadena la comparten el backend y todos los TPV, eso no se deshace después. La comprobación pasa a `_is_verifactu_order()`, que es el guardián que `_process_order()` consulta de verdad; de paso se elimina `_should_send_to_verifactu()`, que no llamaba nadie en todo el repositorio.

**Recuperar el encadenamiento pendiente.** Al fallar, el error solo se escribía en el log y el pedido quedaba fuera de la cadena sin vía de vuelta: `resend_verifactu` exige una entrada previa que ese pedido nunca tuvo. Ahora el fallo se anota en el propio pedido, un cron de barrido encadena lo pendiente de más antiguo a más reciente, y un botón hace lo mismo sobre uno concreto. El barrido aísla y confirma cada pedido por separado, para no retener el bloqueo de la cadena durante toda la pasada.

Alcanza también a `l10n_es_verifactu_oca`: el mixin señala la colisión de la cadena como `VerifactuChainingLocked`, subclase de `UserError`, que es la única forma fiable de distinguir un fallo pasajero de uno permanente — el mensaje pasa por `_()`.
