### PR TITLE
[17.0][FIX] l10n_es_verifactu_oca: deduplicate connection failures

### DIFF
--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry.py
@@ -3,8 +3,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import datetime
 import json
+import logging
 
 from requests import Session
+from requests.exceptions import RequestException
 from zeep import Client, Settings
 from zeep.cache import SqliteCache
 from zeep.plugins import HistoryPlugin
@@ -13,6 +15,8 @@ from zeep.transports import Transport
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import split_every
+
+_logger = logging.getLogger(__name__)
 
 VERIFACTU_SEND_STATES = [
     ("not_sent", "Not sent"),
@@ -290,13 +294,50 @@ class VerifactuInvoiceEntry(models.Model):
             response_line.document.write(doc_vals)
         return doc_vals
 
+    def _get_reusable_connection_error_response(self, connection_error):
+        last_lines = self.mapped("last_response_line_id")
+        if len(last_lines) != len(self):
+            return self.env["verifactu.invoice.entry.response"]
+        responses = last_lines.mapped("entry_response_id")
+        if (
+            len(responses) == 1
+            and responses.connection_error == connection_error
+            and set(last_lines.mapped("entry_id").ids) == set(self.ids)
+        ):
+            return responses
+        return self.env["verifactu.invoice.entry.response"]
+
+    def _create_connection_error_response_lines(self, response, connection_error):
+        for rec in self:
+            if not rec.document:
+                continue
+            vals = {
+                "entry_id": rec.id,
+                "model": rec.model,
+                "document_id": rec.document_id,
+                "response": connection_error,
+                "entry_response_id": response.id,
+                "send_state": "not_sent",
+                "error_code": "CONNECTION_ERROR",
+            }
+            response_line = (
+                self.env["verifactu.invoice.entry.response.line"].sudo().create(vals)
+            )
+            rec.document.last_verifactu_response_line_id = response_line
+            rec.last_response_line_id = response_line
+            rec.document.write(
+                {
+                    "aeat_send_failed": True,
+                    "aeat_send_error": connection_error,
+                }
+            )
+
     def _send_documents_to_verifactu(self):
         if not self:
             return False
         rec = self[0]
         header = rec._get_verifactu_aeat_header()
         registro_factura_list = []
-        create_exception = False
         for rec in self:
             rec.send_attempt += 1
             if rec.document:
@@ -304,40 +345,53 @@ class VerifactuInvoiceEntry(models.Model):
                     cancel=rec.entry_type == "cancel"
                 )
                 registro_factura_list.append(inv_dict)
+        connection_error = False
         try:
             serv = rec._connect_verifactu()
             res = serv.RegFactuSistemaFacturacion(header, registro_factura_list)
-        except Exception:
-            res = {}
-            create_exception = True
-        response_name = ""
-        response = (
-            self.env["verifactu.invoice.entry.response"]
-            .sudo()
-            .create(
-                {
-                    "header": json.dumps(header),
-                    "name": response_name,
-                    "invoice_data": json.dumps(registro_factura_list),
-                    "response": res,
-                    "verifactu_csv": "CSV" in res and res["CSV"] or _("-"),
-                }
+        except (RequestException, ConnectionError) as error:
+            connection_error = repr(error)
+            _logger.exception(
+                "VERI*FACTU call failed for documents %s",
+                self.mapped("document_name"),
             )
-        )
-        response.complete_open_activity_on_exception()
-        if create_exception:
-            if not response.date_response:
-                response.date_response = fields.Datetime.now()
+            res = {}
+        response_model = self.env["verifactu.invoice.entry.response"].sudo()
+        response_vals = {
+            "header": json.dumps(header),
+            "name": _("Connection error with VERI*FACTU") if connection_error else "",
+            "invoice_data": json.dumps(registro_factura_list),
+            "response": res,
+            "verifactu_csv": "CSV" in res and res["CSV"] or _("-"),
+            "connection_error": connection_error,
+        }
+        if connection_error:
+            response = self._get_reusable_connection_error_response(connection_error)
+            if response:
+                response.write(
+                    {
+                        "header": response_vals["header"],
+                        "invoice_data": response_vals["invoice_data"],
+                        "date_response": fields.Datetime.now(),
+                    }
+                )
+                return True
+            response_vals["date_response"] = fields.Datetime.now()
+            response = response_model.create(response_vals)
+            response.complete_open_activity_on_exception()
+            self._create_connection_error_response_lines(response, connection_error)
             response.create_activity_on_exception()
+            return True
+        response = response_model.create(response_vals)
+        response.complete_open_activity_on_exception()
         create_response_activity = self._create_response_lines(
             response=response, header=header, verifactu_response=res
         )
-        updated_response_name = _("VERI*FACTU sending")
-        if create_exception:
-            updated_response_name = _("Connection error with VERI*FACTU")
-        elif create_response_activity:
-            updated_response_name = _("Incorrect invoices sent to VERI*FACTU")
-        response.name = updated_response_name
+        response.name = (
+            _("Incorrect invoices sent to VERI*FACTU")
+            if create_response_activity
+            else _("VERI*FACTU sending")
+        )
         if create_response_activity:
             response.create_send_response_activity()
         return True

--- a/l10n_es_verifactu_oca/models/verifactu_invoice_entry_response.py
+++ b/l10n_es_verifactu_oca/models/verifactu_invoice_entry_response.py
@@ -13,6 +13,10 @@ class VerifactuInvoiceEntryResponse(models.Model):
     name = fields.Char()
     invoice_data = fields.Text()
     response = fields.Text()
+    connection_error = fields.Text(
+        readonly=True,
+        help="Technical details of an exception raised while contacting VERI*FACTU.",
+    )
     verifactu_csv = fields.Text(string="VERI*FACTU CSV")
     date_response = fields.Datetime(readonly=True)
     activity_type_id = fields.Many2one(

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -14,6 +14,7 @@ from freezegun import freeze_time
 
 from odoo import Command
 from odoo.exceptions import UserError
+from odoo.tools import mute_logger
 from odoo.tools.misc import file_path
 
 from .common import TestVerifactuCommon
@@ -373,6 +374,38 @@ class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):
                 "Invoice send be marked as failed after VERI*FACTU processing.",
             )
 
