### PR TITLE
 [16.0][FIX] l10n_es_verifactu_pos_oca: alinear el QR del ticket con el registro

### DIFF
--- a/l10n_es_verifactu_pos_oca/README.rst
+++ b/l10n_es_verifactu_pos_oca/README.rst
@@ -42,6 +42,18 @@ Módulo para la presentación inmediata de la facturación desde TPV.
 Known issues / Roadmap
 ======================
 
+* The amount in the ticket QR code is the order total, while the registration
+  adjusts it by the taxes mapped as not included in it: the base of the exempt
+  not subject ones goes down, and the quota of the withholdings -- negative --
+  pushes it up. They only differ when the order carries one of those taxes;
+  working it out in the PoS would mean replicating the backend tax mapping in
+  the frontend.
+* On a PoS that does not issue simplified invoices the ticket carries no QR
+  code, while the backend does register the sale, falling back to the PoS
+  reference as its serial number.
+* Both the registration and the ticket QR code date the document by the UTC
+  day, not by the legal day in the company's time zone, so a sale made in the
+  first hours of the day is declared on the previous one.
 * Implement cancelling simplified and complete invoices from the PoS
 * Configure new chaining from PoS Config
 * Invoicing already sent simplified invoice (PoS Order). Send anullment for the simplified and send a new one for the complete.

--- a/l10n_es_verifactu_pos_oca/models/pos_config.py
+++ b/l10n_es_verifactu_pos_oca/models/pos_config.py
@@ -4,6 +4,13 @@ from odoo import api, fields, models
 class PosConfig(models.Model):
     _inherit = "pos.config"
 
+    verifactu_journal_enabled = fields.Boolean(
+        related="journal_id.verifactu_enabled",
+        string="VERI*FACTU journal enabled",
+        help="The registration needs the PoS journal to have VERI*FACTU "
+        "enabled. Needed on PoS to keep the QR code out of the tickets that "
+        "the backend does not register.",
+    )
     verifactu_base_url = fields.Char(
         string="Verifactu Base URL",
         compute="_compute_verifactu_base_url",

--- a/l10n_es_verifactu_pos_oca/models/pos_session.py
+++ b/l10n_es_verifactu_pos_oca/models/pos_session.py
@@ -9,6 +9,7 @@ class PosSession(models.Model):
         params["search_params"]["fields"].extend(
             [
                 "verifactu_enabled",
+                "verifactu_start_date",
             ]
         )
         return params

--- a/l10n_es_verifactu_pos_oca/readme/ROADMAP.rst
+++ b/l10n_es_verifactu_pos_oca/readme/ROADMAP.rst
@@ -1,3 +1,15 @@
+* The amount in the ticket QR code is the order total, while the registration
+  adjusts it by the taxes mapped as not included in it: the base of the exempt
+  not subject ones goes down, and the quota of the withholdings -- negative --
+  pushes it up. They only differ when the order carries one of those taxes;
+  working it out in the PoS would mean replicating the backend tax mapping in
+  the frontend.
+* On a PoS that does not issue simplified invoices the ticket carries no QR
+  code, while the backend does register the sale, falling back to the PoS
+  reference as its serial number.
+* Both the registration and the ticket QR code date the document by the UTC
+  day, not by the legal day in the company's time zone, so a sale made in the
+  first hours of the day is declared on the previous one.
 * Implement cancelling simplified and complete invoices from the PoS
 * Configure new chaining from PoS Config
 * Invoicing already sent simplified invoice (PoS Order). Send anullment for the simplified and send a new one for the complete.

--- a/l10n_es_verifactu_pos_oca/static/description/index.html
+++ b/l10n_es_verifactu_pos_oca/static/description/index.html
@@ -392,6 +392,18 @@ ul.auto-toc {
 <div class="section" id="known-issues-roadmap">
 <h2><a class="toc-backref" href="#toc-entry-1">Known issues / Roadmap</a></h2>
 <ul class="simple">
+<li>The amount in the ticket QR code is the order total, while the registration
+adjusts it by the taxes mapped as not included in it: the base of the exempt
+not subject ones goes down, and the quota of the withholdings – negative –
+pushes it up. They only differ when the order carries one of those taxes;
+working it out in the PoS would mean replicating the backend tax mapping in
+the frontend.</li>
+<li>On a PoS that does not issue simplified invoices the ticket carries no QR
+code, while the backend does register the sale, falling back to the PoS
+reference as its serial number.</li>
+<li>Both the registration and the ticket QR code date the document by the UTC
+day, not by the legal day in the company’s time zone, so a sale made in the
+first hours of the day is declared on the previous one.</li>
 <li>Implement cancelling simplified and complete invoices from the PoS</li>
 <li>Configure new chaining from PoS Config</li>
 <li>Invoicing already sent simplified invoice (PoS Order). Send anullment for the simplified and send a new one for the complete.</li>

--- a/l10n_es_verifactu_pos_oca/static/src/js/models.js
+++ b/l10n_es_verifactu_pos_oca/static/src/js/models.js
@@ -15,24 +15,37 @@ odoo.define("l10n_es_verifactu_pos_oca.models", function (require) {
                 return result;
             }
 
+            _get_verifactu_document_date() {
+                // The registration dates the document by the UTC date of
+                // `date_order`, which is the date sent from here as
+                // `creation_date`, so the QR code follows it to keep both on
+                // the same day for orders around midnight. That day is the UTC
+                // one and not the legal one -- see the ROADMAP.
+                return moment.utc(this.validation_date || this.creation_date);
+            }
+
             _build_verifactu_qr_url() {
                 const baseUrl = this.pos.config.verifactu_base_url;
                 const vatNumber = (this.pos.company.vat || "").replace(/^ES/i, "");
-                const date = this.validation_date || this.creation_date;
-                const formattedDate = moment(date).format("DD-MM-YYYY");
                 const params = new URLSearchParams({
                     nif: vatNumber,
-                    numserie: this.l10n_es_unique_id,
-                    fecha: formattedDate,
-                    importe: this.get_total_with_tax(),
+                    numserie: (this.l10n_es_unique_id || "").substring(0, 60),
+                    fecha: this._get_verifactu_document_date().format("DD-MM-YYYY"),
+                    importe: this.get_total_with_tax().toFixed(2),
                 });
                 return `${baseUrl}?${params.toString()}`;
             }
 
             _get_verifactu_qr_code_data() {
+                const startDate = this.pos.company.verifactu_start_date;
                 const isEnabled =
                     this.pos.company.verifactu_enabled &&
+                    this.pos.config.verifactu_journal_enabled &&
                     this.is_simplified_invoice &&
+                    !this.is_to_invoice() &&
+                    (!startDate ||
+                        this._get_verifactu_document_date().format("YYYY-MM-DD") >=
+                            startDate) &&
                     (!this.fiscal_position ||
                         (this.fiscal_position && this.fiscal_position.aeat_active));
 

--- a/l10n_es_verifactu_pos_oca/tests/test_l10n_es_verifactu_pos.py
+++ b/l10n_es_verifactu_pos_oca/tests/test_l10n_es_verifactu_pos.py
@@ -172,9 +172,11 @@ class TestL10nEsVerifactuPOS(TestVerifactuCommon):
                         },
                     )
                 ],
+                # `_order_fields` reads it from the order data, so it has to be
+                # in here to reach the record.
+                "to_invoice": not simplified,
             },
             "id": uid,
