### PR TITLE
[17.0][FIX] l10n_es_verifactu_oca: make posting atomic under concurrency

### DIFF
--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -467,12 +467,30 @@ class AccountMove(models.Model):
         )
 
     def _post(self, soft=True):
-        res = super()._post(soft=soft)
-        for record in self.sorted(lambda inv: inv.name):
-            if record.verifactu_enabled and record.aeat_state == "not_sent":
+        verifactu_records = self.filtered(
+            lambda inv: inv.verifactu_enabled and inv.aeat_state == "not_sent"
+        )
+        if not verifactu_records:
+            return super()._post(soft=soft)
+        with self.env.cr.savepoint():
+            verifactu_records._lock_verifactu_chaining()
+            res = super()._post(soft=soft)
+            for record in (res & verifactu_records).sorted(lambda inv: inv.name):
                 record._check_verifactu_configuration()
                 record.verifactu_registration_date = datetime.now()
                 record._generate_verifactu_chaining()
+            missing_entries = verifactu_records.filtered(
+                lambda inv: inv.state == "posted"
+                and not inv.last_verifactu_invoice_entry_id
+            )
+            if missing_entries:
+                raise UserError(
+                    _(
+                        "The following invoices could not be posted because their "
+                        "VERI*FACTU entry was not generated: %s",
+                        ", ".join(missing_entries.mapped("display_name")),
+                    )
+                )
         return res
 
     def _check_verifactu_configuration(self, suffixes=None):

--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -9,7 +9,6 @@ import json
 from hashlib import sha256
 from urllib.parse import urlencode
 
-import psycopg2
 import qrcode
 
 from odoo import _, api, fields, models
@@ -313,64 +312,71 @@ class VerifactuMixin(models.AbstractModel):
     def _get_verifactu_chaining(self):
         return NotImplementedError
 
+    def _lock_verifactu_chaining(self):
+        """Lock all involved chains before their documents are posted.
+
+        PostgreSQL concurrency errors must reach Odoo's transaction retry
+        mechanism unchanged.
+        """
+        chainings = self.env["verifactu.chaining"]
+        for document in self:
+            chainings |= document._get_verifactu_chaining()
+        if not chainings:
+            return
+        chainings.flush_recordset(["last_verifactu_invoice_entry_id"])
+        self.env.cr.execute(
+            f"SELECT id FROM {chainings._table} "
+            "WHERE id = ANY(%s) ORDER BY id FOR UPDATE NOWAIT",
+            [chainings.ids],
+        )
+
     def _generate_verifactu_chaining(self, entry_type=False):
         """Generate VERI*FACTU invoice entry for company-wide chaining."""
         self.ensure_one()
         chaining = self._get_verifactu_chaining()
         chaining.flush_recordset(["last_verifactu_invoice_entry_id"])
         cancel = entry_type and entry_type == "cancel"
