### PR TITLE
[18.0][IMP] l10n_es_verifactu_oca: canje de facturas simplificadas por factura completa (F3)

### DIFF
--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import pytz
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 VERIFACTU_VALID_INVOICE_STATES = ["posted"]
 VERIFACTU_OPERATION_MAPPING = {
@@ -40,6 +40,57 @@ class AccountMove(models.Model):
         " of article 80 of LIVA for notifying to VERI*FACTU with the proper"
         " invoice type.",
     )
+    verifactu_substituted_invoice_ids = fields.Many2many(
+        string="VERI*FACTU substituted simplified invoices",
+        comodel_name="account.move",
+        relation="account_move_verifactu_substituted_rel",
+        column1="move_id",
+        column2="substituted_move_id",
+        copy=False,
+        domain="[('move_type', '=', 'out_invoice'), ('state', '=', 'posted')]",
+        help="Simplified invoices that this invoice substitutes. Filling it "
+        "makes the invoice be registered at VERI*FACTU as F3, quoting them in "
+        "the FacturasSustituidas block. The substituted invoices are left as "
+        "they are: a substitution is not a rectification, so they must be "
+        "neither cancelled nor rectified, and their amounts are not declared "
+        "again.",
+    )
+
+    @api.constrains("verifactu_substituted_invoice_ids")
+    def _check_verifactu_substituted_invoice_ids(self):
+        """A simplified invoice can only be exchanged for one ordinary invoice.
+
+        Substituting it twice would declare the same operation as two different
+        F3, which is precisely what the substitution mechanism avoids.
+        """
+        for move in self.filtered("verifactu_substituted_invoice_ids"):
+            substituted = move.verifactu_substituted_invoice_ids
+            if move in substituted:
+                raise ValidationError(
+                    _("An invoice cannot substitute itself: %s", move.display_name)
+                )
+            duplicated = self.search(
+                [
+                    ("id", "!=", move.id),
+                    ("state", "!=", "cancel"),
+                    ("verifactu_substituted_invoice_ids", "in", substituted.ids),
+                ],
+                limit=1,
+            )
+            if duplicated:
+                raise ValidationError(
+                    _(
+                        "Some of the simplified invoices substituted by %(move)s "
+                        "are already substituted by %(duplicated)s. A simplified "
+                        "invoice can only be exchanged for one ordinary invoice.",
+                        move=move.display_name,
+                        duplicated=duplicated.display_name,
+                    )
+                )
+
+    def _get_verifactu_substituted_documents(self):
+        documents = super()._get_verifactu_substituted_documents()
+        return documents + list(self.verifactu_substituted_invoice_ids)
 
     @api.depends("move_type")
     def _compute_verifactu_refund_type(self):
@@ -116,6 +167,11 @@ class AccountMove(models.Model):
                     invoice_type = self.verifactu_refund_specific_type
                 else:
                     invoice_type = "R5" if is_simplified else "R1"
+            elif self._get_verifactu_substituted_documents():
+                # Ordinary invoice issued in substitution of simplified
+                # invoices already registered and declared. It is not a
+                # rectification: the substituted ones stay as they are.
+                invoice_type = "F3"
         return invoice_type
 
     def _get_verifactu_description(self):
@@ -261,6 +317,13 @@ class AccountMove(models.Model):
                 #         origin.amount_total_signed - origin.amount_untaxed_signed
                 #     ),
                 # }
+        if verifactu_doc_type == "F3":
+            inv_dict["FacturasSustituidas"] = {
+                "IDFacturaSustituida": [
+                    substituted["IDFacturaSustituida"]
+                    for substituted in self._get_verifactu_substituted_invoices_dict()
+                ]
+            }
         inv_dict["DescripcionOperacion"] = self._get_verifactu_description()
         if verifactu_doc_type not in ("F2", "R5"):
             inv_dict["Destinatarios"] = self._get_verifactu_receiver_dict()
@@ -491,7 +554,45 @@ class AccountMove(models.Model):
             suffixes.append(_("- There are some inconsistent taxes on lines."))
         if not self._check_all_taxes_mapped():
             suffixes.append(_("- It does not have all taxes mapped."))
+        suffixes += self._check_verifactu_substituted_documents()
         return super()._check_verifactu_configuration(suffixes=suffixes)
