### PR TITLE
[18.0][FIX] l10n_es_aeat: don't use identifier type 02 for a non-VAT-shaped vat

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -102,7 +102,9 @@ class ResPartner(models.Model):
             # Return mapped vats like Greece. Take into account mapped countries
             country_code = aeat_country_code
             vat_number = vat_number[2:]
-            identifier_type = "02"
+            identifier_type = (
+                "02" if self.simple_vat_check(country_code, vat_number) else "04"
+            )
         else:
             if self.country_id.code:
                 country_code = self.country_id.code
@@ -114,7 +116,13 @@ class ResPartner(models.Model):
                 self._map_aeat_country_code(country_code)
                 in self._get_aeat_europe_codes()
             ):
-                identifier_type = "02"
+                # An EU country alone doesn't mean `vat_number` is really a
+                # valid intra-community VAT (e.g. an Italian "codice
+                # fiscale" for an individual isn't a "partita IVA" and the
+                # SII rejects it under IDType 02 with error 1104).
+                identifier_type = (
+                    "02" if self.simple_vat_check(country_code, vat_number) else "04"
+                )
             else:
                 country_code = self._map_aeat_country_code(country_code, extended=True)
                 identifier_type = "04"

--- a/l10n_es_aeat/tests/test_l10n_es_aeat.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat.py
@@ -70,6 +70,28 @@ class TestL10nEsAeat(BaseCommon):
         self.assertEqual(identifier_type, "02")
         self.assertEqual(vat_number, "61954506077")
 
+    def test_parse_vat_info_it_valid_vat(self):
+        self.partner.write(
+            {"vat": "12345670017", "country_id": self.env.ref("base.it").id}
+        )
+        country_code, identifier_type, vat_number = self.partner._parse_aeat_vat_info()
+        self.assertEqual(country_code, "IT")
+        self.assertEqual(identifier_type, "02")
+        self.assertEqual(vat_number, "12345670017")
+
+    def test_parse_vat_info_it_codice_fiscale(self):
+        """A personal "codice fiscale" is not a "partita IVA": sending it to
+        the SII as identifier type 02 (NIF-IVA) gets rejected with error
+        1104 "Valor del campo ID incorrecto".
+        """
+        self.partner.write(
+            {"vat": "MRTMTT91D08F205J", "country_id": self.env.ref("base.it").id}
+        )
+        country_code, identifier_type, vat_number = self.partner._parse_aeat_vat_info()
+        self.assertEqual(country_code, "IT")
+        self.assertEqual(identifier_type, "04")
+        self.assertEqual(vat_number, "MRTMTT91D08F205J")
+
     def test_parse_vat_info_gf_wo_prefix(self):
         self.partner.write(
             {"vat": "61954506077", "country_id": self.env.ref("base.gf").id}


### PR DESCRIPTION
`_parse_aeat_vat_info()` calculaba el tipo de identificador SII/AEAT únicamente a partir de la geografía del contacto: si el país estaba en la UE (o el prefijo de 2 letras del `vat` coincidía con un país UE), asignaba directamente el tipo 02 (NIF-IVA), sin comprobar en ningún momento que el contenido de `vat` tuviera realmente forma de NIF-IVA válido para ese país.

Esto provoca que una persona física italiana que tenga guardado su *codice fiscale* (identificador personal de 16 caracteres alfanuméricos) en el campo `vat` — que Odoo permite grabar, ya que `base_vat` no distingue formato de *codice fiscale* frente a *partita IVA* para Italia — reciba el tipo 02 igualmente. Al enviar una factura de ese contacto al SII, la Contraparte se construye con `IDType=02` y el *codice fiscale* como identificador, y la AEAT la rechaza con:

    'CodigoErrorRegistro': 1104,
    'DescripcionErrorRegistro': 'Valor del campo ID incorrecto'

porque un *codice fiscale* no es un NIF-IVA registrado en VIES.

El fix reutiliza el propio validador offline de formato/checksum de `base_vat` (`simple_vat_check`, sin llamada a VIES) antes de dar por bueno el tipo 02: si el `vat` no valida como NIF-IVA real para ese país, se usa el tipo 04 (documento oficial de identificación del país de residencia) en su lugar — el mismo código que este módulo ya usa para identificadores extranjeros que no son un VAT.

@Tecnativa 

ping @carlosdauden @carlos-lopez-tecnativa @juancarlosonate-tecnativa 