### PR TITLE
[19.0][FIX] l10n_es_aeat_sii_oca: don't force identifier type 02 under Régimen Intracomunitario

### DIFF
--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -699,7 +699,17 @@ class SiiMixin(models.AbstractModel):
                     },
                 }
         elif gen_type == 2:
-            return {"IDOtro": {"IDType": "02", "ID": full_eu_vat}}
+            if identifier_type == "02":
+                return {"IDOtro": {"IDType": "02", "ID": full_eu_vat}}
+            if identifier_type:
+                return {
+                    "IDOtro": {
+                        "CodigoPais": country_code,
+                        "IDType": identifier_type,
+                        "ID": identifier,
+                    },
+                }
+            return {"NIF": identifier}
         elif gen_type == 3 and identifier_type:
             # Si usamos identificador tipo 02 en exportaciones, el envío falla con:
             #   {'CodigoErrorRegistro': 1104,

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -266,6 +266,63 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
             },
         )
 
+    def test_intracomunitary_customer_valid_vat(self):
+        """Caso normal: un cliente UE con un NIF-IVA real bajo Régimen
+        Intracomunitario debe seguir identificándose con IDType 02.
+        """
+        self._activate_certificate(self.certificate_password)
+        eu_customer = self.env["res.partner"].create(
+            {
+                "name": "French Customer",
+                "country_id": self.ref("base.fr"),
+                "vat": "FR23334175221",
+            }
+        )
+        invoice = self.invoice.copy(
+            {"partner_id": eu_customer.id, "fiscal_position_id": self.fp_intra.id}
+        )
+        invoice.action_post()
+        sii_info = invoice._get_aeat_invoice_dict()
+        self.assertEqual(
+            sii_info["FacturaExpedida"]["Contraparte"],
+            {
+                "NombreRazon": "French Customer",
+                "IDOtro": {"IDType": "02", "ID": "FR23334175221"},
+            },
+        )
+
+    def test_intracomunitary_customer_without_valid_vat(self):
+        """Un cliente bajo Régimen Intracomunitario cuya identificación (por
+        override manual de aeat_identification_type/aeat_identification) no
+        es un NIF-IVA real no debe forzarse a IDType 02, o el SII rechaza la
+        factura con el error 1104 "Valor del campo ID incorrecto".
+        """
+        self._activate_certificate(self.certificate_password)
+        eu_customer = self.env["res.partner"].create(
+            {
+                "name": "Italian Individual Customer",
+                "country_id": self.ref("base.it"),
+                "aeat_identification_type": "06",
+                "aeat_identification": "FAKECODICEFISCALE",
+            }
+        )
+        invoice = self.invoice.copy(
+            {"partner_id": eu_customer.id, "fiscal_position_id": self.fp_intra.id}
+        )
+        invoice.action_post()
+        sii_info = invoice._get_aeat_invoice_dict()
+        self.assertEqual(
+            sii_info["FacturaExpedida"]["Contraparte"],
+            {
+                "NombreRazon": "Italian Individual Customer",
+                "IDOtro": {
+                    "CodigoPais": "IT",
+                    "IDType": "06",
+                    "ID": "FAKECODICEFISCALE",
+                },
+            },
+        )
+
     def test_partner_sii_enabled(self):
         company_02 = self.env["res.company"].create({"name": "Company 02"})
         self.env.user.company_ids += company_02


### PR DESCRIPTION
fw-port: https://github.com/OCA/l10n-spain/pull/5165

@Tecnativa 

ping @carlos-lopez-tecnativa @carlosdauden @EmilioPascual 