### PR TITLE
[17.0][FIX] l10n_es_verifactu_oca: report Macrodato flag in the RegistroAlta

### DIFF
--- a/l10n_es_verifactu_oca/models/account_move.py
+++ b/l10n_es_verifactu_oca/models/account_move.py
@@ -276,6 +276,8 @@ class AccountMove(models.Model):
                 "Huella": self.verifactu_hash,
             }
         )
+        if self.verifactu_macrodata:
+            inv_dict["Macrodato"] = "S"
         if self.aeat_state in ("sent_w_errors", "incorrect"):
             # en caso de subsanación, debe generar un nuevo hash en la factura
             inv_dict["Subsanacion"] = "S"

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -458,6 +458,23 @@ class TestL10nEsAeatVerifactuQR(TestVerifactuCommon):
                 "Invoice should be marked as cancelled after VERI*FACTU processing.",
             )
 
+    def test_verifactu_macrodata(self):
+        """Macrodato must be reported as "S" in the RegistroAlta when the total
+        is over the limit; otherwise AEAT rejects the record (error 1139).
+
+        The omission case (normal amount -> no Macrodato) is already covered by
+        the reference-JSON tests, whose fixtures contain no Macrodato key.
+        """
+        self.assertFalse(self.invoice.verifactu_macrodata)
+        self.invoice.invoice_line_ids.price_unit = 130000000
+        self.assertTrue(self.invoice.verifactu_macrodata)
+        self._activate_certificate(self.certificate_password)
+        self.invoice.action_post()
+        self.assertEqual(
+            self.invoice._get_verifactu_invoice_dict()["RegistroAlta"].get("Macrodato"),
+            "S",
+        )
+
 
 class TestVerifactuSendResponse(TestVerifactuCommon):
     def test_create_activity_on_exception(self):


### PR DESCRIPTION
Synthesized forward-port of #5117 and the test from #5094 

The verifactu_macrodata indicator was computed but never included in the record sent to AEAT, so invoices with ImporteTotal >= 100.000.000 were rejected with error 1139. Report Macrodato="S" when the flag is set.

@Tecnativa 