-            "to_invoice": not simplified,
         }
 
     def test_simplified_invoice_verifactu_flow(self):
@@ -708,6 +710,52 @@ class TestL10nEsVerifactuPOS(TestVerifactuCommon):
         # Order-level description takes precedence
         order.verifactu_description = "Order description"
         self.assertEqual(order._get_verifactu_description(), "Order description")
+
+    def test_pos_verifactu_invoiced_order_is_not_registered(self):
+        """An order to be invoiced is registered as an invoice, not as a ticket.
+
+        The ticket must not show a QR code either, so the PoS UI needs the same
+        condition. This test pins the backend side of that contract.
+        """
+        orders_data = [self._create_ui_order_data(simplified=False)]
+        order_ids = self.env["pos.order"].create_from_ui(orders_data)
+        order = self.env["pos.order"].browse(order_ids[0]["id"])
+
+        self.assertTrue(order.to_invoice)
+        self.assertFalse(
+            order._is_verifactu_order(),
+            "An order to be invoiced must not take a link in the chain",
+        )
+        self.assertFalse(order.last_verifactu_invoice_entry_id)
+        # The sale is registered, but through its invoice.
+        self.assertTrue(order.account_move.last_verifactu_invoice_entry_id)
+
+    def test_pos_verifactu_start_date_is_loaded_in_pos_ui(self):
+        """The PoS UI needs the start date to hide the QR code before it."""
+        params = self.pos_session._loader_params_res_company()
+        self.assertIn("verifactu_start_date", params["search_params"]["fields"])
+
+    def test_pos_verifactu_journal_flag_reaches_the_pos_ui(self):
+        """The PoS UI needs the journal flag to hide the QR when it is off.
+
+        The journal the registration looks at is the PoS one, which a standard
+        install creates with type `general` (core `pos_config.generate_pos_journal`),
+        so the constraint requiring VERI*FACTU on sale journals does not reach
+        it: its flag can be off and the backend then registers nothing.
+        """
+        general_journal = self.env["account.journal"].create(
+            {
+                "name": "Point of Sale general",
+                "type": "general",
+                "code": "POSSG",
+                "company_id": self.company.id,
+            }
+        )
+        self.pos_config.journal_id = general_journal
+        self.assertTrue(self.pos_config.verifactu_journal_enabled)
+
+        general_journal.verifactu_enabled = False
+        self.assertFalse(self.pos_config.verifactu_journal_enabled)
 
     def test_pos_verifactu_subsanacion_rechazo(self):
         """Test Subsanacion and RechazoPrevio flags in invoice dict"""


### PR DESCRIPTION
El QR del ticket es lo que permite al cliente comprobar su compra en la AEAT, así que debe aparecer sólo cuando la venta está registrada y llevar los datos con los que se registró.

Deja de imprimirse en los tickets que no se registran como tales: los marcados para facturar, cuya venta se registra a través de su factura, los anteriores a la fecha de inicio de la compañía, y los de una caja cuyo diario no tiene VERI*FACTU activo. El TPV recibe ahora los dos datos que le faltaban para comprobarlo.

Su contenido se construye como el del registro: importe con dos decimales, número de serie recortado a 60 caracteres y la misma fecha. Antes el QR usaba la local mientras el registro toma la UTC así que podían quedar en días distintos.
