### PR TITLE
[18.0][IMP] l10n_es_aeat_sii_oca: Add F6 invoice type

### DIFF
--- a/l10n_es_aeat_sii_oca/i18n/es.po
+++ b/l10n_es_aeat_sii_oca/i18n/es.po
@@ -492,6 +492,12 @@ msgid "Is Supplier Invoice Number Required?"
 msgstr "¿Es requerido el nº de factura de proveedor?"
 
 #. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_bank_statement_line__sii_is_accounting_receipt
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_is_accounting_receipt
+msgid "Is accounting receipt?"
+msgstr "¿Es justificante contable?"
+
+#. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_res_company__sii_test
 msgid "Is it the SII test environment?"
 msgstr "¿Es un entorno de pruebas del SII?"

--- a/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
+++ b/l10n_es_aeat_sii_oca/i18n/l10n_es_aeat_sii_oca.pot
@@ -462,6 +462,12 @@ msgid "Is Supplier Invoice Number Required?"
 msgstr ""
 
 #. module: l10n_es_aeat_sii_oca
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_bank_statement_line__sii_is_accounting_receipt
+#: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_account_move__sii_is_accounting_receipt
+msgid "Is accounting receipt?"
+msgstr ""
+
+#. module: l10n_es_aeat_sii_oca
 #: model:ir.model.fields,field_description:l10n_es_aeat_sii_oca.field_res_company__sii_test
 msgid "Is it the SII test environment?"
 msgstr ""

--- a/l10n_es_aeat_sii_oca/models/account_move.py
+++ b/l10n_es_aeat_sii_oca/models/account_move.py
@@ -86,6 +86,7 @@ class AccountMove(models.Model):
         "The invoice number should start with LC, QZC, QRC, A01 or A02.",
         copy=False,
     )
+    sii_is_accounting_receipt = fields.Boolean(string="Is accounting receipt?")
     sii_dua_invoice = fields.Boolean(compute="_compute_dua_invoice")
 
     @api.depends("move_type")
@@ -296,11 +297,17 @@ class AccountMove(models.Model):
         return res
 
     def _get_sii_invoice_type(self):
+        self.ensure_one()
         invoice_type = ""
         if self.sii_lc_operation:
             return "LC"
         if self.move_type in ["in_invoice", "in_refund"]:
-            invoice_type = "R4" if self.move_type == "in_refund" else "F1"
+            if self.move_type == "in_refund":
+                invoice_type = "R4"
+            elif self.sii_is_accounting_receipt:
+                invoice_type = "F6"
+            else:
+                invoice_type = "F1"
         elif self.move_type in ["out_invoice", "out_refund"]:
             is_simplified = self._is_aeat_simplified_invoice()
             invoice_type = "F2" if is_simplified else "F1"

--- a/l10n_es_aeat_sii_oca/views/account_move_views.xml
+++ b/l10n_es_aeat_sii_oca/views/account_move_views.xml
@@ -44,6 +44,10 @@
                             string="Description"
                             required="sii_enabled"
                         />
+                        <field
+                            name="sii_is_accounting_receipt"
+                            invisible="move_type != 'in_invoice'"
+                        />
                         <field name="thirdparty_invoice" />
                         <field
                             name="thirdparty_number"


### PR DESCRIPTION
La clave F6 corresponde exclusivamente a los justificantes contables o material contable de soporte en las facturas recibidas. Se usa para registrar operaciones contabilizadas que no tienen una factura estándar pero sirven de justificante fiscal válido.

https://sede.agenciatributaria.gob.es/Sede/impuestos-tasas/iva/iva-libros-registro-iva-traves-aeat/preguntas-frecuentes/4-libro-registro-facturas-recibidas.html?faqId=27874256ad6ca510VgnVCM100000dc381e0aRCRD

It's implemented as a boolean only visible for vendor bills.

@Tecnativa TT64236