### PR TITLE
[18.0][IMP] l10n_es_verifactu_oca: seal existing entries on activation

### DIFF
--- a/l10n_es_verifactu_oca/models/res_company.py
+++ b/l10n_es_verifactu_oca/models/res_company.py
@@ -45,4 +45,14 @@ class ResCompany(models.Model):
             self.env["account.journal"].search(
                 [("company_id", "in", self.ids), ("type", "=", "sale")]
             ).verifactu_enabled = True
+            self.env["account.move"].search(
+                [
+                    ("company_id", "in", self.ids),
+                    ("journal_id.type", "=", "sale"),
+                    ("state", "=", "posted"),
+                    ("inalterable_hash", "=", False),
+                ]
+            )._hash_moves(
+                force_hash=True, raise_if_gap=False, raise_if_no_document=False
+            )
         return res

--- a/l10n_es_verifactu_oca/readme/CONFIGURE.md
+++ b/l10n_es_verifactu_oca/readme/CONFIGURE.md
@@ -25,3 +25,9 @@ con los siguientes comandos para tratar de solucionarlo:
     clave de registro VERI\*FACTU.
 2.  Para aplicar las claves ejecute el asistente de actualización del
     módulo accountchart_update.
+
+Al activar VERI\*FACTU se sellan con la huella de inalterabilidad todos
+los asientos publicados de los diarios de venta, incluso si la
+numeración tiene huecos. Esos asientos ya no se podrán modificar ni
+volver a borrador, así que corrija cualquier factura pendiente antes de
+activarlo.

--- a/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
+++ b/l10n_es_verifactu_oca/tests/test_10n_es_verifactu.py
@@ -575,3 +575,47 @@ class TestVerifactuSendResponse(TestVerifactuCommon):
         )
         with self.assertRaises(UserError):
             self.invoice._check_verifactu_configuration()
+
+
+class TestVerifactuSealOnActivation(TestVerifactuCommon):
+    def _create_invoice(self, name, date):
+        return self.env["account.move"].create(
+            {
+                "company_id": self.company.id,
+                "partner_id": self.partner.id,
+                "move_type": "out_invoice",
+                "invoice_date": date,
+                "date": date,
+                "name": name,
+                "aeat_state": "sent",
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "account_id": self.account_expense.id,
+                            "name": "Test line",
+                            "price_unit": 100,
+                            "quantity": 1,
+                        }
+                    )
+                ],
+            }
+        )
+
+    def test_history_with_gap_is_sealed_on_activation(self):
+        journal = self.env["account.journal"].search(
+            [("company_id", "=", self.company.id), ("type", "=", "sale")], limit=1
+        )
+        self.company.verifactu_enabled = False
+        journal.restrict_mode_hash_table = False
+        first = self._create_invoice("SEAL/2026/00001", "2026-01-10")
+        first.action_post()
+        third = self._create_invoice("SEAL/2026/00003", "2026-01-20")
+        third.action_post()
+        self.assertFalse(first.inalterable_hash)
+        self.company.verifactu_enabled = True
+        self.assertTrue(first.inalterable_hash)
+        self.assertTrue(third.inalterable_hash)
+        fourth = self._create_invoice("SEAL/2026/00004", "2026-02-01")
+        fourth.action_post()
+        self.assertTrue(fourth.inalterable_hash)


### PR DESCRIPTION
Antes del PR:

https://github.com/user-attachments/assets/31c030ea-d702-4118-ac7c-b9adae5aa49b



Después del PR:

https://github.com/user-attachments/assets/f16453d3-853e-443f-b9aa-05d7692544f7



La idea es hashear las facturas pasadas una vez se activa el verifactu para evitar el caso comentado en: 
https://github.com/OCA/l10n-spain/issues/5170