### PR TITLE
[18.0][FIX] l10n_es_verifactu_oca: keep hash lock when disabling VERI*FACTU

### DIFF
--- a/l10n_es_verifactu_oca/models/account_journal.py
+++ b/l10n_es_verifactu_oca/models/account_journal.py
@@ -26,16 +26,22 @@ class AccountJournal(models.Model):
         "company_id", "company_id.verifactu_enabled", "verifactu_enabled", "type"
     )  # company_id* triggers aren't launched anyway - see res.company~write method
     def _compute_restrict_mode_hash_table(self):
-        self.restrict_mode_hash_table = False
-        self.restrict_mode_hash_table_readonly = False
+        locked = set()
+        if self._origin.ids:
+            self.env.cr.execute(
+                "SELECT id FROM account_journal WHERE id IN %s "
+                "AND restrict_mode_hash_table",
+                (tuple(self._origin.ids),),
+            )
+            locked = {row[0] for row in self.env.cr.fetchall()}
         for record in self:
-            if (
+            verifactu = (
                 record.company_id.verifactu_enabled
                 and record.verifactu_enabled
                 and record.type == "sale"
-            ):
-                record.restrict_mode_hash_table = True
-                record.restrict_mode_hash_table_readonly = True
+            )
+            record.restrict_mode_hash_table_readonly = verifactu
+            record.restrict_mode_hash_table = verifactu or record._origin.id in locked
 
     def check_hash_modification(self, vals):
         verifactu_enabled = vals.get("verifactu_enabled", self.verifactu_enabled)

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -575,3 +575,17 @@ class TestVerifactuSendResponse(TestVerifactuCommon):
         )
         with self.assertRaises(UserError):
             self.invoice._check_verifactu_configuration()
+
+
+class TestVerifactuJournalRestrictMode(TestVerifactuCommon):
+    def test_restrict_mode_kept_when_disabling_verifactu(self):
+        journal = self.env["account.journal"].search(
+            [("company_id", "=", self.company.id), ("type", "=", "sale")], limit=1
+        )
+        self.assertTrue(journal.restrict_mode_hash_table)
+        invoice = self._create_test_invoice()
+        invoice.action_post()
+        self.assertTrue(invoice.inalterable_hash)
+        self.company.verifactu_enabled = False
+        self.assertFalse(journal.restrict_mode_hash_table_readonly)
+        self.assertTrue(journal.restrict_mode_hash_table)


### PR DESCRIPTION
## Antes del PR
https://github.com/user-attachments/assets/aa84f743-c0ef-47bb-87ba-6b0a7f585e71

## Después del PR
https://github.com/user-attachments/assets/b0273552-3923-4254-acc0-f18f2a0bf08d



