### PR TITLE
[16.0][FIX] l10n_es_aeat_sii_oca: accept AEAT identification for foreign partners

### DIFF
--- a/l10n_es_aeat/models/res_partner.py
+++ b/l10n_es_aeat/models/res_partner.py
@@ -89,7 +89,6 @@ class ResPartner(models.Model):
             )
         return europe.country_ids.mapped("code") + ["XI"]
 
-    @ormcache("self.vat, self.country_id")
     def _parse_aeat_vat_info(self):
         """Return tuple with split info (country_code, identifier_type and
         vat_number) from vat and country partner

--- a/l10n_es_aeat/tests/test_l10n_es_aeat.py
+++ b/l10n_es_aeat/tests/test_l10n_es_aeat.py
@@ -101,6 +101,38 @@ class TestL10nEsAeat(TransactionCase):
         self.assertEqual(identifier_type, "04")
         self.assertEqual(vat_number, "CU12345678Z")
 
+    def test_parse_vat_info_no_collision_between_partners(self):
+        """Two partners without VAT and the same country must not share their
+        AEAT identification. This guards against a caching regression where the
+        result was keyed only on (vat, country_id), so partners without VAT in
+        the same country returned another partner's aeat_identification.
+        """
+        portugal = self.env.ref("base.pt")
+        partner_a = self.env["res.partner"].create(
+            {
+                "name": "PT partner A",
+                "country_id": portugal.id,
+                "aeat_identification": "PT_IDENTIFICATION_A",
+                "aeat_identification_type": "06",
+            }
+        )
+        partner_b = self.env["res.partner"].create(
+            {
+                "name": "PT partner B",
+                "country_id": portugal.id,
+                "aeat_identification": "PT_IDENTIFICATION_B",
+                "aeat_identification_type": "06",
+            }
+        )
+        self.assertEqual(
+            partner_a._parse_aeat_vat_info(),
+            ("PT", "06", "PT_IDENTIFICATION_A"),
+        )
+        self.assertEqual(
+            partner_b._parse_aeat_vat_info(),
+            ("PT", "06", "PT_IDENTIFICATION_B"),
+        )
+
     def test_unique_date_range(self):
         self.env["l10n.es.aeat.map.tax"].create(
             {"date_from": "2020-01-01", "model": 303}

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -635,8 +635,14 @@ class SiiMixin(models.AbstractModel):
                     "IDOtro": {
                         "CodigoPais": country_code,
                         "IDType": identifier_type,
+                        # The country prefix rebuilds a VAT number, whose
+                        # prefix _parse_aeat_vat_info() stripped. An AEAT
+                        # document (passport, residence certificate, other) is
+                        # returned as-is, so prepending the country would send
+                        # a made-up identifier.
                         "ID": vat_country_code + identifier
-                        if self._aeat_get_partner()._map_aeat_country_code(
+                        if identifier_type == "02"
+                        and self._aeat_get_partner()._map_aeat_country_code(
                             vat_country_code
                         )
                         in self._aeat_get_partner()._get_aeat_europe_codes()

--- a/l10n_es_aeat_sii_oca/models/sii_mixin.py
+++ b/l10n_es_aeat_sii_oca/models/sii_mixin.py
@@ -342,6 +342,9 @@ class SiiMixin(models.AbstractModel):
             if (
                 (gen_type != 3 or country_code == "ES")
                 and not partner.vat
+                and not (
+                    partner.aeat_identification_type and partner.aeat_identification
+                )
                 and not is_simplified_invoice
             ):
                 raise UserError(_("The partner has not a VAT configured."))

--- a/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
+++ b/l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py
@@ -457,6 +457,29 @@ class TestL10nEsAeatSii(TestL10nEsAeatSiiBase):
         with self.assertRaises(exceptions.UserError):
             invoice._aeat_check_exceptions()
 
+    def test_sii_identifier_eu_passport_not_prefixed(self):
+        """An AEAT document must not get the country code prepended.
+
+        The prefix rebuilds a VAT number, whose country prefix
+        _parse_aeat_vat_info() strips. An AEAT identification is returned
+        as-is, so prepending the country sends a made-up identifier: an EU
+        customer's passport "12AB345" was reported as "FR12AB345".
+        """
+        partner = self.env["res.partner"].create(
+            {
+                "name": "EU partner with passport",
+                "country_id": self.env.ref("base.fr").id,
+                "vat": False,
+                "aeat_identification_type": "03",
+                "aeat_identification": "12AB345",
+            }
+        )
+        invoice = self._create_invoice_for_sii("out_invoice")
+        invoice.partner_id = partner
+        invoice.fiscal_position_id = False
+        self.assertEqual(invoice._get_sii_gen_type(), 1)
+        self.assertEqual(invoice._get_sii_identifier()["IDOtro"]["ID"], "12AB345")
+
     def test_aeat_check_exceptions_case_supplier_on_post(self):
         """Check sii exceptions when posting supplier bills"""
         supplier = self.supplier.copy()


### PR DESCRIPTION
### Description
With SII enabled, an invoice to a foreign customer who has no VAT number but is identified by an AEAT document (passport, residence certificate, other) fails with *"The partner has not a VAT configured."*, blocking the sale.

The SII guard only accepts `partner.vat` and ignores `aeat_identification` / `aeat_identification_type`, even though the rest of the pipeline already supports them. It also derives `gen_type` from the fiscal position rather than the partner country, so a point of sale offering only a national position hits the check on every such sale. Unblocking that path exposes two further defects that were unreachable before, because the guard rejected the whole population that triggers them.

### Cases Covered with This Improvement

1. **Foreign partner with an AEAT document**: the identification is accepted as a valid fiscal identifier, independently of the fiscal position. Both value and type are required, otherwise `_parse_aeat_vat_info()` drops the value and sends the `"NO_DISPONIBLE"` placeholder. Domestic (ES) partners without VAT, partners with no country and intracommunity operations stay rejected: AEAT refuses an empty or `"ES"` `CodigoPais`, and the intracommunity branch hardcodes `IDType "02"`, so a passport there would fabricate a non-existent VAT number.

2. **Country prefix on non-VAT identifiers**: the country code was prepended based on the partner country instead of the identifier type. Correct when rebuilding a VAT number (`IDType 02`), but `aeat_identification_type` only accepts `03`/`05`/`06`, so an EU passport `12AB345` was reported as `FR12AB345`. It is now applied only to VAT identifiers, leaving every VAT-only case byte-for-byte unchanged.

3. **Cache collision between partners**: `_parse_aeat_vat_info()` was cached on `(vat, country_id)`, but its result also depends on the AEAT identification fields. Two partners sharing a country and having no VAT — any two foreign customers — collided on the same entry, and the second one was reported with the first one's identification, with no visible error.

### Implemented Solution
Case 1 relaxes the guard in `sii.mixin._aeat_check_exceptions()`; case 2 conditions the prefix on `identifier_type == "02"` in `sii.mixin._get_sii_identifier()`; case 3 extends the `ormcache` key of `res.partner._parse_aeat_vat_info()` in `l10n_es_aeat`. Covered by tests in `l10n_es_aeat_sii_oca/tests/test_l10n_es_aeat_sii.py`.

FL-556-9651