### PR TITLE
[18.0][FIX] l10n_es_aeat_sii_oca: don't force identifier type 02 under Régimen Intracomunitario

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -707,7 +707,17 @@ class SiiMixin(models.AbstractModel):
                     },
                 }
         elif gen_type == 2:
-            return {"IDOtro": {"IDType": "02", "ID": full_eu_vat}}
+            if identifier_type == "02":
+                return {"IDOtro": {"IDType": "02", "ID": full_eu_vat}}
+            if identifier_type:
+                return {
+                    "IDOtro": {
+                        "CodigoPais": country_code,
+                        "IDType": identifier_type,
+                        "ID": identifier,
+                    },
+                }
+            return {"NIF": identifier}
         elif gen_type == 3 and identifier_type:
             # Si usamos identificador tipo 02 en exportaciones, el envío falla con:
             #   {'CodigoErrorRegistro': 1104,

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -266,6 +266,63 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
             },
         )
 
+    def test_intracomunitary_customer_valid_vat(self):
+        """Caso normal: un cliente UE con un NIF-IVA real bajo Régimen
+        Intracomunitario debe seguir identificándose con IDType 02.
+        """
+        self._activate_certificate(self.certificate_password)
+        eu_customer = self.env["res.partner"].create(
+            {
+                "name": "French Customer",
+                "country_id": self.ref("base.fr"),
+                "vat": "FR23334175221",
+            }
+        )
+        invoice = self.invoice.copy(
+            {"partner_id": eu_customer.id, "fiscal_position_id": self.fp_intra.id}
+        )
+        invoice.action_post()
+        sii_info = invoice._get_aeat_invoice_dict()
+        self.assertEqual(
+            sii_info["FacturaExpedida"]["Contraparte"],
+            {
+                "NombreRazon": "French Customer",
+                "IDOtro": {"IDType": "02", "ID": "FR23334175221"},
+            },
+        )
+
+    def test_intracomunitary_customer_without_valid_vat(self):
+        """Un cliente bajo Régimen Intracomunitario cuya identificación (por
+        override manual de aeat_identification_type/aeat_identification) no
+        es un NIF-IVA real no debe forzarse a IDType 02, o el SII rechaza la
+        factura con el error 1104 "Valor del campo ID incorrecto".
+        """
+        self._activate_certificate(self.certificate_password)
+        eu_customer = self.env["res.partner"].create(
+            {
+                "name": "Italian Individual Customer",
+                "country_id": self.ref("base.it"),
+                "aeat_identification_type": "06",
+                "aeat_identification": "FAKECODICEFISCALE",
+            }
+        )
+        invoice = self.invoice.copy(
+            {"partner_id": eu_customer.id, "fiscal_position_id": self.fp_intra.id}
+        )
+        invoice.action_post()
+        sii_info = invoice._get_aeat_invoice_dict()
+        self.assertEqual(
+            sii_info["FacturaExpedida"]["Contraparte"],
+            {
+                "NombreRazon": "Italian Individual Customer",
+                "IDOtro": {
+                    "CodigoPais": "IT",
+                    "IDType": "06",
+                    "ID": "FAKECODICEFISCALE",
+                },
+            },
+        )
+
     def test_partner_sii_enabled(self):
         company_02 = self.env["res.company"].create({"name": "Company 02"})
         self.env.user.company_ids += company_02


### PR DESCRIPTION
En `_get_sii_identifier()`, la rama de régimen intracomunitario (`gen_type == 2`) construía siempre la Contraparte como `{"IDOtro": {"IDType": "02", "ID": ...}}`, sin mirar en ningún momento el `identifier_type` que devuelve `_parse_aeat_vat_info()` — a diferencia de las otras dos ramas de esta misma función (`gen_type == 1` y `gen_type == 3`), que sí lo respetan.

Esto tiene dos consecuencias:

1. Ignora por completo el override manual `aeat_identification_type`/`aeat_identification` del contacto (pensado precisamente para "el cliente no se identifica con un VAT extranjero sino con su pasaporte/certificado de residencia/otro documento"): aunque el usuario marque explícitamente que ese cliente no tiene NIF-IVA, bajo Régimen Intracomunitario se le sigue enviando como tipo 02.
2. Si el `vat` del contacto no es realmente un NIF-IVA válido para su país (p. ej. el caso ya corregido en `l10n_es_aeat` de un *codice fiscale* italiano, ver PR OCA/l10n-spain#5164), el SII rechaza la factura con:

       'CodigoErrorRegistro': 1104,
       'DescripcionErrorRegistro': 'Valor del campo ID incorrecto'

exactamente igual que en el caso ya corregido, pero por esta otra vía (que no depende de que #5164 esté mergeado).

El fix hace que esta rama respete `identifier_type` igual que las otras dos: si es `02` mantiene el comportamiento actual; si es otro tipo (03/04/05/06, típicamente por el override manual), construye el `IDOtro` con `CodigoPais`+`IDType`+`ID` como en el resto de la función; si viene vacío (caso doméstico, `NIF`) devuelve `{"NIF": identifier}`.

Depends on:
- [x] https://github.com/OCA/l10n-spain/pull/5036

@Tecnativa

ping @carlosdauden @carlos-lopez-tecnativa @juancarlosonate-tecnativa 