### PR TITLE
[18.0][IMP] l10n_es_pos_oca: Improve the ReceiptHeader data that is displayed

### DIFF
--- a/l10n_es_pos_oca/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/l10n_es_pos_oca/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -7,20 +7,29 @@
     >
         <xpath expr="//div[@t-if='props.data.company.name']" position="before">
             <t t-if="props.data.is_simplified_config and !props.data.to_invoice">
-                <div>Simplified invoice</div>
-                <div
+                <div name="simplified_invoice-number">
+                    Simplified invoice:&#160;
+                    <span
                     class="simplified-invoice-number"
                     t-esc="props.data.l10n_es_unique_id"
                 />
+                </div>
             </t>
         </xpath>
+        <xpath
+            expr="//div[@t-if='props.data.company.name' and @t-esc='props.data.company.name']"
+            position="attributes"
+        >
+            <!-- Hide the name because contact_address already contains the name !-->
+            <attribute name="class">d-none</attribute>
+        </xpath>
         <xpath expr="//div[@t-if='props.data.company.name']" position="after">
-            <div t-if="props.data.company.street" t-esc="props.data.company.street" />
-            <div t-if="props.data.company.zip" t-esc="props.data.company.zip" />
-            <div t-if="props.data.company.city" t-esc="props.data.company.city" />
-            <div t-if="props.data.company.state_id">(<t
-                t-esc="props.data.company.state_id.name"
-            />)</div>
+            <div
+                t-if="props.data.company.partner_id"
+                class="company_contact_address"
+                style="white-space: pre-line"
+                t-esc="props.data.company.partner_id.contact_address"
+            />
         </xpath>
         <xpath expr="//div[hasclass('pos-receipt-contact')]" position="inside">
             <t t-set="partner" t-value="props.data.partner" />


### PR DESCRIPTION
Improve the ReceiptHeader data that is displayed

**Before**
<img width="632" height="533" alt="antes" src="https://github.com/user-attachments/assets/6fd8a7ae-8903-41f8-807d-4b166ab58f1e" />

**After**
<img width="625" height="504" alt="despues" src="https://github.com/user-attachments/assets/444ab66e-2524-4569-b29a-7edf437b3425" />

Please @pedrobaeza and @Andrii9090-tecnativa can you review it?

@Tecnativa TT64225