+    @mute_logger("odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry")
+    def test_connection_error_is_visible_and_not_duplicated(self):
+        self._activate_certificate(self.certificate_password)
+        self.invoice.action_post()
+        entry = self.invoice.last_verifactu_invoice_entry_id
+        response_model = self.env["verifactu.invoice.entry.response"]
+        initial_response_count = response_model.search_count([])
+        with patch(
+            "odoo.addons.l10n_es_verifactu_oca.models."
+            "verifactu_invoice_entry.VerifactuInvoiceEntry._connect_verifactu",
+            side_effect=ConnectionError("Test connection failure"),
+        ):
+            entry._send_documents_to_verifactu()
+            first_response = entry.last_response_line_id.entry_response_id
+            entry._send_documents_to_verifactu()
+        self.assertEqual(response_model.search_count([]), initial_response_count + 1)
+        self.assertEqual(entry.send_attempt, 2)
+        self.assertEqual(len(first_response.response_line_ids), 1)
+        self.assertEqual(
+            first_response.connection_error,
+            "ConnectionError('Test connection failure')",
+        )
+        self.assertEqual(
+            entry.last_response_line_id.entry_response_id,
+            first_response,
+        )
+        self.assertTrue(self.invoice.aeat_send_failed)
+        self.assertEqual(
+            self.invoice.aeat_send_error,
+            "ConnectionError('Test connection failure')",
+        )
+
     def test_send_invoices_to_verifactu_duplicated(self):
         self._activate_certificate(self.certificate_password)
         self.invoice.action_post()
@@ -460,6 +493,7 @@ class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):
 
 
 class TestVerifactuSendResponse(TestVerifactuCommon):
+    @mute_logger("odoo.addons.l10n_es_verifactu_oca.models.verifactu_invoice_entry")
     def test_create_activity_on_exception(self):
         """
         Creates an activity whenever the connection with VERI*FACTU

--- a/l10n_es_verifactu_oca/views/verifactu_invoice_entry_response_view.xml
+++ b/l10n_es_verifactu_oca/views/verifactu_invoice_entry_response_view.xml
@@ -46,6 +46,11 @@
                         <page string="Details">
                             <group>
                                 <group name="verifactu1">
+                                    <field
+                                        name="connection_error"
+                                        readonly="1"
+                                        invisible="not connection_error"
+                                    />
                                     <field name="response" readonly="1" />
                                     <field name="header" readonly="1" />
                                     <field name="invoice_data" readonly="1" />
@@ -57,7 +62,7 @@
                                 </group>
                             </group>
                         </page>
-                        <page string="Details">
+                        <page string="Response lines">
                             <field name="response_line_ids" readonly="1">
                                     <tree>
                                         <field name="entry_id" column_invisible="1" />


### PR DESCRIPTION
## Problem

Connection failures currently lose the original exception details and create a new generic response and activity on every cron retry. This makes troubleshooting difficult and can continuously grow the response history for an unchanged failure.

Closes #4810.
Closes #4952.

## Solution

- Store the exception representation in a dedicated `connection_error` field and show it on the response form.
- Log the exception with its traceback and affected document names.
- Create one response line per affected entry so invoices remain traceable from the connection failure.
- Mark affected invoices as failed and expose the actual error through `aeat_send_error`.
- Reuse the latest response when the same exception recurs for exactly the same entry batch, updating its timestamp and payload instead of creating duplicate responses, lines, or activities.
- Keep the existing automatic retry behavior and attempt counter unchanged.
- Rename the duplicated second “Details” tab to “Response lines”.

## Impact

Repeated retries for an unchanged connection error keep a single response and activity, while operators can see the original technical cause and the exact affected invoices. A different error or a different entry batch still creates a separate response.

## Validation

- Standalone clean database: 27 tests, 0 failures, 0 errors.
- Combined with the concurrent-posting fix from #5158: 30 tests, 0 failures, 0 errors.
- Functional two-entry batch test over three identical failures:
  - one response throughout all retries;
  - two response lines linked to the affected entries;
  - one exception activity;
  - original exception visible;
  - transaction rolled back and test data restored.


## AI assistance

Assisted-by: OpenAI Codex