### PR TITLE
[19.0][FIX] l10n_es_aeat_sii_oca: env.tz returns a tzinfo, not a string

### DIFF
--- a/l10n_es_aeat_sii_oca/models/res_company.py
+++ b/l10n_es_aeat_sii_oca/models/res_company.py
@@ -6,8 +6,6 @@
 
 from datetime import datetime, timedelta
 
-import pytz
-
 from odoo import fields, models
 
 
@@ -81,7 +79,7 @@ class ResCompany(models.Model):
     def _get_sii_sending_time(self):
         if self.send_mode == "fixed":
             tz = self.env.tz
-            offset = datetime.now(pytz.timezone(tz)).strftime("%z") if tz else "+00"
+            offset = datetime.now(tz).strftime("%z")
             hour_diff = int(offset[:3])
             hour, minute = divmod(self.sent_time * 60, 60)
             hour = int(hour - hour_diff)


### PR DESCRIPTION
## Steps to reproduce

1. Set the company SII send mode to **Fixed** (`send_mode = "fixed"`) and a sending time.
2. Post a customer invoice with SII enabled.

## Current behaviour

```
File ".../l10n_es_aeat_sii_oca/models/account_move.py", line 493, in _post
  invoice._process_sii_send()
File ".../l10n_es_aeat_sii_oca/models/sii_mixin.py", line 291, in _process_sii_send
  record.sii_send_date = record.company_id._get_sii_sending_time()
File ".../l10n_es_aeat_sii_oca/models/res_company.py", line 84, in _get_sii_sending_time
  offset = datetime.now(pytz.timezone(tz)).strftime("%z") if tz else "+00"
File ".../pytz/__init__.py", line 170, in timezone
  if zone.upper() == 'UTC':
AttributeError: 'Europe/Madrid' object has no attribute 'upper'
```

The invoice cannot be posted at all.

## Cause

In 19.0 `Environment.tz` is a property that returns an **already built `tzinfo`
object**, never a string (`odoo/orm/environments.py`):

```python
@functools.cached_property
def tz(self) -> tzinfo:
    """Return the current timezone info, defaults to UTC."""
    timezone = self.context.get('tz') or self.user.tz
    if timezone:
        try:
            return pytz.timezone(timezone)
        except Exception:
            _logger.debug("Invalid timezone %r", timezone, exc_info=True)
    return pytz.utc
```

Wrapping that object in `pytz.timezone()` again fails, because pytz expects a
zone name and calls `.upper()` on it.

This is a regression from the 19.0 migration (5a43fe9c). In 18.0 the value was
read from the context and was a string, so the `pytz.timezone()` call was correct:

```python
tz = self.env.context.get("tz", self.env.user.partner_id.tz)
offset = datetime.now(pytz.timezone(tz)).strftime("%z") if tz else "+00"
```

Only `send_mode = "fixed"` is affected; `auto` and `delayed` never reach that branch,
which is likely why it went unnoticed.

## Fix

Pass the `tzinfo` straight to `datetime.now()`.

The `if tz else "+00"` fallback is dropped: `env.tz` defaults to `pytz.utc` and is
never falsy, so the branch was dead code. The `pytz` import becomes unused and is
removed as well.

## Testing

On Odoo 19.0, company timezone `Europe/Madrid`, `send_mode = "fixed"`, `sent_time = 22.0`:

| | Result |
|---|---|
| Before | `AttributeError: 'Europe/Madrid' object has no attribute 'upper'` |
| After | `2026-09-01 20:00:09` (22:00 Europe/Madrid stored as UTC) |
