### PR TITLE
[16.0][FIX] l10n_es_ticketbai: Avoid AccessError on ir.model.data for non-admin users

### DIFF
--- a/l10n_es_ticketbai/models/res_company.py
+++ b/l10n_es_ticketbai/models/res_company.py
@@ -70,16 +70,21 @@ class ResCompany(models.Model):
         """Low level cached search for a fiscal position given its template and
         company.
         """
-        xmlids = self.env["ir.model.data"].search_read(
-            [
-                ("model", "=", "account.fiscal.position.template"),
-                ("res_id", "=", fp_template.id),
-            ],
-            ["name", "module"],
+        xmlids = (
+            self.sudo()
+            .env["ir.model.data"]
+            .search_read(
+                [
+                    ("model", "=", "account.fiscal.position.template"),
+                    ("res_id", "=", fp_template.id),
+                ],
+                ["name", "module"],
+            )
         )
         return (
             xmlids
-            and self.env["ir.model.data"]
+            and self.sudo()
+            .env["ir.model.data"]
             .search(
                 [
                     ("model", "=", "account.fiscal.position"),

--- a/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
+++ b/l10n_es_ticketbai/tests/test_l10n_es_ticketbai_customer_invoice.py
@@ -670,3 +670,14 @@ class TestL10nEsTicketBAICustomerInvoice(TestL10nEsTicketBAI):
                     },
                 )
             ]
+
+    def test_get_fp_id_from_fp_template_non_admin_user(self):
+        """Non-admin billing users must be able to resolve fiscal position templates
+        without AccessError on ir.model.data (see #5078)."""
+        fp_template = self.env["account.fiscal.position.template"].search([], limit=1)
+        if not fp_template:
+            return
+        company = self.main_company.with_user(self.account_billing)
+        # Should not raise AccessError on ir.model.data
+        res = company._get_fp_id_from_fp_template(fp_template, self.main_company)
+        self.assertIsNotNone(res)


### PR DESCRIPTION
In `_get_fp_id_from_fp_template()`, searching `ir.model.data` without `sudo()` causes an `AccessError` for non-admin users who belong to `account.group_account_invoice` without `base.group_erp_manager` (for example, when creating credit notes via the reversal wizard).

Use `self.sudo().env["ir.model.data"]` for both `search_read` and `search`, aligning with the existing pattern in `l10n_es_aeat/models/res_company.py`.

Add a unit test verifying that non-admin billing users can call `_get_fp_id_from_fp_template()` without triggering an `AccessError`.

Closes #5078