-        try:
-            with self.env.cr.savepoint():
-                self.env.cr.execute(
-                    f"SELECT last_verifactu_invoice_entry_id FROM {chaining._table}"
-                    " WHERE id = %s FOR UPDATE NOWAIT",
-                    [chaining.id],
-                )
-                result = self.env.cr.fetchone()
-                previous_invoice_entry_id = result[0] if result and result[0] else False
-                invoice_vals = {
-                    "verifactu_chaining_id": chaining.id,
-                    "model": self._name,
-                    "document_id": self.id,
-                    "document_name": self.name,
-                    "previous_invoice_entry_id": previous_invoice_entry_id,
-                    "company_id": self.company_id.id,
-                    "document_hash": "",
-                }
-                if entry_type:
-                    invoice_vals["entry_type"] = entry_type
-                invoice_entry = self.env["verifactu.invoice.entry"].create(invoice_vals)
-                self.last_verifactu_invoice_entry_id = invoice_entry
-                verifactu_hash_values = self._get_verifactu_hash_string(cancel=cancel)
-                self.verifactu_hash_string = verifactu_hash_values
-                hash_string = sha256(verifactu_hash_values.encode("utf-8"))
-                self.verifactu_hash = hash_string.hexdigest().upper()
-                # Generate JSON data for AEAT
+        with self.env.cr.savepoint():
+            self.env.cr.execute(
+                f"SELECT last_verifactu_invoice_entry_id FROM {chaining._table}"
+                " WHERE id = %s FOR UPDATE NOWAIT",
+                [chaining.id],
+            )
+            result = self.env.cr.fetchone()
+            previous_invoice_entry_id = result[0] if result and result[0] else False
+            invoice_vals = {
+                "verifactu_chaining_id": chaining.id,
+                "model": self._name,
+                "document_id": self.id,
+                "document_name": self.name,
+                "previous_invoice_entry_id": previous_invoice_entry_id,
+                "company_id": self.company_id.id,
+                "document_hash": "",
+            }
+            if entry_type:
+                invoice_vals["entry_type"] = entry_type
+            invoice_entry = self.env["verifactu.invoice.entry"].create(invoice_vals)
+            self.last_verifactu_invoice_entry_id = invoice_entry
+            verifactu_hash_values = self._get_verifactu_hash_string(cancel=cancel)
+            self.verifactu_hash_string = verifactu_hash_values
+            hash_string = sha256(verifactu_hash_values.encode("utf-8"))
+            self.verifactu_hash = hash_string.hexdigest().upper()
+            # Generate JSON data for AEAT
+            aeat_json_data = ""
+            try:
+                inv_dict = self._get_verifactu_invoice_dict(cancel=cancel)
+                aeat_json_data = json.dumps(inv_dict, indent=4)
+            except Exception:
+                # If JSON generation fails, store empty string
                 aeat_json_data = ""
-                try:
-                    inv_dict = self._get_verifactu_invoice_dict(cancel=cancel)
-                    aeat_json_data = json.dumps(inv_dict, indent=4)
-                except Exception:
-                    # If JSON generation fails, store empty string
-                    aeat_json_data = ""
-                invoice_entry.document_hash = hash_string.hexdigest().upper()
-                invoice_entry.aeat_json_data = aeat_json_data
-                self.env.cr.execute(
-                    f"UPDATE {chaining._table} "
-                    "SET last_verifactu_invoice_entry_id = %s WHERE id = %s",
-                    [invoice_entry.id, chaining.id],
-                )
-                chaining.invalidate_recordset(["last_verifactu_invoice_entry_id"])
-        except psycopg2.OperationalError as err:
-            if err.pgcode == "55P03":  # could not obtain the lock
-                raise UserError(
-                    _(
-                        "Could not obtain last document sent to VERI*FACTU for "
-                        "chaining %s.",
-                        chaining.name,
-                    )
-                ) from err
-            raise
+            invoice_entry.document_hash = hash_string.hexdigest().upper()
+            invoice_entry.aeat_json_data = aeat_json_data
+            self.env.cr.execute(
+                f"UPDATE {chaining._table} "
+                "SET last_verifactu_invoice_entry_id = %s WHERE id = %s",
+                [invoice_entry.id, chaining.id],
+            )
+            chaining.invalidate_recordset(["last_verifactu_invoice_entry_id"])
 
     def _get_verifactu_document_type(self):
         raise NotImplementedError()

--- a/l10n_es_verifactu_oca/tests/test_verifactu_invoice.py
+++ b/l10n_es_verifactu_oca/tests/test_verifactu_invoice.py
@@ -2,12 +2,73 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from datetime import date, timedelta
+from unittest.mock import patch
+
+import psycopg2
+from psycopg2 import errorcodes
+
+from odoo.exceptions import UserError
 
 from .common import TestVerifactuCommon
 
 
+class RetryableLockError(psycopg2.OperationalError):
+    @property
+    def pgcode(self):
+        return errorcodes.LOCK_NOT_AVAILABLE
+
+
 class TestVerifactuInvoice(TestVerifactuCommon):
     """Test class for VeriFactu Invoice functionality."""