+
+    def _check_verifactu_substituted_documents(self):
+        """Checks that only apply to an invoice substituting simplified ones (F3)."""
+        suffixes = []
+        if self._get_verifactu_document_type() != "F3":
+            return suffixes
+        # An F3 always carries the destinatario, and a counter customer is
+        # often created without a VAT number or without a country.
+        partner = self._aeat_get_partner()
+        if not partner or not partner._is_valid_verifactu_receiver():
+            suffixes.append(
+                _(
+                    "- It substitutes simplified invoices, so it is registered "
+                    "as F3, which must always identify the customer. Set the "
+                    "customer's VAT number, and also their country when that "
+                    "number is not Spanish."
+                )
+            )
+        for document in self._get_verifactu_substituted_documents():
+            if not document.last_verifactu_invoice_entry_id:
+                suffixes.append(
+                    _(
+                        "- It substitutes %s, which was never registered at "
+                        "VERI*FACTU. Only an already registered and declared "
+                        "simplified invoice can be substituted.",
+                        document.display_name,
+                    )
+                )
+            elif document._get_verifactu_document_type() not in ("F2", "R5"):
+                suffixes.append(
+                    _(
+                        "- It substitutes %s, which is not a simplified "
+                        "invoice. Only simplified invoices can be substituted.",
+                        document.display_name,
+                    )
+                )
+        return suffixes
 
     def _check_inconsistent_taxes(self):
         document_date = self._get_document_date()
@@ -557,6 +658,10 @@ class AccountMove(models.Model):
                     self._raise_exception_verifactu(_("third-party number"))
                 elif "name" in vals:
                     self._raise_exception_verifactu(_("invoice number"))
+                elif "verifactu_substituted_invoice_ids" in vals:
+                    self._raise_exception_verifactu(
+                        _("substituted simplified invoices")
+                    )
         return super().write(vals)
 
     def button_cancel(self):

--- a/l10n_es_verifactu_oca/models/res_partner.py
+++ b/l10n_es_verifactu_oca/models/res_partner.py
@@ -24,3 +24,16 @@ class ResPartner(models.Model):
             if partner.verifactu_enabled:
                 partner.aeat_sending_enabled = True
         return res
+
+    def _is_valid_verifactu_receiver(self):
+        """Whether this partner can be the destinatario of a registro de alta.
+
+        Document types that must identify the customer (F1, F3, R1-R4) need
+        either a Spanish NIF or a foreign identifier stating its country: an
+        ``IDOtro`` without ``CodigoPais`` declares a document of nowhere.
+        """
+        self.ensure_one()
+        if not self.vat:
+            return False
+        country_code, _identifier_type, identifier = self._parse_aeat_vat_info()
+        return bool(identifier and (country_code == "ES" or self.country_id.code))

--- a/l10n_es_verifactu_oca/models/verifactu_mixin.py
+++ b/l10n_es_verifactu_oca/models/verifactu_mixin.py
@@ -375,6 +375,46 @@ class VerifactuMixin(models.AbstractModel):
     def _get_verifactu_document_type(self):
         raise NotImplementedError()
 
+    def _get_verifactu_substituted_documents(self):
+        """Documents that this one substitutes ("canje" of art. 15.6 §2 ROF).
+
+        A document substituting others is registered as F3: an ordinary invoice
+        issued in substitution of simplified invoices that were already
+        registered and declared. The substituted documents are neither
+        cancelled nor rectified, and their amounts are not taken into account
+        again, per the AEAT "Aclaraciones a dudas de los desarrolladores" v1.3,
+        section 27.
+
+        :return: list of documents implementing this mixin. They may belong to
+            different models (a POS ticket and an invoice are both possible
+            simplified invoices), so this is a list and not a single recordset.
+        """
+        return []
+
+    def _get_verifactu_substituted_invoices_dict(self):
+        """Build the ``FacturasSustituidas`` block of the alta record."""
+        return [
+            {
+                "IDFacturaSustituida": {
+                    "IDEmisorFactura": document._get_verifactu_issuer(),
+                    "NumSerieFactura": document._get_document_serial_number(),
+                    "FechaExpedicionFactura": document._get_verifactu_date(
+                        document._get_document_date()
+                    ),
+                }
+            }
+            for document in self._get_verifactu_substituted_documents()
+        ]
+
+    def get_verifactu_document(self, invoice_num, ids):
+        """
+        Models that inherit this mixin must implement this method to return
+        the document based on the invoice number
+        Used in verifactu.invoice.entry model to find the document
+        for the response lines.
+        """
+        raise NotImplementedError()
+
     def _get_verifactu_description(self):
         raise NotImplementedError()
 

--- a/l10n_es_verifactu_oca/readme/USAGE.md
+++ b/l10n_es_verifactu_oca/readme/USAGE.md
@@ -1,3 +1,20 @@
 Cuando se valida una factura, automáticamente genera el registro de
 envío para verifactu. Cada minuto se enviarán todos aquellos registros
 pendientes de enviar mediante un cron.
