### PR TITLE
[17.0][FIX] delivery_mrw: Avoid singleton error in check_mrw_en_franquicia constraint

### DIFF
--- a/delivery_mrw/models/delivery_carrier.py
+++ b/delivery_mrw/models/delivery_carrier.py
@@ -171,7 +171,9 @@ class DeliveryCarrier(models.Model):
 
     @api.constrains("mrw_en_franquicia")
     def check_mrw_en_franquicia(self):
-        if self.mrw_en_franquicia in ("R", "A"):
+        if any(
+            c.delivery_type == "mrw" and c.mrw_en_franquicia in ("R", "A") for c in self
+        ):
             raise UserError(
                 _(
                     "For the moment MRW only supports:\n"

--- a/delivery_mrw/tests/test_delivery_mrw.py
+++ b/delivery_mrw/tests/test_delivery_mrw.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest import mock
 
+from odoo.exceptions import UserError
 from odoo.tests import Form
 
 from odoo.addons.base.tests.common import BaseCommon
@@ -103,3 +104,14 @@ class TestDeliveryMRW(BaseCommon):
         self.assertEqual(
             manifest_data[-1]["carrier_tracking_ref"], self.picking.carrier_tracking_ref
         )
+
+    def test_check_mrw_en_franquicia(self):
+        with self.assertRaises(UserError):
+            self.env["delivery.carrier"].create(
+                {
+                    "name": "MRW Invalid",
+                    "delivery_type": "mrw",
+                    "product_id": self.shipping_product.id,
+                    "mrw_en_franquicia": "R",
+                }
+            )


### PR DESCRIPTION
The constraint `check_mrw_en_franquicia` accessed `self.mrw_en_franquicia` without looping over `self`, causing a `ValueError: Expected singleton` when multiple `delivery.carrier` records are created in a single batch `create([...])` call.

Iterate over `self` and verify `carrier.delivery_type == 'mrw'` before evaluating the constraint.
Add a unit test covering batch carrier creation.

Closes #5201
