### PR TITLE
[16.0][FIX] l10n_es_verifactu_oca: no declarar tracking en el mixin

### DIFF
--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -18,6 +18,8 @@ class AccountMove(models.Model):
     _name = "account.move"
     _inherit = ["account.move", "verifactu.mixin"]
 
+    verifactu_hash_string = fields.Char(tracking=True)
+    verifactu_hash = fields.Char(tracking=True)
     verifactu_refund_specific_type = fields.Selection(
         string="VERI*FACTU refund specific type",
         selection=[

--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -40,10 +40,8 @@ class VerifactuMixin(models.AbstractModel):
         compute="_compute_verifactu_enabled",
         search="_search_verifactu_enabled",
     )
-    verifactu_hash_string = fields.Char(
-        string="VERI*FACTU hash string", copy=False, tracking=True
-    )
-    verifactu_hash = fields.Char(string="VERI*FACTU hash", copy=False, tracking=True)
+    verifactu_hash_string = fields.Char(string="VERI*FACTU hash string", copy=False)
+    verifactu_hash = fields.Char(string="VERI*FACTU hash", copy=False)
     verifactu_refund_type = fields.Selection(
         string="VERI*FACTU refund type",
         selection=[

--- a/l10n_es_verifactu_oca/tests/test_verifactu_invoice.py
+++ b/l10n_es_verifactu_oca/tests/test_verifactu_invoice.py
@@ -380,3 +380,45 @@ class TestVerifactuInvoice(TestVerifactuCommon):
             self.company,
             "Should be able to create chain entry with company context",
         )
+
+    def test_hash_fields_are_tracked_on_the_invoice(self):
+        """A change of the chain fingerprint is recorded in the invoice chatter."""
+        invoice = self._create_and_prepare_invoice()
+        # A record created in the same transaction has its tracking discarded
+        # until the pending callbacks run, so they are run before writing.
+        invoice.flush_recordset()
+        self.env.cr.precommit.run()
+        invoice.write(
+            {
+                "verifactu_hash": "0" * 64,
+                "verifactu_hash_string": "IDEmisorFactura=A12345674&NumSerie=TEST",
+            }
+        )
+        # Tracking values are written by a precommit callback too.
+        invoice.flush_recordset()
+        self.env.cr.precommit.run()
+        tracked = invoice.message_ids.tracking_value_ids.mapped("field.name")
+        self.assertIn(
+            "verifactu_hash",
+            tracked,
+            "Changing the hash should leave a tracking value on the invoice",
+        )
+        self.assertIn(
+            "verifactu_hash_string",
+            tracked,
+            "Changing the hash string should leave a tracking value on the invoice",
+        )
+
+    def test_hash_fields_are_not_tracked_on_the_mixin(self):
+        """The mixin leaves tracking to the consumers that have a chatter.
+
+        Declaring it on the mixin reaches consumers that do not inherit
+        `mail.thread`, where the parameter does nothing and only logs a warning
+        on every registry load.
+        """
+        mixin_fields = self.env["verifactu.mixin"]._fields
+        for field_name in ("verifactu_hash", "verifactu_hash_string"):
+            self.assertFalse(
+                getattr(mixin_fields[field_name], "tracking", False),
+                f"{field_name} must not declare tracking on the mixin",
+            )


### PR DESCRIPTION
Los dos campos de huella se declaran con tracking=True en el mixin, que también usa pos.order en l10n_es_verifactu_pos_oca, un modelo que no hereda mail.thread. Ahí el parámetro no hace nada  y Odoo deja un aviso en el log por cada campo en cada carga del registro. 
Pasa por tanto a declararse en account.move, que sí tiene chatter.