+
+## Canje de facturas simplificadas (F3)
+
+Para emitir una factura completa en sustitución de facturas
+simplificadas ya registradas y declaradas, indíquelas en el campo
+**Facturas simplificadas sustituidas** de la pestaña VERI\*FACTU antes de
+validar. La factura se registrará como **F3** citándolas en el bloque
+`FacturasSustituidas`.
+
+Las simplificadas sustituidas no se anulan ni se rectifican, y su
+importe no vuelve a declararse: el canje no es una rectificación (AEAT,
+*Aclaraciones a dudas de los desarrolladores* v1.3, apartado 27). Tenga
+en cuenta además que la F3 tampoco se vuelve a cobrar, ya que los tiques
+sustituidos ya se cobraron en su momento.
+
+Como toda F3 debe identificar al destinatario, no se puede validar sin
+un cliente con NIF, y una simplificada sólo puede canjearse una vez.

--- a/l10n_es_verifactu_oca/tests/__init__.py
+++ b/l10n_es_verifactu_oca/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_10n_es_verifactu
 from . import test_verifactu_invoice
+from . import test_verifactu_substitution

--- a/l10n_es_verifactu_oca/tests/test_verifactu_substitution.py
+++ b/l10n_es_verifactu_oca/tests/test_verifactu_substitution.py
@@ -1,0 +1,201 @@
+# Copyright 2026 MDSX - Manuel Diez Silva
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import Command
+from odoo.exceptions import UserError, ValidationError
+
+from .common import TestVerifactuCommon
+
+
+class TestVerifactuSubstitution(TestVerifactuCommon):
+    """Invoices issued in substitution of simplified ones (canje, F3).
+
+    Reference: AEAT, "Aclaraciones a dudas de los desarrolladores" v1.3
+    (4-dic-2025), section 27, and art. 15.6 §2 of RD 1619/2012.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.tax_21 = cls.env.ref(
+            f"account.{cls.company.id}_account_tax_template_s_iva21b"
+        )
+        cls.simplified_partner = cls.env["res.partner"].create(
+            {
+                "name": "Cliente de mostrador",
+                "aeat_simplified_invoice": True,
+                "country_id": cls.env.ref("base.es").id,
+            }
+        )
+
+    def _create_invoice(self, partner=None, amount=100, date="2026-01-01"):
+        return self.env["account.move"].create(
+            {
+                "company_id": self.company.id,
+                "partner_id": (partner or self.partner).id,
+                "invoice_date": date,
+                "move_type": "out_invoice",
+                "fiscal_position_id": self.fp_nacional.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "account_id": self.account_expense.id,
+                            "name": "Test line",
+                            "price_unit": amount,
+                            "quantity": 1,
+                            "tax_ids": [Command.set(self.tax_21.ids)],
+                        },
+                    )
+                ],
+            }
+        )
+
+    def _create_simplified_invoice(self, **kwargs):
+        """A posted F2, already registered in the chain."""
+        invoice = self._create_invoice(partner=self.simplified_partner, **kwargs)
+        invoice.action_post()
+        return invoice
+
+    def test_no_substitution_is_a_regular_invoice(self):
+        invoice = self._create_invoice()
+        self.assertEqual(invoice._get_verifactu_document_type(), "F1")
+        self.assertEqual(invoice._get_verifactu_substituted_documents(), [])
+
+    def test_substitution_document_type(self):
+        simplified = self._create_simplified_invoice()
+        self.assertEqual(simplified._get_verifactu_document_type(), "F2")
+        canje = self._create_invoice()
+        canje.verifactu_substituted_invoice_ids = simplified
+        self.assertEqual(canje._get_verifactu_document_type(), "F3")
+
+    def test_substitution_payload(self):
+        simplified = self._create_simplified_invoice()
+        canje = self._create_invoice()
+        canje.verifactu_substituted_invoice_ids = simplified
+        canje.action_post()
+        alta = canje._get_verifactu_invoice_dict()["RegistroAlta"]
+        self.assertEqual(alta["TipoFactura"], "F3")
+        issuer = self.company.partner_id._parse_aeat_vat_info()[2]
+        self.assertEqual(
+            alta["FacturasSustituidas"],
+            {
+                "IDFacturaSustituida": [
+                    {
+                        "IDEmisorFactura": issuer,
+                        "NumSerieFactura": simplified.name,
+                        "FechaExpedicionFactura": "01-01-2026",
+                    }
+                ]
+            },
+        )
+        # An F3 always carries the destinatario and never claims art. 6.1.d
+        self.assertIn("Destinatarios", alta)
+        self.assertNotIn("FacturaSinIdentifDestinatarioArt61d", alta)
+        # Substituting is not rectifying
+        self.assertNotIn("TipoRectificativa", alta)
+        self.assertNotIn("FacturasRectificadas", alta)
+
+    def test_substitution_payload_several_simplified_invoices(self):
+        """One F3 may replace many simplified invoices."""
+        first = self._create_simplified_invoice(date="2026-01-01")
+        second = self._create_simplified_invoice(date="2026-01-02")
+        canje = self._create_invoice(date="2026-01-03")
+        canje.verifactu_substituted_invoice_ids = first + second
+        canje.action_post()
+        alta = canje._get_verifactu_invoice_dict()["RegistroAlta"]
+        substituted = alta["FacturasSustituidas"]["IDFacturaSustituida"]
+        self.assertEqual(
+            [x["NumSerieFactura"] for x in substituted], [first.name, second.name]
+        )
+        self.assertEqual(
+            [x["FechaExpedicionFactura"] for x in substituted],
+            ["01-01-2026", "02-01-2026"],
+        )
+
+    def test_substitution_hash_literal(self):
+        """The hash covers TipoFactura, but not the substituted invoices."""
+        simplified = self._create_simplified_invoice()
+        canje = self._create_invoice()
+        canje.verifactu_substituted_invoice_ids = simplified
+        canje.action_post()
+        self.assertIn("TipoFactura=F3&", canje.verifactu_hash_string)
+        self.assertNotIn("Sustitu", canje.verifactu_hash_string)
+
+    def test_substituted_invoice_is_left_alone(self):
+        """The substituted invoice is neither cancelled nor rectified."""
+        simplified = self._create_simplified_invoice()
+        entry = simplified.last_verifactu_invoice_entry_id
+        canje = self._create_invoice()
+        canje.verifactu_substituted_invoice_ids = simplified
+        canje.action_post()
+        self.assertEqual(simplified.state, "posted")
+        self.assertEqual(simplified.last_verifactu_invoice_entry_id, entry)
+        self.assertEqual(entry.entry_type, "register")
+
+    def test_substitution_requires_customer_vat(self):
+        """An F3 without destinatario is not valid."""
+        simplified = self._create_simplified_invoice()
+        canje = self._create_invoice(partner=self.simplified_partner)
+        canje.verifactu_substituted_invoice_ids = simplified
+        with self.assertRaisesRegex(UserError, "identify the customer"):
+            canje.action_post()
+
+    def test_substitution_requires_an_identifiable_customer(self):
+        """A VAT number alone is not enough if it cannot be placed in a country.
+
+        Without a country the receiver goes out as an IDOtro with no
+        CodigoPais, which declares a foreign document of nowhere for what is
+        actually a Spanish NIF.
+        """
+        countryless = self.env["res.partner"].create(
+            {"name": "Cliente sin país", "vat": "89890001K"}
+        )
+        self.assertFalse(countryless._is_valid_verifactu_receiver())
+        simplified = self._create_simplified_invoice()
+        canje = self._create_invoice(partner=countryless)
+        canje.verifactu_substituted_invoice_ids = simplified
+        # The savepoint undoes the posting the same way the failed transaction
+        # does in real use, leaving the invoice in draft to be corrected.
+        with self.assertRaisesRegex(UserError, "identify the customer"):
+            with self.env.cr.savepoint():
+                canje.action_post()
+        self.assertEqual(canje.state, "draft")
+        countryless.country_id = self.env.ref("base.es")
+        self.assertTrue(countryless._is_valid_verifactu_receiver())
+        canje.action_post()
+        alta = canje._get_verifactu_invoice_dict()["RegistroAlta"]
+        self.assertEqual(alta["Destinatarios"]["IDDestinatario"]["NIF"], "89890001K")
+
+    def test_substituted_invoice_must_be_registered(self):
+        """Only an already declared simplified invoice can be substituted."""
+        never_sent = self._create_invoice(partner=self.simplified_partner)
+        canje = self._create_invoice()
+        canje.verifactu_substituted_invoice_ids = never_sent
+        with self.assertRaisesRegex(UserError, "never registered at VERI"):
+            canje.action_post()
+
+    def test_substituted_invoice_must_be_simplified(self):
+        ordinary = self._create_invoice()
+        ordinary.action_post()
+        canje = self._create_invoice()
+        canje.verifactu_substituted_invoice_ids = ordinary
+        with self.assertRaisesRegex(UserError, "not a simplified"):
+            canje.action_post()
+
+    def test_substitution_only_once(self):
+        """A simplified invoice can only be exchanged for one ordinary invoice."""
+        simplified = self._create_simplified_invoice()
+        first = self._create_invoice()
+        first.verifactu_substituted_invoice_ids = simplified
+        first.action_post()
+        second = self._create_invoice()
+        with self.assertRaises(ValidationError):
+            second.verifactu_substituted_invoice_ids = simplified
+            second.flush_recordset()
+
+    def test_invoice_cannot_substitute_itself(self):
+        invoice = self._create_invoice()
+        with self.assertRaises(ValidationError):
+            invoice.verifactu_substituted_invoice_ids = invoice
+            invoice.flush_recordset()

--- a/l10n_es_verifactu_oca/views/account_move_view.xml
+++ b/l10n_es_verifactu_oca/views/account_move_view.xml
@@ -59,6 +59,13 @@
                                 required="verifactu_enabled"
                                 readonly="aeat_state in ('sent', 'cancel')"
                             />
+                            <field
+                                name="verifactu_substituted_invoice_ids"
+                                string="Substituted simplified invoices"
+                                widget="many2many_tags"
+                                invisible="not verifactu_enabled or move_type != 'out_invoice'"
+                                readonly="aeat_state != 'not_sent'"
+                            />
                             <field name="verifactu_description" string="Description" />
                             <field
                                 name="verifactu_cancel_reason"


### PR DESCRIPTION
## El problema

Cuando se expide una **factura completa en sustitución de facturas simplificadas** ya registradas y declaradas (el «canje» del tique por factura), el registro de alta debe llevar `TipoFactura = F3` e identificar las simplificadas sustituidas en el bloque `FacturasSustituidas`.

El módulo sólo contemplaba F1/F2/R1–R5, así que un canje salía como una **segunda F1 por el importe íntegro**, declarando dos veces la misma operación a la AEAT.

Referencias: AEAT, *Aclaraciones a dudas de los desarrolladores* **v1.3 (4-dic-2025), apartado 27 «Facturas expedidas en sustitución de facturas simplificadas»**; art. 15.6 §2 del ROF (RD 1619/2012); DGT V2543-06.

## La solución

- Nuevo campo `verifactu_substituted_invoice_ids` en `account.move` para indicar las simplificadas sustituidas.
- `_get_verifactu_document_type()` devuelve **F3** cuando está informado.
- `_get_verifactu_invoice_dict_out()` construye el bloque `FacturasSustituidas`.
- Método extensible `_get_verifactu_substituted_documents()` en el mixin: devuelve una **lista** y no un recordset, porque las simplificadas sustituidas pueden pertenecer a modelos distintos (un tique de TPV y una factura son ambos posibles). Así `l10n_es_verifactu_pos_oca` puede añadir las suyas.

Las sustituidas **se dejan como están**: el canje no es una rectificación, así que ni se anulan ni se rectifican, y sus importes no se vuelven a declarar (apartado 27: *«NO hay que anular la/s factura/s simplificada/s expedida/s a la/s que "canjea" esta nueva factura de canje de tipo F3»*).

**La huella no cambia**: `TipoFactura` ya forma parte del literal y `FacturasSustituidas` no.

## Validaciones

Como toda F3 debe identificar al destinatario, no se registra si:

- el cliente no resuelve a un NIF español ni a un identificador extranjero **con país**. Un `IDOtro` sin `CodigoPais` declara un documento de ninguna parte, y es un caso muy fácil de provocar con clientes de mostrador creados sin país;
- la sustituida no llegó a registrarse en VERI\*FACTU, o no es una simplificada;
- la simplificada ya fue canjeada: sólo puede cambiarse por una factura ordinaria.

## Pruebas

12 tests nuevos en `test_verifactu_substitution.py`. El payload se ha contrastado además contra el XSD `SuministroInformacion.xsd` al que apunta el WSDL (`FacturasSustituidas` → `IDFacturaSustituida`, `IDFacturaARType`, `maxOccurs="1000"`), y serializado con zeep para comprobar que salen todas las sustituidas cuando hay más de una.

Probado contra el entorno de pruebas de la AEAT, que aceptó con CSV una F2 y la F3 que la cita.

## Notas

- Independiente de #5142 (mismo módulo, ficheros distintos; sólo coincide la línea de versión del manifiesto).
- El lado del TPV va aparte, ya que `l10n_es_verifactu_pos_oca` aún no está en 18.0: depende de #4583.

## Uso de IA

Este trabajo se ha desarrollado con asistencia de IA, declarada en el commit con `Assisted-by: Claude Opus 5` conforme a la [política de IA de la OCA](https://github.com/OCA/.github/blob/master/AI_POLICY.md).