+
+    def test_post_is_atomic_when_chaining_fails(self):
+        """The invoice posting is rolled back even if its error is caught."""
+        self._activate_certificate(self.certificate_password)
+        invoice = self.invoice.copy()
+        with patch.object(
+            type(invoice),
+            "_generate_verifactu_chaining",
+            side_effect=UserError("Forced chaining error"),
+        ):
+            with self.assertRaisesRegex(UserError, "Forced chaining error"):
+                invoice.action_post()
+        invoice.invalidate_recordset()
+        self.assertEqual(invoice.state, "draft")
+        self.assertFalse(invoice.last_verifactu_invoice_entry_id)
+        self.assertFalse(
+            self.env["verifactu.invoice.entry"].search_count(
+                [("model", "=", invoice._name), ("document_id", "=", invoice.id)]
+            )
+        )
+
+    def test_post_requires_verifactu_entry(self):
+        """A posted VERI*FACTU invoice must have a chaining entry."""
+        self._activate_certificate(self.certificate_password)
+        invoice = self.invoice.copy()
+        with patch.object(
+            type(invoice), "_generate_verifactu_chaining", return_value=None
+        ):
+            with self.assertRaisesRegex(UserError, "entry was not generated"):
+                invoice.action_post()
+        invoice.invalidate_recordset()
+        self.assertEqual(invoice.state, "draft")
+        self.assertFalse(invoice.last_verifactu_invoice_entry_id)
+
+    def test_lock_conflict_remains_retryable(self):
+        """A chain lock conflict reaches Odoo's retry mechanism unchanged."""
+        self._activate_certificate(self.certificate_password)
+        invoice = self.invoice.copy()
+        lock_error = RetryableLockError("Forced lock conflict")
+        with patch.object(
+            type(invoice), "_lock_verifactu_chaining", side_effect=lock_error
+        ):
+            with self.assertRaises(RetryableLockError) as raised:
+                invoice.action_post()
+        self.assertIs(raised.exception, lock_error)
+        self.assertEqual(raised.exception.pgcode, errorcodes.LOCK_NOT_AVAILABLE)
+        invoice.invalidate_recordset()
+        self.assertEqual(invoice.state, "draft")
+        self.assertFalse(invoice.last_verifactu_invoice_entry_id)
 
     def _generate_invoice_entry(self, invoice):
         """


### PR DESCRIPTION
## Problem

Concurrent posting of VERI*FACTU invoices can leave the accounting move posted and numbered before the chaining row is safely locked.

The current flow calls `super()._post()` before generating the VERI*FACTU entry. In addition, PostgreSQL lock error `55P03` is converted into a `UserError`, so Odoo's native transaction retry mechanism cannot retry the complete posting transaction.

This addresses the concurrency scenario reported in #4604.

## Solution

- Lock all involved `verifactu.chaining` rows before calling `super()._post()`.
- Acquire multiple chain locks in deterministic ID order with `FOR UPDATE NOWAIT`.
- Let PostgreSQL concurrency errors propagate unchanged so Odoo's native `service.model.retrying()` can roll back and retry the full transaction.
- Wrap posting and entry generation in an outer savepoint.
- Enforce a postcondition preventing a posted VERI*FACTU invoice without its chaining entry.
- Preserve the original posting path when no VERI*FACTU invoice is involved.

## Validation

- `python -m compileall`: passed.
- `git diff --check`: passed.
- Clean Odoo 17 / PostgreSQL 15 installation of `l10n_es_verifactu_oca`: passed.
- Full tagged module test suite: 0 failures, 0 errors.
- Added regression coverage for:
  - rollback when chaining fails after accounting posting;
  - rejection and rollback if no VERI*FACTU entry is generated;
  - propagation of retryable PostgreSQL `55P03`.
- Real two-transaction concurrency test:
  - transaction A posted the first invoice while holding the chaining row lock;
  - transaction B received two real `55P03` lock conflicts;
  - Odoo retried transaction B three times through `service.model.retrying()`;
  - both invoices finished posted with consecutive numbers;
  - entries were correctly linked as `35 -> 36`;
  - no posted invoice was left without a VERI*FACTU entry.

## Impact

Posting remains atomic under concurrent workers while preserving Odoo's standard retry behavior and the existing non-VERI*FACTU flow.

## AI assistance

Assisted-by: OpenAI Codex