### PR TITLE
[17.0][FIX] l10n_es_intrastat_report: Corregir 'required' código de región

### DIFF
--- a/l10n_es_intrastat_report/views/l10n_es_intrastat_product.xml
+++ b/l10n_es_intrastat_report/views/l10n_es_intrastat_product.xml
@@ -32,6 +32,11 @@
                     invisible="declaration_type != 'dispatches' or company_country_code != 'ES'"
                 />
             </field>
+            <field name="region_code" position="attributes">
+                <attribute
+                    name="required"
+                >reporting_level == 'extended' and company_country_code != 'ES'</attribute>
+            </field>
         </field>
     </record>
     <record


### PR DESCRIPTION
## Motivo

La [vista genérica](https://github.com/OCA/intrastat-extrastat/blob/17.0/intrastat_product/views/intrastat_product_declaration.xml#L280) de `intrastat_product` marca `region_code` como obligatorio en declaraciones `extended`. Sin embargo, la localización española utiliza `intrastat_state_id` para informar la provincia y no utiliza `region_code` al generar el CSV.

Esto provoca una validación visual incoherente en las compañías españolas. La vista actual de OCA no adapta esta restricción. 
<img width="1783" height="1198" alt="imagen" src="https://github.com/user-attachments/assets/d9b72b38-502a-479a-bdb4-3daf88b03249" />

## Cambio

Se modifica `l10n_es_intrastat_product_computation_line_view_form` para que `region_code` solo sea obligatorio fuera de España:

```xml
<field name="region_code" position="attributes">
    <attribute name="required">
        reporting_level == 'extended' and company_country_code != 'ES'
    </attribute>
</field>
```

## Impacto

- `region_code` queda opcional para España.
- Se mantiene obligatorio para otras localizaciones en nivel `extended`.
- No cambia la generación del CSV español.
